### PR TITLE
Preserve minimal model history across LLM calls

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -7,9 +7,9 @@ session.subscribe((event) => {
   console.log(event);
 });
 
-const first = session.submit({ type: "user-message", text: "first input" });
+const first = session.submit({ type: "user-text", text: "first input" });
 const second = session.submit({
-  type: "user-message",
+  type: "user-text",
   text: "queued input",
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,13 @@ export { Agent } from "./runtime/agent";
 export { runAgentLoop } from "./runtime/agent-loop";
 export { createMockLlm, mockLlm } from "./runtime/mock-llm";
 export type { Llm, LlmContext, LlmOutput, LlmOutputPart } from "./runtime/mock-llm";
-export type { AgentEvent, AgentEventListener, AgentSession, SessionInput } from "./runtime/session";
+export type {
+  AgentEvent,
+  AgentEventListener,
+  AgentSession,
+  AssistantText,
+  ModelHistoryItem,
+  SessionInput,
+  ToolCall,
+  UserText,
+} from "./runtime/session";

--- a/src/runtime/agent-loop.test.ts
+++ b/src/runtime/agent-loop.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { runAgentLoop } from "./agent-loop";
 import type { AgentEvent } from "./session/events";
 import type { Llm, LlmOutput } from "./mock-llm";
+import type { ModelHistoryItem } from "./session";
 
 const createScriptedLlm = (outputs: LlmOutput[]): Llm => {
   let index = 0;
@@ -9,24 +10,33 @@ const createScriptedLlm = (outputs: LlmOutput[]): Llm => {
 };
 
 const events: AgentEvent[] = [];
+const history: ModelHistoryItem[] = [];
 const llm = createScriptedLlm([
   [
-    { type: "text", text: "I should keep going." },
+    { type: "assistant-text", text: "I should keep going." },
     { type: "tool-call", toolName: "continue" },
   ],
-  [{ type: "text", text: "DONE" }],
+  [{ type: "assistant-text", text: "DONE" }],
 ]);
 
-assert.equal(await runAgentLoop({ emit: (event) => events.push(event), llm }), "completed");
+assert.equal(
+  await runAgentLoop({ emit: (event) => events.push(event), history, llm }),
+  "completed",
+);
 assert.deepEqual(
   events.map((event) => event.type),
   [
     "step-start",
-    "text",
+    "assistant-text",
     "tool-call",
     "step-end",
     "step-start",
-    "text",
+    "assistant-text",
     "step-end",
   ]
 );
+assert.deepEqual(history, [
+  { type: "assistant-text", text: "I should keep going." },
+  { type: "tool-call", toolName: "continue" },
+  { type: "assistant-text", text: "DONE" },
+]);

--- a/src/runtime/agent-loop.ts
+++ b/src/runtime/agent-loop.ts
@@ -1,8 +1,10 @@
 import type { AgentEventListener } from "./session/events";
+import type { ModelHistoryItem } from "./session";
 import { mockLlm, type Llm } from "./mock-llm";
 
 type RunAgentLoopOptions = {
   emit: AgentEventListener;
+  history: ModelHistoryItem[];
   llm?: Llm;
   signal?: AbortSignal;
 };
@@ -11,6 +13,7 @@ export type AgentLoopResult = "completed" | "aborted";
 
 export async function runAgentLoop({
   emit,
+  history,
   llm = mockLlm,
   signal = new AbortController().signal,
 }: RunAgentLoopOptions): Promise<AgentLoopResult> {
@@ -20,7 +23,7 @@ export async function runAgentLoop({
     }
 
     emit({ type: "step-start" });
-    const output = await llm({ signal });
+    const output = await llm({ history: structuredClone(history), signal });
     let shouldContinue = false;
 
     if (signal.aborted) {
@@ -32,12 +35,14 @@ export async function runAgentLoop({
         return "aborted";
       }
 
-      if (part.type === "text") {
-        emit({ type: "text", text: part.text });
+      history.push(structuredClone(part));
+
+      if (part.type === "assistant-text") {
+        emit(part);
         continue;
       }
 
-      emit({ type: "tool-call", toolName: part.toolName });
+      emit(part);
       shouldContinue = true;
     }
 

--- a/src/runtime/mock-llm.ts
+++ b/src/runtime/mock-llm.ts
@@ -1,9 +1,12 @@
-export type LlmOutputPart =
-  | { type: "text"; text: string }
-  | { type: "tool-call"; toolName: string };
+import type { AssistantText, ModelHistoryItem, ToolCall } from "./session";
+
+export type LlmOutputPart = AssistantText | ToolCall;
 
 export type LlmOutput = LlmOutputPart[];
-export type LlmContext = { signal: AbortSignal };
+export type LlmContext = {
+  history: readonly ModelHistoryItem[];
+  signal: AbortSignal;
+};
 export type Llm = (context: LlmContext) => Promise<LlmOutput>;
 
 const mockLlmDelayMs = 300;
@@ -31,7 +34,7 @@ export function createMockLlm(): Llm {
     const roll = Math.random();
 
     if (roll < 0.3) {
-      return [{ type: "text", text: "DONE" }];
+      return [{ type: "assistant-text", text: "DONE" }];
     }
 
     if (roll < 0.65) {
@@ -39,7 +42,7 @@ export function createMockLlm(): Llm {
     }
 
     return [
-      { type: "text", text: "I should keep going." },
+      { type: "assistant-text", text: "I should keep going." },
       { type: "tool-call", toolName: "continue" },
     ];
   };

--- a/src/runtime/session/events.ts
+++ b/src/runtime/session/events.ts
@@ -1,6 +1,12 @@
+export type UserText = { type: "user-text"; text: string };
+export type AssistantText = { type: "assistant-text"; text: string };
+export type ToolCall = { type: "tool-call"; toolName: string };
+
+export type ModelHistoryItem = UserText | AssistantText | ToolCall;
+
 export type AgentEvent =
   /** User input was accepted into the session queue. */
-  | { type: "user-message"; text: string }
+  | UserText
   /** A queued user input started running as a turn. */
   | { type: "turn-start" }
   /** The active turn was interrupted before normal completion. */
@@ -12,9 +18,9 @@ export type AgentEvent =
   /** One model/tool-loop iteration started within the active turn. */
   | { type: "step-start" }
   /** The model produced visible assistant text. */
-  | { type: "text"; text: string }
+  | AssistantText
   /** The model requested a tool call. */
-  | { type: "tool-call"; toolName: string }
+  | ToolCall
   /** One model/tool-loop iteration finished within the active turn. */
   | { type: "step-end" };
 

--- a/src/runtime/session/index.ts
+++ b/src/runtime/session/index.ts
@@ -1,2 +1,9 @@
-export type { AgentEvent, AgentEventListener } from "./events";
+export type {
+  AgentEvent,
+  AgentEventListener,
+  AssistantText,
+  ModelHistoryItem,
+  ToolCall,
+  UserText,
+} from "./events";
 export { AgentSession, type SessionInput } from "./session";

--- a/src/runtime/session/session.test.ts
+++ b/src/runtime/session/session.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { Agent } from "../agent";
-import type { AgentEvent } from "./index";
+import type { AgentEvent, ModelHistoryItem } from "./index";
 import type { Llm } from "../mock-llm";
 
 const createDeferred = () => {
@@ -12,24 +12,26 @@ const createDeferred = () => {
 };
 
 const firstLlmCall = createDeferred();
+const seenHistory: ModelHistoryItem[][] = [];
 let calls = 0;
-const llm: Llm = async () => {
+const llm: Llm = async ({ history }) => {
   calls += 1;
+  seenHistory.push([...history]);
 
   if (calls === 1) {
     await firstLlmCall.promise;
     return [{ type: "tool-call", toolName: "continue" }];
   }
 
-  return [{ type: "text", text: "DONE" }];
+  return [{ type: "assistant-text", text: "DONE" }];
 };
 
 const session = new Agent({ llm }).createSession();
 const events: AgentEvent[] = [];
 session.subscribe((event) => events.push(event));
 
-const firstSubmit = session.submit({ type: "user-message", text: "first" });
-const secondSubmit = session.submit({ type: "user-message", text: "second" });
+const firstSubmit = session.submit({ type: "user-text", text: "first" });
+const secondSubmit = session.submit({ type: "user-text", text: "second" });
 
 session.interrupt();
 firstLlmCall.resolve();
@@ -37,21 +39,63 @@ firstLlmCall.resolve();
 await Promise.all([firstSubmit, secondSubmit]);
 
 assert.equal(calls, 2);
+assert.deepEqual(seenHistory, [
+  [{ type: "user-text", text: "first" }],
+  [
+    { type: "user-text", text: "first" },
+    { type: "user-text", text: "second" },
+  ],
+]);
+assert.deepEqual(session.history(), [
+  { type: "user-text", text: "first" },
+  { type: "user-text", text: "second" },
+  { type: "assistant-text", text: "DONE" },
+]);
 assert.deepEqual(
   events.map((event) => event.type),
   [
-    "user-message",
+    "user-text",
     "turn-start",
     "step-start",
-    "user-message",
+    "user-text",
     "turn-abort",
     "turn-start",
     "step-start",
-    "text",
+    "assistant-text",
     "step-end",
     "turn-end",
   ]
 );
+
+const toolLoopHistories: ModelHistoryItem[][] = [];
+let toolLoopCalls = 0;
+const toolLoopSession = new Agent({
+  llm: async ({ history }) => {
+    toolLoopCalls += 1;
+    toolLoopHistories.push([...history]);
+
+    if (toolLoopCalls === 1) {
+      return [{ type: "tool-call", toolName: "continue" }];
+    }
+
+    return [{ type: "assistant-text", text: "DONE" }];
+  },
+}).createSession();
+
+await toolLoopSession.submit({ type: "user-text", text: "remember me" });
+
+assert.deepEqual(toolLoopHistories, [
+  [{ type: "user-text", text: "remember me" }],
+  [
+    { type: "user-text", text: "remember me" },
+    { type: "tool-call", toolName: "continue" },
+  ],
+]);
+assert.deepEqual(toolLoopSession.history(), [
+  { type: "user-text", text: "remember me" },
+  { type: "tool-call", toolName: "continue" },
+  { type: "assistant-text", text: "DONE" },
+]);
 
 const failingSession = new Agent({
   llm: async () => {
@@ -62,13 +106,13 @@ const failingEvents: AgentEvent[] = [];
 failingSession.subscribe((event) => failingEvents.push(event));
 
 await assert.rejects(
-  failingSession.submit({ type: "user-message", text: "fail" }),
+  failingSession.submit({ type: "user-text", text: "fail" }),
   /model unavailable/
 );
 
 assert.deepEqual(
   failingEvents.map((event) => event.type),
-  ["user-message", "turn-start", "step-start", "turn-error"]
+  ["user-text", "turn-start", "step-start", "turn-error"]
 );
 assert.deepEqual(failingEvents.at(-1), {
   type: "turn-error",

--- a/src/runtime/session/session.ts
+++ b/src/runtime/session/session.ts
@@ -1,8 +1,8 @@
 import { runAgentLoop } from "../agent-loop";
-import type { AgentEvent, AgentEventListener } from "./events";
+import type { AgentEvent, AgentEventListener, ModelHistoryItem } from "./events";
 import type { Llm } from "../mock-llm";
 
-export type SessionInput = { type: "user-message"; text: string };
+export type SessionInput = { type: "user-text"; text: string };
 
 type QueuedInput = {
   input: SessionInput;
@@ -13,6 +13,7 @@ type QueuedInput = {
 export class AgentSession {
   readonly #listeners = new Set<AgentEventListener>();
   readonly #llm: Llm;
+  readonly #history: ModelHistoryItem[] = [];
   readonly #inputQueue: QueuedInput[] = [];
   #running = false;
   #activeAbort?: AbortController;
@@ -27,10 +28,15 @@ export class AgentSession {
   }
 
   submit(input: SessionInput): Promise<void> {
-    this.#emit(input);
+    const acceptedInput = structuredClone(input);
+    this.#emit(acceptedInput);
 
     const queued = new Promise<void>((resolve, reject) => {
-      this.#inputQueue.push({ input, resolve, reject });
+      this.#inputQueue.push({
+        input: structuredClone(acceptedInput),
+        resolve,
+        reject,
+      });
     });
 
     void this.#drainInputQueue();
@@ -39,6 +45,10 @@ export class AgentSession {
 
   interrupt(): void {
     this.#activeAbort?.abort();
+  }
+
+  history(): ModelHistoryItem[] {
+    return structuredClone(this.#history);
   }
 
   async #drainInputQueue(): Promise<void> {
@@ -60,8 +70,10 @@ export class AgentSession {
 
         try {
           this.#emit({ type: "turn-start" });
+          this.#history.push(structuredClone(item.input));
           const result = await runAgentLoop({
             emit: (event) => this.#emit(event),
+            history: this.#history,
             llm: this.#llm,
             signal: this.#activeAbort.signal,
           });


### PR DESCRIPTION
## Summary
- Align model-history item and event names around `user-text`, `assistant-text`, and `tool-call`.
- Add a minimal session-owned model history array and pass it into every LLM call.
- Append LLM output parts back into history so tool-loop follow-up calls keep context.

## Why
The current runtime accepted queued user input and emitted events, but LLM calls did not receive prior context. This keeps the implementation minimal: no snapshot store, no replay engine, no time-travel API, just the in-memory history needed for LLM continuity.

## Verification
- `pnpm run test`
- `pnpm run typecheck`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal, in-memory model history to each session and passes it into every LLM call, so follow-up tool-loop calls keep context. Also aligns event and type names to `user-text`, `assistant-text`, and `tool-call`.

- New Features
  - Keep a session-owned history of `user-text`, `assistant-text`, and `tool-call`.
  - Pass `history` through `LlmContext` on every call and append model output parts during the loop.
  - Export `UserText`, `AssistantText`, `ToolCall`, and `ModelHistoryItem` from `src/index.ts`.

- Migration
  - Rename: `user-message` -> `user-text`, `text` -> `assistant-text`.
  - Update LLM signature to accept `({ history, signal })`.
  - If calling `runAgentLoop` directly, provide `history: ModelHistoryItem[]`.

<sup>Written for commit 6d25c5844ac37373e769cffdcbfba23dad5e0794. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/6?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

