### PR TITLE
[codex] Add queued sessions for interruptible input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pss-next
 
-Small prototype for a minimal agent runtime: a mock LLM emits text, a tool call, or text followed by a tool call; the loop continues on tool calls, and consumers observe progress through agent events.
+Small prototype for a minimal agent runtime: a mock LLM emits text, a tool call, or text followed by a tool call; sessions accept user messages through a queue and consumers observe progress through agent events.
 
 ```bash
 pnpm install

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,10 +1,50 @@
-import { Agent } from "../src";
+import { Agent, type Llm } from "../src";
 
-const agent = new Agent();
+const sleep = (ms: number, signal: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const done = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const timeout = setTimeout(done, ms);
+    signal.addEventListener("abort", done, { once: true });
+  });
+
+let llmCalls = 0;
+const llm: Llm = async ({ signal }) => {
+  llmCalls += 1;
+
+  if (llmCalls === 1) {
+    await sleep(1000, signal);
+    return [{ type: "tool-call", toolName: "continue" }];
+  }
+
+  await sleep(300, signal);
+  return [{ type: "text", text: "DONE" }];
+};
+
+const agent = new Agent({ llm });
 const session = agent.createSession();
 
 session.subscribe((event) => {
   console.log(event);
 });
 
-await session.submit({ type: "user-message", text: "do something" });
+const first = session.submit({ type: "user-message", text: "long running input" });
+const second = session.submit({
+  type: "user-message",
+  text: "queued input while first is running",
+});
+
+setTimeout(() => {
+  console.log("interrupt active turn");
+  session.interrupt();
+}, 300);
+
+await Promise.all([first, second]);

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,9 +1,10 @@
 import { Agent } from "../src";
 
 const agent = new Agent();
+const session = agent.createSession();
 
-agent.subscribe((event) => {
+session.subscribe((event) => {
   console.log(event);
 });
 
-await agent.run();
+await session.submit({ type: "user-message", text: "do something" });

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,50 +1,20 @@
-import { Agent, type Llm } from "../src";
+import { Agent } from "../src";
 
-const sleep = (ms: number, signal: AbortSignal): Promise<void> =>
-  new Promise((resolve) => {
-    if (signal.aborted) {
-      resolve();
-      return;
-    }
-
-    const done = () => {
-      clearTimeout(timeout);
-      signal.removeEventListener("abort", done);
-      resolve();
-    };
-    const timeout = setTimeout(done, ms);
-    signal.addEventListener("abort", done, { once: true });
-  });
-
-let llmCalls = 0;
-const llm: Llm = async ({ signal }) => {
-  llmCalls += 1;
-
-  if (llmCalls === 1) {
-    await sleep(1000, signal);
-    return [{ type: "tool-call", toolName: "continue" }];
-  }
-
-  await sleep(300, signal);
-  return [{ type: "text", text: "DONE" }];
-};
-
-const agent = new Agent({ llm });
+const agent = new Agent();
 const session = agent.createSession();
 
 session.subscribe((event) => {
   console.log(event);
 });
 
-const first = session.submit({ type: "user-message", text: "long running input" });
+const first = session.submit({ type: "user-message", text: "first input" });
 const second = session.submit({
   type: "user-message",
-  text: "queued input while first is running",
+  text: "queued input",
 });
 
 setTimeout(() => {
-  console.log("interrupt active turn");
   session.interrupt();
-}, 300);
+}, 100);
 
 await Promise.all([first, second]);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx examples/basic.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx src/runtime/agent-loop.test.ts"
+    "test": "tsx src/runtime/agent-loop.test.ts && tsx src/runtime/session.test.ts"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export { Agent } from "./runtime/agent";
 export { runAgentLoop } from "./runtime/agent-loop";
 export type { AgentEvent, AgentEventListener } from "./runtime/events";
 export { createMockLlm, mockLlm } from "./runtime/mock-llm";
-export type { Llm, LlmOutput, LlmOutputPart } from "./runtime/mock-llm";
+export type { Llm, LlmContext, LlmOutput, LlmOutputPart } from "./runtime/mock-llm";
+export type { AgentSession, SessionInput } from "./runtime/session";

--- a/src/runtime/agent-loop.test.ts
+++ b/src/runtime/agent-loop.test.ts
@@ -17,16 +17,16 @@ const llm = createScriptedLlm([
   [{ type: "text", text: "DONE" }],
 ]);
 
-assert.equal(await runAgentLoop({ emit: (event) => events.push(event), llm }), undefined);
+assert.equal(await runAgentLoop({ emit: (event) => events.push(event), llm }), "completed");
 assert.deepEqual(
   events.map((event) => event.type),
   [
-    "turn-start",
+    "step-start",
     "text",
     "tool-call",
-    "turn-end",
-    "turn-start",
+    "step-end",
+    "step-start",
     "text",
-    "turn-end",
+    "step-end",
   ]
 );

--- a/src/runtime/agent-loop.test.ts
+++ b/src/runtime/agent-loop.test.ts
@@ -21,7 +21,6 @@ assert.equal(await runAgentLoop({ emit: (event) => events.push(event), llm }), u
 assert.deepEqual(
   events.map((event) => event.type),
   [
-    "agent-start",
     "turn-start",
     "text",
     "tool-call",
@@ -29,6 +28,5 @@ assert.deepEqual(
     "turn-start",
     "text",
     "turn-end",
-    "agent-end",
   ]
 );

--- a/src/runtime/agent-loop.ts
+++ b/src/runtime/agent-loop.ts
@@ -12,11 +12,8 @@ export async function runAgentLoop({
   llm = mockLlm,
   signal = new AbortController().signal,
 }: RunAgentLoopOptions): Promise<void> {
-  emit({ type: "agent-start" });
-
   while (true) {
     if (signal.aborted) {
-      emit({ type: "agent-end" });
       return;
     }
 
@@ -26,14 +23,12 @@ export async function runAgentLoop({
 
     if (signal.aborted) {
       emit({ type: "turn-abort" });
-      emit({ type: "agent-end" });
       return;
     }
 
     for (const part of output) {
       if (signal.aborted) {
         emit({ type: "turn-abort" });
-        emit({ type: "agent-end" });
         return;
       }
 
@@ -49,7 +44,6 @@ export async function runAgentLoop({
     emit({ type: "turn-end" });
 
     if (!shouldContinue) {
-      emit({ type: "agent-end" });
       return;
     }
   }

--- a/src/runtime/agent-loop.ts
+++ b/src/runtime/agent-loop.ts
@@ -7,29 +7,29 @@ type RunAgentLoopOptions = {
   signal?: AbortSignal;
 };
 
+export type AgentLoopResult = "completed" | "aborted";
+
 export async function runAgentLoop({
   emit,
   llm = mockLlm,
   signal = new AbortController().signal,
-}: RunAgentLoopOptions): Promise<void> {
+}: RunAgentLoopOptions): Promise<AgentLoopResult> {
   while (true) {
     if (signal.aborted) {
-      return;
+      return "aborted";
     }
 
-    emit({ type: "turn-start" });
+    emit({ type: "step-start" });
     const output = await llm({ signal });
     let shouldContinue = false;
 
     if (signal.aborted) {
-      emit({ type: "turn-abort" });
-      return;
+      return "aborted";
     }
 
     for (const part of output) {
       if (signal.aborted) {
-        emit({ type: "turn-abort" });
-        return;
+        return "aborted";
       }
 
       if (part.type === "text") {
@@ -41,10 +41,10 @@ export async function runAgentLoop({
       shouldContinue = true;
     }
 
-    emit({ type: "turn-end" });
+    emit({ type: "step-end" });
 
     if (!shouldContinue) {
-      return;
+      return "completed";
     }
   }
 }

--- a/src/runtime/agent-loop.ts
+++ b/src/runtime/agent-loop.ts
@@ -4,20 +4,39 @@ import { mockLlm, type Llm } from "./mock-llm";
 type RunAgentLoopOptions = {
   emit: AgentEventListener;
   llm?: Llm;
+  signal?: AbortSignal;
 };
 
 export async function runAgentLoop({
   emit,
   llm = mockLlm,
+  signal = new AbortController().signal,
 }: RunAgentLoopOptions): Promise<void> {
   emit({ type: "agent-start" });
 
   while (true) {
+    if (signal.aborted) {
+      emit({ type: "agent-end" });
+      return;
+    }
+
     emit({ type: "turn-start" });
-    const output = await llm();
+    const output = await llm({ signal });
     let shouldContinue = false;
 
+    if (signal.aborted) {
+      emit({ type: "turn-abort" });
+      emit({ type: "agent-end" });
+      return;
+    }
+
     for (const part of output) {
+      if (signal.aborted) {
+        emit({ type: "turn-abort" });
+        emit({ type: "agent-end" });
+        return;
+      }
+
       if (part.type === "text") {
         emit({ type: "text", text: part.text });
         continue;

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -1,34 +1,18 @@
-import { runAgentLoop } from "./agent-loop";
-import type { AgentEvent, AgentEventListener } from "./events";
 import { mockLlm, type Llm } from "./mock-llm";
+import { AgentSession } from "./session";
 
 type AgentOptions = {
   llm?: Llm;
 };
 
 export class Agent {
-  readonly #listeners = new Set<AgentEventListener>();
   readonly #llm: Llm;
 
   constructor(options: AgentOptions = {}) {
     this.#llm = options.llm ?? mockLlm;
   }
 
-  subscribe(listener: AgentEventListener): () => void {
-    this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
-  }
-
-  run(): Promise<void> {
-    return runAgentLoop({
-      emit: (event) => this.#emit(event),
-      llm: this.#llm,
-    });
-  }
-
-  #emit(event: AgentEvent): void {
-    for (const listener of this.#listeners) {
-      listener(event);
-    }
+  createSession(): AgentSession {
+    return new AgentSession(this.#llm);
   }
 }

--- a/src/runtime/events.ts
+++ b/src/runtime/events.ts
@@ -1,8 +1,10 @@
 export type AgentEvent =
   | { type: "agent-start" }
+  | { type: "user-message"; text: string }
   | { type: "turn-start" }
   | { type: "text"; text: string }
   | { type: "tool-call"; toolName: string }
+  | { type: "turn-abort" }
   | { type: "turn-end" }
   | { type: "agent-end" };
 

--- a/src/runtime/events.ts
+++ b/src/runtime/events.ts
@@ -1,11 +1,11 @@
 export type AgentEvent =
-  | { type: "agent-start" }
   | { type: "user-message"; text: string }
   | { type: "turn-start" }
-  | { type: "text"; text: string }
-  | { type: "tool-call"; toolName: string }
   | { type: "turn-abort" }
   | { type: "turn-end" }
-  | { type: "agent-end" };
+  | { type: "step-start" }
+  | { type: "text"; text: string }
+  | { type: "tool-call"; toolName: string }
+  | { type: "step-end" };
 
 export type AgentEventListener = (event: AgentEvent) => void;

--- a/src/runtime/events.ts
+++ b/src/runtime/events.ts
@@ -1,12 +1,21 @@
 export type AgentEvent =
+  /** User input was accepted into the session queue. */
   | { type: "user-message"; text: string }
+  /** A queued user input started running as a turn. */
   | { type: "turn-start" }
+  /** The active turn was interrupted before normal completion. */
   | { type: "turn-abort" }
+  /** The active turn hit an unrecoverable runtime failure. */
   | { type: "turn-error"; message: string }
+  /** The active turn completed normally. */
   | { type: "turn-end" }
+  /** One model/tool-loop iteration started within the active turn. */
   | { type: "step-start" }
+  /** The model produced visible assistant text. */
   | { type: "text"; text: string }
+  /** The model requested a tool call. */
   | { type: "tool-call"; toolName: string }
+  /** One model/tool-loop iteration finished within the active turn. */
   | { type: "step-end" };
 
 export type AgentEventListener = (event: AgentEvent) => void;

--- a/src/runtime/events.ts
+++ b/src/runtime/events.ts
@@ -2,6 +2,7 @@ export type AgentEvent =
   | { type: "user-message"; text: string }
   | { type: "turn-start" }
   | { type: "turn-abort" }
+  | { type: "turn-error"; message: string }
   | { type: "turn-end" }
   | { type: "step-start" }
   | { type: "text"; text: string }

--- a/src/runtime/mock-llm.ts
+++ b/src/runtime/mock-llm.ts
@@ -3,10 +3,31 @@ export type LlmOutputPart =
   | { type: "tool-call"; toolName: string };
 
 export type LlmOutput = LlmOutputPart[];
-export type Llm = () => Promise<LlmOutput>;
+export type LlmContext = { signal: AbortSignal };
+export type Llm = (context: LlmContext) => Promise<LlmOutput>;
+
+const mockLlmDelayMs = 300;
+
+const delay = (ms: number, signal: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const done = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const timeout = setTimeout(done, ms);
+    signal.addEventListener("abort", done, { once: true });
+  });
 
 export function createMockLlm(): Llm {
-  return async () => {
+  return async ({ signal }) => {
+    await delay(mockLlmDelayMs, signal);
+
     const roll = Math.random();
 
     if (roll < 0.3) {

--- a/src/runtime/session.test.ts
+++ b/src/runtime/session.test.ts
@@ -41,13 +41,14 @@ assert.deepEqual(
   events.map((event) => event.type),
   [
     "user-message",
-    "agent-start",
     "turn-start",
+    "step-start",
     "user-message",
     "turn-abort",
     "turn-start",
+    "step-start",
     "text",
+    "step-end",
     "turn-end",
-    "agent-end",
   ]
 );

--- a/src/runtime/session.test.ts
+++ b/src/runtime/session.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { Agent } from "./agent";
+import type { AgentEvent } from "./events";
+import type { Llm } from "./mock-llm";
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+const firstLlmCall = createDeferred();
+let calls = 0;
+const llm: Llm = async () => {
+  calls += 1;
+
+  if (calls === 1) {
+    await firstLlmCall.promise;
+    return [{ type: "tool-call", toolName: "continue" }];
+  }
+
+  return [{ type: "text", text: "DONE" }];
+};
+
+const session = new Agent({ llm }).createSession();
+const events: AgentEvent[] = [];
+session.subscribe((event) => events.push(event));
+
+const firstSubmit = session.submit({ type: "user-message", text: "first" });
+const secondSubmit = session.submit({ type: "user-message", text: "second" });
+
+session.interrupt();
+firstLlmCall.resolve();
+
+await Promise.all([firstSubmit, secondSubmit]);
+
+assert.equal(calls, 2);
+assert.deepEqual(
+  events.map((event) => event.type),
+  [
+    "user-message",
+    "agent-start",
+    "turn-start",
+    "user-message",
+    "turn-abort",
+    "agent-end",
+    "agent-start",
+    "turn-start",
+    "text",
+    "turn-end",
+    "agent-end",
+  ]
+);

--- a/src/runtime/session.test.ts
+++ b/src/runtime/session.test.ts
@@ -52,3 +52,25 @@ assert.deepEqual(
     "turn-end",
   ]
 );
+
+const failingSession = new Agent({
+  llm: async () => {
+    throw new Error("model unavailable");
+  },
+}).createSession();
+const failingEvents: AgentEvent[] = [];
+failingSession.subscribe((event) => failingEvents.push(event));
+
+await assert.rejects(
+  failingSession.submit({ type: "user-message", text: "fail" }),
+  /model unavailable/
+);
+
+assert.deepEqual(
+  failingEvents.map((event) => event.type),
+  ["user-message", "turn-start", "step-start", "turn-error"]
+);
+assert.deepEqual(failingEvents.at(-1), {
+  type: "turn-error",
+  message: "model unavailable",
+});

--- a/src/runtime/session.test.ts
+++ b/src/runtime/session.test.ts
@@ -45,8 +45,6 @@ assert.deepEqual(
     "turn-start",
     "user-message",
     "turn-abort",
-    "agent-end",
-    "agent-start",
     "turn-start",
     "text",
     "turn-end",

--- a/src/runtime/session.ts
+++ b/src/runtime/session.ts
@@ -70,6 +70,7 @@ export class AgentSession {
           });
           item.resolve();
         } catch (error) {
+          this.#emit({ type: "turn-error", message: errorMessage(error) });
           item.reject(error);
         } finally {
           this.#activeAbort = undefined;
@@ -85,4 +86,12 @@ export class AgentSession {
       listener(event);
     }
   }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
 }

--- a/src/runtime/session.ts
+++ b/src/runtime/session.ts
@@ -1,0 +1,84 @@
+import { runAgentLoop } from "./agent-loop";
+import type { AgentEvent, AgentEventListener } from "./events";
+import type { Llm } from "./mock-llm";
+
+export type SessionInput = { type: "user-message"; text: string };
+
+type QueuedInput = {
+  input: SessionInput;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+export class AgentSession {
+  readonly #listeners = new Set<AgentEventListener>();
+  readonly #llm: Llm;
+  readonly #inputQueue: QueuedInput[] = [];
+  #running = false;
+  #activeAbort?: AbortController;
+
+  constructor(llm: Llm) {
+    this.#llm = llm;
+  }
+
+  subscribe(listener: AgentEventListener): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  submit(input: SessionInput): Promise<void> {
+    this.#emit(input);
+
+    const queued = new Promise<void>((resolve, reject) => {
+      this.#inputQueue.push({ input, resolve, reject });
+    });
+
+    void this.#drainInputQueue();
+    return queued;
+  }
+
+  interrupt(): void {
+    this.#activeAbort?.abort();
+  }
+
+  async #drainInputQueue(): Promise<void> {
+    if (this.#running) {
+      return;
+    }
+
+    this.#running = true;
+
+    try {
+      while (this.#inputQueue.length > 0) {
+        const item = this.#inputQueue.shift();
+
+        if (!item) {
+          continue;
+        }
+
+        this.#activeAbort = new AbortController();
+
+        try {
+          await runAgentLoop({
+            emit: (event) => this.#emit(event),
+            llm: this.#llm,
+            signal: this.#activeAbort.signal,
+          });
+          item.resolve();
+        } catch (error) {
+          item.reject(error);
+        } finally {
+          this.#activeAbort = undefined;
+        }
+      }
+    } finally {
+      this.#running = false;
+    }
+  }
+
+  #emit(event: AgentEvent): void {
+    for (const listener of this.#listeners) {
+      listener(event);
+    }
+  }
+}

--- a/src/runtime/session.ts
+++ b/src/runtime/session.ts
@@ -47,6 +47,7 @@ export class AgentSession {
     }
 
     this.#running = true;
+    this.#emit({ type: "agent-start" });
 
     try {
       while (this.#inputQueue.length > 0) {
@@ -72,6 +73,7 @@ export class AgentSession {
         }
       }
     } finally {
+      this.#emit({ type: "agent-end" });
       this.#running = false;
     }
   }

--- a/src/runtime/session.ts
+++ b/src/runtime/session.ts
@@ -47,7 +47,6 @@ export class AgentSession {
     }
 
     this.#running = true;
-    this.#emit({ type: "agent-start" });
 
     try {
       while (this.#inputQueue.length > 0) {
@@ -60,10 +59,14 @@ export class AgentSession {
         this.#activeAbort = new AbortController();
 
         try {
-          await runAgentLoop({
+          this.#emit({ type: "turn-start" });
+          const result = await runAgentLoop({
             emit: (event) => this.#emit(event),
             llm: this.#llm,
             signal: this.#activeAbort.signal,
+          });
+          this.#emit({
+            type: result === "aborted" ? "turn-abort" : "turn-end",
           });
           item.resolve();
         } catch (error) {
@@ -73,7 +76,6 @@ export class AgentSession {
         }
       }
     } finally {
-      this.#emit({ type: "agent-end" });
       this.#running = false;
     }
   }


### PR DESCRIPTION
## Summary
- Add `Agent.createSession()` and a session-owned `subscribe/submit/interrupt` surface.
- Replace legacy `Agent.subscribe/run` usage with `session.subscribe()` and queued `session.submit({ type: "user-message", text })`.
- Add abort-aware loop handling plus a 300ms mock LLM delay for easier interrupt/queue reproduction.
- Add session queue coverage for submit-while-running + interrupt behavior.

## Slop scan fixes included
- Removed duplicate Agent-level subscription/run surface so the active conversation owns events.
- Kept `AgentSession` as a type-only root export; consumers still create sessions via `Agent`.
- Cleaned the mock delay abort listener so it unregisters after resolution.
- Standardized queue naming around `QueuedInput`, `#inputQueue`, and `#drainInputQueue()`.

## Validation
- `pnpm run test`
- `pnpm run typecheck`
- `pnpm run dev`
- `git diff --check`

## Remaining risks
- The mock LLM still does not consume user text or history.
- No persistent session store/history yet.
- Real provider streaming and tool execution are still out of scope for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds queued, interruptible sessions with session-owned events, aligns lifecycle names so user inputs are turns and LLM calls are steps, and ensures turns close with a `turn-error` on uncaught failures. Create a session, queue user messages, and interrupt the active turn while queued inputs run next.

- New Features
  - Session API: `agent.createSession()` with `session.subscribe()`, `session.submit({ type: "user-message", text })`, and `session.interrupt()`; one active run and queued inputs drain in order.
  - Abort-aware loop with `AbortSignal`; `runAgentLoop` returns `"completed" | "aborted"` and emits `step-start/step-end`; events include `user-message`, `turn-start/turn-end/turn-abort/turn-error`.
  - `Llm` now receives `({ signal })`; `mockLlm` adds an abortable ~300ms delay. Exported `LlmContext`, `AgentSession`, and `SessionInput`.
  - Documented event semantics inline on the `AgentEvent` union for clarity.

- Migration
  - Replace `Agent.subscribe/run` with: `const session = agent.createSession(); session.subscribe(...); await session.submit({ type: "user-message", text: "..." });`
  - Update custom `Llm` to accept `({ signal })` and respect aborts.
  - Update event handling: remove `agent-start/agent-end`; listen for `turn-start/turn-end/turn-abort/turn-error` and `step-start/step-end`.

<sup>Written for commit 170858f86dc62699b62048b7486ccd709138c23b. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/2?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

