### PR TITLE
[codex] Add coding-agent CLI package entrypoints

### DIFF
--- a/.changeset/coding-agent-cli-bin.md
+++ b/.changeset/coding-agent-cli-bin.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-coding-agent": patch
+---
+
+Add the publishable `pss` CLI entrypoint for global installs and package runners.

--- a/README.md
+++ b/README.md
@@ -1,139 +1,69 @@
 # pss-next
 
-`pss-next` is now a Turborepo monorepo with two publishable packages:
+Small agent runtime workspace.
 
-- `@minpeter/pss-runtime` — generic agent runtime, sessions, model loop, and event stream.
-- `@minpeter/pss-coding-agent` — coding-agent product tools plus optional TUI wiring.
+- `@minpeter/pss-runtime` — runtime, sessions, model loop.
+- `@minpeter/pss-coding-agent` — web tools, model wiring, and the `pss` TUI.
 
-The runtime stays product-agnostic. Import coding-agent tools explicitly when you
-want the web search/fetch product layer.
-
-## Development
-
-```bash
-pnpm install
-pnpm dev
-pnpm dev:tui
-pnpm typecheck
-pnpm test
-pnpm build
-pnpm lint
-```
-
-`pnpm dev` runs `examples/basic.ts` through the workspace package names with the
-`@minpeter/pss-source` condition, so local development uses `packages/*/src` without
-publishing first.
+## Use
 
 ```ts
 import { tools } from "@minpeter/pss-coding-agent";
 import { createCodingAgentModel } from "@minpeter/pss-coding-agent/model";
 import { Agent } from "@minpeter/pss-runtime";
 
-const agent = new Agent({
+const session = new Agent({
   model: createCodingAgentModel(),
   tools,
-});
-const session = agent.createSession();
+}).createSession();
 ```
 
-## Environment
+Run the TUI:
 
-Copy `.env.example` to `.env` and set the OpenAI-compatible model used by the
-example app and coding-agent TUI. `@minpeter/pss-coding-agent/model` validates
-these values before constructing a `LanguageModel`:
+```sh
+pnpm dlx @minpeter/pss-coding-agent
+```
+
+or install it:
+
+```sh
+pnpm add -g @minpeter/pss-coding-agent
+pss
+```
+
+## Develop
+
+```sh
+pnpm install
+pnpm dev
+pnpm dev:tui
+pnpm test
+pnpm typecheck
+pnpm lint
+pnpm build
+```
+
+## Env
+
+Copy `.env.example` to `.env`.
 
 ```env
 AI_API_KEY=...
 AI_BASE_URL=...
-AI_MODEL=minimax/MiniMax-M2.7
+AI_MODEL=...
+TINYFISH_API_KEY=...
 ```
 
-Coding-agent web tools additionally require TinyFish credentials when invoked:
+`TINYFISH_API_KEY` may contain semicolon-delimited tokens.
 
-```env
-TINYFISH_API_KEY=tf-token-1;tf-token-2
-```
+## Release
 
-`TINYFISH_API_KEY` accepts semicolon-delimited token pools. Empty segments and
-whitespace are ignored, and the tools rotate usable keys across calls.
-
-## Packages
-
-### `@minpeter/pss-runtime`
-
-Use this package when you need the reusable runtime only:
-
-```ts
-import {
-  Agent,
-  type AgentModel,
-  type RuntimeLlmContext,
-} from "@minpeter/pss-runtime";
-
-const model: AgentModel = createYourLanguageModel();
-const agent = new Agent({ model });
-```
-
-The package accepts a caller-owned `LanguageModel` and does not read
-`AI_API_KEY`, `AI_BASE_URL`, or `AI_MODEL` itself. It exposes a narrow runtime API
-and explicit interop aliases instead of re-exporting broad AI SDK canary types
-from the root declaration.
-
-### `@minpeter/pss-coding-agent`
-
-Use this package when you need the default coding tools:
-
-```ts
-import { tools, webFetchTool, webSearchTool } from "@minpeter/pss-coding-agent";
-import { createCodingAgentModel } from "@minpeter/pss-coding-agent/model";
-```
-
-The root import is side-effect-free. Launch the interactive TUI through the
-subpath or the root script:
-
-```bash
-pnpm dev:tui
-node --conditions=@minpeter/pss-source --import tsx packages/coding-agent/src/tui.ts
-```
-
-## Release plan
-
-This repo uses Changesets and public npm packages under the `@minpeter` scope:
-`@minpeter/pss-runtime` and `@minpeter/pss-coding-agent`.
-
-Release checklist:
-
-```bash
+```sh
 pnpm changeset
 pnpm version-packages
-pnpm install --lockfile-only
-pnpm lint
-pnpm typecheck
-pnpm test
 pnpm build
 pnpm verify:release
-npm pack ./packages/runtime --dry-run --json
-npm pack ./packages/coding-agent --dry-run --json
-npm publish ./packages/runtime --dry-run --access public
-npm publish ./packages/coding-agent --dry-run --access public
+pnpm release
 ```
 
-The GitHub release workflow runs the same validation and then uses
-`changesets/action` with `pnpm release`. Publishing is configured for npm Trusted
-Publishing/OIDC, not `NPM_TOKEN`. Before real publishes, add a Trusted Publisher
-for each npm package with:
-
-- Provider: GitHub Actions
-- Organization/user: `minpeter`
-- Repository: `pss-next`
-- Workflow filename: `release.yml`
-
-Trusted publishing requires GitHub-hosted runners, `permissions.id-token: write`,
-Node 22.14+ and npm CLI 11.5.1+. The workflow uses Node 24 and does not store a
-long-lived npm publish token.
-
-If these packages do not exist on npm yet, create the first package versions with
-a one-time interactive local publish using your npm account and 2FA, then add the
-Trusted Publisher entries above before relying on the GitHub release workflow for
-subsequent publishes. npm's `npm trust` configuration requires the package to
-already exist on the registry.
+Releases use Changesets and npm Trusted Publishing.

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -1,26 +1,38 @@
 # @minpeter/pss-coding-agent
 
-Coding-agent product package for pss-next. It provides TinyFish-backed web tools
-and keeps TUI startup isolated from the side-effect-free root import.
+Web tools, model wiring, and the `pss` TUI for pss-next.
 
 ```ts
 import { tools } from "@minpeter/pss-coding-agent";
 import { createCodingAgentModel } from "@minpeter/pss-coding-agent/model";
 import { Agent } from "@minpeter/pss-runtime";
 
-const agent = new Agent({
+const session = new Agent({
   model: createCodingAgentModel(),
   tools,
-});
+}).createSession();
 ```
 
-Set `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL` to configure the
-OpenAI-compatible model used by `createCodingAgentModel`; the
-model subpath validates these values before constructing a `LanguageModel`.
-Set `TINYFISH_API_KEY` before invoking `web_search` or `web_fetch`. Token pools
-can be provided as semicolon-delimited values and are validated when the tools
-are invoked.
+## CLI
 
-```bash
-node --conditions=@minpeter/pss-source --import tsx packages/coding-agent/src/tui.ts
+```sh
+pnpm dlx @minpeter/pss-coding-agent
+```
+
+```sh
+pnpm add -g @minpeter/pss-coding-agent
+pss
+```
+
+Bin aliases: `pss`, `pss-coding-agent`.
+
+## Env
+
+Set `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL` for the model.
+Set `TINYFISH_API_KEY` before using `web_search` or `web_fetch`.
+
+## Dev
+
+```sh
+pnpm dev:tui
 ```

--- a/packages/coding-agent/bin/pss.js
+++ b/packages/coding-agent/bin/pss.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/tui.js";

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -27,8 +27,13 @@
       "import": "./dist/tui.js"
     }
   },
+  "bin": {
+    "pss": "./bin/pss.js",
+    "pss-coding-agent": "./bin/pss.js"
+  },
   "files": [
     "dist",
+    "bin",
     "README.md"
   ],
   "repository": {

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -5,6 +5,12 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 
 const DEFAULT_PACKAGES = ["runtime", "coding-agent"];
+const REQUIRED_PACKAGE_BINS = {
+  "coding-agent": {
+    pss: "./bin/pss.js",
+    "pss-coding-agent": "./bin/pss.js",
+  },
+};
 const RAW_RUNTIME_DECLARATION_TOKENS = [
   "LanguageModel",
   "ToolSet",
@@ -167,6 +173,142 @@ function findPublishedTestArtifacts({ cwd, packages }) {
   return errors;
 }
 
+function findPackageBinEntrypointErrors({
+  cwd,
+  packages,
+  platform = process.platform,
+}) {
+  const errors = [];
+
+  for (const packageName of packages) {
+    const requiredBins = REQUIRED_PACKAGE_BINS[packageName];
+    if (!requiredBins) {
+      continue;
+    }
+
+    const packageRoot = join(cwd, "packages", packageName);
+    const packageJsonPath = join(packageRoot, "package.json");
+    const packageJson = readJsonForVerification({ cwd, file: packageJsonPath });
+
+    if (packageJson.error) {
+      errors.push(packageJson.error);
+      continue;
+    }
+
+    if (!(isRecord(packageJson.value) && isRecord(packageJson.value.bin))) {
+      errors.push(
+        `${relativeToCwd(cwd, packageJsonPath)}: missing bin object for CLI entrypoints`
+      );
+      continue;
+    }
+
+    const { bin } = packageJson.value;
+    const checkedTargets = new Set();
+    for (const [command, expectedTarget] of Object.entries(requiredBins)) {
+      if (bin[command] !== expectedTarget) {
+        errors.push(
+          `${relativeToCwd(cwd, packageJsonPath)}: bin.${command} must target ${expectedTarget}`
+        );
+        continue;
+      }
+
+      const targetPath = resolve(packageRoot, expectedTarget);
+      if (checkedTargets.has(targetPath)) {
+        continue;
+      }
+
+      checkedTargets.add(targetPath);
+      errors.push(
+        ...findBinTargetFileErrors({
+          command,
+          cwd,
+          packageJsonPath,
+          platform,
+          targetPath,
+        })
+      );
+    }
+  }
+
+  return errors;
+}
+
+function readJsonForVerification({ cwd, file }) {
+  try {
+    return { value: JSON.parse(readFileSync(file, "utf8")) };
+  } catch (error) {
+    return {
+      error: `${relativeToCwd(cwd, file)}: cannot read package.json (${errorMessage(error)})`,
+    };
+  }
+}
+
+function findBinTargetFileErrors({
+  command,
+  cwd,
+  packageJsonPath,
+  platform,
+  targetPath,
+}) {
+  if (!existsSync(targetPath)) {
+    return [
+      `${relativeToCwd(cwd, packageJsonPath)}: bin.${command} target ${relativeToCwd(dirname(packageJsonPath), targetPath)} is missing`,
+    ];
+  }
+
+  const relativeTarget = relativeToCwd(cwd, targetPath);
+  const text = readTextForVerification(targetPath);
+  const mode = readModeForVerification(targetPath);
+  const errors = [];
+
+  if (text.error) {
+    errors.push(
+      `${relativeTarget}: cannot read CLI bin target (${text.error})`
+    );
+  } else if (!text.value.startsWith("#!")) {
+    errors.push(`${relativeTarget}: CLI bin target must start with a shebang`);
+  }
+
+  if (mode.error) {
+    errors.push(
+      `${relativeTarget}: cannot stat CLI bin target (${mode.error})`
+    );
+  } else if (platform !== "win32" && !hasExecutablePermission(mode.value)) {
+    errors.push(`${relativeTarget}: CLI bin target must be executable`);
+  }
+
+  return errors;
+}
+
+function readTextForVerification(file) {
+  try {
+    return { value: readFileSync(file, "utf8") };
+  } catch (error) {
+    return { error: errorMessage(error) };
+  }
+}
+
+function readModeForVerification(file) {
+  try {
+    return { value: statSync(file).mode };
+  } catch (error) {
+    return { error: errorMessage(error) };
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function hasExecutablePermission(mode) {
+  // biome-ignore lint/suspicious/noBitwiseOperators: POSIX file mode checks are the canonical use of execute-bit masks.
+  return (mode & 0o111) !== 0;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function findRuntimeDeclarationLeaks({ cwd, packages }) {
   if (!packages.includes("runtime")) {
     return [];
@@ -227,6 +369,7 @@ function relativeToCwd(cwd, file) {
 function verifyReleaseArtifacts(options) {
   return [
     ...requirePackageDists(options),
+    ...findPackageBinEntrypointErrors(options),
     ...findExtensionlessRelativeImports(options),
     ...findPublishedTestArtifacts(options),
     ...findRuntimeDeclarationLeaks(options),
@@ -259,6 +402,7 @@ if (isMainModule(import.meta.url)) {
 
 export {
   findExtensionlessRelativeImports,
+  findPackageBinEntrypointErrors,
   findPublishedTestArtifacts,
   findRuntimeDeclarationLeaks,
   isMainModule,

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -7,6 +13,9 @@ import {
   isMainModule,
   verifyReleaseArtifacts,
 } from "./verify-release-artifacts.mjs";
+
+const cliBinReadFailurePattern =
+  /^packages\/coding-agent\/bin\/pss\.js: cannot read CLI bin target /;
 
 let tempRoots = [];
 
@@ -20,6 +29,21 @@ function createFixture() {
       join(cwd, "packages", packageName, "dist", "index.js"),
       "export const ok = true;\n"
     );
+    writeFileSync(
+      join(cwd, "packages", packageName, "package.json"),
+      JSON.stringify(
+        packageName === "coding-agent"
+          ? {
+              bin: {
+                pss: "./bin/pss.js",
+                "pss-coding-agent": "./bin/pss.js",
+              },
+            }
+          : {},
+        null,
+        2
+      )
+    );
     const declaration =
       packageName === "runtime"
         ? 'export type { AgentModel, AgentTools, RuntimeCreateLlmOptions, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
@@ -32,6 +56,19 @@ function createFixture() {
       writeFileSync(
         join(cwd, "packages", packageName, "dist", "llm.d.ts"),
         "export declare const ok: true;\n"
+      );
+    } else {
+      mkdirSync(join(cwd, "packages", packageName, "bin"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(cwd, "packages", packageName, "bin", "pss.js"),
+        "#!/usr/bin/env node\nimport '../dist/tui.js';\n",
+        { mode: 0o755 }
+      );
+      writeFileSync(
+        join(cwd, "packages", packageName, "dist", "tui.js"),
+        "export const ok = true;\n"
       );
     }
   }
@@ -108,6 +145,71 @@ describe("verifyReleaseArtifacts", () => {
       "packages/runtime/dist/test-fixtures.d.ts: test or fixture artifact must not be published",
       "packages/coding-agent/dist/web-fetch.test.js: test or fixture artifact must not be published",
     ]);
+  });
+
+  it("rejects missing CLI bin metadata for the coding-agent package", () => {
+    const cwd = createFixture();
+    writeFileSync(
+      join(cwd, "packages", "coding-agent", "package.json"),
+      JSON.stringify({ bin: { pss: "./bin/pss.js" } })
+    );
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["coding-agent"] })).toEqual(
+      [
+        "packages/coding-agent/package.json: bin.pss-coding-agent must target ./bin/pss.js",
+      ]
+    );
+  });
+
+  it("rejects CLI bin targets without a shebang", () => {
+    const cwd = createFixture();
+    writeFileSync(
+      join(cwd, "packages", "coding-agent", "bin", "pss.js"),
+      "import '../dist/tui.js';\n"
+    );
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["coding-agent"] })).toEqual(
+      [
+        "packages/coding-agent/bin/pss.js: CLI bin target must start with a shebang",
+      ]
+    );
+  });
+
+  it("rejects CLI bin targets without executable mode", () => {
+    const cwd = createFixture();
+    const binPath = join(cwd, "packages", "coding-agent", "bin", "pss.js");
+    writeFileSync(binPath, "#!/usr/bin/env node\nimport '../dist/tui.js';\n");
+    chmodSync(binPath, 0o644);
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["coding-agent"] })).toEqual(
+      ["packages/coding-agent/bin/pss.js: CLI bin target must be executable"]
+    );
+  });
+
+  it("skips CLI bin executable mode checks on Windows", () => {
+    const cwd = createFixture();
+    const binPath = join(cwd, "packages", "coding-agent", "bin", "pss.js");
+    writeFileSync(binPath, "#!/usr/bin/env node\nimport '../dist/tui.js';\n");
+    chmodSync(binPath, 0o644);
+
+    expect(
+      verifyReleaseArtifacts({
+        cwd,
+        packages: ["coding-agent"],
+        platform: "win32",
+      })
+    ).toEqual([]);
+  });
+
+  it("reports CLI bin target read failures instead of throwing", () => {
+    const cwd = createFixture();
+    const binPath = join(cwd, "packages", "coding-agent", "bin", "pss.js");
+    rmSync(binPath);
+    mkdirSync(binPath);
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["coding-agent"] })).toEqual(
+      [expect.stringMatching(cliBinReadFailurePattern)]
+    );
   });
 
   it("rejects raw AI SDK canary types from runtime public declarations", () => {


### PR DESCRIPTION
## Summary

- add publishable `pss` and `pss-coding-agent` bin entrypoints for `@minpeter/pss-coding-agent`
- use a tiny executable `bin/pss.js` shim so source checkouts do not warn before `dist/` exists
- document global install and `npx`/`pnpm dlx`/`pnpx`/`bunx` usage
- extend release artifact verification to guard bin metadata, shebang, and executable mode

## Why

`@minpeter/pss-coding-agent` was publishable as an importable package, but package-manager runner flows had no binary contract. This makes global installs expose `pss` and lets one-shot runners execute the package directly after publish.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm verify:release`
- local tarball smoke with `pnpm pack` for runtime + coding-agent
- `npm install` local tarballs + `pss` launch smoke
- `npx --package <runtime.tgz> --package <coding-agent.tgz> pss`
- `pnpm --package <runtime.tgz> --package <coding-agent.tgz> dlx pss`
- `bunx --package <runtime.tgz> --package <coding-agent.tgz> pss`

## Notes

The local tarball smokes include the runtime tarball because registry-style `@minpeter/pss-coding-agent` execution depends on `@minpeter/pss-runtime` also being published.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish CLI entrypoints for the coding agent so users can run `pss` directly after install or via one-shot runners. Adds strict release checks to keep the CLI contract stable and updates docs.

- New Features
  - Exposes `pss` and `pss-coding-agent` binaries from `@minpeter/pss-coding-agent`.
  - Adds tiny `bin/pss.js` shim (shebang + import of `dist/tui.js`) to avoid source-checkout warnings before build.
  - Documents global install and one-shot usage (`npx`, `pnpm dlx`, `pnpx`, `bunx`).
  - Extends release verification to validate bin aliases, target presence, shebang, and executable mode, with tests.

<sup>Written for commit 35f85cbf27a067d753ca6f86a544f28ac7ff75c7. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/22?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

