### PR TITLE
[codex] Add Vitest test toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "tsx examples/basic.ts",
     "dev:tui": "tsx examples/pi-tui.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx src/runtime/agent-loop.test.ts && tsx src/runtime/session/mapping.test.ts && tsx src/runtime/session/session.test.ts",
+    "test": "vitest run",
     "lint": "ultracite check .",
     "format": "ultracite fix ."
   },
@@ -18,7 +18,8 @@
     "@types/node": "latest",
     "tsx": "latest",
     "typescript": "latest",
-    "ultracite": "7.7.0"
+    "ultracite": "7.7.0",
+    "vitest": "^4.1.6"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "3.0.0-canary.48",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       ultracite:
         specifier: 7.7.0
         version: 7.7.0
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.9.0))
 
 packages:
 
@@ -128,6 +131,15 @@ packages:
   '@earendil-works/pi-tui@0.74.1':
     resolution: {integrity: sha512-wQj2TRG43/BBNyd/lReQJWtTCOJVyIwI+7Ifp3hNITfTtQr4zQdMeF7uxqEMQ73LI6rQO7Ljx0P2w+oMx8uyIA==}
     engines: {node: '>=20.0.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -285,8 +297,124 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
+  '@rolldown/binding-android-arm64@1.0.1':
+    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/node@25.8.0':
     resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
@@ -294,6 +422,35 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
@@ -304,6 +461,10 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -312,12 +473,19 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -327,18 +495,32 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -348,6 +530,15 @@ packages:
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -374,9 +565,82 @@ packages:
   koffi@2.16.2:
     resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -391,10 +655,18 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nypm@0.6.6:
     resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
     engines: {node: '>=18'}
     hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -407,6 +679,22 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -415,12 +703,39 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.22.0:
     resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
@@ -447,9 +762,98 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  vite@8.0.13:
+    resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   yaml@2.9.0:
@@ -541,6 +945,22 @@ snapshots:
     optionalDependencies:
       koffi: 2.16.2
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
@@ -619,13 +1039,130 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@oxc-project/types@0.130.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/node@25.8.0':
     dependencies:
       undici-types: 7.24.6
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@workflow/serde@4.1.0': {}
 
@@ -636,15 +1173,21 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.0-canary.41(zod@4.4.3)
       zod: 4.4.3
 
+  assertion-error@2.0.1: {}
+
   balanced-match@4.0.4: {}
 
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
+  chai@6.2.2: {}
+
   citty@0.2.2: {}
 
   commander@14.0.3: {}
+
+  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -654,7 +1197,11 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  detect-libc@2.1.2: {}
+
   dotenv@17.4.2: {}
+
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -685,7 +1232,13 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   eventsource-parser@3.0.8: {}
+
+  expect-type@1.3.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -696,6 +1249,10 @@ snapshots:
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fsevents@2.3.3:
     optional: true
@@ -717,7 +1274,60 @@ snapshots:
   koffi@2.16.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lru-cache@11.3.6: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@15.0.12: {}
 
@@ -727,11 +1337,15 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  nanoid@3.3.12: {}
+
   nypm@0.6.6:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
       tinyexec: 1.1.2
+
+  obug@2.1.1: {}
 
   path-key@3.1.1: {}
 
@@ -742,15 +1356,66 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.0.1:
+    dependencies:
+      '@oxc-project/types': 0.130.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.1
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-darwin-x64': 1.0.1
+      '@rolldown/binding-freebsd-x64': 1.0.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
+      '@rolldown/binding-linux-s390x-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-openharmony-arm64': 1.0.1
+      '@rolldown/binding-wasm32-wasi': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   sisteransi@1.0.5: {}
 
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.22.0:
     dependencies:
@@ -774,9 +1439,55 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.8.0
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      tsx: 4.22.0
+      yaml: 2.9.0
+
+  vitest@4.1.6(@types/node@25.8.0)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.8.0
+    transitivePeerDependencies:
+      - msw
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yaml@2.9.0: {}
 

--- a/src/runtime/agent-loop.test.ts
+++ b/src/runtime/agent-loop.test.ts
@@ -1,131 +1,96 @@
-import assert from "node:assert/strict";
-import type { AssistantModelMessage, ToolCallPart, ToolModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
 import { runAgentLoop } from "./agent-loop";
-import type { Llm, LlmOutput } from "./llm";
+import type { Llm } from "./llm";
 import type { AgentEvent } from "./session/events";
 import { AgentModelHistory } from "./session/history";
+import {
+  assistantMessage,
+  continueToolCall,
+  continueToolResult,
+  createScriptedLlm,
+  eventTypes,
+} from "./test-fixtures";
 
-const createScriptedLlm = (outputs: LlmOutput[]): Llm => {
-  let index = 0;
-  return () => Promise.resolve(outputs[index++] ?? []);
-};
+describe("runAgentLoop", () => {
+  it("continues while assistant messages request the continue tool", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const toolCall = continueToolCall("call-continue-1");
+    const llm = createScriptedLlm([
+      [
+        assistantMessage([
+          { type: "text", text: "I should keep going." },
+          toolCall,
+        ]),
+        continueToolResult(toolCall),
+      ],
+      [assistantMessage("DONE")],
+    ]);
 
-const continueToolCall = (toolCallId: string): ToolCallPart => ({
-  type: "tool-call",
-  toolCallId,
-  toolName: "continue",
-  input: {},
+    await expect(
+      runAgentLoop({ emit: (event) => events.push(event), history, llm })
+    ).resolves.toBe("completed");
+
+    expect(events).toEqual([
+      { type: "step-start" },
+      { type: "assistant-text", text: "I should keep going." },
+      { type: "tool-call", toolName: "continue" },
+      { type: "step-end" },
+      { type: "step-start" },
+      { type: "assistant-text", text: "DONE" },
+      { type: "step-end" },
+    ]);
+    expect(history.modelSnapshot()).toEqual([
+      assistantMessage([
+        { type: "text", text: "I should keep going." },
+        toolCall,
+      ]),
+      continueToolResult(toolCall),
+      assistantMessage("DONE"),
+    ]);
+  });
+
+  it("returns aborted when the LLM rejects after the signal is aborted", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const controller = new AbortController();
+    const abortingLlm: Llm = () => {
+      controller.abort();
+      return Promise.reject(new Error("model request aborted"));
+    };
+
+    await expect(
+      runAgentLoop({
+        emit: (event) => events.push(event),
+        history,
+        llm: abortingLlm,
+        signal: controller.signal,
+      })
+    ).resolves.toBe("aborted");
+
+    expect(eventTypes(events)).toEqual(["step-start"]);
+    expect(history.modelSnapshot()).toEqual([]);
+  });
+
+  it("returns aborted when the LLM resolves empty output after the signal is aborted", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const controller = new AbortController();
+    const emptyAbortingLlm: Llm = () => {
+      controller.abort();
+      return Promise.resolve([]);
+    };
+
+    await expect(
+      runAgentLoop({
+        emit: (event) => events.push(event),
+        history,
+        llm: emptyAbortingLlm,
+        signal: controller.signal,
+      })
+    ).resolves.toBe("aborted");
+
+    expect(eventTypes(events)).toEqual(["step-start"]);
+    expect(history.modelSnapshot()).toEqual([]);
+  });
 });
-
-const assistantMessage = (
-  content: AssistantModelMessage["content"]
-): AssistantModelMessage => ({
-  role: "assistant",
-  content,
-});
-
-const continueToolResult = (toolCall: ToolCallPart): ToolModelMessage => ({
-  role: "tool",
-  content: [
-    {
-      type: "tool-result",
-      toolCallId: toolCall.toolCallId,
-      toolName: toolCall.toolName,
-      output: { type: "json", value: {} },
-    },
-  ],
-});
-
-const events: AgentEvent[] = [];
-const history = new AgentModelHistory();
-const callContinue1 = continueToolCall("call-continue-1");
-const llm = createScriptedLlm([
-  [
-    assistantMessage([
-      { type: "text", text: "I should keep going." },
-      callContinue1,
-    ]),
-    continueToolResult(callContinue1),
-  ],
-  [assistantMessage("DONE")],
-]);
-
-assert.equal(
-  await runAgentLoop({ emit: (event) => events.push(event), history, llm }),
-  "completed"
-);
-assert.deepEqual(
-  events.map((event) => event.type),
-  [
-    "step-start",
-    "assistant-text",
-    "tool-call",
-    "step-end",
-    "step-start",
-    "assistant-text",
-    "step-end",
-  ]
-);
-assert.deepEqual(events, [
-  { type: "step-start" },
-  { type: "assistant-text", text: "I should keep going." },
-  { type: "tool-call", toolName: "continue" },
-  { type: "step-end" },
-  { type: "step-start" },
-  { type: "assistant-text", text: "DONE" },
-  { type: "step-end" },
-]);
-assert.deepEqual(history.modelSnapshot(), [
-  assistantMessage([
-    { type: "text", text: "I should keep going." },
-    callContinue1,
-  ]),
-  continueToolResult(callContinue1),
-  assistantMessage("DONE"),
-]);
-
-const abortEvents: AgentEvent[] = [];
-const abortHistory = new AgentModelHistory();
-const abortController = new AbortController();
-const abortingLlm: Llm = () => {
-  abortController.abort();
-  return Promise.reject(new Error("model request aborted"));
-};
-
-assert.equal(
-  await runAgentLoop({
-    emit: (event) => abortEvents.push(event),
-    history: abortHistory,
-    llm: abortingLlm,
-    signal: abortController.signal,
-  }),
-  "aborted"
-);
-assert.deepEqual(
-  abortEvents.map((event) => event.type),
-  ["step-start"]
-);
-assert.deepEqual(abortHistory.modelSnapshot(), []);
-
-const emptyAbortEvents: AgentEvent[] = [];
-const emptyAbortHistory = new AgentModelHistory();
-const emptyAbortController = new AbortController();
-const emptyAbortingLlm: Llm = () => {
-  emptyAbortController.abort();
-  return Promise.resolve([]);
-};
-
-assert.equal(
-  await runAgentLoop({
-    emit: (event) => emptyAbortEvents.push(event),
-    history: emptyAbortHistory,
-    llm: emptyAbortingLlm,
-    signal: emptyAbortController.signal,
-  }),
-  "aborted"
-);
-assert.deepEqual(
-  emptyAbortEvents.map((event) => event.type),
-  ["step-start"]
-);
-assert.deepEqual(emptyAbortHistory.modelSnapshot(), []);

--- a/src/runtime/session/mapping.test.ts
+++ b/src/runtime/session/mapping.test.ts
@@ -1,62 +1,46 @@
-import assert from "node:assert/strict";
-import type { AssistantModelMessage, ToolCallPart, ToolModelMessage } from "ai";
-import type { UserText } from "./events";
+import { describe, expect, it } from "vitest";
+import {
+  assistantMessage,
+  continueToolCall,
+  continueToolResult,
+  userText,
+} from "../test-fixtures";
 import { modelMessageToAgentEvents, userTextToModelMessage } from "./mapping";
 
-const userText = (text: string): UserText => ({ type: "user-text", text });
+describe("session mapping", () => {
+  it("maps user text to an AI SDK user model message", () => {
+    expect(userTextToModelMessage(userText("hello"))).toEqual({
+      role: "user",
+      content: "hello",
+    });
+  });
 
-const assistantMessage = (
-  content: AssistantModelMessage["content"]
-): AssistantModelMessage => ({
-  role: "assistant",
-  content,
+  it("projects assistant text and tool calls to public agent events", () => {
+    const toolCall = continueToolCall("call-continue");
+
+    expect(modelMessageToAgentEvents(assistantMessage("DONE"))).toEqual([
+      { type: "assistant-text", text: "DONE" },
+    ]);
+    expect(
+      modelMessageToAgentEvents(
+        assistantMessage([
+          { type: "text", text: "thinking aloud" },
+          { type: "text", text: "" },
+          toolCall,
+        ])
+      )
+    ).toEqual([
+      { type: "assistant-text", text: "thinking aloud" },
+      { type: "tool-call", toolName: "continue" },
+    ]);
+  });
+
+  it("does not project non-assistant messages to public agent events", () => {
+    const toolCall = continueToolCall("call-continue");
+
+    expect(
+      modelMessageToAgentEvents(userTextToModelMessage(userText("hi")))
+    ).toEqual([]);
+    expect(modelMessageToAgentEvents(continueToolResult(toolCall))).toEqual([]);
+  });
 });
-
-const continueToolCall = (toolCallId: string): ToolCallPart => ({
-  type: "tool-call",
-  toolCallId,
-  toolName: "continue",
-  input: {},
-});
-
-const continueToolResult = (toolCall: ToolCallPart): ToolModelMessage => ({
-  role: "tool",
-  content: [
-    {
-      type: "tool-result",
-      toolCallId: toolCall.toolCallId,
-      toolName: toolCall.toolName,
-      output: { type: "json", value: {} },
-    },
-  ],
-});
-
-assert.deepEqual(userTextToModelMessage(userText("hello")), {
-  role: "user",
-  content: "hello",
-});
-
-assert.deepEqual(modelMessageToAgentEvents(assistantMessage("DONE")), [
-  { type: "assistant-text", text: "DONE" },
-]);
-
-const toolCall = continueToolCall("call-continue");
-assert.deepEqual(
-  modelMessageToAgentEvents(
-    assistantMessage([
-      { type: "text", text: "thinking aloud" },
-      { type: "text", text: "" },
-      toolCall,
-    ])
-  ),
-  [
-    { type: "assistant-text", text: "thinking aloud" },
-    { type: "tool-call", toolName: "continue" },
-  ]
-);
-
-assert.deepEqual(
-  modelMessageToAgentEvents(userTextToModelMessage(userText("hi"))),
-  []
-);
-assert.deepEqual(modelMessageToAgentEvents(continueToolResult(toolCall)), []);

--- a/src/runtime/session/session.test.ts
+++ b/src/runtime/session/session.test.ts
@@ -1,214 +1,184 @@
-import assert from "node:assert/strict";
-import type {
-  AssistantModelMessage,
-  ModelMessage,
-  ToolCallPart,
-  ToolModelMessage,
-} from "ai";
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
 import { Agent } from "../agent";
 import type { Llm } from "../llm";
-import type { AgentEvent, UserText } from "./index";
+import {
+  assistantMessage,
+  continueToolCall,
+  continueToolResult,
+  createDeferred,
+  eventTypes,
+  userText,
+} from "../test-fixtures";
+import type { AgentEvent } from "./index";
 import { userTextToModelMessage } from "./mapping";
 
-const createDeferred = () => {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
+describe("AgentSession", () => {
+  it("queues submitted input and aborts the active turn before the next input runs", async () => {
+    const firstLlmCall = createDeferred();
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const llm: Llm = async ({ history }) => {
+      calls += 1;
+      seenHistory.push([...history]);
+
+      if (calls === 1) {
+        await firstLlmCall.promise;
+        const toolCall = continueToolCall("call-interrupted-continue");
+        return [assistantMessage([toolCall]), continueToolResult(toolCall)];
+      }
+
+      return [assistantMessage("DONE")];
+    };
+    const session = new Agent({ llm }).createSession();
+    const events: AgentEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const firstSubmit = session.submit(userText("first"));
+    const secondSubmit = session.submit(userText("second"));
+
+    session.interrupt();
+    firstLlmCall.resolve();
+
+    await Promise.all([firstSubmit, secondSubmit]);
+
+    expect(calls).toBe(2);
+    expect(seenHistory).toEqual([
+      [userTextToModelMessage(userText("first"))],
+      [
+        userTextToModelMessage(userText("first")),
+        userTextToModelMessage(userText("second")),
+      ],
+    ]);
+    expect(events).toEqual([
+      { type: "user-text", text: "first" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "user-text", text: "second" },
+      { type: "turn-abort" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "assistant-text", text: "DONE" },
+      { type: "step-end" },
+      { type: "turn-end" },
+    ]);
   });
-  return { promise, resolve };
-};
 
-const continueToolCall = (toolCallId: string): ToolCallPart => ({
-  type: "tool-call",
-  toolCallId,
-  toolName: "continue",
-  input: {},
-});
+  it("continues the model loop after a continue tool call", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const session = new Agent({
+      llm: ({ history }) => {
+        calls += 1;
+        seenHistory.push([...history]);
 
-const userText = (text: string): UserText => ({ type: "user-text", text });
-const assistantMessage = (
-  content: AssistantModelMessage["content"]
-): AssistantModelMessage => ({
-  role: "assistant",
-  content,
-});
+        if (calls === 1) {
+          const toolCall = continueToolCall("call-tool-loop-continue");
+          return Promise.resolve([
+            assistantMessage([toolCall]),
+            continueToolResult(toolCall),
+          ]);
+        }
 
-const continueToolResult = (toolCall: ToolCallPart): ToolModelMessage => ({
-  role: "tool",
-  content: [
-    {
-      type: "tool-result",
-      toolCallId: toolCall.toolCallId,
-      toolName: toolCall.toolName,
-      output: { type: "json", value: {} },
-    },
-  ],
-});
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    }).createSession();
 
-const firstLlmCall = createDeferred();
-const seenHistory: ModelMessage[][] = [];
-let calls = 0;
-const llm: Llm = async ({ history }) => {
-  calls += 1;
-  seenHistory.push([...history]);
+    await session.submit(userText("remember me"));
 
-  if (calls === 1) {
-    await firstLlmCall.promise;
-    const toolCall = continueToolCall("call-interrupted-continue");
-    return [assistantMessage([toolCall]), continueToolResult(toolCall)];
-  }
-
-  return [assistantMessage("DONE")];
-};
-
-const session = new Agent({ llm }).createSession();
-const events: AgentEvent[] = [];
-session.subscribe((event) => events.push(event));
-
-const firstSubmit = session.submit(userText("first"));
-const secondSubmit = session.submit(userText("second"));
-
-session.interrupt();
-firstLlmCall.resolve();
-
-await Promise.all([firstSubmit, secondSubmit]);
-
-assert.equal(calls, 2);
-assert.deepEqual(seenHistory, [
-  [userTextToModelMessage(userText("first"))],
-  [
-    userTextToModelMessage(userText("first")),
-    userTextToModelMessage(userText("second")),
-  ],
-]);
-assert.deepEqual(
-  events.map((event) => event.type),
-  [
-    "user-text",
-    "turn-start",
-    "step-start",
-    "user-text",
-    "turn-abort",
-    "turn-start",
-    "step-start",
-    "assistant-text",
-    "step-end",
-    "turn-end",
-  ]
-);
-
-const toolLoopHistories: ModelMessage[][] = [];
-let toolLoopCalls = 0;
-const toolLoopSession = new Agent({
-  llm: ({ history }) => {
-    toolLoopCalls += 1;
-    toolLoopHistories.push([...history]);
-
-    if (toolLoopCalls === 1) {
-      const toolCall = continueToolCall("call-tool-loop-continue");
-      return Promise.resolve([
+    const toolCall = continueToolCall("call-tool-loop-continue");
+    expect(seenHistory).toEqual([
+      [userTextToModelMessage(userText("remember me"))],
+      [
+        userTextToModelMessage(userText("remember me")),
         assistantMessage([toolCall]),
         continueToolResult(toolCall),
-      ]);
-    }
+      ],
+    ]);
+  });
 
-    return Promise.resolve([assistantMessage("DONE")]);
-  },
-}).createSession();
+  it("emits turn-error and rejects the submitted input when the LLM fails", async () => {
+    const session = new Agent({
+      llm: () => Promise.reject(new Error("model unavailable")),
+    }).createSession();
+    const events: AgentEvent[] = [];
+    session.subscribe((event) => events.push(event));
 
-await toolLoopSession.submit(userText("remember me"));
+    await expect(session.submit(userText("fail"))).rejects.toThrow(
+      "model unavailable"
+    );
 
-const toolLoopCall = continueToolCall("call-tool-loop-continue");
+    expect(events).toEqual([
+      { type: "user-text", text: "fail" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "turn-error", message: "model unavailable" },
+    ]);
+  });
 
-assert.deepEqual(toolLoopHistories, [
-  [userTextToModelMessage(userText("remember me"))],
-  [
-    userTextToModelMessage(userText("remember me")),
-    assistantMessage([toolLoopCall]),
-    continueToolResult(toolLoopCall),
-  ],
-]);
+  it("kills the session by aborting active work and rejecting queued input", async () => {
+    const llmCall = createDeferred();
+    let calls = 0;
+    const session = new Agent({
+      llm: async () => {
+        calls += 1;
+        await llmCall.promise;
+        return [assistantMessage("should not render")];
+      },
+    }).createSession();
+    const events: AgentEvent[] = [];
+    session.subscribe((event) => events.push(event));
 
-const failingSession = new Agent({
-  llm: () => Promise.reject(new Error("model unavailable")),
-}).createSession();
-const failingEvents: AgentEvent[] = [];
-failingSession.subscribe((event) => failingEvents.push(event));
+    const activeSubmit = session.submit(userText("active"));
+    const queuedSubmit = session.submit(userText("queued"));
+    const queuedResult = queuedSubmit.then(
+      () => "resolved",
+      (error: unknown) => error
+    );
 
-await assert.rejects(
-  failingSession.submit(userText("fail")),
-  /model unavailable/
-);
+    session.kill();
+    llmCall.resolve();
 
-assert.deepEqual(
-  failingEvents.map((event) => event.type),
-  ["user-text", "turn-start", "step-start", "turn-error"]
-);
-assert.deepEqual(failingEvents.at(-1), {
-  type: "turn-error",
-  message: "model unavailable",
+    await activeSubmit;
+    const queuedError = await queuedResult;
+
+    expect(calls).toBe(1);
+    expect(queuedError).toBeInstanceOf(Error);
+    expect((queuedError as Error).message).toBe("Session killed");
+    await expect(session.submit(userText("after kill"))).rejects.toThrow(
+      "Session killed"
+    );
+    expect(events).toEqual([
+      { type: "user-text", text: "active" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "user-text", text: "queued" },
+      { type: "turn-abort" },
+    ]);
+  });
+
+  it("rejects input if a user-text listener kills the session before queueing", async () => {
+    let calls = 0;
+    const session = new Agent({
+      llm: () => {
+        calls += 1;
+        return Promise.resolve([assistantMessage("should not run")]);
+      },
+    }).createSession();
+    const events: AgentEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+
+      if (event.type === "user-text") {
+        session.kill();
+      }
+    });
+
+    await expect(session.submit(userText("kill now"))).rejects.toThrow(
+      "Session killed"
+    );
+
+    expect(calls).toBe(0);
+    expect(eventTypes(events)).toEqual(["user-text"]);
+  });
 });
-
-const killLlmCall = createDeferred();
-let killCalls = 0;
-const killedSession = new Agent({
-  llm: async () => {
-    killCalls += 1;
-    await killLlmCall.promise;
-    return [assistantMessage("should not render")];
-  },
-}).createSession();
-const killedEvents: AgentEvent[] = [];
-killedSession.subscribe((event) => killedEvents.push(event));
-
-const activeSubmit = killedSession.submit(userText("active"));
-const queuedSubmit = killedSession.submit(userText("queued"));
-const queuedResult = queuedSubmit.then(
-  () => "resolved",
-  (error: unknown) => error
-);
-
-killedSession.kill();
-killLlmCall.resolve();
-
-await activeSubmit;
-const queuedError = await queuedResult;
-
-assert.equal(killCalls, 1);
-assert.ok(queuedError instanceof Error);
-assert.equal(queuedError.message, "Session killed");
-await assert.rejects(
-  killedSession.submit(userText("after kill")),
-  /Session killed/
-);
-assert.deepEqual(
-  killedEvents.map((event) => event.type),
-  ["user-text", "turn-start", "step-start", "user-text", "turn-abort"]
-);
-
-let listenerKilledCalls = 0;
-const listenerKilledSession = new Agent({
-  llm: () => {
-    listenerKilledCalls += 1;
-    return Promise.resolve([assistantMessage("should not run")]);
-  },
-}).createSession();
-const listenerKilledEvents: AgentEvent[] = [];
-listenerKilledSession.subscribe((event) => {
-  listenerKilledEvents.push(event);
-
-  if (event.type === "user-text") {
-    listenerKilledSession.kill();
-  }
-});
-
-await assert.rejects(
-  listenerKilledSession.submit(userText("kill now")),
-  /Session killed/
-);
-
-assert.equal(listenerKilledCalls, 0);
-assert.deepEqual(
-  listenerKilledEvents.map((event) => event.type),
-  ["user-text"]
-);

--- a/src/runtime/test-fixtures.ts
+++ b/src/runtime/test-fixtures.ts
@@ -1,0 +1,55 @@
+import type { AssistantModelMessage, ToolCallPart, ToolModelMessage } from "ai";
+import type { Llm, LlmOutput } from "./llm";
+import type { AgentEvent, UserText } from "./session";
+
+export const assistantMessage = (
+  content: AssistantModelMessage["content"]
+): AssistantModelMessage => ({
+  role: "assistant",
+  content,
+});
+
+export const continueToolCall = (toolCallId: string): ToolCallPart => ({
+  type: "tool-call",
+  toolCallId,
+  toolName: "continue",
+  input: {},
+});
+
+export const continueToolResult = (
+  toolCall: ToolCallPart
+): ToolModelMessage => ({
+  role: "tool",
+  content: [
+    {
+      type: "tool-result",
+      toolCallId: toolCall.toolCallId,
+      toolName: toolCall.toolName,
+      output: { type: "json", value: {} },
+    },
+  ],
+});
+
+export const createDeferred = (): {
+  promise: Promise<void>;
+  resolve: () => void;
+} => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+export const createScriptedLlm = (outputs: LlmOutput[]): Llm => {
+  let index = 0;
+  return () => Promise.resolve(outputs[index++] ?? []);
+};
+
+export const eventTypes = (events: AgentEvent[]) =>
+  events.map((event) => event.type);
+
+export const userText = (text: string): UserText => ({
+  type: "user-text",
+  text,
+});


### PR DESCRIPTION
## Summary

- switch the runtime test command from chained `tsx` scripts to `vitest run`
- convert runtime tests to `describe`/`it`/`expect` cases
- add `src/runtime/test-support.ts` for shared AI SDK message/event test builders

## Why

The runtime tests were becoming script-like and repetitive as more behavior landed. Vitest gives us named cases, clearer failures, and a small test-only fixture layer without changing the runtime API.

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched runtime tests to `vitest` suites and added `src/runtime/test-fixtures.ts` for shared builders. Tests now assert full event payloads and cover abort/kill and tool-loop flows; no runtime behavior changes.

- **Refactors**
  - Converted tests to `describe`/`it`/`expect` with focused cases (agent loop aborts, session kill/interrupt, mapping).
  - Centralized fixtures: message/event builders (`userText`, `assistantMessage`, `continueToolCall`/`continueToolResult`), `createDeferred`/`createScriptedLlm`, and `eventTypes`.

- **Dependencies**
  - Added `vitest@^4.1.6` (dev) and updated test script to `vitest run`.

<sup>Written for commit 76316f5e024783f6a2d470964b58219ab8a34610. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/12?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

