### PR TITLE
fix: avoid persisting internal continue tool protocol

### DIFF
--- a/src/runtime/agent-loop.test.ts
+++ b/src/runtime/agent-loop.test.ts
@@ -7,30 +7,47 @@ import {
   assistantMessage,
   continueToolCall,
   continueToolResult,
-  createScriptedLlm,
   eventTypes,
 } from "./test-fixtures";
+
+const continueToolHistoryMarker = (count: number) => ({
+  role: "user" as const,
+  content: `[internal tool result] The continue tool call completed successfully for this step. Count completed in this step: ${count}. If more internal loop steps are still required, call continue again; otherwise answer normally without more continue calls.`,
+});
 
 describe("runAgentLoop", () => {
   it("continues while assistant messages request the continue tool", async () => {
     const events: AgentEvent[] = [];
     const history = new AgentModelHistory();
+    const seenHistory: ReturnType<AgentModelHistory["modelSnapshot"]>[] = [];
     const toolCall = continueToolCall("call-continue-1");
-    const llm = createScriptedLlm([
-      [
-        assistantMessage([
-          { type: "text", text: "I should keep going." },
-          toolCall,
-        ]),
-        continueToolResult(toolCall),
-      ],
-      [assistantMessage("DONE")],
-    ]);
+    const llm: Llm = ({ history }) => {
+      seenHistory.push([...history]);
+
+      if (seenHistory.length === 1) {
+        return Promise.resolve([
+          assistantMessage([
+            { type: "text", text: "I should keep going." },
+            toolCall,
+          ]),
+          continueToolResult(toolCall),
+        ]);
+      }
+
+      return Promise.resolve([assistantMessage("DONE")]);
+    };
 
     await expect(
       runAgentLoop({ emit: (event) => events.push(event), history, llm })
     ).resolves.toBe("completed");
 
+    expect(seenHistory).toEqual([
+      [],
+      [
+        assistantMessage([{ type: "text", text: "I should keep going." }]),
+        continueToolHistoryMarker(1),
+      ],
+    ]);
     expect(events).toEqual([
       { type: "step-start" },
       { type: "assistant-text", text: "I should keep going." },
@@ -41,11 +58,45 @@ describe("runAgentLoop", () => {
       { type: "step-end" },
     ]);
     expect(history.modelSnapshot()).toEqual([
-      assistantMessage([
-        { type: "text", text: "I should keep going." },
-        toolCall,
-      ]),
-      continueToolResult(toolCall),
+      assistantMessage([{ type: "text", text: "I should keep going." }]),
+      continueToolHistoryMarker(1),
+      assistantMessage("DONE"),
+    ]);
+  });
+
+  it("replaces continue-only tool protocol with a safe history marker", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const seenHistory: ReturnType<AgentModelHistory["modelSnapshot"]>[] = [];
+    const toolCall = continueToolCall("call-continue-only");
+    const llm: Llm = ({ history }) => {
+      seenHistory.push([...history]);
+
+      if (seenHistory.length === 1) {
+        return Promise.resolve([
+          assistantMessage([toolCall]),
+          continueToolResult(toolCall),
+        ]);
+      }
+
+      return Promise.resolve([assistantMessage("DONE")]);
+    };
+
+    await expect(
+      runAgentLoop({ emit: (event) => events.push(event), history, llm })
+    ).resolves.toBe("completed");
+
+    expect(seenHistory).toEqual([[], [continueToolHistoryMarker(1)]]);
+    expect(events).toEqual([
+      { type: "step-start" },
+      { type: "tool-call", toolName: "continue" },
+      { type: "step-end" },
+      { type: "step-start" },
+      { type: "assistant-text", text: "DONE" },
+      { type: "step-end" },
+    ]);
+    expect(history.modelSnapshot()).toEqual([
+      continueToolHistoryMarker(1),
       assistantMessage("DONE"),
     ]);
   });

--- a/src/runtime/agent-loop.ts
+++ b/src/runtime/agent-loop.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage } from "ai";
+import type { AssistantModelMessage, ModelMessage, ToolModelMessage } from "ai";
 import type { Llm, LlmOutput } from "./llm";
 import type { AgentEventListener } from "./session/events";
 import { modelMessageToAgentEvents } from "./session/mapping";
@@ -17,6 +17,7 @@ interface RunAgentLoopOptions {
 
 export type AgentLoopResult = "completed" | "aborted";
 type StepOutputResult = "continue" | "completed" | "aborted";
+const INTERNAL_CONTINUE_TOOL_NAME = "continue";
 
 export async function runAgentLoop({
   emit,
@@ -88,17 +89,97 @@ function appendStepOutput({
       return "aborted";
     }
 
-    history.appendModelMessage(message);
+    for (const historyMessage of stripInternalContinueProtocol(message)) {
+      history.appendModelMessage(historyMessage);
+    }
+
     const events = modelMessageToAgentEvents(message);
 
     for (const event of events) {
       emit(event);
     }
 
-    if (events.some((event) => event.type === "tool-call")) {
+    if (
+      events.some(
+        (event) =>
+          event.type === "tool-call" &&
+          event.toolName === INTERNAL_CONTINUE_TOOL_NAME
+      )
+    ) {
       shouldContinue = true;
     }
   }
 
   return shouldContinue ? "continue" : "completed";
+}
+
+function stripInternalContinueProtocol(message: ModelMessage): ModelMessage[] {
+  if (message.role === "assistant") {
+    const stripped = stripAssistantContinueToolCalls(message);
+    return stripped ? [stripped] : [];
+  }
+
+  if (message.role === "tool") {
+    return stripContinueToolResults(message);
+  }
+
+  return [message];
+}
+
+function stripAssistantContinueToolCalls(
+  message: AssistantModelMessage
+): AssistantModelMessage | null {
+  if (typeof message.content === "string") {
+    return message;
+  }
+
+  const content = message.content.filter(
+    (part) =>
+      part.type !== "tool-call" || part.toolName !== INTERNAL_CONTINUE_TOOL_NAME
+  );
+
+  if (!content.some(isPersistableAssistantContentPart)) {
+    return null;
+  }
+
+  return content.length === message.content.length
+    ? message
+    : { ...message, content };
+}
+
+function isPersistableAssistantContentPart(
+  part: Exclude<AssistantModelMessage["content"], string>[number]
+): boolean {
+  return part.type !== "text" || part.text !== "" || !!part.providerOptions;
+}
+
+function stripContinueToolResults(message: ToolModelMessage): ModelMessage[] {
+  const continueResultCount = message.content.filter(
+    (part) =>
+      part.type === "tool-result" &&
+      part.toolName === INTERNAL_CONTINUE_TOOL_NAME
+  ).length;
+  const content = message.content.filter(
+    (part) =>
+      part.type !== "tool-result" ||
+      part.toolName !== INTERNAL_CONTINUE_TOOL_NAME
+  );
+  const messages: ModelMessage[] = [];
+
+  if (content.length > 0) {
+    messages.push(
+      content.length === message.content.length
+        ? message
+        : { ...message, content }
+    );
+  }
+
+  if (continueResultCount > 0) {
+    messages.push({
+      role: "user",
+      content: `[internal tool result] The continue tool call completed successfully for this step. Count completed in this step: ${continueResultCount}. If more internal loop steps are still required, call continue again; otherwise answer normally without more continue calls.`,
+    });
+  }
+
+  return messages;
 }

--- a/src/runtime/session/session.test.ts
+++ b/src/runtime/session/session.test.ts
@@ -13,6 +13,11 @@ import {
 import type { AgentEvent } from "./index";
 import { userTextToModelMessage } from "./mapping";
 
+const continueToolHistoryMarker = (count: number) => ({
+  role: "user" as const,
+  content: `[internal tool result] The continue tool call completed successfully for this step. Count completed in this step: ${count}. If more internal loop steps are still required, call continue again; otherwise answer normally without more continue calls.`,
+});
+
 describe("AgentSession", () => {
   it("queues submitted input and aborts the active turn before the next input runs", async () => {
     const firstLlmCall = createDeferred();
@@ -86,13 +91,11 @@ describe("AgentSession", () => {
 
     await session.submit(userText("remember me"));
 
-    const toolCall = continueToolCall("call-tool-loop-continue");
     expect(seenHistory).toEqual([
       [userTextToModelMessage(userText("remember me"))],
       [
         userTextToModelMessage(userText("remember me")),
-        assistantMessage([toolCall]),
-        continueToolResult(toolCall),
+        continueToolHistoryMarker(1),
       ],
     ]);
   });


### PR DESCRIPTION
## Summary
- Filter internal `continue` tool-call parts out of persisted assistant history.
- Replace internal `continue` tool results with a safe user-history marker instead of replaying OpenAI tool protocol.
- Keep public `tool-call` events and loop continuation behavior intact.
- Add regression coverage for mixed text+continue and continue-only outputs.

## Root Cause
DeepSeek/OpenGateway can return tool-call responses with reasoning tokens but without `reasoning_content`. Replaying the raw assistant `tool_calls` + `tool` result in the next request triggers `The reasoning_content in the thinking mode must be passed back to the API.`

## Test Plan
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Live `.env` smoke test against `deepseek/deepseek-v4-flash`: exact 1 and exact 3 `continue` calls both complete with `DONE` and no provider error.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents replaying internal `continue` tool protocol by stripping it from persisted history and replacing it with a safe user-history marker. This avoids DeepSeek/OpenGateway errors about missing `reasoning_content` while keeping loop behavior and public events unchanged.

- **Bug Fixes**
  - Remove internal `continue` tool-call parts from assistant messages before saving history.
  - Convert internal `continue` tool results into a single user marker with a count; do not replay raw tool protocol.
  - Preserve public `tool-call` events and loop continuation.
  - Add tests for mixed text+continue and continue-only outputs.

<sup>Written for commit 89e0d759ce7f9fac8cad9421b55a9c6941d67a3b. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/14?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

