### PR TITLE
[codex] Keep mock LLM events primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pss-next
 
-Small prototype for a minimal agent runtime: a mock LLM emits either text or a tool call, the loop continues on tool calls, and consumers observe progress through agent events.
+Small prototype for a minimal agent runtime: a mock LLM emits text, a tool call, or text followed by a tool call; the loop continues on tool calls, and consumers observe progress through agent events.
 
 ```bash
 pnpm install

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export { Agent } from "./runtime/agent";
 export { runAgentLoop } from "./runtime/agent-loop";
 export type { AgentEvent, AgentEventListener } from "./runtime/events";
 export { createMockLlm, mockLlm } from "./runtime/mock-llm";
-export type { LlmOutput } from "./runtime/mock-llm";
+export type { Llm, LlmOutput, LlmOutputPart } from "./runtime/mock-llm";

--- a/src/runtime/agent-loop.test.ts
+++ b/src/runtime/agent-loop.test.ts
@@ -1,40 +1,34 @@
 import assert from "node:assert/strict";
 import { runAgentLoop } from "./agent-loop";
 import type { AgentEvent } from "./events";
-import { createMockLlm } from "./mock-llm";
+import type { Llm, LlmOutput } from "./mock-llm";
 
-assert.deepEqual(await createMockLlm(() => 0.29)(), {
-  type: "text",
-  text: "DONE",
-});
-assert.deepEqual(await createMockLlm(() => 0.3)(), {
-  type: "tool-call",
-  toolName: "continue",
-});
+const createScriptedLlm = (outputs: LlmOutput[]): Llm => {
+  let index = 0;
+  return async () => outputs[index++] ?? [];
+};
 
 const events: AgentEvent[] = [];
-const originalRandom = Math.random;
-let calls = 0;
-Math.random = () => {
-  calls += 1;
-  return calls === 1 ? 0.7 : 0.2;
-};
-try {
-  assert.equal(await runAgentLoop((event) => events.push(event)), "DONE");
-} finally {
-  Math.random = originalRandom;
-}
-assert.equal(calls, 2);
+const llm = createScriptedLlm([
+  [
+    { type: "text", text: "I should keep going." },
+    { type: "tool-call", toolName: "continue" },
+  ],
+  [{ type: "text", text: "DONE" }],
+]);
+
+assert.equal(await runAgentLoop({ emit: (event) => events.push(event), llm }), undefined);
 assert.deepEqual(
   events.map((event) => event.type),
   [
-    "agent_start",
-    "turn_start",
-    "tool_call",
-    "turn_end",
-    "turn_start",
-    "message",
-    "turn_end",
-    "agent_end",
+    "agent-start",
+    "turn-start",
+    "text",
+    "tool-call",
+    "turn-end",
+    "turn-start",
+    "text",
+    "turn-end",
+    "agent-end",
   ]
 );

--- a/src/runtime/agent-loop.ts
+++ b/src/runtime/agent-loop.ts
@@ -1,21 +1,37 @@
 import type { AgentEventListener } from "./events";
-import { mockLlm } from "./mock-llm";
+import { mockLlm, type Llm } from "./mock-llm";
 
-export async function runAgentLoop(emit: AgentEventListener): Promise<string> {
-  emit({ type: "agent_start" });
+type RunAgentLoopOptions = {
+  emit: AgentEventListener;
+  llm?: Llm;
+};
+
+export async function runAgentLoop({
+  emit,
+  llm = mockLlm,
+}: RunAgentLoopOptions): Promise<void> {
+  emit({ type: "agent-start" });
 
   while (true) {
-    emit({ type: "turn_start" });
-    const output = await mockLlm();
+    emit({ type: "turn-start" });
+    const output = await llm();
+    let shouldContinue = false;
 
-    if (output.type === "text") {
-      emit({ type: "message", text: output.text });
-      emit({ type: "turn_end" });
-      emit({ type: "agent_end" });
-      return output.text;
+    for (const part of output) {
+      if (part.type === "text") {
+        emit({ type: "text", text: part.text });
+        continue;
+      }
+
+      emit({ type: "tool-call", toolName: part.toolName });
+      shouldContinue = true;
     }
 
-    emit({ type: "tool_call", toolName: output.toolName });
-    emit({ type: "turn_end" });
+    emit({ type: "turn-end" });
+
+    if (!shouldContinue) {
+      emit({ type: "agent-end" });
+      return;
+    }
   }
 }

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -1,16 +1,29 @@
 import { runAgentLoop } from "./agent-loop";
 import type { AgentEvent, AgentEventListener } from "./events";
+import { mockLlm, type Llm } from "./mock-llm";
+
+type AgentOptions = {
+  llm?: Llm;
+};
 
 export class Agent {
   readonly #listeners = new Set<AgentEventListener>();
+  readonly #llm: Llm;
+
+  constructor(options: AgentOptions = {}) {
+    this.#llm = options.llm ?? mockLlm;
+  }
 
   subscribe(listener: AgentEventListener): () => void {
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);
   }
 
-  run(): Promise<string> {
-    return runAgentLoop((event) => this.#emit(event));
+  run(): Promise<void> {
+    return runAgentLoop({
+      emit: (event) => this.#emit(event),
+      llm: this.#llm,
+    });
   }
 
   #emit(event: AgentEvent): void {

--- a/src/runtime/events.ts
+++ b/src/runtime/events.ts
@@ -1,9 +1,9 @@
 export type AgentEvent =
-  | { type: "agent_start" }
-  | { type: "turn_start" }
-  | { type: "message"; text: string }
-  | { type: "tool_call"; toolName: string }
-  | { type: "turn_end" }
-  | { type: "agent_end" };
+  | { type: "agent-start" }
+  | { type: "turn-start" }
+  | { type: "text"; text: string }
+  | { type: "tool-call"; toolName: string }
+  | { type: "turn-end" }
+  | { type: "agent-end" };
 
 export type AgentEventListener = (event: AgentEvent) => void;

--- a/src/runtime/mock-llm.ts
+++ b/src/runtime/mock-llm.ts
@@ -1,12 +1,27 @@
-export type LlmOutput =
+export type LlmOutputPart =
   | { type: "text"; text: string }
   | { type: "tool-call"; toolName: string };
 
-export function createMockLlm(random?: () => number) {
-  return async (): Promise<LlmOutput> =>
-    (random ?? Math.random)() < 0.3
-      ? { type: "text", text: "DONE" }
-      : { type: "tool-call", toolName: "continue" };
+export type LlmOutput = LlmOutputPart[];
+export type Llm = () => Promise<LlmOutput>;
+
+export function createMockLlm(): Llm {
+  return async () => {
+    const roll = Math.random();
+
+    if (roll < 0.3) {
+      return [{ type: "text", text: "DONE" }];
+    }
+
+    if (roll < 0.65) {
+      return [{ type: "tool-call", toolName: "continue" }];
+    }
+
+    return [
+      { type: "text", text: "I should keep going." },
+      { type: "tool-call", toolName: "continue" },
+    ];
+  };
 }
 
 export const mockLlm = createMockLlm();


### PR DESCRIPTION
## Summary
- Keep mock LLM output as ordered primitive parts (`text`, `tool-call`).
- Make `runAgentLoop` / `Agent.run` complete via events instead of returning final text.
- Move deterministic test behavior into a test-local scripted LLM instead of exposing random injection on `createMockLlm`.

## Why
The prototype is converging on a subscription/event-stream runtime. Returning final text or adding composite output/event names creates a second output channel and drifts away from raw LLM parts.

## Validation
- `pnpm run test`
- `pnpm run typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep mock LLM output as ordered primitive parts and drive agent completion through events only. This removes the final-text return path and standardizes event names and payloads.

- **Refactors**
  - LLM now returns `LlmOutputPart[]` (`text` and `tool-call`) via `Llm`; added exports `Llm`, `LlmOutput`, `LlmOutputPart`.
  - Events renamed to kebab-case and simplified: `agent-start`, `turn-start`, `text`, `tool-call`, `turn-end`, `agent-end` (replaces `message`/`tool_call`).
  - `runAgentLoop` takes `{ emit, llm }`, emits events for all parts, and returns `void` (defaults to `mockLlm`).
  - `Agent` accepts optional `llm`; `run()` returns `Promise<void>` and completes on `agent-end`.
  - Tests inject a scripted `Llm` for determinism; `createMockLlm` no longer accepts a random seed and may emit text followed by a tool call.

- **Migration**
  - Listen for `text` (not `message`) and updated kebab-case event names.
  - Do not read return values from `Agent.run` or `runAgentLoop`; rely on `agent-end`.
  - Update custom LLMs to implement `Llm` and return `LlmOutputPart[]`.
  - In tests, pass a scripted `llm` via `runAgentLoop({ llm })` or `new Agent({ llm })`.

<sup>Written for commit adb56f54941675d462292821f1089930b8907ac7. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/1?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

