### PR TITLE
Normalize web fetch URLs before provider calls

### DIFF
--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -293,7 +293,7 @@ describe("web tools", () => {
       format: "markdown",
       image_links: false,
       links: false,
-      urls: ["https://example.com", "https://x.test/404"],
+      urls: ["https://example.com/", "https://x.test/404"],
     });
     expect(output).toEqual({
       errors: [
@@ -308,6 +308,38 @@ describe("web tools", () => {
           url: "https://example.com",
         },
       ],
+    });
+  });
+
+  it("web_fetch sends normalized parsed URLs to TinyFish", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          errors: [],
+          results: [
+            {
+              final_url: "https://example.com/b%20c?x=1%202",
+              format: "markdown",
+              text: "Example body",
+              url: "https://example.com/b%20c?x=1%202",
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    );
+
+    await executeTool(webFetchTool, {
+      urls: [" HTTPS://Example.COM:443/a/../b c?x=1 2 "],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(JSON.parse(String(init?.body))).toEqual({
+      format: "markdown",
+      image_links: false,
+      links: false,
+      urls: ["https://example.com/b%20c?x=1%202"],
     });
   });
 
@@ -353,13 +385,13 @@ describe("web tools", () => {
         format: "markdown",
         image_links: false,
         links: false,
-        urls: ["https://example.com"],
+        urls: ["https://example.com/"],
       },
       {
         format: "markdown",
         image_links: false,
         links: false,
-        urls: ["https://example.com"],
+        urls: ["https://example.com/"],
       },
     ]);
     expect(output).toEqual({

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -161,5 +161,5 @@ function readHttpUrl(value: unknown): string {
     throw new Error("web_fetch only accepts http and https URLs.");
   }
 
-  return url;
+  return parsedUrl.href;
 }


### PR DESCRIPTION
## Summary
- Send parser-normalized `web_fetch` URLs to TinyFish instead of the trimmed raw input.
- Cover normalization behavior in the web tool tests, including default slash and encoded spaces.

## Why
The tool already validates each URL with `new URL(...)`, but it previously sent the raw trimmed string to the provider. This could let malformed-but-parseable inputs drift from the canonical URL the parser accepted.

## Validation
- `pnpm test -- src/tools/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize URLs in `web_fetch` requests so the provider receives the canonical `href`. This removes drift between validated inputs and the payload (trailing slash, host casing, dot segments, spaces).

- **Bug Fixes**
  - Return `parsedUrl.href` from `readHttpUrl` so payload uses normalized URLs.
  - Add tests covering normalization (default slash and percent-encoded spaces).

<sup>Written for commit cea171da647636082e9ab35be6eeb08b6a19a078. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/17?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

