### PR TITLE
Add minimal pi-tui CLI example

### DIFF
--- a/examples/pi-tui.ts
+++ b/examples/pi-tui.ts
@@ -1,0 +1,108 @@
+import {
+  Container,
+  Input,
+  ProcessTerminal,
+  Text,
+  TUI,
+  matchesKey,
+} from "@earendil-works/pi-tui";
+import { Agent, type AgentEvent } from "../src";
+
+const agent = new Agent();
+const session = agent.createSession();
+
+const terminal = new ProcessTerminal();
+const tui = new TUI(terminal);
+
+const chat = new Container();
+const input = new Input();
+
+tui.addChild(
+  new Text(
+    "\x1b[1mpss-next\x1b[0m \x1b[2m(Esc to interrupt · Ctrl-C to quit)\x1b[0m",
+    1,
+    0
+  )
+);
+tui.addChild(chat);
+tui.addChild(input);
+tui.setFocus(input);
+
+let finish: () => void;
+const done = new Promise<void>((resolve) => {
+  finish = resolve;
+});
+
+const addLine = (text: string): void => {
+  chat.addChild(new Text(text, 1, 0));
+  tui.requestRender();
+};
+
+const formatEvent = (event: AgentEvent): string | undefined => {
+  switch (event.type) {
+    case "user-text":
+      return `\x1b[36myou\x1b[0m: ${event.text}`;
+    case "assistant-text":
+      return `\x1b[32massistant\x1b[0m: ${event.text}`;
+    case "tool-call":
+      return `\x1b[33mtool\x1b[0m: ${event.toolName}`;
+    case "turn-start":
+      return "\x1b[2mrunning...\x1b[0m";
+    case "turn-abort":
+      return "\x1b[2minterrupted\x1b[0m";
+    case "turn-error":
+      return `\x1b[31merror\x1b[0m: ${event.message}`;
+    case "turn-end":
+      return "\x1b[2mdone\x1b[0m";
+    case "step-start":
+    case "step-end":
+      return undefined;
+  }
+};
+
+session.subscribe((event) => {
+  const line = formatEvent(event);
+  if (line) {
+    addLine(line);
+  }
+});
+
+input.onSubmit = (text) => {
+  input.setValue("");
+
+  const trimmed = text.trim();
+  if (!trimmed) {
+    tui.requestRender();
+    return;
+  }
+
+  void session
+    .submit({ type: "user-text", text: trimmed })
+    .catch((error: unknown) => {
+      addLine(
+        `\x1b[31merror\x1b[0m: ${error instanceof Error ? error.message : String(error)}`
+      );
+    });
+};
+
+const removeInputListener = tui.addInputListener((data) => {
+  // Avoid input.onEscape because pi-tui maps both Escape and Ctrl-C to it.
+  if (matchesKey(data, "escape")) {
+    session.interrupt();
+    return { consume: true };
+  }
+
+  if (!matchesKey(data, "ctrl+c")) {
+    return undefined;
+  }
+
+  removeInputListener();
+  tui.stop();
+  finish();
+  return { consume: true };
+});
+
+tui.start();
+tui.requestRender();
+
+await done;

--- a/examples/pi-tui.ts
+++ b/examples/pi-tui.ts
@@ -39,7 +39,7 @@ const addLine = (text: string): void => {
 };
 
 const safeText = (text: string): string =>
-  text.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g, "");
+  text.replace(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g, "");
 
 const formatEvent = (event: AgentEvent): string | undefined => {
   switch (event.type) {

--- a/examples/pi-tui.ts
+++ b/examples/pi-tui.ts
@@ -101,7 +101,7 @@ const removeInputListener = tui.addInputListener((data) => {
   }
 
   removeInputListener();
-  session.interrupt();
+  session.kill();
   tui.stop();
   finish();
   return { consume: true };

--- a/examples/pi-tui.ts
+++ b/examples/pi-tui.ts
@@ -38,20 +38,23 @@ const addLine = (text: string): void => {
   tui.requestRender();
 };
 
+const safeText = (text: string): string =>
+  text.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g, "");
+
 const formatEvent = (event: AgentEvent): string | undefined => {
   switch (event.type) {
     case "user-text":
-      return `\x1b[36myou\x1b[0m: ${event.text}`;
+      return `\x1b[36myou\x1b[0m: ${safeText(event.text)}`;
     case "assistant-text":
-      return `\x1b[32massistant\x1b[0m: ${event.text}`;
+      return `\x1b[32massistant\x1b[0m: ${safeText(event.text)}`;
     case "tool-call":
-      return `\x1b[33mtool\x1b[0m: ${event.toolName}`;
+      return `\x1b[33mtool\x1b[0m: ${safeText(event.toolName)}`;
     case "turn-start":
       return "\x1b[2mrunning...\x1b[0m";
     case "turn-abort":
       return "\x1b[2minterrupted\x1b[0m";
     case "turn-error":
-      return `\x1b[31merror\x1b[0m: ${event.message}`;
+      return `\x1b[31merror\x1b[0m: ${safeText(event.message)}`;
     case "turn-end":
       return "\x1b[2mdone\x1b[0m";
     case "step-start":
@@ -79,8 +82,9 @@ input.onSubmit = (text) => {
   void session
     .submit({ type: "user-text", text: trimmed })
     .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
       addLine(
-        `\x1b[31merror\x1b[0m: ${error instanceof Error ? error.message : String(error)}`
+        `\x1b[31merror\x1b[0m: ${safeText(message)}`
       );
     });
 };
@@ -97,6 +101,7 @@ const removeInputListener = tui.addInputListener((data) => {
   }
 
   removeInputListener();
+  session.interrupt();
   tui.stop();
   finish();
   return { consume: true };

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "packageManager": "pnpm@10.0.0",
   "scripts": {
     "dev": "tsx examples/basic.ts",
+    "dev:tui": "tsx examples/pi-tui.ts",
     "typecheck": "tsc --noEmit",
     "test": "tsx src/runtime/agent-loop.test.ts && tsx src/runtime/session/session.test.ts"
   },
   "devDependencies": {
+    "@earendil-works/pi-tui": "^0.74.1",
     "@types/node": "latest",
     "tsx": "latest",
     "typescript": "latest"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@earendil-works/pi-tui':
+        specifier: ^0.74.1
+        version: 0.74.1
       '@types/node':
         specifier: latest
         version: 25.8.0
@@ -19,6 +22,10 @@ importers:
         version: 6.0.3
 
 packages:
+
+  '@earendil-works/pi-tui@0.74.1':
+    resolution: {integrity: sha512-wQj2TRG43/BBNyd/lReQJWtTCOJVyIwI+7Ifp3hNITfTtQr4zQdMeF7uxqEMQ73LI6rQO7Ljx0P2w+oMx8uyIA==}
+    engines: {node: '>=20.0.0'}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -189,6 +196,18 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  koffi@2.16.2:
+    resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   tsx@4.22.0:
     resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
     engines: {node: '>=18.0.0'}
@@ -203,6 +222,13 @@ packages:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
 snapshots:
+
+  '@earendil-works/pi-tui@0.74.1':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 15.0.12
+    optionalDependencies:
+      koffi: 2.16.2
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
@@ -317,6 +343,13 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  get-east-asian-width@1.6.0: {}
+
+  koffi@2.16.2:
+    optional: true
+
+  marked@15.0.12: {}
 
   tsx@4.22.0:
     dependencies:

--- a/src/runtime/session/session.test.ts
+++ b/src/runtime/session/session.test.ts
@@ -161,3 +161,31 @@ assert.deepEqual(
   killedEvents.map((event) => event.type),
   ["user-text", "turn-start", "step-start", "user-text", "turn-abort"]
 );
+
+let listenerKilledCalls = 0;
+const listenerKilledSession = new Agent({
+  llm: async () => {
+    listenerKilledCalls += 1;
+    return [{ type: "assistant-text", text: "should not run" }];
+  },
+}).createSession();
+const listenerKilledEvents: AgentEvent[] = [];
+listenerKilledSession.subscribe((event) => {
+  listenerKilledEvents.push(event);
+
+  if (event.type === "user-text") {
+    listenerKilledSession.kill();
+  }
+});
+
+await assert.rejects(
+  listenerKilledSession.submit({ type: "user-text", text: "kill now" }),
+  /Session killed/
+);
+
+assert.equal(listenerKilledCalls, 0);
+assert.deepEqual(listenerKilledSession.history(), []);
+assert.deepEqual(
+  listenerKilledEvents.map((event) => event.type),
+  ["user-text"]
+);

--- a/src/runtime/session/session.test.ts
+++ b/src/runtime/session/session.test.ts
@@ -118,3 +118,46 @@ assert.deepEqual(failingEvents.at(-1), {
   type: "turn-error",
   message: "model unavailable",
 });
+
+const killLlmCall = createDeferred();
+let killCalls = 0;
+const killedSession = new Agent({
+  llm: async () => {
+    killCalls += 1;
+    await killLlmCall.promise;
+    return [{ type: "assistant-text", text: "should not render" }];
+  },
+}).createSession();
+const killedEvents: AgentEvent[] = [];
+killedSession.subscribe((event) => killedEvents.push(event));
+
+const activeSubmit = killedSession.submit({ type: "user-text", text: "active" });
+const queuedSubmit = killedSession.submit({ type: "user-text", text: "queued" });
+const queuedResult = queuedSubmit.then(
+  () => "resolved",
+  (error: unknown) => error
+);
+
+killedSession.kill();
+killLlmCall.resolve();
+
+await activeSubmit;
+const queuedError = await queuedResult;
+
+assert.equal(killCalls, 1);
+assert.ok(queuedError instanceof Error);
+assert.equal(queuedError.message, "Session killed");
+assert.deepEqual(killedSession.history(), [
+  { type: "user-text", text: "active" },
+]);
+await assert.rejects(
+  killedSession.submit({ type: "user-text", text: "after kill" }),
+  /Session killed/
+);
+assert.deepEqual(killedSession.history(), [
+  { type: "user-text", text: "active" },
+]);
+assert.deepEqual(
+  killedEvents.map((event) => event.type),
+  ["user-text", "turn-start", "step-start", "user-text", "turn-abort"]
+);

--- a/src/runtime/session/session.ts
+++ b/src/runtime/session/session.ts
@@ -36,6 +36,10 @@ export class AgentSession {
     const acceptedInput = structuredClone(input);
     this.#emit(acceptedInput);
 
+    if (this.#killed) {
+      return Promise.reject(sessionKilledError());
+    }
+
     const queued = new Promise<void>((resolve, reject) => {
       this.#inputQueue.push({
         input: structuredClone(acceptedInput),

--- a/src/runtime/session/session.ts
+++ b/src/runtime/session/session.ts
@@ -17,6 +17,7 @@ export class AgentSession {
   readonly #inputQueue: QueuedInput[] = [];
   #running = false;
   #activeAbort?: AbortController;
+  #killed = false;
 
   constructor(llm: Llm) {
     this.#llm = llm;
@@ -28,6 +29,10 @@ export class AgentSession {
   }
 
   submit(input: SessionInput): Promise<void> {
+    if (this.#killed) {
+      return Promise.reject(sessionKilledError());
+    }
+
     const acceptedInput = structuredClone(input);
     this.#emit(acceptedInput);
 
@@ -47,6 +52,19 @@ export class AgentSession {
     this.#activeAbort?.abort();
   }
 
+  kill(): void {
+    if (this.#killed) {
+      return;
+    }
+
+    this.#killed = true;
+    this.#activeAbort?.abort();
+
+    while (this.#inputQueue.length > 0) {
+      this.#inputQueue.shift()?.reject(sessionKilledError());
+    }
+  }
+
   history(): ModelHistoryItem[] {
     return structuredClone(this.#history);
   }
@@ -59,7 +77,7 @@ export class AgentSession {
     this.#running = true;
 
     try {
-      while (this.#inputQueue.length > 0) {
+      while (!this.#killed && this.#inputQueue.length > 0) {
         const item = this.#inputQueue.shift();
 
         if (!item) {
@@ -106,4 +124,8 @@ function errorMessage(error: unknown): string {
   }
 
   return String(error);
+}
+
+function sessionKilledError(): Error {
+  return new Error("Session killed");
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "examples/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Add a minimal pi-tui example that accepts real terminal input and submits it to an AgentSession
- Render session events back into the TUI with lightweight role highlighting
- Add Esc interrupt / Ctrl-C quit handling and include examples in typecheck

## Verification
- pnpm run test
- pnpm run typecheck
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal `pi-tui` CLI that streams terminal input into an Agent session and renders events back to the terminal. Adds `AgentSession.kill()` so Ctrl-C cleanly aborts the active turn, cancels queued input, and rejects new submissions; Esc still interrupts only. Also fixes a race where a submit listener killing the session could leave a submission stranded.

- **New Features**
  - `examples/pi-tui.ts`: input -> `session.submit` -> `session.subscribe` -> render loop with lightweight role colors; run with `pnpm run dev:tui` (uses `@earendil-works/pi-tui`).
  - `AgentSession.kill()`: terminates the session, aborts the active turn, cancels queued inputs, and rejects submissions after kill; Ctrl-C in the TUI uses this.

- **Bug Fixes**
  - Sanitize dynamic event text (strip all C0 controls except tab/newline) and kill the session before stopping the TUI on quit.
  - Prevent stranded submissions if a submit listener calls `kill()` during event emission by re-checking the killed state before queueing.

<sup>Written for commit 59feaee3d2a0e62f490ce5bc8bbe144f4311fd25. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/7?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

