### PR TITLE
[codex] Add raw recoverable session history

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Small prototype for a minimal agent runtime: a mock LLM emits text, a tool call, or text followed by a tool call; sessions accept user messages through a queue and consumers observe progress through agent events.
 
+Sessions own raw history. The event log records every emitted event, while model history records the smaller sequence passed back into the LLM. A session snapshot can be saved, restored, or viewed at an earlier sequence for time-travel-style inspection.
+
 ```bash
 pnpm install
 pnpm run dev

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -7,9 +7,9 @@ session.subscribe((event) => {
   console.log(event);
 });
 
-const first = session.submit({ type: "user-message", text: "first input" });
+const first = session.submit({ type: "user-text", text: "first input" });
 const second = session.submit({
-  type: "user-message",
+  type: "user-text",
   text: "queued input",
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,17 @@ export { Agent } from "./runtime/agent";
 export { runAgentLoop } from "./runtime/agent-loop";
 export { createMockLlm, mockLlm } from "./runtime/mock-llm";
 export type { Llm, LlmContext, LlmOutput, LlmOutputPart } from "./runtime/mock-llm";
-export type { AgentEvent, AgentEventListener, AgentSession, SessionInput } from "./runtime/session";
+export {
+  InMemorySessionHistoryStore,
+  SessionHistory,
+  type AgentEvent,
+  type AgentEventListener,
+  type AgentSession,
+  type ModelHistoryItem,
+  type ModelHistoryRecord,
+  type SessionEventRecord,
+  type SessionHistoryStore,
+  type SessionHistoryView,
+  type SessionInput,
+  type SessionSnapshot,
+} from "./runtime/session";

--- a/src/runtime/agent-loop.test.ts
+++ b/src/runtime/agent-loop.test.ts
@@ -22,11 +22,11 @@ assert.deepEqual(
   events.map((event) => event.type),
   [
     "step-start",
-    "text",
+    "assistant-text",
     "tool-call",
     "step-end",
     "step-start",
-    "text",
+    "assistant-text",
     "step-end",
   ]
 );

--- a/src/runtime/agent-loop.ts
+++ b/src/runtime/agent-loop.ts
@@ -1,9 +1,11 @@
 import type { AgentEventListener } from "./session/events";
+import type { ModelHistoryItem } from "./session/history";
 import { mockLlm, type Llm } from "./mock-llm";
 
 type RunAgentLoopOptions = {
   emit: AgentEventListener;
   llm?: Llm;
+  modelHistory?: () => ModelHistoryItem[];
   signal?: AbortSignal;
 };
 
@@ -12,6 +14,7 @@ export type AgentLoopResult = "completed" | "aborted";
 export async function runAgentLoop({
   emit,
   llm = mockLlm,
+  modelHistory = () => [],
   signal = new AbortController().signal,
 }: RunAgentLoopOptions): Promise<AgentLoopResult> {
   while (true) {
@@ -20,7 +23,7 @@ export async function runAgentLoop({
     }
 
     emit({ type: "step-start" });
-    const output = await llm({ signal });
+    const output = await llm({ history: modelHistory(), signal });
     let shouldContinue = false;
 
     if (signal.aborted) {

--- a/src/runtime/agent-loop.ts
+++ b/src/runtime/agent-loop.ts
@@ -36,7 +36,7 @@ export async function runAgentLoop({
       }
 
       if (part.type === "text") {
-        emit({ type: "text", text: part.text });
+        emit({ type: "assistant-text", text: part.text });
         continue;
       }
 

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -1,18 +1,37 @@
 import { mockLlm, type Llm } from "./mock-llm";
-import { AgentSession } from "./session";
+import {
+  AgentSession,
+  type SessionHistoryStore,
+  type SessionSnapshot,
+} from "./session";
 
 type AgentOptions = {
   llm?: Llm;
+  historyStore?: SessionHistoryStore;
+};
+
+type CreateSessionOptions = {
+  // Persisted sessions need a caller-owned stable id, e.g. a DB row, chat room, or file key.
+  id?: string;
+  snapshot?: SessionSnapshot;
+  historyStore?: SessionHistoryStore;
 };
 
 export class Agent {
   readonly #llm: Llm;
+  readonly #historyStore?: SessionHistoryStore;
 
   constructor(options: AgentOptions = {}) {
     this.#llm = options.llm ?? mockLlm;
+    this.#historyStore = options.historyStore;
   }
 
-  createSession(): AgentSession {
-    return new AgentSession(this.#llm);
+  createSession(options: CreateSessionOptions = {}): AgentSession {
+    return new AgentSession({
+      id: options.id ?? crypto.randomUUID(),
+      llm: this.#llm,
+      snapshot: options.snapshot,
+      historyStore: options.historyStore ?? this.#historyStore,
+    });
   }
 }

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -28,7 +28,7 @@ export class Agent {
 
   createSession(options: CreateSessionOptions = {}): AgentSession {
     return new AgentSession({
-      id: options.id ?? crypto.randomUUID(),
+      id: options.id ?? options.snapshot?.sessionId ?? crypto.randomUUID(),
       llm: this.#llm,
       snapshot: options.snapshot,
       historyStore: options.historyStore ?? this.#historyStore,

--- a/src/runtime/mock-llm.ts
+++ b/src/runtime/mock-llm.ts
@@ -1,9 +1,11 @@
+import type { ModelHistoryItem } from "./session";
+
 export type LlmOutputPart =
   | { type: "text"; text: string }
   | { type: "tool-call"; toolName: string };
 
 export type LlmOutput = LlmOutputPart[];
-export type LlmContext = { signal: AbortSignal };
+export type LlmContext = { history: ModelHistoryItem[]; signal: AbortSignal };
 export type Llm = (context: LlmContext) => Promise<LlmOutput>;
 
 const mockLlmDelayMs = 300;

--- a/src/runtime/session.test.ts
+++ b/src/runtime/session.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { Agent } from "./agent";
-import { InMemorySessionHistoryStore, type AgentEvent, type ModelHistoryItem } from "./session";
+import {
+  InMemorySessionHistoryStore,
+  type AgentEvent,
+  type ModelHistoryItem,
+  type SessionHistoryStore,
+  type SessionSnapshot,
+} from "./session";
 import type { Llm } from "./mock-llm";
 
 const createDeferred = () => {
@@ -10,6 +16,9 @@ const createDeferred = () => {
   });
   return { promise, resolve };
 };
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 const firstLlmCall = createDeferred();
 let calls = 0;
@@ -84,6 +93,89 @@ assert.deepEqual(
   ]
 );
 
+const abortedTurnGate = createDeferred();
+const abortedTurnHistories: ModelHistoryItem[][] = [];
+let abortedTurnCalls = 0;
+const abortedTurnLlm: Llm = async ({ history }) => {
+  abortedTurnCalls += 1;
+  abortedTurnHistories.push(history);
+
+  if (abortedTurnCalls === 1) {
+    await abortedTurnGate.promise;
+    return [{ type: "tool-call", toolName: "continue" }];
+  }
+
+  return [{ type: "text", text: "queued done" }];
+};
+const abortedTurnSession = new Agent({ llm: abortedTurnLlm }).createSession({
+  id: "aborted-turn-history",
+});
+const abortedFirstSubmit = abortedTurnSession.submit({
+  type: "user-text",
+  text: "aborted input",
+});
+const queuedAfterAbortSubmit = abortedTurnSession.submit({
+  type: "user-text",
+  text: "queued after abort",
+});
+abortedTurnSession.interrupt();
+abortedTurnGate.resolve();
+await Promise.all([abortedFirstSubmit, queuedAfterAbortSubmit]);
+
+assert.deepEqual(abortedTurnHistories, [
+  [{ type: "user-text", text: "aborted input" }],
+  [
+    { type: "user-text", text: "aborted input" },
+    { type: "user-text", text: "queued after abort" },
+  ],
+]);
+assert.deepEqual(
+  abortedTurnSession.snapshot().modelHistory.map((record) => record.item),
+  [
+    { type: "user-text", text: "aborted input" },
+    { type: "user-text", text: "queued after abort" },
+    { type: "assistant-text", text: "queued done" },
+  ],
+);
+
+const activeSaveGate = createDeferred();
+const activeSaveStore = new InMemorySessionHistoryStore();
+const activeSaveLlm: Llm = async () => {
+  await activeSaveGate.promise;
+  return [{ type: "text", text: "active done" }];
+};
+const activeSaveSession = new Agent({
+  historyStore: activeSaveStore,
+  llm: activeSaveLlm,
+}).createSession({ id: "active-save" });
+const activeSaveFirstSubmit = activeSaveSession.submit({
+  type: "user-text",
+  text: "active input",
+});
+const activeSaveQueuedSubmit = activeSaveSession.submit({
+  type: "user-text",
+  text: "queued while active",
+});
+await delay(0);
+
+assert.doesNotThrow(() =>
+  new Agent({ llm: activeSaveLlm }).createSession({
+    id: "active-save",
+    snapshot: activeSaveSession.snapshot(),
+  }),
+);
+const activeSavedSnapshot = await activeSaveStore.load("active-save");
+assert.ok(activeSavedSnapshot);
+assert.doesNotThrow(() =>
+  new Agent({ llm: activeSaveLlm }).createSession({
+    id: "active-save",
+    snapshot: activeSavedSnapshot,
+  }),
+);
+
+activeSaveGate.resolve();
+await Promise.all([activeSaveFirstSubmit, activeSaveQueuedSubmit]);
+
 const seenHistory: ModelHistoryItem[][] = [];
 let historyCalls = 0;
 const historyLlm: Llm = async ({ history }) => {
@@ -100,7 +192,9 @@ const historyLlm: Llm = async ({ history }) => {
   return [{ type: "text", text: "DONE" }];
 };
 
-const historySession = new Agent({ llm: historyLlm }).createSession({ id: "history-test" });
+const historySession = new Agent({ llm: historyLlm }).createSession({
+  id: "history-test",
+});
 await historySession.submit({ type: "user-text", text: "remember me" });
 
 assert.deepEqual(seenHistory, [
@@ -113,13 +207,24 @@ assert.deepEqual(seenHistory, [
 ]);
 
 const fullSnapshot = historySession.snapshot();
-const toolCallSequence = fullSnapshot.events.find((record) => record.event.type === "tool-call")?.sequence;
+const toolCallSequence = fullSnapshot.events.find(
+  (record) => record.event.type === "tool-call",
+)?.sequence;
 assert.ok(toolCallSequence);
 
-const toolCallView = historySession.history.viewAt(toolCallSequence);
+assert.throws(
+  () => historySession.viewAt(-1),
+  /Invalid history sequence -1/,
+);
+assert.throws(
+  () => historySession.viewAt(1.5),
+  /Invalid history sequence 1.5/,
+);
+
+const toolCallView = historySession.viewAt(toolCallSequence);
 assert.deepEqual(
   toolCallView.events.map((record) => record.event.type),
-  ["user-text", "turn-start", "step-start", "assistant-text", "tool-call"]
+  ["user-text", "turn-start", "step-start", "assistant-text", "tool-call"],
 );
 assert.deepEqual(toolCallView.modelHistory.at(-1)?.item, {
   type: "tool-call",
@@ -132,6 +237,274 @@ const restoredSession = new Agent({ llm: historyLlm }).createSession({
 });
 assert.deepEqual(restoredSession.snapshot(), toolCallView);
 
+assert.throws(
+  () =>
+    new Agent({ llm: historyLlm }).createSession({
+      id: "history-test",
+      snapshot: { ...fullSnapshot, nextSequence: 0 },
+    }),
+  /Invalid snapshot nextSequence: 0/,
+);
+assert.throws(
+  () =>
+    new Agent({ llm: historyLlm }).createSession({
+      id: "history-test",
+      snapshot: {
+        ...fullSnapshot,
+        events: [{ ...fullSnapshot.events[0]!, sequence: 0 }],
+      },
+    }),
+  /Invalid events sequence: 0/,
+);
+assert.throws(
+  () =>
+    new Agent({ llm: historyLlm }).createSession({
+      id: "history-test",
+      snapshot: {
+        ...fullSnapshot,
+        modelHistory: [
+          {
+            ...fullSnapshot.modelHistory[0]!,
+            sequence: fullSnapshot.nextSequence,
+          },
+        ],
+      },
+    }),
+  new RegExp(`Invalid modelHistory sequence: ${fullSnapshot.nextSequence}`),
+);
+assert.throws(
+  () =>
+    new Agent({ llm: historyLlm }).createSession({
+      id: "history-test",
+      snapshot: {
+        ...fullSnapshot,
+        events: [
+          {
+            event: { type: "unknown" } as unknown as AgentEvent,
+            sequence: 1,
+          },
+        ],
+      },
+    }),
+  /Invalid agent event type: unknown/,
+);
+assert.throws(
+  () =>
+    new Agent({ llm: historyLlm }).createSession({
+      id: "history-test",
+      snapshot: null as unknown as SessionSnapshot,
+    }),
+  /Invalid session snapshot: expected an object/,
+);
+assert.throws(
+  () =>
+    new Agent({ llm: historyLlm }).createSession({
+      id: "history-test",
+      snapshot: {
+        ...fullSnapshot,
+        events: [null as never],
+      },
+    }),
+  /Invalid events sequence: undefined/,
+);
+assert.throws(
+  () =>
+    new Agent({ llm: historyLlm }).createSession({
+      id: "history-test",
+      snapshot: {
+        ...fullSnapshot,
+        events: [
+          { sequence: 1, event: { type: "user-text", text: "real user" } },
+          { sequence: 2, event: { type: "step-start" } },
+        ],
+        modelHistory: [
+          {
+            sequence: 2,
+            item: { type: "assistant-text", text: "ghost assistant" },
+          },
+        ],
+        nextSequence: 3,
+      },
+    }),
+  /Invalid modelHistory: does not match event replay/,
+);
+assert.throws(
+  () =>
+    new Agent({ llm: historyLlm }).createSession({
+      id: "history-test",
+      snapshot: {
+        ...fullSnapshot,
+        events: [{ sequence: 1, event: { type: "turn-start" } }],
+        modelHistory: [],
+        nextSequence: 2,
+      },
+    }),
+  /Invalid events: turn-start at sequence 1 has no pending user input/,
+);
+
+const restoredPendingHistory: ModelHistoryItem[][] = [];
+let restoredPendingCalls = 0;
+const restoredPendingLlm: Llm = async ({ history }) => {
+  restoredPendingCalls += 1;
+  restoredPendingHistory.push(history);
+
+  return [
+    {
+      type: "text",
+      text: restoredPendingCalls === 1 ? "old done" : "new done",
+    },
+  ];
+};
+const restoredPendingSession = new Agent({
+  llm: restoredPendingLlm,
+}).createSession({
+  id: "restore-pending",
+  snapshot: {
+    events: [
+      { event: { type: "user-text", text: "old pending" }, sequence: 1 },
+    ],
+    modelHistory: [],
+    nextSequence: 2,
+    sessionId: "restore-pending",
+    version: "pss-session-v1",
+  },
+});
+
+await restoredPendingSession.submit({
+  type: "user-text",
+  text: "new input",
+});
+
+assert.equal(restoredPendingCalls, 2);
+assert.deepEqual(restoredPendingHistory, [
+  [{ type: "user-text", text: "old pending" }],
+  [
+    { type: "user-text", text: "old pending" },
+    { type: "assistant-text", text: "old done" },
+    { type: "user-text", text: "new input" },
+  ],
+]);
+assert.doesNotThrow(() =>
+  new Agent({ llm: restoredPendingLlm }).createSession({
+    id: "restore-pending",
+    snapshot: restoredPendingSession.snapshot(),
+  }),
+);
+
+const mutableInputGate = createDeferred();
+let mutableInputCalls = 0;
+const mutableInputLlm: Llm = async ({ history }) => {
+  mutableInputCalls += 1;
+  const textHistory = history.filter((item) => item.type !== "tool-call");
+  const lastText = textHistory.at(-1)?.text;
+
+  if (mutableInputCalls === 1) {
+    await mutableInputGate.promise;
+  }
+
+  return [{ type: "text", text: `done ${lastText}` }];
+};
+const mutableInputSession = new Agent({ llm: mutableInputLlm }).createSession({
+  id: "mutable-input",
+});
+const mutableEvents: AgentEvent[] = [];
+mutableInputSession.subscribe((event) => mutableEvents.push(event));
+
+const blockingInput = { type: "user-text" as const, text: "blocking" };
+const mutableInput = { type: "user-text" as const, text: "original" };
+const blockingSubmit = mutableInputSession.submit(blockingInput);
+const mutableSubmit = mutableInputSession.submit(mutableInput);
+mutableInput.text = "mutated";
+mutableInputGate.resolve();
+await Promise.all([blockingSubmit, mutableSubmit]);
+
+assert.deepEqual(
+  mutableEvents.filter((event) => event.type === "user-text"),
+  [
+    { type: "user-text", text: "blocking" },
+    { type: "user-text", text: "original" },
+  ],
+);
+assert.deepEqual(
+  mutableInputSession.snapshot().modelHistory.map((record) => record.item),
+  [
+    { type: "user-text", text: "blocking" },
+    { type: "assistant-text", text: "done blocking" },
+    { type: "user-text", text: "original" },
+    { type: "assistant-text", text: "done original" },
+  ],
+);
+assert.doesNotThrow(() =>
+  new Agent({ llm: mutableInputLlm }).createSession({
+    id: "mutable-input",
+    snapshot: mutableInputSession.snapshot(),
+  }),
+);
+
+const listenerMutationGate = createDeferred();
+let listenerMutationCalls = 0;
+const listenerMutationLlm: Llm = async () => {
+  listenerMutationCalls += 1;
+
+  if (listenerMutationCalls === 1) {
+    await listenerMutationGate.promise;
+  }
+
+  return [{ type: "text", text: "listener-safe" }];
+};
+const listenerMutationSession = new Agent({
+  llm: listenerMutationLlm,
+}).createSession({ id: "listener-mutation" });
+listenerMutationSession.subscribe((event) => {
+  if (event.type === "user-text" || event.type === "assistant-text") {
+    event.text = "listener-mutated";
+  }
+});
+
+const firstListenerSubmit = listenerMutationSession.submit({
+  type: "user-text",
+  text: "first listener input",
+});
+const secondListenerSubmit = listenerMutationSession.submit({
+  type: "user-text",
+  text: "second listener input",
+});
+listenerMutationGate.resolve();
+await Promise.all([firstListenerSubmit, secondListenerSubmit]);
+
+assert.deepEqual(
+  listenerMutationSession.snapshot().events.map((record) => record.event),
+  [
+    { type: "user-text", text: "first listener input" },
+    { type: "turn-start" },
+    { type: "step-start" },
+    { type: "user-text", text: "second listener input" },
+    { type: "assistant-text", text: "listener-safe" },
+    { type: "step-end" },
+    { type: "turn-end" },
+    { type: "turn-start" },
+    { type: "step-start" },
+    { type: "assistant-text", text: "listener-safe" },
+    { type: "step-end" },
+    { type: "turn-end" },
+  ],
+);
+assert.deepEqual(
+  listenerMutationSession.snapshot().modelHistory.map((record) => record.item),
+  [
+    { type: "user-text", text: "first listener input" },
+    { type: "assistant-text", text: "listener-safe" },
+    { type: "user-text", text: "second listener input" },
+    { type: "assistant-text", text: "listener-safe" },
+  ],
+);
+assert.doesNotThrow(() =>
+  new Agent({ llm: listenerMutationLlm }).createSession({
+    id: "listener-mutation",
+    snapshot: listenerMutationSession.snapshot(),
+  }),
+);
+
 const historyStore = new InMemorySessionHistoryStore();
 const persistedSession = new Agent({
   historyStore,
@@ -143,7 +516,14 @@ await persistedSession.submit({ type: "user-text", text: "persist this" });
 const persistedSnapshot = await historyStore.load("persisted");
 assert.deepEqual(
   persistedSnapshot?.events.map((record) => record.event.type),
-  ["user-text", "turn-start", "step-start", "assistant-text", "step-end", "turn-end"],
+  [
+    "user-text",
+    "turn-start",
+    "step-start",
+    "assistant-text",
+    "step-end",
+    "turn-end",
+  ],
 );
 assert.deepEqual(
   persistedSnapshot?.modelHistory.map((record) => record.item),
@@ -151,4 +531,41 @@ assert.deepEqual(
     { type: "user-text", text: "persist this" },
     { type: "assistant-text", text: "stored" },
   ]
+);
+
+let delayedSaveCalls = 0;
+let delayedSavedSnapshot: SessionSnapshot | undefined;
+const delayedStore: SessionHistoryStore = {
+  async load() {
+    return delayedSavedSnapshot;
+  },
+  async save(snapshot) {
+    delayedSaveCalls += 1;
+
+    if (delayedSaveCalls === 1) {
+      await delay(50);
+    }
+
+    delayedSavedSnapshot = structuredClone(snapshot);
+  },
+};
+const delayedSession = new Agent({
+  historyStore: delayedStore,
+  llm: async () => [{ type: "text", text: "stored after delay" }],
+}).createSession({ id: "delayed" });
+
+await delayedSession.submit({ type: "user-text", text: "save in order" });
+await delay(80);
+
+assert.equal(delayedSaveCalls, 2);
+assert.deepEqual(
+  delayedSavedSnapshot?.events.map((record) => record.event.type),
+  [
+    "user-text",
+    "turn-start",
+    "step-start",
+    "assistant-text",
+    "step-end",
+    "turn-end",
+  ],
 );

--- a/src/runtime/session.test.ts
+++ b/src/runtime/session.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { Agent } from "./agent";
-import type { AgentEvent } from "./session";
+import { InMemorySessionHistoryStore, type AgentEvent, type ModelHistoryItem } from "./session";
 import type { Llm } from "./mock-llm";
 
 const createDeferred = () => {
@@ -74,3 +74,77 @@ assert.deepEqual(failingEvents.at(-1), {
   type: "turn-error",
   message: "model unavailable",
 });
+
+assert.deepEqual(
+  session.snapshot().modelHistory.map((record) => record.item),
+  [
+    { type: "user-message", text: "first" },
+    { type: "user-message", text: "second" },
+    { type: "assistant-text", text: "DONE" },
+  ]
+);
+
+const seenHistory: ModelHistoryItem[][] = [];
+let historyCalls = 0;
+const historyLlm: Llm = async ({ history }) => {
+  historyCalls += 1;
+  seenHistory.push(history);
+
+  if (historyCalls === 1) {
+    return [
+      { type: "text", text: "Looking it up." },
+      { type: "tool-call", toolName: "continue" },
+    ];
+  }
+
+  return [{ type: "text", text: "DONE" }];
+};
+
+const historySession = new Agent({ llm: historyLlm }).createSession({ id: "history-test" });
+await historySession.submit({ type: "user-message", text: "remember me" });
+
+assert.deepEqual(seenHistory, [
+  [{ type: "user-message", text: "remember me" }],
+  [
+    { type: "user-message", text: "remember me" },
+    { type: "assistant-text", text: "Looking it up." },
+    { type: "tool-call", toolName: "continue" },
+  ],
+]);
+
+const fullSnapshot = historySession.snapshot();
+const toolCallSequence = fullSnapshot.events.find((record) => record.event.type === "tool-call")?.sequence;
+assert.ok(toolCallSequence);
+
+const toolCallView = historySession.history.viewAt(toolCallSequence);
+assert.deepEqual(
+  toolCallView.events.map((record) => record.event.type),
+  ["user-message", "turn-start", "step-start", "text", "tool-call"]
+);
+assert.deepEqual(toolCallView.modelHistory.at(-1)?.item, {
+  type: "tool-call",
+  toolName: "continue",
+});
+
+const restoredSession = new Agent({ llm: historyLlm }).createSession({
+  id: "history-test",
+  snapshot: toolCallView,
+});
+assert.deepEqual(restoredSession.snapshot(), toolCallView);
+
+const historyStore = new InMemorySessionHistoryStore();
+const persistedSession = new Agent({
+  historyStore,
+  llm: async () => [{ type: "text", text: "stored" }],
+}).createSession({ id: "persisted" });
+
+await persistedSession.submit({ type: "user-message", text: "persist this" });
+
+const persistedSnapshot = await historyStore.load("persisted");
+assert.deepEqual(
+  persistedSnapshot?.modelHistory.map((record) => record.item),
+  [
+    { type: "user-message", text: "persist this" },
+    { type: "assistant-text", text: "stored" },
+  ]
+);

--- a/src/runtime/session.test.ts
+++ b/src/runtime/session.test.ts
@@ -28,8 +28,8 @@ const session = new Agent({ llm }).createSession();
 const events: AgentEvent[] = [];
 session.subscribe((event) => events.push(event));
 
-const firstSubmit = session.submit({ type: "user-message", text: "first" });
-const secondSubmit = session.submit({ type: "user-message", text: "second" });
+const firstSubmit = session.submit({ type: "user-text", text: "first" });
+const secondSubmit = session.submit({ type: "user-text", text: "second" });
 
 session.interrupt();
 firstLlmCall.resolve();
@@ -40,14 +40,14 @@ assert.equal(calls, 2);
 assert.deepEqual(
   events.map((event) => event.type),
   [
-    "user-message",
+    "user-text",
     "turn-start",
     "step-start",
-    "user-message",
+    "user-text",
     "turn-abort",
     "turn-start",
     "step-start",
-    "text",
+    "assistant-text",
     "step-end",
     "turn-end",
   ]
@@ -62,13 +62,13 @@ const failingEvents: AgentEvent[] = [];
 failingSession.subscribe((event) => failingEvents.push(event));
 
 await assert.rejects(
-  failingSession.submit({ type: "user-message", text: "fail" }),
+  failingSession.submit({ type: "user-text", text: "fail" }),
   /model unavailable/
 );
 
 assert.deepEqual(
   failingEvents.map((event) => event.type),
-  ["user-message", "turn-start", "step-start", "turn-error"]
+  ["user-text", "turn-start", "step-start", "turn-error"]
 );
 assert.deepEqual(failingEvents.at(-1), {
   type: "turn-error",
@@ -78,8 +78,8 @@ assert.deepEqual(failingEvents.at(-1), {
 assert.deepEqual(
   session.snapshot().modelHistory.map((record) => record.item),
   [
-    { type: "user-message", text: "first" },
-    { type: "user-message", text: "second" },
+    { type: "user-text", text: "first" },
+    { type: "user-text", text: "second" },
     { type: "assistant-text", text: "DONE" },
   ]
 );
@@ -101,12 +101,12 @@ const historyLlm: Llm = async ({ history }) => {
 };
 
 const historySession = new Agent({ llm: historyLlm }).createSession({ id: "history-test" });
-await historySession.submit({ type: "user-message", text: "remember me" });
+await historySession.submit({ type: "user-text", text: "remember me" });
 
 assert.deepEqual(seenHistory, [
-  [{ type: "user-message", text: "remember me" }],
+  [{ type: "user-text", text: "remember me" }],
   [
-    { type: "user-message", text: "remember me" },
+    { type: "user-text", text: "remember me" },
     { type: "assistant-text", text: "Looking it up." },
     { type: "tool-call", toolName: "continue" },
   ],
@@ -119,7 +119,7 @@ assert.ok(toolCallSequence);
 const toolCallView = historySession.history.viewAt(toolCallSequence);
 assert.deepEqual(
   toolCallView.events.map((record) => record.event.type),
-  ["user-message", "turn-start", "step-start", "text", "tool-call"]
+  ["user-text", "turn-start", "step-start", "assistant-text", "tool-call"]
 );
 assert.deepEqual(toolCallView.modelHistory.at(-1)?.item, {
   type: "tool-call",
@@ -138,13 +138,13 @@ const persistedSession = new Agent({
   llm: async () => [{ type: "text", text: "stored" }],
 }).createSession({ id: "persisted" });
 
-await persistedSession.submit({ type: "user-message", text: "persist this" });
+await persistedSession.submit({ type: "user-text", text: "persist this" });
 
 const persistedSnapshot = await historyStore.load("persisted");
 assert.deepEqual(
   persistedSnapshot?.modelHistory.map((record) => record.item),
   [
-    { type: "user-message", text: "persist this" },
+    { type: "user-text", text: "persist this" },
     { type: "assistant-text", text: "stored" },
   ]
 );

--- a/src/runtime/session.test.ts
+++ b/src/runtime/session.test.ts
@@ -142,6 +142,10 @@ await persistedSession.submit({ type: "user-text", text: "persist this" });
 
 const persistedSnapshot = await historyStore.load("persisted");
 assert.deepEqual(
+  persistedSnapshot?.events.map((record) => record.event.type),
+  ["user-text", "turn-start", "step-start", "assistant-text", "step-end", "turn-end"],
+);
+assert.deepEqual(
   persistedSnapshot?.modelHistory.map((record) => record.item),
   [
     { type: "user-text", text: "persist this" },

--- a/src/runtime/session/events.ts
+++ b/src/runtime/session/events.ts
@@ -1,6 +1,6 @@
 export type AgentEvent =
   /** User input was accepted into the session queue. */
-  | { type: "user-message"; text: string }
+  | { type: "user-text"; text: string }
   /** A queued user input started running as a turn. */
   | { type: "turn-start" }
   /** The active turn was interrupted before normal completion. */
@@ -12,7 +12,7 @@ export type AgentEvent =
   /** One model/tool-loop iteration started within the active turn. */
   | { type: "step-start" }
   /** The model produced visible assistant text. */
-  | { type: "text"; text: string }
+  | { type: "assistant-text"; text: string }
   /** The model requested a tool call. */
   | { type: "tool-call"; toolName: string }
   /** One model/tool-loop iteration finished within the active turn. */

--- a/src/runtime/session/history.ts
+++ b/src/runtime/session/history.ts
@@ -9,6 +9,7 @@ export type ModelHistoryItem = Extract<
   AgentEvent,
   { type: "user-text" | "assistant-text" | "tool-call" }
 >;
+export type PendingUserInput = Extract<AgentEvent, { type: "user-text" }>;
 
 export type ModelHistoryRecord = {
   sequence: number;
@@ -41,12 +42,11 @@ export class SessionHistory {
   readonly #sessionId: string;
   #nextSequence = 1;
   #events: SessionEventRecord[] = [];
-  #modelHistory: ModelHistoryRecord[] = [];
 
   constructor(sessionId: string, snapshot?: SessionSnapshot) {
     this.#sessionId = sessionId;
 
-    if (snapshot) {
+    if (snapshot !== undefined) {
       this.restore(snapshot);
     }
   }
@@ -62,23 +62,19 @@ export class SessionHistory {
     return clone(record);
   }
 
-  appendModelItem(
-    sequence: number,
-    item: ModelHistoryItem,
-  ): ModelHistoryRecord {
-    const record = { sequence, item: clone(item) };
-    this.#modelHistory.push(record);
-    return clone(record);
+  modelHistory(): ModelHistoryItem[] {
+    return replayEvents(this.#events).modelHistory.map((record) =>
+      clone(record.item),
+    );
   }
 
-  modelHistory(): ModelHistoryItem[] {
-    return this.#modelHistory.map((record) => clone(record.item));
+  pendingInputs(): PendingUserInput[] {
+    return replayEvents(this.#events).pendingInputs;
   }
 
   snapshot(): SessionSnapshot {
     return this.#snapshotFrom({
       events: this.#events,
-      modelHistory: this.#modelHistory,
       nextSequence: this.#nextSequence,
     });
   }
@@ -86,48 +82,30 @@ export class SessionHistory {
   viewAt(sequence: number): SessionHistoryView {
     const maxSequence = this.#nextSequence - 1;
 
-    if (sequence > maxSequence) {
-      throw new Error(
-        `Cannot view future sequence ${sequence} (current max is ${maxSequence})`,
-      );
-    }
+    assertViewSequence(sequence, maxSequence);
 
     return this.#snapshotFrom({
       events: this.#events.filter((record) => record.sequence <= sequence),
-      modelHistory: this.#modelHistory.filter(
-        (record) => record.sequence <= sequence,
-      ),
       nextSequence: sequence + 1,
     });
   }
 
   restore(snapshot: SessionSnapshot): void {
-    if (snapshot.version !== "pss-session-v1") {
-      throw new Error(
-        `Unsupported session snapshot version: ${snapshot.version}`,
-      );
-    }
-
-    if (snapshot.sessionId !== this.#sessionId) {
-      throw new Error(
-        `Cannot restore snapshot for session ${snapshot.sessionId} into ${this.#sessionId}`,
-      );
-    }
+    assertValidSnapshot(snapshot, this.#sessionId);
 
     this.#nextSequence = snapshot.nextSequence;
     this.#events = clone(snapshot.events);
-    this.#modelHistory = clone(snapshot.modelHistory);
   }
 
   #snapshotFrom({
     events,
-    modelHistory,
     nextSequence,
   }: {
     events: SessionEventRecord[];
-    modelHistory: ModelHistoryRecord[];
     nextSequence: number;
   }): SessionSnapshot {
+    const modelHistory = replayEvents(events).modelHistory;
+
     return {
       version: "pss-session-v1",
       sessionId: this.#sessionId,
@@ -140,4 +118,241 @@ export class SessionHistory {
 
 function clone<T>(value: T): T {
   return structuredClone(value);
+}
+
+function assertViewSequence(sequence: number, maxSequence: number): void {
+  if (
+    !Number.isSafeInteger(sequence) ||
+    sequence < 0 ||
+    sequence > maxSequence
+  ) {
+    throw new Error(
+      `Invalid history sequence ${sequence} (current max is ${maxSequence})`,
+    );
+  }
+}
+
+function assertValidSnapshot(
+  snapshot: SessionSnapshot,
+  sessionId: string,
+): void {
+  if (!isRecord(snapshot)) {
+    throw new Error("Invalid session snapshot: expected an object");
+  }
+
+  if (snapshot.version !== "pss-session-v1") {
+    throw new Error(`Unsupported session snapshot version: ${snapshot.version}`);
+  }
+
+  if (snapshot.sessionId !== sessionId) {
+    throw new Error(
+      `Cannot restore snapshot for session ${snapshot.sessionId} into ${sessionId}`,
+    );
+  }
+
+  if (!Number.isSafeInteger(snapshot.nextSequence) || snapshot.nextSequence < 1) {
+    throw new Error(`Invalid snapshot nextSequence: ${snapshot.nextSequence}`);
+  }
+
+  assertRecords({
+    contiguous: true,
+    label: "events",
+    nextSequence: snapshot.nextSequence,
+    records: snapshot.events,
+    validateValue: (record) => assertAgentEvent(record.event),
+  });
+  assertRecords({
+    label: "modelHistory",
+    nextSequence: snapshot.nextSequence,
+    records: snapshot.modelHistory,
+    validateValue: (record) => assertModelHistoryItem(record.item),
+  });
+  assertModelHistoryMatchesEvents(snapshot.events, snapshot.modelHistory);
+}
+
+function assertRecords<T extends { sequence: number }>({
+  contiguous = false,
+  label,
+  nextSequence,
+  records,
+  validateValue,
+}: {
+  contiguous?: boolean;
+  label: string;
+  nextSequence: number;
+  records: T[];
+  validateValue: (record: T) => void;
+}): void {
+  if (!Array.isArray(records)) {
+    throw new Error(`Invalid ${label}: expected an array`);
+  }
+
+  let previousSequence = 0;
+  let expectedSequence = 1;
+
+  for (const record of records) {
+    if (
+      !isRecord(record) ||
+      !Number.isSafeInteger(record.sequence) ||
+      record.sequence <= previousSequence ||
+      record.sequence >= nextSequence ||
+      (contiguous && record.sequence !== expectedSequence)
+    ) {
+      throw new Error(
+        `Invalid ${label} sequence: ${String(
+          isRecord(record) ? record.sequence : undefined,
+        )}`,
+      );
+    }
+
+    validateValue(record);
+    previousSequence = record.sequence;
+    expectedSequence += 1;
+  }
+
+  if (contiguous && expectedSequence !== nextSequence) {
+    throw new Error(
+      `Invalid ${label} sequence: expected ${expectedSequence} before nextSequence ${nextSequence}`,
+    );
+  }
+}
+
+function assertModelHistoryMatchesEvents(
+  events: SessionEventRecord[],
+  modelHistory: ModelHistoryRecord[],
+): void {
+  const expected = replayEvents(events).modelHistory;
+
+  if (JSON.stringify(modelHistory) !== JSON.stringify(expected)) {
+    throw new Error("Invalid modelHistory: does not match event replay");
+  }
+}
+
+function replayEvents(events: SessionEventRecord[]): {
+  modelHistory: ModelHistoryRecord[];
+  pendingInputs: PendingUserInput[];
+} {
+  const pendingInputs: PendingUserInput[] = [];
+  let activeTurnHistory: ModelHistoryRecord[] | undefined;
+  const modelHistory: ModelHistoryRecord[] = [];
+
+  for (const record of events) {
+    if (record.event.type === "user-text") {
+      pendingInputs.push(clone(record.event));
+      continue;
+    }
+
+    if (record.event.type === "turn-start") {
+      const input = pendingInputs.shift();
+
+      if (!input) {
+        throw new Error(
+          `Invalid events: turn-start at sequence ${record.sequence} has no pending user input`,
+        );
+      }
+
+      activeTurnHistory = [{ sequence: record.sequence, item: clone(input) }];
+      continue;
+    }
+
+    if (record.event.type === "turn-end") {
+      if (activeTurnHistory) {
+        modelHistory.push(...activeTurnHistory.map((item) => clone(item)));
+        activeTurnHistory = undefined;
+      }
+
+      continue;
+    }
+
+    if (
+      record.event.type === "turn-abort" ||
+      record.event.type === "turn-error"
+    ) {
+      const userInput = activeTurnHistory?.[0];
+
+      if (userInput) {
+        modelHistory.push(clone(userInput));
+      }
+
+      activeTurnHistory = undefined;
+      continue;
+    }
+
+    const item = toModelHistoryItem(record.event);
+
+    if (item) {
+      activeTurnHistory?.push({ sequence: record.sequence, item: clone(item) });
+    }
+  }
+
+  return {
+    modelHistory: [
+      ...modelHistory,
+      ...(activeTurnHistory ?? []).map((item) => clone(item)),
+    ],
+    pendingInputs: pendingInputs.map((input) => clone(input)),
+  };
+}
+
+function assertAgentEvent(event: AgentEvent): void {
+  if (!isRecord(event)) {
+    throw new Error("Invalid agent event: expected an object");
+  }
+
+  switch (event.type) {
+    case "user-text":
+    case "assistant-text":
+      assertString(event.text, event.type, "text");
+      return;
+    case "tool-call":
+      assertString(event.toolName, event.type, "toolName");
+      return;
+    case "turn-error":
+      assertString(event.message, event.type, "message");
+      return;
+    case "turn-start":
+    case "turn-abort":
+    case "turn-end":
+    case "step-start":
+    case "step-end":
+      return;
+    default:
+      throw new Error(
+        `Invalid agent event type: ${String(
+          (event as { type?: unknown }).type,
+        )}`,
+      );
+  }
+}
+
+function assertModelHistoryItem(item: ModelHistoryItem): void {
+  if (!isRecord(item)) {
+    throw new Error("Invalid model history item: expected an object");
+  }
+
+  switch (item.type) {
+    case "user-text":
+    case "assistant-text":
+      assertString(item.text, item.type, "text");
+      return;
+    case "tool-call":
+      assertString(item.toolName, item.type, "toolName");
+      return;
+    default:
+      throw new Error(
+        `Invalid model history item type: ${String(
+          (item as { type?: unknown }).type,
+        )}`,
+      );
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function assertString(value: unknown, eventType: string, field: string): void {
+  if (typeof value !== "string") {
+    throw new Error(`Invalid ${eventType}.${field}: expected a string`);
+  }
 }

--- a/src/runtime/session/history.ts
+++ b/src/runtime/session/history.ts
@@ -1,0 +1,116 @@
+import type { AgentEvent } from "./events";
+
+export type SessionEventRecord = {
+  sequence: number;
+  event: AgentEvent;
+};
+
+export type ModelHistoryItem =
+  | { type: "user-message"; text: string }
+  | { type: "assistant-text"; text: string }
+  | { type: "tool-call"; toolName: string }
+  | { type: "tool-result"; toolName: string; output: unknown }
+  | { type: "reasoning"; text: string };
+
+export type ModelHistoryRecord = {
+  sequence: number;
+  item: ModelHistoryItem;
+};
+
+export type SessionSnapshot = {
+  version: "pss-session-v1";
+  sessionId: string;
+  nextSequence: number;
+  events: SessionEventRecord[];
+  modelHistory: ModelHistoryRecord[];
+};
+
+export type SessionHistoryView = SessionSnapshot;
+
+export class SessionHistory {
+  readonly #sessionId: string;
+  #nextSequence = 1;
+  #events: SessionEventRecord[] = [];
+  #modelHistory: ModelHistoryRecord[] = [];
+
+  constructor(sessionId: string, snapshot?: SessionSnapshot) {
+    this.#sessionId = sessionId;
+
+    if (snapshot) {
+      this.restore(snapshot);
+    }
+  }
+
+  get sessionId(): string {
+    return this.#sessionId;
+  }
+
+  appendEvent(event: AgentEvent): SessionEventRecord {
+    const record = { sequence: this.#nextSequence, event: clone(event) };
+    this.#nextSequence += 1;
+    this.#events.push(record);
+    return clone(record);
+  }
+
+  appendModelItem(sequence: number, item: ModelHistoryItem): ModelHistoryRecord {
+    const record = { sequence, item: clone(item) };
+    this.#modelHistory.push(record);
+    return clone(record);
+  }
+
+  modelHistory(): ModelHistoryItem[] {
+    return this.#modelHistory.map((record) => clone(record.item));
+  }
+
+  snapshot(): SessionSnapshot {
+    return this.#snapshotFrom({
+      events: this.#events,
+      modelHistory: this.#modelHistory,
+      nextSequence: this.#nextSequence,
+    });
+  }
+
+  viewAt(sequence: number): SessionHistoryView {
+    return this.#snapshotFrom({
+      events: this.#events.filter((record) => record.sequence <= sequence),
+      modelHistory: this.#modelHistory.filter((record) => record.sequence <= sequence),
+      nextSequence: sequence + 1,
+    });
+  }
+
+  restore(snapshot: SessionSnapshot): void {
+    if (snapshot.version !== "pss-session-v1") {
+      throw new Error(`Unsupported session snapshot version: ${snapshot.version}`);
+    }
+
+    if (snapshot.sessionId !== this.#sessionId) {
+      throw new Error(`Cannot restore snapshot for session ${snapshot.sessionId} into ${this.#sessionId}`);
+    }
+
+    this.#nextSequence = snapshot.nextSequence;
+    this.#events = clone(snapshot.events);
+    this.#modelHistory = clone(snapshot.modelHistory);
+  }
+
+  #snapshotFrom({
+    events,
+    modelHistory,
+    nextSequence,
+  }: {
+    events: SessionEventRecord[];
+    modelHistory: ModelHistoryRecord[];
+    nextSequence: number;
+  }): SessionSnapshot {
+    return {
+      version: "pss-session-v1",
+      sessionId: this.#sessionId,
+      nextSequence,
+      events: clone(events),
+      modelHistory: clone(modelHistory),
+    };
+  }
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/src/runtime/session/history.ts
+++ b/src/runtime/session/history.ts
@@ -5,12 +5,10 @@ export type SessionEventRecord = {
   event: AgentEvent;
 };
 
-export type ModelHistoryItem =
-  | { type: "user-message"; text: string }
-  | { type: "assistant-text"; text: string }
-  | { type: "tool-call"; toolName: string }
-  | { type: "tool-result"; toolName: string; output: unknown }
-  | { type: "reasoning"; text: string };
+export type ModelHistoryItem = Extract<
+  AgentEvent,
+  { type: "user-text" | "assistant-text" | "tool-call" }
+>;
 
 export type ModelHistoryRecord = {
   sequence: number;
@@ -26,6 +24,18 @@ export type SessionSnapshot = {
 };
 
 export type SessionHistoryView = SessionSnapshot;
+
+export function toModelHistoryItem(
+  event: AgentEvent,
+): ModelHistoryItem | undefined {
+  if (
+    event.type === "user-text" ||
+    event.type === "assistant-text" ||
+    event.type === "tool-call"
+  ) {
+    return event;
+  }
+}
 
 export class SessionHistory {
   readonly #sessionId: string;
@@ -52,7 +62,10 @@ export class SessionHistory {
     return clone(record);
   }
 
-  appendModelItem(sequence: number, item: ModelHistoryItem): ModelHistoryRecord {
+  appendModelItem(
+    sequence: number,
+    item: ModelHistoryItem,
+  ): ModelHistoryRecord {
     const record = { sequence, item: clone(item) };
     this.#modelHistory.push(record);
     return clone(record);
@@ -71,20 +84,34 @@ export class SessionHistory {
   }
 
   viewAt(sequence: number): SessionHistoryView {
+    const maxSequence = this.#nextSequence - 1;
+
+    if (sequence > maxSequence) {
+      throw new Error(
+        `Cannot view future sequence ${sequence} (current max is ${maxSequence})`,
+      );
+    }
+
     return this.#snapshotFrom({
       events: this.#events.filter((record) => record.sequence <= sequence),
-      modelHistory: this.#modelHistory.filter((record) => record.sequence <= sequence),
+      modelHistory: this.#modelHistory.filter(
+        (record) => record.sequence <= sequence,
+      ),
       nextSequence: sequence + 1,
     });
   }
 
   restore(snapshot: SessionSnapshot): void {
     if (snapshot.version !== "pss-session-v1") {
-      throw new Error(`Unsupported session snapshot version: ${snapshot.version}`);
+      throw new Error(
+        `Unsupported session snapshot version: ${snapshot.version}`,
+      );
     }
 
     if (snapshot.sessionId !== this.#sessionId) {
-      throw new Error(`Cannot restore snapshot for session ${snapshot.sessionId} into ${this.#sessionId}`);
+      throw new Error(
+        `Cannot restore snapshot for session ${snapshot.sessionId} into ${this.#sessionId}`,
+      );
     }
 
     this.#nextSequence = snapshot.nextSequence;

--- a/src/runtime/session/index.ts
+++ b/src/runtime/session/index.ts
@@ -1,2 +1,11 @@
 export type { AgentEvent, AgentEventListener } from "./events";
-export { AgentSession, type SessionInput } from "./session";
+export {
+  SessionHistory,
+  type ModelHistoryItem,
+  type ModelHistoryRecord,
+  type SessionEventRecord,
+  type SessionHistoryView,
+  type SessionSnapshot,
+} from "./history";
+export { AgentSession, type AgentSessionOptions, type SessionInput } from "./session";
+export { InMemorySessionHistoryStore, type SessionHistoryStore } from "./store";

--- a/src/runtime/session/session.ts
+++ b/src/runtime/session/session.ts
@@ -109,12 +109,11 @@ export class AgentSession {
             signal: this.#activeAbort.signal,
           });
 
-          await this.save();
-
           this.#emit({
             type: result === "aborted" ? "turn-abort" : "turn-end",
           });
           turnClosed = true;
+          await this.save();
           item.resolve();
         } catch (error) {
           if (!turnClosed) {

--- a/src/runtime/session/session.ts
+++ b/src/runtime/session/session.ts
@@ -1,8 +1,17 @@
 import { runAgentLoop } from "../agent-loop";
-import type { AgentEvent, AgentEventListener } from "./events";
 import type { Llm } from "../mock-llm";
+import type { AgentEvent, AgentEventListener } from "./events";
+import { SessionHistory, type SessionSnapshot } from "./history";
+import type { SessionHistoryStore } from "./store";
 
 export type SessionInput = { type: "user-message"; text: string };
+
+export type AgentSessionOptions = {
+  id: string;
+  llm: Llm;
+  snapshot?: SessionSnapshot;
+  historyStore?: SessionHistoryStore;
+};
 
 type QueuedInput = {
   input: SessionInput;
@@ -13,12 +22,18 @@ type QueuedInput = {
 export class AgentSession {
   readonly #listeners = new Set<AgentEventListener>();
   readonly #llm: Llm;
+  readonly #historyStore?: SessionHistoryStore;
+  readonly id: string;
+  readonly history: SessionHistory;
   readonly #inputQueue: QueuedInput[] = [];
   #running = false;
   #activeAbort?: AbortController;
 
-  constructor(llm: Llm) {
+  constructor({ id, llm, snapshot, historyStore }: AgentSessionOptions) {
+    this.id = id;
     this.#llm = llm;
+    this.#historyStore = historyStore;
+    this.history = new SessionHistory(id, snapshot);
   }
 
   subscribe(listener: AgentEventListener): () => void {
@@ -41,6 +56,22 @@ export class AgentSession {
     this.#activeAbort?.abort();
   }
 
+  snapshot(): SessionSnapshot {
+    return this.history.snapshot();
+  }
+
+  restore(snapshot: SessionSnapshot): void {
+    if (this.#running) {
+      throw new Error("Cannot restore history while the session is running");
+    }
+
+    this.history.restore(snapshot);
+  }
+
+  async save(): Promise<void> {
+    await this.#historyStore?.save(this.snapshot());
+  }
+
   async #drainInputQueue(): Promise<void> {
     if (this.#running) {
       return;
@@ -57,20 +88,32 @@ export class AgentSession {
         }
 
         this.#activeAbort = new AbortController();
+        let turnClosed = false;
 
         try {
-          this.#emit({ type: "turn-start" });
+          const turnStart = this.#emit({ type: "turn-start" });
+          this.history.appendModelItem(turnStart.sequence, {
+            type: "user-message",
+            text: item.input.text,
+          });
+
           const result = await runAgentLoop({
-            emit: (event) => this.#emit(event),
+            emit: (event) => this.#emitLoopEvent(event),
             llm: this.#llm,
+            modelHistory: () => this.history.modelHistory(),
             signal: this.#activeAbort.signal,
           });
           this.#emit({
             type: result === "aborted" ? "turn-abort" : "turn-end",
           });
+          turnClosed = true;
+          await this.save();
           item.resolve();
         } catch (error) {
-          this.#emit({ type: "turn-error", message: errorMessage(error) });
+          if (!turnClosed) {
+            this.#emit({ type: "turn-error", message: errorMessage(error) });
+            await this.#trySave();
+          }
           item.reject(error);
         } finally {
           this.#activeAbort = undefined;
@@ -81,10 +124,41 @@ export class AgentSession {
     }
   }
 
-  #emit(event: AgentEvent): void {
+  #emitLoopEvent(event: AgentEvent): void {
+    const record = this.#emit(event);
+
+    if (event.type === "text") {
+      this.history.appendModelItem(record.sequence, {
+        type: "assistant-text",
+        text: event.text,
+      });
+      return;
+    }
+
+    if (event.type === "tool-call") {
+      this.history.appendModelItem(record.sequence, {
+        type: "tool-call",
+        toolName: event.toolName,
+      });
+    }
+  }
+
+  async #trySave(): Promise<void> {
+    try {
+      await this.save();
+    } catch {
+      // Preserve the original turn failure for submit() callers.
+    }
+  }
+
+  #emit(event: AgentEvent): { sequence: number } {
+    const record = this.history.appendEvent(event);
+
     for (const listener of this.#listeners) {
       listener(event);
     }
+
+    return record;
   }
 }
 

--- a/src/runtime/session/session.ts
+++ b/src/runtime/session/session.ts
@@ -3,7 +3,8 @@ import type { Llm } from "../mock-llm";
 import type { AgentEvent, AgentEventListener } from "./events";
 import {
   SessionHistory,
-  toModelHistoryItem,
+  type PendingUserInput,
+  type SessionHistoryView,
   type SessionSnapshot,
 } from "./history";
 import type { SessionHistoryStore } from "./store";
@@ -27,9 +28,10 @@ export class AgentSession {
   readonly #listeners = new Set<AgentEventListener>();
   readonly #llm: Llm;
   readonly #historyStore?: SessionHistoryStore;
+  readonly #history: SessionHistory;
   readonly id: string;
-  readonly history: SessionHistory;
   readonly #inputQueue: QueuedInput[] = [];
+  #saveQueue: Promise<void> = Promise.resolve();
   #running = false;
   #activeAbort?: AbortController;
 
@@ -37,7 +39,8 @@ export class AgentSession {
     this.id = id;
     this.#llm = llm;
     this.#historyStore = historyStore;
-    this.history = new SessionHistory(id, snapshot);
+    this.#history = new SessionHistory(id, snapshot);
+    this.#restorePendingInputs();
   }
 
   subscribe(listener: AgentEventListener): () => void {
@@ -46,14 +49,16 @@ export class AgentSession {
   }
 
   submit(input: SessionInput): Promise<void> {
-    this.#emit(input);
+    const acceptedInput = clone(input);
+    const queuedInput = clone(acceptedInput);
+    this.#emit(acceptedInput);
 
     if (this.#historyStore) {
       void this.save().catch(() => {});
     }
 
     const queued = new Promise<void>((resolve, reject) => {
-      this.#inputQueue.push({ input, resolve, reject });
+      this.#inputQueue.push({ input: queuedInput, resolve, reject });
     });
 
     void this.#drainInputQueue();
@@ -65,7 +70,11 @@ export class AgentSession {
   }
 
   snapshot(): SessionSnapshot {
-    return this.history.snapshot();
+    return this.#history.snapshot();
+  }
+
+  viewAt(sequence: number): SessionHistoryView {
+    return this.#history.viewAt(sequence);
   }
 
   restore(snapshot: SessionSnapshot): void {
@@ -73,11 +82,19 @@ export class AgentSession {
       throw new Error("Cannot restore history while the session is running");
     }
 
-    this.history.restore(snapshot);
+    this.#history.restore(snapshot);
+    this.#restorePendingInputs();
   }
 
   async save(): Promise<void> {
-    await this.#historyStore?.save(this.snapshot());
+    if (!this.#historyStore) {
+      return;
+    }
+
+    const snapshot = this.snapshot();
+    const save = this.#saveQueue.then(() => this.#historyStore?.save(snapshot));
+    this.#saveQueue = save.catch(() => {});
+    await save;
   }
 
   async #drainInputQueue(): Promise<void> {
@@ -99,13 +116,12 @@ export class AgentSession {
         let turnClosed = false;
 
         try {
-          const turnStart = this.#emit({ type: "turn-start" });
-          this.history.appendModelItem(turnStart.sequence, item.input);
+          this.#emit({ type: "turn-start" });
 
           const result = await runAgentLoop({
-            emit: (event) => this.#emitLoopEvent(event),
+            emit: (event) => this.#emit(event),
             llm: this.#llm,
-            modelHistory: () => this.history.modelHistory(),
+            modelHistory: () => this.#history.modelHistory(),
             signal: this.#activeAbort.signal,
           });
 
@@ -130,15 +146,6 @@ export class AgentSession {
     }
   }
 
-  #emitLoopEvent(event: AgentEvent): void {
-    const record = this.#emit(event);
-    const modelHistoryItem = toModelHistoryItem(event);
-
-    if (modelHistoryItem) {
-      this.history.appendModelItem(record.sequence, modelHistoryItem);
-    }
-  }
-
   async #trySave(): Promise<void> {
     try {
       await this.save();
@@ -147,15 +154,35 @@ export class AgentSession {
     }
   }
 
+  #restorePendingInputs(): void {
+    this.#inputQueue.length = 0;
+
+    for (const input of this.#history.pendingInputs()) {
+      this.#inputQueue.push(createRestoredInput(input));
+    }
+  }
+
   #emit(event: AgentEvent): { sequence: number } {
-    const record = this.history.appendEvent(event);
+    const record = this.#history.appendEvent(event);
 
     for (const listener of this.#listeners) {
-      listener(event);
+      listener(clone(event));
     }
 
     return record;
   }
+}
+
+function createRestoredInput(input: PendingUserInput): QueuedInput {
+  return {
+    input: clone(input),
+    reject: () => {},
+    resolve: () => {},
+  };
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
 }
 
 function errorMessage(error: unknown): string {

--- a/src/runtime/session/session.ts
+++ b/src/runtime/session/session.ts
@@ -1,10 +1,14 @@
 import { runAgentLoop } from "../agent-loop";
 import type { Llm } from "../mock-llm";
 import type { AgentEvent, AgentEventListener } from "./events";
-import { SessionHistory, type SessionSnapshot } from "./history";
+import {
+  SessionHistory,
+  toModelHistoryItem,
+  type SessionSnapshot,
+} from "./history";
 import type { SessionHistoryStore } from "./store";
 
-export type SessionInput = { type: "user-message"; text: string };
+export type SessionInput = { type: "user-text"; text: string };
 
 export type AgentSessionOptions = {
   id: string;
@@ -43,6 +47,10 @@ export class AgentSession {
 
   submit(input: SessionInput): Promise<void> {
     this.#emit(input);
+
+    if (this.#historyStore) {
+      void this.save().catch(() => {});
+    }
 
     const queued = new Promise<void>((resolve, reject) => {
       this.#inputQueue.push({ input, resolve, reject });
@@ -92,10 +100,7 @@ export class AgentSession {
 
         try {
           const turnStart = this.#emit({ type: "turn-start" });
-          this.history.appendModelItem(turnStart.sequence, {
-            type: "user-message",
-            text: item.input.text,
-          });
+          this.history.appendModelItem(turnStart.sequence, item.input);
 
           const result = await runAgentLoop({
             emit: (event) => this.#emitLoopEvent(event),
@@ -103,11 +108,13 @@ export class AgentSession {
             modelHistory: () => this.history.modelHistory(),
             signal: this.#activeAbort.signal,
           });
+
+          await this.save();
+
           this.#emit({
             type: result === "aborted" ? "turn-abort" : "turn-end",
           });
           turnClosed = true;
-          await this.save();
           item.resolve();
         } catch (error) {
           if (!turnClosed) {
@@ -126,20 +133,10 @@ export class AgentSession {
 
   #emitLoopEvent(event: AgentEvent): void {
     const record = this.#emit(event);
+    const modelHistoryItem = toModelHistoryItem(event);
 
-    if (event.type === "text") {
-      this.history.appendModelItem(record.sequence, {
-        type: "assistant-text",
-        text: event.text,
-      });
-      return;
-    }
-
-    if (event.type === "tool-call") {
-      this.history.appendModelItem(record.sequence, {
-        type: "tool-call",
-        toolName: event.toolName,
-      });
+    if (modelHistoryItem) {
+      this.history.appendModelItem(record.sequence, modelHistoryItem);
     }
   }
 

--- a/src/runtime/session/store.ts
+++ b/src/runtime/session/store.ts
@@ -1,0 +1,19 @@
+import type { SessionSnapshot } from "./history";
+
+export interface SessionHistoryStore {
+  load(sessionId: string): Promise<SessionSnapshot | undefined>;
+  save(snapshot: SessionSnapshot): Promise<void>;
+}
+
+export class InMemorySessionHistoryStore implements SessionHistoryStore {
+  readonly #snapshots = new Map<string, SessionSnapshot>();
+
+  async load(sessionId: string): Promise<SessionSnapshot | undefined> {
+    const snapshot = this.#snapshots.get(sessionId);
+    return snapshot ? structuredClone(snapshot) : undefined;
+  }
+
+  async save(snapshot: SessionSnapshot): Promise<void> {
+    this.#snapshots.set(snapshot.sessionId, structuredClone(snapshot));
+  }
+}


### PR DESCRIPTION
## Summary

- Add raw append-only event history (`SessionEventRecord[]`) alongside a separate, minimal model history (`ModelHistoryItem[]`) that is passed into every LLM call.
- Thread `modelHistory` through `runAgentLoop` and `AgentSession` so the LLM only ever sees history that has already been emitted (never queued inputs that belong to a later turn).
- Implement `SessionHistory` with `snapshot()`, `viewAt(sequence)` for time-travel inspection, and restore-from-snapshot support.
- Define the `SessionHistoryStore` interface + `InMemorySessionHistoryStore` implementation, ready for pluggable persistence (file, D1, Postgres, etc.).
- `Agent` and `createSession()` now accept an optional stable `id` (defaults to `crypto.randomUUID()`) and `snapshot` / `historyStore` for persistence scenarios.
- Export all new history types via the session barrel and root `index.ts`.
- Update `LlmContext` to `{ history: ModelHistoryItem[]; signal: AbortSignal }`.

## Why

The previous design kept all state implicit inside the LLM context. Explicit raw history enables:

- Reliable snapshot/restore and resumability
- "Time travel" debugging via `viewAt(any past sequence)`
- Clean contract for persistence layers
- Safer LLM calls (model history never contains unstarted user messages)

Everything remains in-memory for this PR. Real stores will implement the `SessionHistoryStore` interface.

## Verification

- `pnpm run test` (extensive new coverage for history, snapshot, viewAt, and history-threading)
- `pnpm run typecheck`
- `pnpm run dev`

## Stack

Depends on #4 (session module move). Merge #4 first; this PR's base branch is `codex/session-module-files`.

## Notes

- `viewAt(sequence)` returns a `SessionHistoryView` with both the event prefix and the corresponding model history up to that point.
- Pending `submit()` calls that have not yet started a turn are intentionally excluded from the model history passed to the LLM.
- `AgentSession` now owns its `SessionHistory` instance; the `Agent` can be configured with a shared `historyStore` for cross-session persistence concerns.
