### PR TITLE
refactor: inject tools through agent options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 AI_API_KEY=
 AI_BASE_URL=https://apis.opengateway.ai/v1
-AI_MODEL=moonshotai/kimi-k2.6
+AI_MODEL=deepseek/deepseek-v4-flash

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Agent } from "./runtime/agent";
+export { Agent, type AgentOptions } from "./runtime/agent";
 export { runAgentLoop } from "./runtime/agent-loop";
 export type {
   CreateLlmOptions,
@@ -17,3 +17,6 @@ export type {
   ToolCall,
   UserText,
 } from "./runtime/session";
+export type { AgentTools, DefaultTools } from "./tools";
+export { tools } from "./tools";
+export { continueTool } from "./tools/continue";

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -1,11 +1,13 @@
 import type { LanguageModel } from "ai";
+import { type AgentTools, tools as defaultTools } from "../tools";
 import { createLlm, type Llm } from "./llm";
 import { AgentSession } from "./session/session";
 
-interface AgentOptions {
+export interface AgentOptions {
   instructions?: string;
   llm?: Llm;
   model?: LanguageModel;
+  tools?: AgentTools;
 }
 
 export class Agent {
@@ -17,6 +19,7 @@ export class Agent {
       createLlm({
         instructions: options.instructions,
         model: options.model,
+        tools: options.tools ?? defaultTools,
       });
   }
 

--- a/src/runtime/env.ts
+++ b/src/runtime/env.ts
@@ -6,5 +6,5 @@ export const env = {
   AI_API_KEY: process.env.AI_API_KEY?.trim() || undefined,
   AI_BASE_URL:
     process.env.AI_BASE_URL?.trim() || "https://apis.opengateway.ai/v1",
-  AI_MODEL: process.env.AI_MODEL?.trim() || "moonshotai/kimi-k2.6",
+  AI_MODEL: process.env.AI_MODEL?.trim() || "deepseek/deepseek-v4-flash",
 } as const;

--- a/src/runtime/llm.test.ts
+++ b/src/runtime/llm.test.ts
@@ -1,0 +1,109 @@
+import type { LanguageModel } from "ai";
+import { jsonSchema, tool } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type AgentTools, tools } from "../tools";
+import { Agent } from "./agent";
+import { createLlm } from "./llm";
+import { assistantMessage, userText } from "./test-fixtures";
+
+const generateTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+
+  return {
+    ...actual,
+    generateText: generateTextMock,
+  };
+});
+
+const fakeModel = {} as LanguageModel;
+
+const createNoopTool = () =>
+  tool({
+    description: "No-op test tool.",
+    execute: () => ({}),
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    }),
+    outputSchema: jsonSchema({
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    }),
+  });
+
+describe("createLlm", () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  it("passes injected tools to generateText", async () => {
+    const injectedTools = { injected: createNoopTool() } satisfies AgentTools;
+    const signal = new AbortController().signal;
+    const history = [{ role: "user" as const, content: "hello" }];
+    const llm = createLlm({
+      instructions: "test instructions",
+      model: fakeModel,
+      tools: injectedTools,
+    });
+
+    await expect(llm({ history, signal })).resolves.toEqual([
+      assistantMessage("DONE"),
+    ]);
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: signal,
+        instructions: "test instructions",
+        messages: history,
+        model: fakeModel,
+        tools: injectedTools,
+      })
+    );
+  });
+});
+
+describe("Agent tool wiring", () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  it("passes injected AgentOptions tools into createLlm/generateText", async () => {
+    const injectedTools = { injected: createNoopTool() } satisfies AgentTools;
+    const session = new Agent({
+      model: fakeModel,
+      tools: injectedTools,
+    }).createSession();
+
+    await session.submit(userText("use injected tools"));
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: fakeModel,
+        tools: injectedTools,
+      })
+    );
+  });
+
+  it("defaults new Agent() to the shared continue tool map", async () => {
+    const session = new Agent().createSession();
+
+    await session.submit(userText("use default tools"));
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools,
+      })
+    );
+    expect(tools.continue).toBeDefined();
+  });
+});

--- a/src/runtime/llm.ts
+++ b/src/runtime/llm.ts
@@ -1,11 +1,6 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import {
-  generateText,
-  jsonSchema,
-  type LanguageModel,
-  type ModelMessage,
-  tool,
-} from "ai";
+import { generateText, type LanguageModel, type ModelMessage } from "ai";
+import type { AgentTools } from "../tools";
 import { env } from "./env";
 
 export type LlmOutput = Awaited<
@@ -23,6 +18,7 @@ export type Llm = (context: LlmContext) => Promise<LlmOutput>;
 export interface CreateLlmOptions {
   instructions?: string;
   model?: LanguageModel;
+  tools?: AgentTools;
 }
 
 const defaultProvider = createOpenAICompatible({
@@ -33,27 +29,10 @@ const defaultProvider = createOpenAICompatible({
 
 export const defaultModel = defaultProvider(env.AI_MODEL);
 
-const continueTool = tool({
-  description:
-    "Request one more agent loop step before producing a final answer.",
-  execute: () => ({}),
-  inputSchema: jsonSchema({
-    type: "object",
-    properties: {},
-    additionalProperties: false,
-  }),
-  outputSchema: jsonSchema({
-    type: "object",
-    properties: {},
-    additionalProperties: false,
-  }),
-});
-
-const continueTools = { continue: continueTool };
-
 export function createLlm({
   model = defaultModel,
   instructions,
+  tools,
 }: CreateLlmOptions = {}): Llm {
   return async ({ history, signal }) => {
     const { responseMessages } = await generateText({
@@ -61,7 +40,7 @@ export function createLlm({
       instructions,
       messages: [...history],
       model,
-      tools: continueTools,
+      tools,
     });
 
     return responseMessages;

--- a/src/tools/continue.ts
+++ b/src/tools/continue.ts
@@ -1,0 +1,17 @@
+import { jsonSchema, tool } from "ai";
+
+export const continueTool = tool({
+  description:
+    "Request one more agent loop step before producing a final answer.",
+  execute: () => ({}),
+  inputSchema: jsonSchema({
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  }),
+  outputSchema: jsonSchema({
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  }),
+});

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { tools } from ".";
+import { continueTool } from "./continue";
+
+describe("tools", () => {
+  it("exports the continue tool through the shared tools map", () => {
+    expect(tools.continue).toBe(continueTool);
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,8 @@
+import type { ToolSet } from "ai";
+import { continueTool } from "./continue";
+
+export type AgentTools = ToolSet;
+
+export const tools = { continue: continueTool } satisfies AgentTools;
+
+export type DefaultTools = typeof tools;


### PR DESCRIPTION
## Summary
- Move the built-in continue tool out of `runtime/llm.ts` into a dedicated `src/tools` registry.
- Make tools an `AgentOptions` capability input, with `new Agent()` defaulting to the shared continue tool map.
- Thread injected tools through `createLlm` to AI SDK `generateText` instead of hardcoding tools in the LLM adapter.
- Update the default model from `moonshotai/kimi-k2.6` to `deepseek/deepseek-v4-flash`.

## Review
- Ran OMX `$code-reviewer` on the uncommitted diff.
- Verdict: non-blocking / mergeable.
- Notes called out intentional semantics:
  - direct `createLlm()` now only uses tools passed by caller;
  - `AgentOptions.tools` replaces the default tool map unless consumers spread defaults.

## Test Plan
- [x] `git diff --check`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 5 files / 15 tests
- [x] `pnpm run lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject tools via `AgentOptions` and move the built-in continue tool into a shared `src/tools` registry. Tools are now passed through `createLlm` to `ai`’s `generateText`, and the default model is `deepseek/deepseek-v4-flash`.

- **New Features**
  - `Agent` accepts a `tools` map via `AgentOptions`; defaults to the shared continue tool set.
  - Exported `AgentOptions`, `AgentTools`, `DefaultTools`, `tools`, and `continueTool`.

- **Refactors**
  - Moved the continue tool from `runtime/llm.ts` to `src/tools` and centralized a shared registry.
  - `createLlm` no longer hardcodes tools; it forwards caller-provided tools to `ai` `generateText`.
  - Updated default model and `.env.example` to `deepseek/deepseek-v4-flash`.

<sup>Written for commit 54a77754a21e5508c3f8533bd47767c94d3ef3c7. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/13?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

