### PR TITLE
feat: add history hydration and getHistory to AgentSession

### DIFF
--- a/.changeset/three-ears-feel.md
+++ b/.changeset/three-ears-feel.md
@@ -1,0 +1,6 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add initial message history hydration, `getHistory()` snapshot retrieval, and public `AgentMessage` export to `AgentSession`.
+

--- a/.changeset/three-ears-feel.md
+++ b/.changeset/three-ears-feel.md
@@ -8,4 +8,3 @@ Enhance `AgentSession` with state hydration, mutation tracking, and broader Type
 - Introduce `getHistory()` to retrieve the current snapshot of the agent's message history.
 - Add `onHistoryChange` lifecycle callback hook to `AgentSession` (and underlying `AgentModelHistory`) to observe and persist serialized mutation-time history snapshots.
 - Export `AgentMessage` globally from `@minpeter/pss-runtime` for clean external representation of internal AI SDK message structures.
-

--- a/.changeset/three-ears-feel.md
+++ b/.changeset/three-ears-feel.md
@@ -2,5 +2,11 @@
 "@minpeter/pss-runtime": patch
 ---
 
-Add initial message history hydration, `getHistory()` snapshot retrieval, and public `AgentMessage` export to `AgentSession`.
+Enhance `AgentSession` with state hydration, mutation tracking, and broader TypeScript type exports:
+
+- Add `history` hydration via `SessionOptions` in `Agent.createSession()` and `AgentSession` constructor.
+- Introduce `getHistory()` to retrieve the current snapshot of the agent's message history.
+- Add `onHistoryChange` lifecycle callback hook to `AgentSession` (and underlying `AgentModelHistory`) to observe and persist history mutations reactively.
+- Export `AgentMessage` globally from `@minpeter/pss-runtime` for clean external representation of internal AI SDK message structures.
+
 

--- a/.changeset/three-ears-feel.md
+++ b/.changeset/three-ears-feel.md
@@ -7,4 +7,5 @@ Enhance `AgentSession` with state hydration, mutation tracking, and broader Type
 - Add `history` hydration via `SessionOptions` in `Agent.createSession()` and `AgentSession` constructor.
 - Introduce `getHistory()` to retrieve the current snapshot of the agent's message history.
 - Add `onHistoryChange` lifecycle callback hook to `AgentSession` (and underlying `AgentModelHistory`) to observe and persist serialized mutation-time history snapshots.
+- Keep `kill()` from hanging active turns that are waiting on stalled history persistence.
 - Export `AgentMessage` globally from `@minpeter/pss-runtime` for clean external representation of internal AI SDK message structures.

--- a/.changeset/three-ears-feel.md
+++ b/.changeset/three-ears-feel.md
@@ -6,7 +6,6 @@ Enhance `AgentSession` with state hydration, mutation tracking, and broader Type
 
 - Add `history` hydration via `SessionOptions` in `Agent.createSession()` and `AgentSession` constructor.
 - Introduce `getHistory()` to retrieve the current snapshot of the agent's message history.
-- Add `onHistoryChange` lifecycle callback hook to `AgentSession` (and underlying `AgentModelHistory`) to observe and persist history mutations reactively.
+- Add `onHistoryChange` lifecycle callback hook to `AgentSession` (and underlying `AgentModelHistory`) to observe and persist serialized mutation-time history snapshots.
 - Export `AgentMessage` globally from `@minpeter/pss-runtime` for clean external representation of internal AI SDK message structures.
-
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -26,7 +26,7 @@ stateless request handlers, background jobs, and tests that persist history
 outside the runtime.
 
 ```ts
-import { Agent, type AgentMessage } from "@minpeter/pss-runtime";
+import { type AgentMessage } from "@minpeter/pss-runtime";
 
 const history: AgentMessage[] = [
   { role: "user", content: "Hello!" },
@@ -82,7 +82,7 @@ export class AgentDurableObject {
       });
     }
 
-    // 3. Process the incoming request (e.g. submit user text and stream back events)
+    // Process the incoming request (e.g. submit user text and stream back events).
     // ...
   }
 }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -49,11 +49,16 @@ By utilizing the `onHistoryChange` lifecycle hook, you can automatically capture
 import { Agent, type AgentMessage, type AgentSession } from "@minpeter/pss-runtime";
 
 export class AgentDurableObject {
+  private agent: Agent;
   private session: AgentSession | null = null;
   private storage: DurableObjectStorage;
 
   constructor(state: DurableObjectState) {
     this.storage = state.storage;
+    this.agent = new Agent({
+      instructions: "You are a helpful assistant.",
+      model: yourLanguageModel,
+    });
   }
 
   async fetch(request: Request) {
@@ -61,7 +66,7 @@ export class AgentDurableObject {
       // 1. Hydrate history from the Durable Object local storage on startup
       const savedHistory = await this.storage.get<AgentMessage[]>("history") || [];
 
-      this.session = agent.createSession({
+      this.session = this.agent.createSession({
         history: savedHistory,
         onHistoryChange: async (newHistory) => {
           // 2. Automatically persist mutations reactively in the background!

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -18,32 +18,40 @@ Pass a caller-owned `LanguageModel` through `model`, or pass a custom `llm`.
 Product tools are intentionally not included; pass tools from a separate package
 when constructing an `Agent`.
 
-## Advanced Features
+## Session history
 
-### 1. Stateless History Hydration & Dehydration
-For serverless or stateless environments (like Cloudflare Workers), where the agent instance is re-created on every request, you can hydrate the session with an existing message history and retrieve the updated history snapshot after execution.
+Use `history` when the caller already owns the stored model-message history and
+needs a new `AgentSession` to continue from that state. This is the best fit for
+stateless request handlers, background jobs, and tests that persist history
+outside the runtime.
 
 ```ts
 import { Agent, type AgentMessage } from "@minpeter/pss-runtime";
 
-// Hydrate session with historical messages
 const history: AgentMessage[] = [
   { role: "user", content: "Hello!" },
-  { role: "assistant", content: "Hi! How can I help you today?" }
+  { role: "assistant", content: "Hi! How can I help you today?" },
 ];
 
-const session = agent.createSession({
-  history,
-});
+const session = agent.createSession({ history });
 
-// Retrieve history snapshot at any point
 const currentHistory: AgentMessage[] = session.getHistory();
 ```
 
-### 2. Reactive Storage Synchronization (`onHistoryChange`)
-In stateful serverless environments like **Cloudflare Durable Objects**, keeping the agent's message history synchronized to persistent storage (e.g. SQLite, Durable Object Storage) can be tedious. 
+`getHistory()` returns a cloned snapshot, so callers can persist or inspect it
+without mutating the session.
 
-By utilizing the `onHistoryChange` lifecycle hook, you can automatically capture history mutations reactively and persist them out-of-band without cluttering your routing or execution loop logic:
+### Reactive storage synchronization
+
+Use `onHistoryChange` when the host should persist every history mutation as the
+turn runs. Calls are serialized, receive the mutation-time snapshot, and are
+awaited before `submit()` resolves, rejects, or advances to the next queued
+turn. If persistence fails, the turn rolls back in-memory history and surfaces a
+`turn-error`.
+
+This is the best fit for stateful serverless hosts such as Cloudflare Durable
+Objects, where a long-lived session mirrors history into Durable Object Storage,
+SQLite, or another caller-owned store.
 
 ```ts
 import { Agent, type AgentMessage, type AgentSession } from "@minpeter/pss-runtime";
@@ -63,14 +71,13 @@ export class AgentDurableObject {
 
   async fetch(request: Request) {
     if (!this.session) {
-      // 1. Hydrate history from the Durable Object local storage on startup
-      const savedHistory = await this.storage.get<AgentMessage[]>("history") || [];
+      const history =
+        (await this.storage.get<AgentMessage[]>("history")) ?? [];
 
       this.session = this.agent.createSession({
-        history: savedHistory,
-        onHistoryChange: async (newHistory) => {
-          // 2. Automatically persist mutations reactively in the background!
-          await this.storage.put("history", newHistory);
+        history,
+        onHistoryChange: async (nextHistory) => {
+          await this.storage.put("history", nextHistory);
         },
       });
     }
@@ -81,8 +88,10 @@ export class AgentDurableObject {
 }
 ```
 
-### 3. Safe Event Subscriptions
-When subscribing to session events (such as text streaming, tool calls, and turn lifecycle updates), it is highly recommended to unsubscribe in a `finally` block to prevent event listener leaks, especially in persistent environments or multi-turn execution loops.
+### Safe event subscriptions
+
+When subscribing to session events, unsubscribe in a `finally` block to prevent
+listener leaks in persistent environments or multi-turn execution loops.
 
 ```ts
 const session = agent.createSession();
@@ -106,4 +115,3 @@ try {
   unsubscribe();
 }
 ```
-

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -27,13 +27,13 @@ For serverless or stateless environments (like Cloudflare Workers), where the ag
 import { Agent, type AgentMessage } from "@minpeter/pss-runtime";
 
 // Hydrate session with historical messages
-const initialHistory: AgentMessage[] = [
+const history: AgentMessage[] = [
   { role: "user", content: "Hello!" },
   { role: "assistant", content: "Hi! How can I help you today?" }
 ];
 
 const session = agent.createSession({
-  history: initialHistory,
+  history,
 });
 
 // Retrieve history snapshot at any point

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -17,3 +17,52 @@ The runtime does not read environment variables or create a default provider.
 Pass a caller-owned `LanguageModel` through `model`, or pass a custom `llm`.
 Product tools are intentionally not included; pass tools from a separate package
 when constructing an `Agent`.
+
+## Advanced Features
+
+### 1. Stateless History Hydration & Dehydration
+For serverless or stateless environments (like Cloudflare Workers), where the agent instance is re-created on every request, you can hydrate the session with an existing message history and retrieve the updated history snapshot after execution.
+
+```ts
+import { Agent, type AgentMessage } from "@minpeter/pss-runtime";
+
+// Hydrate session with historical messages
+const initialHistory: AgentMessage[] = [
+  { role: "user", content: "Hello!" },
+  { role: "assistant", content: "Hi! How can I help you today?" }
+];
+
+const session = agent.createSession({
+  history: initialHistory,
+});
+
+// Retrieve history snapshot at any point
+const currentHistory: AgentMessage[] = session.getHistory();
+```
+
+### 2. Safe Event Subscriptions
+When subscribing to session events (such as text streaming, tool calls, and turn lifecycle updates), it is highly recommended to unsubscribe in a `finally` block to prevent event listener leaks, especially in persistent environments or multi-turn execution loops.
+
+```ts
+const session = agent.createSession();
+
+// Subscribe to events and get the unsubscribe function
+const unsubscribe = session.subscribe((event) => {
+  switch (event.type) {
+    case "assistant-text":
+      process.stdout.write(event.text);
+      break;
+    case "tool-call":
+      console.log(`\nCalling tool: ${event.name}`);
+      break;
+  }
+});
+
+try {
+  await session.submit({ type: "user-text", text: "What's the weather today?" });
+} finally {
+  // Always clean up to prevent memory/listener leaks!
+  unsubscribe();
+}
+```
+

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -46,7 +46,7 @@ In stateful serverless environments like **Cloudflare Durable Objects**, keeping
 By utilizing the `onHistoryChange` lifecycle hook, you can automatically capture history mutations reactively and persist them out-of-band without cluttering your routing or execution loop logic:
 
 ```ts
-import { Agent, type AgentMessage } from "@minpeter/pss-runtime";
+import { Agent, type AgentMessage, type AgentSession } from "@minpeter/pss-runtime";
 
 export class AgentDurableObject {
   private session: AgentSession | null = null;

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -40,19 +40,40 @@ const session = agent.createSession({
 const currentHistory: AgentMessage[] = session.getHistory();
 ```
 
-### 2. Auto-Synchronization with `onHistoryChange`
-Alternatively, instead of retrieving the history snapshot manually after execution, you can register an `onHistoryChange` callback hook. It will be triggered automatically whenever the message history is mutated (e.g. when a user message is appended, or a model/tool message is generated).
+### 2. Reactive Storage Synchronization (`onHistoryChange`)
+In stateful serverless environments like **Cloudflare Durable Objects**, keeping the agent's message history synchronized to persistent storage (e.g. SQLite, Durable Object Storage) can be tedious. 
 
-This is ideal for stateful serverless environments like **Cloudflare Durable Objects** to synchronize state to local SSD storage or external databases in the background.
+By utilizing the `onHistoryChange` lifecycle hook, you can automatically capture history mutations reactively and persist them out-of-band without cluttering your routing or execution loop logic:
 
 ```ts
-const session = agent.createSession({
-  history: initialHistory,
-  onHistoryChange: (newHistory) => {
-    // Automatically called whenever history is updated!
-    console.log("History updated, length:", newHistory.length);
-  },
-});
+import { Agent, type AgentMessage } from "@minpeter/pss-runtime";
+
+export class AgentDurableObject {
+  private session: AgentSession | null = null;
+  private storage: DurableObjectStorage;
+
+  constructor(state: DurableObjectState) {
+    this.storage = state.storage;
+  }
+
+  async fetch(request: Request) {
+    if (!this.session) {
+      // 1. Hydrate history from the Durable Object local storage on startup
+      const savedHistory = await this.storage.get<AgentMessage[]>("history") || [];
+
+      this.session = agent.createSession({
+        history: savedHistory,
+        onHistoryChange: async (newHistory) => {
+          // 2. Automatically persist mutations reactively in the background!
+          await this.storage.put("history", newHistory);
+        },
+      });
+    }
+
+    // 3. Process the incoming request (e.g. submit user text and stream back events)
+    // ...
+  }
+}
 ```
 
 ### 3. Safe Event Subscriptions

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -40,7 +40,22 @@ const session = agent.createSession({
 const currentHistory: AgentMessage[] = session.getHistory();
 ```
 
-### 2. Safe Event Subscriptions
+### 2. Auto-Synchronization with `onHistoryChange`
+Alternatively, instead of retrieving the history snapshot manually after execution, you can register an `onHistoryChange` callback hook. It will be triggered automatically whenever the message history is mutated (e.g. when a user message is appended, or a model/tool message is generated).
+
+This is ideal for stateful serverless environments like **Cloudflare Durable Objects** to synchronize state to local SSD storage or external databases in the background.
+
+```ts
+const session = agent.createSession({
+  history: initialHistory,
+  onHistoryChange: (newHistory) => {
+    // Automatically called whenever history is updated!
+    console.log("History updated, length:", newHistory.length);
+  },
+});
+```
+
+### 3. Safe Event Subscriptions
 When subscribing to session events (such as text streaming, tool calls, and turn lifecycle updates), it is highly recommended to unsubscribe in a `finally` block to prevent event listener leaks, especially in persistent environments or multi-turn execution loops.
 
 ```ts

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel } from "ai";
 import { type AgentTools, createLlm, type Llm } from "./llm";
-import { AgentSession } from "./session/session";
+import { AgentSession, type SessionOptions } from "./session/session";
 
 interface AgentModelOptions {
   instructions?: string;
@@ -33,8 +33,8 @@ export class Agent {
         });
   }
 
-  createSession(): AgentSession {
-    return new AgentSession(this.#llm);
+  createSession(options?: SessionOptions): AgentSession {
+    return new AgentSession(this.#llm, options);
   }
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,7 +1,7 @@
 export { Agent, type AgentOptions } from "./agent";
 export { type AgentLoopResult, runAgentLoop } from "./agent-loop";
-export type { ModelMessage as AgentMessage } from "ai";
 export type {
+  AgentMessage,
   AgentModel,
   AgentTool,
   AgentToolExecute,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -23,5 +23,8 @@ export type {
   ToolResult,
   UserText,
 } from "./session/events";
-export { AgentSession, type SessionInput, type SessionOptions } from "./session/session";
-
+export {
+  AgentSession,
+  type SessionInput,
+  type SessionOptions,
+} from "./session/session";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,6 @@
 export { Agent, type AgentOptions } from "./agent";
 export { type AgentLoopResult, runAgentLoop } from "./agent-loop";
+export type { ModelMessage as AgentMessage } from "ai";
 export type {
   AgentModel,
   AgentTool,
@@ -22,4 +23,5 @@ export type {
   ToolResult,
   UserText,
 } from "./session/events";
-export { AgentSession, type SessionInput } from "./session/session";
+export { AgentSession, type SessionInput, type SessionOptions } from "./session/session";
+

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -19,7 +19,6 @@ export type AgentTools = Record<string, AgentTool>;
 export type AgentModel = LanguageModel;
 export type AgentMessage = ModelMessage;
 export type LlmOutput = Awaited<
-
   ReturnType<typeof generateText>
 >["responseMessages"];
 export type LlmOutputPart = LlmOutput[number];

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -17,7 +17,9 @@ export interface AgentTool {
 
 export type AgentTools = Record<string, AgentTool>;
 export type AgentModel = LanguageModel;
+export type AgentMessage = ModelMessage;
 export type LlmOutput = Awaited<
+
   ReturnType<typeof generateText>
 >["responseMessages"];
 export type LlmOutputPart = LlmOutput[number];

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -5,6 +5,12 @@ import { userTextToModelMessage } from "./mapping";
 export class AgentModelHistory {
   readonly #modelHistory: ModelMessage[] = [];
 
+  constructor(initialHistory?: ModelMessage[]) {
+    if (initialHistory) {
+      this.#modelHistory = structuredClone(initialHistory);
+    }
+  }
+
   modelSnapshot(): ModelMessage[] {
     return structuredClone(this.#modelHistory);
   }
@@ -17,3 +23,4 @@ export class AgentModelHistory {
     this.#modelHistory.push(structuredClone(message));
   }
 }
+

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -30,9 +30,13 @@ export class AgentModelHistory {
     this.#triggerChange();
   }
 
-  rollback(snapshot: ModelMessage[]): void {
+  rollback(snapshot: ModelMessage[], options?: { notify?: boolean }): void {
     this.#modelHistory.length = 0;
     this.#modelHistory.push(...structuredClone(snapshot));
+    if (options?.notify === false) {
+      return;
+    }
+
     this.#triggerChange();
   }
 

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -27,6 +27,12 @@ export class AgentModelHistory {
     this.#triggerChange();
   }
 
+  rollback(snapshot: ModelMessage[]): void {
+    this.#modelHistory.length = 0;
+    this.#modelHistory.push(...structuredClone(snapshot));
+    this.#triggerChange();
+  }
+
   #triggerChange(): void {
     if (!this.#onChange) {
       return;

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -4,9 +4,12 @@ import { userTextToModelMessage } from "./mapping";
 
 export class AgentModelHistory {
   readonly #modelHistory: ModelMessage[] = [];
-  readonly #onChange?: () => void;
+  readonly #onChange?: (snapshot: ModelMessage[]) => void;
 
-  constructor(history?: ModelMessage[], onChange?: () => void) {
+  constructor(
+    history?: ModelMessage[],
+    onChange?: (snapshot: ModelMessage[]) => void
+  ) {
     if (history) {
       this.#modelHistory = structuredClone(history);
     }
@@ -34,14 +37,6 @@ export class AgentModelHistory {
   }
 
   #triggerChange(): void {
-    if (!this.#onChange) {
-      return;
-    }
-    try {
-      this.#onChange();
-    } catch (error: unknown) {
-      // Catch and log synchronous callback errors to prevent them from breaking the core execution loop.
-      console.error("Error in AgentModelHistory onChange callback:", error);
-    }
+    this.#onChange?.(this.modelSnapshot());
   }
 }

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -19,12 +19,24 @@ export class AgentModelHistory {
 
   appendUserInput(input: UserText): void {
     this.#modelHistory.push(userTextToModelMessage(input));
-    this.#onChange?.();
+    this.#triggerChange();
   }
 
   appendModelMessage(message: ModelMessage): void {
     this.#modelHistory.push(structuredClone(message));
-    this.#onChange?.();
+    this.#triggerChange();
+  }
+
+  #triggerChange(): void {
+    if (!this.#onChange) {
+      return;
+    }
+    try {
+      this.#onChange();
+    } catch (error: unknown) {
+      // Catch and log synchronous callback errors to prevent them from breaking the core execution loop.
+      console.error("Error in AgentModelHistory onChange callback:", error);
+    }
   }
 }
 

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -4,11 +4,13 @@ import { userTextToModelMessage } from "./mapping";
 
 export class AgentModelHistory {
   readonly #modelHistory: ModelMessage[] = [];
+  readonly #onChange?: () => void;
 
-  constructor(initialHistory?: ModelMessage[]) {
+  constructor(initialHistory?: ModelMessage[], onChange?: () => void) {
     if (initialHistory) {
       this.#modelHistory = structuredClone(initialHistory);
     }
+    this.#onChange = onChange;
   }
 
   modelSnapshot(): ModelMessage[] {
@@ -17,10 +19,13 @@ export class AgentModelHistory {
 
   appendUserInput(input: UserText): void {
     this.#modelHistory.push(userTextToModelMessage(input));
+    this.#onChange?.();
   }
 
   appendModelMessage(message: ModelMessage): void {
     this.#modelHistory.push(structuredClone(message));
+    this.#onChange?.();
   }
 }
+
 

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -39,5 +39,3 @@ export class AgentModelHistory {
     }
   }
 }
-
-

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -30,13 +30,9 @@ export class AgentModelHistory {
     this.#triggerChange();
   }
 
-  rollback(snapshot: ModelMessage[], options?: { notify?: boolean }): void {
+  rollback(snapshot: ModelMessage[]): void {
     this.#modelHistory.length = 0;
     this.#modelHistory.push(...structuredClone(snapshot));
-    if (options?.notify === false) {
-      return;
-    }
-
     this.#triggerChange();
   }
 

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -6,9 +6,9 @@ export class AgentModelHistory {
   readonly #modelHistory: ModelMessage[] = [];
   readonly #onChange?: () => void;
 
-  constructor(initialHistory?: ModelMessage[], onChange?: () => void) {
-    if (initialHistory) {
-      this.#modelHistory = structuredClone(initialHistory);
+  constructor(history?: ModelMessage[], onChange?: () => void) {
+    if (history) {
+      this.#modelHistory = structuredClone(history);
     }
     this.#onChange = onChange;
   }

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -200,6 +200,93 @@ describe("AgentSession", () => {
     ]);
   });
 
+  it("queues rollback persistence after kill without blocking on the stalled write", async () => {
+    const firstWriteStarted = createDeferred();
+    const releaseFirstWrite = createDeferred();
+    const rollbackPersisted = createDeferred();
+    const persistedLengths: number[] = [];
+    let calls = 0;
+    const session = new Agent({
+      llm: () => {
+        calls += 1;
+        return Promise.resolve([assistantMessage("should not run")]);
+      },
+    }).createSession({
+      onHistoryChange: async (history) => {
+        persistedLengths.push(history.length);
+
+        if (history.length === 1) {
+          firstWriteStarted.resolve();
+          await releaseFirstWrite.promise;
+        }
+
+        if (history.length === 0) {
+          rollbackPersisted.resolve();
+        }
+      },
+    });
+
+    const activeSubmit = session.submit(userText("active"));
+
+    await firstWriteStarted.promise;
+    session.kill();
+
+    await expect(settleWithin(activeSubmit)).resolves.toBe("resolved");
+    expect(calls).toBe(0);
+    expect(session.getHistory()).toEqual([]);
+    expect(persistedLengths).toEqual([1]);
+
+    releaseFirstWrite.resolve();
+    await rollbackPersisted.promise;
+    expect(persistedLengths).toEqual([1, 0]);
+  });
+
+  it("preserves persistence failures when kill unblocks remaining writes", async () => {
+    const stalledWriteStarted = createDeferred();
+    const events: AgentEvent[] = [];
+    const session = new Agent({
+      llm: () =>
+        Promise.resolve([
+          assistantMessage("persisted failure"),
+          assistantMessage("stalled write"),
+        ]),
+    }).createSession({
+      onHistoryChange: async (history) => {
+        if (history.length === 2) {
+          throw new Error("assistant write failed");
+        }
+
+        if (history.length === 3) {
+          stalledWriteStarted.resolve();
+          await new Promise(() => {
+            // Keep this write pending until kill() unblocks the turn.
+          });
+        }
+      },
+    });
+    session.subscribe((event) => events.push(event));
+
+    const activeSubmit = session.submit(userText("active"));
+
+    await stalledWriteStarted.promise;
+    session.kill();
+
+    await expect(activeSubmit).rejects.toThrow("assistant write failed");
+    expect(session.getHistory()).toEqual([]);
+    expect(events).toEqual([
+      { type: "user-text", text: "active" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "assistant-text", text: "persisted failure" },
+      { type: "assistant-text", text: "stalled write" },
+      { type: "step-end" },
+      {
+        type: "turn-error",
+        message: expect.stringContaining("assistant write failed"),
+      },
+    ]);
+  });
+
   it("rejects input if a user-text listener kills the session before queueing", async () => {
     let calls = 0;
     const session = new Agent({

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -287,6 +287,44 @@ describe("AgentSession", () => {
     ]);
   });
 
+  it("preserves persistence failures that settle immediately after kill", async () => {
+    const writeStarted = createDeferred();
+    const events: AgentEvent[] = [];
+    let rejectWrite: (error: Error) => void = () => {
+      throw new Error("write promise was not initialized");
+    };
+    const session = new Agent({
+      llm: () => {
+        throw new Error("should not run");
+      },
+    }).createSession({
+      onHistoryChange: () => {
+        writeStarted.resolve();
+        return new Promise<void>((_resolve, reject) => {
+          rejectWrite = reject;
+        });
+      },
+    });
+    session.subscribe((event) => events.push(event));
+
+    const activeSubmit = session.submit(userText("active"));
+
+    await writeStarted.promise;
+    session.kill();
+    queueMicrotask(() => rejectWrite(new Error("late write failed")));
+
+    await expect(activeSubmit).rejects.toThrow("late write failed");
+    expect(session.getHistory()).toEqual([]);
+    expect(events).toEqual([
+      { type: "user-text", text: "active" },
+      { type: "turn-start" },
+      {
+        type: "turn-error",
+        message: expect.stringContaining("late write failed"),
+      },
+    ]);
+  });
+
   it("rejects input if a user-text listener kills the session before queueing", async () => {
     let calls = 0;
     const session = new Agent({

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -254,12 +254,14 @@ describe("AgentSession", () => {
       "Failed to persist database state"
     );
 
-    const errors = events.filter((e) => e.type === "turn-error");
+    const errors = events.filter((event) => event.type === "turn-error");
     expect(errors.length).toBe(1);
-    expect(errors[0].type).toBe("turn-error");
-    expect((errors[0] as any).message).toContain(
-      "onHistoryChange failed: Failed to persist database state"
-    );
+    expect(errors[0]).toMatchObject({
+      message: expect.stringContaining(
+        "onHistoryChange failed: Failed to persist database state"
+      ),
+      type: "turn-error",
+    });
     expect(session.getHistory()).toEqual([]); // Rolled back!
   });
 
@@ -281,12 +283,14 @@ describe("AgentSession", () => {
       "Synchronous database persistence failure"
     );
 
-    const errors = events.filter((e) => e.type === "turn-error");
+    const errors = events.filter((event) => event.type === "turn-error");
     expect(errors.length).toBe(1);
-    expect(errors[0].type).toBe("turn-error");
-    expect((errors[0] as any).message).toContain(
-      "onHistoryChange failed: Synchronous database persistence failure"
-    );
+    expect(errors[0]).toMatchObject({
+      message: expect.stringContaining(
+        "onHistoryChange failed: Synchronous database persistence failure"
+      ),
+      type: "turn-error",
+    });
     expect(session.getHistory()).toEqual([]); // Rolled back!
   });
 
@@ -315,5 +319,89 @@ describe("AgentSession", () => {
 
     expect(invocationOrder).toEqual(["start-1", "end-1", "start-2", "end-2"]);
     expect(session.getHistory().length).toBe(2);
+  });
+
+  it("passes mutation-time snapshots to onHistoryChange", async () => {
+    const userMessage = userTextToModelMessage(userText("hi"));
+    const firstAssistantMessage = assistantMessage("first");
+    const secondAssistantMessage = assistantMessage("second");
+    const historicalSnapshots: ModelMessage[][] = [];
+    const session = new Agent({
+      llm: () =>
+        Promise.resolve([firstAssistantMessage, secondAssistantMessage]),
+    }).createSession({
+      onHistoryChange: (history) => {
+        historicalSnapshots.push(history);
+      },
+    });
+
+    await session.submit(userText("hi"));
+
+    expect(historicalSnapshots).toEqual([
+      [userMessage],
+      [userMessage, firstAssistantMessage],
+      [userMessage, firstAssistantMessage, secondAssistantMessage],
+    ]);
+  });
+
+  it("waits for rollback history persistence before rejecting failed turns", async () => {
+    const writes: string[] = [];
+    const session = new Agent({
+      llm: () => Promise.reject(new Error("model failed")),
+    }).createSession({
+      onHistoryChange: async (history) => {
+        const snapshotLength = history.length;
+        writes.push(`start-${snapshotLength}`);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        writes.push(`end-${snapshotLength}`);
+      },
+    });
+
+    await expect(session.submit(userText("hi"))).rejects.toThrow(
+      "model failed"
+    );
+
+    expect(writes).toEqual(["start-1", "end-1", "start-0", "end-0"]);
+    expect(session.getHistory()).toEqual([]);
+  });
+
+  it("waits for all queued history writes before rollback after persistence failure", async () => {
+    const writes: string[] = [];
+    const session = new Agent({
+      llm: () =>
+        Promise.resolve([
+          assistantMessage("first"),
+          assistantMessage("second"),
+        ]),
+    }).createSession({
+      onHistoryChange: async (history) => {
+        const snapshotLength = history.length;
+        writes.push(`start-${snapshotLength}`);
+
+        if (snapshotLength === 1) {
+          writes.push(`fail-${snapshotLength}`);
+          throw new Error("first write failed");
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        writes.push(`end-${snapshotLength}`);
+      },
+    });
+
+    await expect(session.submit(userText("hi"))).rejects.toThrow(
+      "first write failed"
+    );
+
+    expect(writes).toEqual([
+      "start-1",
+      "fail-1",
+      "start-2",
+      "end-2",
+      "start-3",
+      "end-3",
+      "start-0",
+      "end-0",
+    ]);
+    expect(session.getHistory()).toEqual([]);
   });
 });

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -239,4 +239,26 @@ describe("AgentSession", () => {
       ],
     ]);
   });
+
+  it("emits turn-error when onHistoryChange async callback throws or rejects", async () => {
+    const events: AgentEvent[] = [];
+    const session = new Agent({
+      llm: () => Promise.resolve([assistantMessage("hello there")]),
+    }).createSession({
+      onHistoryChange: async () => {
+        throw new Error("Failed to persist database state");
+      },
+    });
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.submit(userText("remember me"));
+
+    const errors = events.filter((e) => e.type === "turn-error");
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0].type).toBe("turn-error");
+    expect((errors[0] as any).message).toContain("onHistoryChange failed: Failed to persist database state");
+  });
 });

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -454,6 +454,27 @@ describe("AgentSession", () => {
     expect(persistedLengths).toEqual([1, 2, 3]);
   });
 
+  it("ignores interrupt when no turn is active", async () => {
+    const persistedLengths: number[] = [];
+    let calls = 0;
+    const session = new Agent({
+      llm: () => {
+        calls += 1;
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    }).createSession({
+      onHistoryChange: (history) => {
+        persistedLengths.push(history.length);
+      },
+    });
+
+    session.interrupt();
+    await session.submit(userText("after idle interrupt"));
+
+    expect(calls).toBe(1);
+    expect(persistedLengths).toEqual([1, 2]);
+  });
+
   it("rejects input if a user-text listener kills the session before queueing", async () => {
     let calls = 0;
     const session = new Agent({

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -255,7 +255,7 @@ describe("AgentSession", () => {
     );
 
     const errors = events.filter((e) => e.type === "turn-error");
-    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.length).toBe(1);
     expect(errors[0].type).toBe("turn-error");
     expect((errors[0] as any).message).toContain(
       "onHistoryChange failed: Failed to persist database state"
@@ -282,7 +282,7 @@ describe("AgentSession", () => {
     );
 
     const errors = events.filter((e) => e.type === "turn-error");
-    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.length).toBe(1);
     expect(errors[0].type).toBe("turn-error");
     expect((errors[0] as any).message).toContain(
       "onHistoryChange failed: Synchronous database persistence failure"

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -261,4 +261,26 @@ describe("AgentSession", () => {
     expect(errors[0].type).toBe("turn-error");
     expect((errors[0] as any).message).toContain("onHistoryChange failed: Failed to persist database state");
   });
+
+  it("emits turn-error when onHistoryChange synchronous callback throws", async () => {
+    const events: AgentEvent[] = [];
+    const session = new Agent({
+      llm: () => Promise.resolve([assistantMessage("hello there")]),
+    }).createSession({
+      onHistoryChange: () => {
+        throw new Error("Synchronous database persistence failure");
+      },
+    });
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.submit(userText("remember me"));
+
+    const errors = events.filter((e) => e.type === "turn-error");
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0].type).toBe("turn-error");
+    expect((errors[0] as any).message).toContain("onHistoryChange failed: Synchronous database persistence failure");
+  });
 });

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -235,7 +235,7 @@ describe("AgentSession", () => {
     ]);
   });
 
-  it("emits turn-error when onHistoryChange async callback throws or rejects", async () => {
+  it("emits turn-error and rejects when onHistoryChange async callback throws or rejects", async () => {
     const events: AgentEvent[] = [];
     const session = new Agent({
       llm: () => Promise.resolve([assistantMessage("hello there")]),
@@ -250,7 +250,9 @@ describe("AgentSession", () => {
       events.push(event);
     });
 
-    await session.submit(userText("remember me"));
+    await expect(session.submit(userText("remember me"))).rejects.toThrow(
+      "Failed to persist database state"
+    );
 
     const errors = events.filter((e) => e.type === "turn-error");
     expect(errors.length).toBeGreaterThanOrEqual(1);
@@ -258,9 +260,10 @@ describe("AgentSession", () => {
     expect((errors[0] as any).message).toContain(
       "onHistoryChange failed: Failed to persist database state"
     );
+    expect(session.getHistory()).toEqual([]); // Rolled back!
   });
 
-  it("emits turn-error when onHistoryChange synchronous callback throws", async () => {
+  it("emits turn-error and rejects when onHistoryChange synchronous callback throws", async () => {
     const events: AgentEvent[] = [];
     const session = new Agent({
       llm: () => Promise.resolve([assistantMessage("hello there")]),
@@ -274,7 +277,9 @@ describe("AgentSession", () => {
       events.push(event);
     });
 
-    await session.submit(userText("remember me"));
+    await expect(session.submit(userText("remember me"))).rejects.toThrow(
+      "Synchronous database persistence failure"
+    );
 
     const errors = events.filter((e) => e.type === "turn-error");
     expect(errors.length).toBeGreaterThanOrEqual(1);
@@ -282,5 +287,33 @@ describe("AgentSession", () => {
     expect((errors[0] as any).message).toContain(
       "onHistoryChange failed: Synchronous database persistence failure"
     );
+    expect(session.getHistory()).toEqual([]); // Rolled back!
+  });
+
+  it("sequences onHistoryChange calls to run sequentially without overlapping", async () => {
+    const activeWrites: number[] = [];
+    const invocationOrder: string[] = [];
+    const session = new Agent({
+      llm: () => Promise.resolve([assistantMessage("hello there")]),
+    }).createSession({
+      onHistoryChange: async (history) => {
+        const id = history.length;
+        activeWrites.push(id);
+        // Expect no concurrent overlapping writes - activeWrites should only have 1 element
+        expect(activeWrites.length).toBe(1);
+
+        invocationOrder.push(`start-${id}`);
+        // Simulate asynchronous database delay
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        invocationOrder.push(`end-${id}`);
+
+        activeWrites.pop();
+      },
+    });
+
+    await session.submit(userText("hi"));
+
+    expect(invocationOrder).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+    expect(session.getHistory().length).toBe(2);
   });
 });

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -181,4 +181,33 @@ describe("AgentSession", () => {
     expect(calls).toBe(0);
     expect(eventTypes(events)).toEqual(["user-text"]);
   });
+
+  it("supports initial history hydration and returns getHistory snapshot", async () => {
+    const initialHistory: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+    ];
+    const seenHistory: ModelMessage[][] = [];
+    const session = new Agent({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    }).createSession({ history: initialHistory });
+
+    expect(session.getHistory()).toEqual(initialHistory);
+
+    await session.submit(userText("remember me"));
+
+    expect(seenHistory[0]).toEqual([
+      ...initialHistory,
+      userTextToModelMessage(userText("remember me")),
+    ]);
+
+    expect(session.getHistory()).toEqual([
+      ...initialHistory,
+      userTextToModelMessage(userText("remember me")),
+      assistantMessage("DONE"),
+    ]);
+  });
 });

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -210,4 +210,33 @@ describe("AgentSession", () => {
       assistantMessage("DONE"),
     ]);
   });
+
+  it("triggers onHistoryChange callback whenever history is mutated", async () => {
+    const initialHistory: ModelMessage[] = [
+      { role: "user", content: "hello" },
+    ];
+    const historicalSnapshots: ModelMessage[][] = [];
+    const session = new Agent({
+      llm: () => Promise.resolve([assistantMessage("hello there")]),
+    }).createSession({
+      history: initialHistory,
+      onHistoryChange: (history) => {
+        historicalSnapshots.push(history);
+      },
+    });
+
+    await session.submit(userText("remember me"));
+
+    expect(historicalSnapshots).toEqual([
+      [
+        ...initialHistory,
+        userTextToModelMessage(userText("remember me")),
+      ],
+      [
+        ...initialHistory,
+        userTextToModelMessage(userText("remember me")),
+        assistantMessage("hello there"),
+      ],
+    ]);
+  });
 });

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -212,9 +212,7 @@ describe("AgentSession", () => {
   });
 
   it("triggers onHistoryChange callback whenever history is mutated", async () => {
-    const initialHistory: ModelMessage[] = [
-      { role: "user", content: "hello" },
-    ];
+    const initialHistory: ModelMessage[] = [{ role: "user", content: "hello" }];
     const historicalSnapshots: ModelMessage[][] = [];
     const session = new Agent({
       llm: () => Promise.resolve([assistantMessage("hello there")]),
@@ -228,10 +226,7 @@ describe("AgentSession", () => {
     await session.submit(userText("remember me"));
 
     expect(historicalSnapshots).toEqual([
-      [
-        ...initialHistory,
-        userTextToModelMessage(userText("remember me")),
-      ],
+      [...initialHistory, userTextToModelMessage(userText("remember me"))],
       [
         ...initialHistory,
         userTextToModelMessage(userText("remember me")),
@@ -246,6 +241,7 @@ describe("AgentSession", () => {
       llm: () => Promise.resolve([assistantMessage("hello there")]),
     }).createSession({
       onHistoryChange: async () => {
+        await Promise.resolve();
         throw new Error("Failed to persist database state");
       },
     });
@@ -259,7 +255,9 @@ describe("AgentSession", () => {
     const errors = events.filter((e) => e.type === "turn-error");
     expect(errors.length).toBeGreaterThanOrEqual(1);
     expect(errors[0].type).toBe("turn-error");
-    expect((errors[0] as any).message).toContain("onHistoryChange failed: Failed to persist database state");
+    expect((errors[0] as any).message).toContain(
+      "onHistoryChange failed: Failed to persist database state"
+    );
   });
 
   it("emits turn-error when onHistoryChange synchronous callback throws", async () => {
@@ -281,6 +279,8 @@ describe("AgentSession", () => {
     const errors = events.filter((e) => e.type === "turn-error");
     expect(errors.length).toBeGreaterThanOrEqual(1);
     expect(errors[0].type).toBe("turn-error");
-    expect((errors[0] as any).message).toContain("onHistoryChange failed: Synchronous database persistence failure");
+    expect((errors[0] as any).message).toContain(
+      "onHistoryChange failed: Synchronous database persistence failure"
+    );
   });
 });

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -237,8 +237,12 @@ describe("AgentSession", () => {
 
   it("emits turn-error and rejects when onHistoryChange async callback throws or rejects", async () => {
     const events: AgentEvent[] = [];
+    let llmCalls = 0;
     const session = new Agent({
-      llm: () => Promise.resolve([assistantMessage("hello there")]),
+      llm: () => {
+        llmCalls += 1;
+        return Promise.resolve([assistantMessage("hello there")]);
+      },
     }).createSession({
       onHistoryChange: async () => {
         await Promise.resolve();
@@ -263,12 +267,17 @@ describe("AgentSession", () => {
       type: "turn-error",
     });
     expect(session.getHistory()).toEqual([]); // Rolled back!
+    expect(llmCalls).toBe(0);
   });
 
   it("emits turn-error and rejects when onHistoryChange synchronous callback throws", async () => {
     const events: AgentEvent[] = [];
+    let llmCalls = 0;
     const session = new Agent({
-      llm: () => Promise.resolve([assistantMessage("hello there")]),
+      llm: () => {
+        llmCalls += 1;
+        return Promise.resolve([assistantMessage("hello there")]);
+      },
     }).createSession({
       onHistoryChange: () => {
         throw new Error("Synchronous database persistence failure");
@@ -292,6 +301,7 @@ describe("AgentSession", () => {
       type: "turn-error",
     });
     expect(session.getHistory()).toEqual([]); // Rolled back!
+    expect(llmCalls).toBe(0);
   });
 
   it("sequences onHistoryChange calls to run sequentially without overlapping", async () => {
@@ -378,9 +388,9 @@ describe("AgentSession", () => {
         const snapshotLength = history.length;
         writes.push(`start-${snapshotLength}`);
 
-        if (snapshotLength === 1) {
+        if (snapshotLength === 2) {
           writes.push(`fail-${snapshotLength}`);
-          throw new Error("first write failed");
+          throw new Error("assistant write failed");
         }
 
         await new Promise((resolve) => setTimeout(resolve, 10));
@@ -389,14 +399,14 @@ describe("AgentSession", () => {
     });
 
     await expect(session.submit(userText("hi"))).rejects.toThrow(
-      "first write failed"
+      "assistant write failed"
     );
 
     expect(writes).toEqual([
       "start-1",
-      "fail-1",
+      "end-1",
       "start-2",
-      "end-2",
+      "fail-2",
       "start-3",
       "end-3",
       "start-0",

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -157,6 +157,49 @@ describe("AgentSession", () => {
     ]);
   });
 
+  it("kills the session by unblocking pending history persistence", async () => {
+    const writeStarted = createDeferred();
+    const write = createDeferred();
+    let calls = 0;
+    const session = new Agent({
+      llm: () => {
+        calls += 1;
+        return Promise.resolve([assistantMessage("should not run")]);
+      },
+    }).createSession({
+      onHistoryChange: async () => {
+        writeStarted.resolve();
+        await write.promise;
+      },
+    });
+    const events: AgentEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const activeSubmit = session.submit(userText("active"));
+    const queuedSubmit = session.submit(userText("queued"));
+    const queuedResult = queuedSubmit.then(
+      () => "resolved",
+      (error: unknown) => error
+    );
+
+    await writeStarted.promise;
+    session.kill();
+
+    await expect(settleWithin(activeSubmit)).resolves.toBe("resolved");
+    const queuedError = await queuedResult;
+
+    expect(calls).toBe(0);
+    expect(session.getHistory()).toEqual([]);
+    expect(queuedError).toBeInstanceOf(Error);
+    expect((queuedError as Error).message).toBe("Session killed");
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "user-text",
+      "turn-abort",
+    ]);
+  });
+
   it("rejects input if a user-text listener kills the session before queueing", async () => {
     let calls = 0;
     const session = new Agent({
@@ -415,3 +458,18 @@ describe("AgentSession", () => {
     expect(session.getHistory()).toEqual([]);
   });
 });
+
+function settleWithin(
+  promise: Promise<void>,
+  timeoutMs = 500
+): Promise<"resolved" | "timeout" | unknown> {
+  return Promise.race([
+    promise.then(
+      () => "resolved" as const,
+      (error: unknown) => error
+    ),
+    new Promise<"timeout">((resolve) => {
+      setTimeout(() => resolve("timeout"), timeoutMs);
+    }),
+  ]);
+}

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -183,7 +183,7 @@ describe("AgentSession", () => {
   });
 
   it("supports initial history hydration and returns getHistory snapshot", async () => {
-    const initialHistory: ModelMessage[] = [
+    const history: ModelMessage[] = [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi there" },
     ];
@@ -193,31 +193,31 @@ describe("AgentSession", () => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
-    }).createSession({ history: initialHistory });
+    }).createSession({ history });
 
-    expect(session.getHistory()).toEqual(initialHistory);
+    expect(session.getHistory()).toEqual(history);
 
     await session.submit(userText("remember me"));
 
     expect(seenHistory[0]).toEqual([
-      ...initialHistory,
+      ...history,
       userTextToModelMessage(userText("remember me")),
     ]);
 
     expect(session.getHistory()).toEqual([
-      ...initialHistory,
+      ...history,
       userTextToModelMessage(userText("remember me")),
       assistantMessage("DONE"),
     ]);
   });
 
   it("triggers onHistoryChange callback whenever history is mutated", async () => {
-    const initialHistory: ModelMessage[] = [{ role: "user", content: "hello" }];
+    const history: ModelMessage[] = [{ role: "user", content: "hello" }];
     const historicalSnapshots: ModelMessage[][] = [];
     const session = new Agent({
       llm: () => Promise.resolve([assistantMessage("hello there")]),
     }).createSession({
-      history: initialHistory,
+      history,
       onHistoryChange: (history) => {
         historicalSnapshots.push(history);
       },
@@ -226,9 +226,9 @@ describe("AgentSession", () => {
     await session.submit(userText("remember me"));
 
     expect(historicalSnapshots).toEqual([
-      [...initialHistory, userTextToModelMessage(userText("remember me"))],
+      [...history, userTextToModelMessage(userText("remember me"))],
       [
-        ...initialHistory,
+        ...history,
         userTextToModelMessage(userText("remember me")),
         assistantMessage("hello there"),
       ],

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -325,6 +325,56 @@ describe("AgentSession", () => {
     ]);
   });
 
+  it("interrupts stalled history persistence so queued input can run", async () => {
+    const firstWriteStarted = createDeferred();
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const session = new Agent({
+      llm: ({ history }) => {
+        calls += 1;
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    }).createSession({
+      onHistoryChange: async (history) => {
+        if (history.length === 1) {
+          firstWriteStarted.resolve();
+          await new Promise(() => {
+            // Keep the first turn persistence pending until interrupt() unblocks it.
+          });
+        }
+      },
+    });
+    const events: AgentEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const firstSubmit = session.submit(userText("first"));
+    const secondSubmit = session.submit(userText("second"));
+
+    await firstWriteStarted.promise;
+    session.interrupt();
+    await Promise.all([firstSubmit, secondSubmit]);
+
+    expect(calls).toBe(1);
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("first")),
+        userTextToModelMessage(userText("second")),
+      ],
+    ]);
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "user-text",
+      "turn-abort",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+  });
+
   it("rejects input if a user-text listener kills the session before queueing", async () => {
     let calls = 0;
     const session = new Agent({

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -182,7 +182,7 @@ describe("AgentSession", () => {
     expect(eventTypes(events)).toEqual(["user-text"]);
   });
 
-  it("supports initial history hydration and returns getHistory snapshot", async () => {
+  it("supports history hydration and returns getHistory snapshot", async () => {
     const history: ModelMessage[] = [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi there" },

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -375,6 +375,85 @@ describe("AgentSession", () => {
     ]);
   });
 
+  it("repairs interrupted persistence after the stalled write resumes", async () => {
+    const firstWriteStarted = createDeferred();
+    const releaseFirstWrite = createDeferred();
+    const repairPersisted = createDeferred();
+    const persistedLengths: number[] = [];
+    let released = false;
+    const session = new Agent({
+      llm: () => Promise.resolve([assistantMessage("DONE")]),
+    }).createSession({
+      onHistoryChange: async (history) => {
+        persistedLengths.push(history.length);
+
+        if (history.length === 1) {
+          firstWriteStarted.resolve();
+          await releaseFirstWrite.promise;
+          released = true;
+          return;
+        }
+
+        if (released && history.length === 3) {
+          repairPersisted.resolve();
+        }
+      },
+    });
+
+    const firstSubmit = session.submit(userText("first"));
+    const secondSubmit = session.submit(userText("second"));
+
+    await firstWriteStarted.promise;
+    session.interrupt();
+    await Promise.all([firstSubmit, secondSubmit]);
+    expect(persistedLengths).toEqual([1, 2, 3]);
+
+    releaseFirstWrite.resolve();
+    await repairPersisted.promise;
+    expect(persistedLengths).toEqual([1, 2, 3, 3]);
+  });
+
+  it("resets interrupt persistence waits before the next queued turn", async () => {
+    const firstLlmCall = createDeferred();
+    const persistedLengths: number[] = [];
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const session = new Agent({
+      llm: async ({ history }) => {
+        calls += 1;
+        seenHistory.push([...history]);
+
+        if (calls === 1) {
+          await firstLlmCall.promise;
+          return [assistantMessage("interrupted")];
+        }
+
+        return [assistantMessage("DONE")];
+      },
+    }).createSession({
+      onHistoryChange: (history) => {
+        persistedLengths.push(history.length);
+      },
+    });
+
+    const firstSubmit = session.submit(userText("first"));
+    const secondSubmit = session.submit(userText("second"));
+
+    session.interrupt();
+    firstLlmCall.resolve();
+
+    await Promise.all([firstSubmit, secondSubmit]);
+
+    expect(calls).toBe(1);
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("first")),
+        userTextToModelMessage(userText("second")),
+      ],
+    ]);
+    expect(persistedLengths).toEqual([1, 2, 3]);
+  });
+
   it("rejects input if a user-text listener kills the session before queueing", async () => {
     let calls = 0;
     const session = new Agent({

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -10,10 +10,18 @@ export interface SessionOptions {
   onHistoryChange?: (history: AgentMessage[]) => void | Promise<void>;
 }
 
+type OnHistoryChange = NonNullable<SessionOptions["onHistoryChange"]>;
+
 interface QueuedInput {
   input: SessionInput;
   reject: (error: unknown) => void;
   resolve: () => void;
+}
+
+const persistenceErrorFlag: unique symbol = Symbol("persistenceError");
+
+interface PersistenceError extends Error {
+  [persistenceErrorFlag]: true;
 }
 
 export class AgentSession {
@@ -25,7 +33,7 @@ export class AgentSession {
   #activeAbort?: AbortController;
   #killed = false;
   #historyPromiseChain: Promise<void> = Promise.resolve();
-  #pendingWrites: Promise<void>[] = [];
+  readonly #pendingWrites = new Set<Promise<void>>();
   #turnErrorEmitted = false;
 
   constructor(llm: Llm, options?: SessionOptions) {
@@ -34,32 +42,7 @@ export class AgentSession {
     this.#history = new AgentModelHistory(
       history,
       onHistoryChange
-        ? () => {
-            const writePromise = this.#historyPromiseChain
-              .then(async () => {
-                await onHistoryChange(this.getHistory());
-              })
-              .catch((error: unknown) => {
-                const message = `onHistoryChange failed: ${errorMessage(error)}`;
-                if (!this.#turnErrorEmitted) {
-                  this.#turnErrorEmitted = true;
-                  this.#emit({
-                    type: "turn-error",
-                    message,
-                  });
-                }
-                const persistenceError = new Error(message);
-                (
-                  persistenceError as Error & { isPersistenceError: boolean }
-                ).isPersistenceError = true;
-                throw persistenceError;
-              });
-
-            this.#historyPromiseChain = writePromise.catch(() => {
-              // Catch errors to ensure the chain continues for subsequent writes
-            });
-            this.#pendingWrites.push(writePromise);
-          }
+        ? (snapshot) => this.#enqueueHistoryChange(snapshot, onHistoryChange)
         : undefined
     );
   }
@@ -94,10 +77,7 @@ export class AgentSession {
     });
 
     this.#drainInputQueue().catch((error: unknown) => {
-      if (!this.#turnErrorEmitted) {
-        this.#turnErrorEmitted = true;
-        this.#emit({ type: "turn-error", message: errorMessage(error) });
-      }
+      this.#emitTurnError(error);
     });
     return queued;
   }
@@ -136,7 +116,7 @@ export class AgentSession {
 
         this.#activeAbort = new AbortController();
         const historySnapshot = this.#history.modelSnapshot();
-        this.#pendingWrites = [];
+        this.#pendingWrites.clear();
 
         try {
           this.#turnErrorEmitted = false;
@@ -150,30 +130,85 @@ export class AgentSession {
             signal: this.#activeAbort.signal,
           });
 
-          await Promise.all(this.#pendingWrites);
+          await this.#awaitPendingHistoryWrites();
 
           this.#emit({
             type: result === "aborted" ? "turn-abort" : "turn-end",
           });
           item.resolve();
         } catch (error) {
-          this.#pendingWrites = [];
           this.#history.rollback(historySnapshot);
-          this.#pendingWrites = [];
+          let rejectionError = error;
 
-          if (!(this.#turnErrorEmitted || isPersistenceError(error))) {
-            this.#turnErrorEmitted = true;
-            this.#emit({ type: "turn-error", message: errorMessage(error) });
+          try {
+            await this.#awaitPendingHistoryWrites();
+          } catch (rollbackOrWriteError) {
+            rejectionError = mergeTurnAndPersistenceErrors(
+              error,
+              rollbackOrWriteError
+            );
           }
-          item.reject(error);
+
+          this.#emitTurnError(rejectionError);
+          item.reject(rejectionError);
         } finally {
-          this.#pendingWrites = [];
+          this.#pendingWrites.clear();
           this.#activeAbort = undefined;
         }
       }
     } finally {
       this.#running = false;
     }
+  }
+
+  #enqueueHistoryChange(
+    snapshot: AgentMessage[],
+    onHistoryChange: OnHistoryChange
+  ): void {
+    const writePromise = this.#historyPromiseChain.then(async () => {
+      try {
+        await onHistoryChange(structuredClone(snapshot));
+      } catch (error: unknown) {
+        throw createPersistenceError(error);
+      }
+    });
+
+    this.#historyPromiseChain = writePromise.catch(() => {
+      // Keep later history writes sequenced even if this write fails.
+    });
+    this.#pendingWrites.add(writePromise);
+    writePromise.then(
+      () => this.#pendingWrites.delete(writePromise),
+      () => this.#pendingWrites.delete(writePromise)
+    );
+  }
+
+  async #awaitPendingHistoryWrites(): Promise<void> {
+    const errors: unknown[] = [];
+
+    while (this.#pendingWrites.size > 0) {
+      const writes = [...this.#pendingWrites];
+      const results = await Promise.allSettled(writes);
+
+      for (const result of results) {
+        if (result.status === "rejected") {
+          errors.push(result.reason);
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      throw combinePersistenceErrors(errors);
+    }
+  }
+
+  #emitTurnError(error: unknown): void {
+    if (this.#turnErrorEmitted) {
+      return;
+    }
+
+    this.#turnErrorEmitted = true;
+    this.#emit({ type: "turn-error", message: errorMessage(error) });
   }
 
   #emit(event: AgentEvent): void {
@@ -183,11 +218,45 @@ export class AgentSession {
   }
 }
 
+function createPersistenceError(error: unknown): PersistenceError {
+  return Object.assign(
+    new Error(`onHistoryChange failed: ${errorMessage(error)}`),
+    { [persistenceErrorFlag]: true as const }
+  );
+}
+
+function combinePersistenceErrors(errors: unknown[]): unknown {
+  if (errors.length === 1) {
+    return errors[0];
+  }
+
+  const messages = [...new Set(errors.map((error) => errorMessage(error)))];
+  return Object.assign(
+    new Error(`Multiple onHistoryChange failures: ${messages.join("; ")}`),
+    { [persistenceErrorFlag]: true as const }
+  );
+}
+
+function mergeTurnAndPersistenceErrors(
+  turnError: unknown,
+  persistenceError: unknown
+): unknown {
+  if (isPersistenceError(turnError)) {
+    return persistenceError;
+  }
+
+  return new Error(
+    `${errorMessage(turnError)}; history rollback persistence failed: ${errorMessage(
+      persistenceError
+    )}`
+  );
+}
+
 function isPersistenceError(error: unknown): boolean {
   return (
     error instanceof Error &&
-    (error as Error & { isPersistenceError?: boolean }).isPersistenceError ===
-      true
+    persistenceErrorFlag in error &&
+    error[persistenceErrorFlag] === true
   );
 }
 

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -31,15 +31,15 @@ export class AgentSession {
     this.#history = new AgentModelHistory(
       history,
       onHistoryChange
-        ? () => {
-            Promise.resolve(onHistoryChange(this.getHistory())).catch(
-              (error: unknown) => {
-                this.#emit({
-                  type: "turn-error",
-                  message: `onHistoryChange failed: ${errorMessage(error)}`,
-                });
-              }
-            );
+        ? async () => {
+            try {
+              await onHistoryChange(this.getHistory());
+            } catch (error: unknown) {
+              this.#emit({
+                type: "turn-error",
+                message: `onHistoryChange failed: ${errorMessage(error)}`,
+              });
+            }
           }
         : undefined
     );

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -18,12 +18,6 @@ interface QueuedInput {
   resolve: () => void;
 }
 
-const persistenceErrorFlag: unique symbol = Symbol("persistenceError");
-
-interface PersistenceError extends Error {
-  [persistenceErrorFlag]: true;
-}
-
 export class AgentSession {
   readonly #listeners = new Set<AgentEventListener>();
   readonly #llm: Llm;
@@ -246,11 +240,8 @@ export class AgentSession {
   }
 }
 
-function createPersistenceError(error: unknown): PersistenceError {
-  return Object.assign(
-    new Error(`onHistoryChange failed: ${errorMessage(error)}`),
-    { [persistenceErrorFlag]: true as const }
-  );
+function createPersistenceError(error: unknown): Error {
+  return new Error(`onHistoryChange failed: ${errorMessage(error)}`);
 }
 
 function combinePersistenceErrors(errors: unknown[]): unknown {
@@ -259,32 +250,17 @@ function combinePersistenceErrors(errors: unknown[]): unknown {
   }
 
   const messages = [...new Set(errors.map((error) => errorMessage(error)))];
-  return Object.assign(
-    new Error(`Multiple onHistoryChange failures: ${messages.join("; ")}`),
-    { [persistenceErrorFlag]: true as const }
-  );
+  return new Error(`Multiple onHistoryChange failures: ${messages.join("; ")}`);
 }
 
 function mergeTurnAndPersistenceErrors(
   turnError: unknown,
   persistenceError: unknown
 ): unknown {
-  if (isPersistenceError(turnError)) {
-    return persistenceError;
-  }
-
   return new Error(
     `${errorMessage(turnError)}; history rollback persistence failed: ${errorMessage(
       persistenceError
     )}`
-  );
-}
-
-function isPersistenceError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    persistenceErrorFlag in error &&
-    error[persistenceErrorFlag] === true
   );
 }
 

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,9 +1,14 @@
+import type { ModelMessage } from "ai";
 import { runAgentLoop } from "../agent-loop";
 import type { Llm } from "../llm";
 import type { AgentEvent, AgentEventListener, UserText } from "./events";
 import { AgentModelHistory } from "./history";
 
 export type SessionInput = UserText;
+
+export interface SessionOptions {
+  history?: ModelMessage[];
+}
 
 interface QueuedInput {
   input: SessionInput;
@@ -14,14 +19,19 @@ interface QueuedInput {
 export class AgentSession {
   readonly #listeners = new Set<AgentEventListener>();
   readonly #llm: Llm;
-  readonly #history = new AgentModelHistory();
+  readonly #history: AgentModelHistory;
   readonly #inputQueue: QueuedInput[] = [];
   #running = false;
   #activeAbort?: AbortController;
   #killed = false;
 
-  constructor(llm: Llm) {
+  constructor(llm: Llm, options?: SessionOptions) {
     this.#llm = llm;
+    this.#history = new AgentModelHistory(options?.history);
+  }
+
+  getHistory(): ModelMessage[] {
+    return this.#history.modelSnapshot();
   }
 
   subscribe(listener: AgentEventListener): () => void {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -30,7 +30,18 @@ export class AgentSession {
     const { history, onHistoryChange } = options ?? {};
     this.#history = new AgentModelHistory(
       history,
-      onHistoryChange ? () => onHistoryChange(this.getHistory()) : undefined
+      onHistoryChange
+        ? () => {
+            Promise.resolve(onHistoryChange(this.getHistory())).catch(
+              (error: unknown) => {
+                this.#emit({
+                  type: "turn-error",
+                  message: `onHistoryChange failed: ${errorMessage(error)}`,
+                });
+              }
+            );
+          }
+        : undefined
     );
   }
 

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -25,6 +25,7 @@ export class AgentSession {
   readonly #inputQueue: QueuedInput[] = [];
   #running = false;
   #activeAbort?: AbortController;
+  readonly #killAbort = new AbortController();
   #killed = false;
   #historyPromiseChain: Promise<void> = Promise.resolve();
   readonly #pendingWrites = new Set<Promise<void>>();
@@ -86,6 +87,7 @@ export class AgentSession {
     }
 
     this.#killed = true;
+    this.#killAbort.abort();
     this.#activeAbort?.abort();
 
     while (this.#inputQueue.length > 0) {
@@ -122,7 +124,9 @@ export class AgentSession {
       this.#turnErrorEmitted = false;
       this.#emit({ type: "turn-start" });
       this.#history.appendUserInput(item.input);
-      const userHistoryWrite = this.#pendingHistoryWrites();
+      const userHistoryWrite = this.#pendingHistoryWrites({
+        unblockOnKill: true,
+      });
       if (userHistoryWrite) {
         await userHistoryWrite;
       }
@@ -134,7 +138,9 @@ export class AgentSession {
         signal: this.#activeAbort.signal,
       });
 
-      const turnHistoryWrites = this.#pendingHistoryWrites();
+      const turnHistoryWrites = this.#pendingHistoryWrites({
+        unblockOnKill: true,
+      });
       if (turnHistoryWrites) {
         await turnHistoryWrites;
       }
@@ -144,6 +150,13 @@ export class AgentSession {
       });
       item.resolve();
     } catch (error) {
+      if (this.#killed && isSessionKilledError(error)) {
+        this.#history.rollback(historySnapshot, { notify: false });
+        this.#emit({ type: "turn-abort" });
+        item.resolve();
+        return;
+      }
+
       await this.#rollbackAndRejectInput(item, historySnapshot, error);
     } finally {
       this.#pendingWrites.clear();
@@ -160,7 +173,9 @@ export class AgentSession {
     let rejectionError = error;
 
     try {
-      const rollbackHistoryWrite = this.#pendingHistoryWrites();
+      const rollbackHistoryWrite = this.#pendingHistoryWrites({
+        unblockOnKill: true,
+      });
       if (rollbackHistoryWrite) {
         await rollbackHistoryWrite;
       }
@@ -197,12 +212,17 @@ export class AgentSession {
     );
   }
 
-  async #awaitPendingHistoryWrites(): Promise<void> {
+  async #awaitPendingHistoryWrites(options?: {
+    unblockOnKill?: boolean;
+  }): Promise<void> {
     const errors: unknown[] = [];
 
     while (this.#pendingWrites.size > 0) {
       const writes = [...this.#pendingWrites];
-      const results = await Promise.allSettled(writes);
+      const settledWrites = Promise.allSettled(writes);
+      const results = options?.unblockOnKill
+        ? await rejectOnKill(settledWrites, this.#killAbort.signal)
+        : await settledWrites;
 
       for (const result of results) {
         if (result.status === "rejected") {
@@ -216,12 +236,14 @@ export class AgentSession {
     }
   }
 
-  #pendingHistoryWrites(): Promise<void> | undefined {
+  #pendingHistoryWrites(options?: {
+    unblockOnKill?: boolean;
+  }): Promise<void> | undefined {
     if (this.#pendingWrites.size === 0) {
       return;
     }
 
-    return this.#awaitPendingHistoryWrites();
+    return this.#awaitPendingHistoryWrites(options);
   }
 
   #emitTurnError(error: unknown): void {
@@ -274,4 +296,33 @@ function errorMessage(error: unknown): string {
 
 function sessionKilledError(): Error {
   return new Error("Session killed");
+}
+
+function isSessionKilledError(error: unknown): boolean {
+  return error instanceof Error && error.message === "Session killed";
+}
+
+function rejectOnKill<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(sessionKilledError());
+  }
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(sessionKilledError());
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
 }

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -49,7 +49,9 @@ export class AgentSession {
                   });
                 }
                 const persistenceError = new Error(message);
-                (persistenceError as any).isPersistenceError = true;
+                (
+                  persistenceError as Error & { isPersistenceError: boolean }
+                ).isPersistenceError = true;
                 throw persistenceError;
               });
 
@@ -159,7 +161,7 @@ export class AgentSession {
           this.#history.rollback(historySnapshot);
           this.#pendingWrites = [];
 
-          if (!this.#turnErrorEmitted) {
+          if (!(this.#turnErrorEmitted || isPersistenceError(error))) {
             this.#turnErrorEmitted = true;
             this.#emit({ type: "turn-error", message: errorMessage(error) });
           }
@@ -179,6 +181,14 @@ export class AgentSession {
       listener(event);
     }
   }
+}
+
+function isPersistenceError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as Error & { isPersistenceError?: boolean }).isPersistenceError ===
+      true
+  );
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -261,10 +261,14 @@ export class AgentSession {
     try {
       return await rejectOnKill(writes, this.#killAbort.signal);
     } catch (error: unknown) {
-      if (isSessionKilledError(error) && this.#settledWriteErrors.size > 0) {
-        const settledErrors = [...this.#settledWriteErrors];
-        this.#settledWriteErrors.clear();
-        throw combinePersistenceErrors(settledErrors);
+      if (isSessionKilledError(error)) {
+        await waitForKillRaceSettlements();
+
+        if (this.#settledWriteErrors.size > 0) {
+          const settledErrors = [...this.#settledWriteErrors];
+          this.#settledWriteErrors.clear();
+          throw combinePersistenceErrors(settledErrors);
+        }
       }
 
       throw error;
@@ -327,25 +331,43 @@ function isSessionKilledError(error: unknown): boolean {
   return error instanceof Error && error.message === "Session killed";
 }
 
+async function waitForKillRaceSettlements(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 function rejectOnKill<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   if (signal.aborted) {
-    return Promise.reject(sessionKilledError());
+    return new Promise((_, reject) => {
+      setTimeout(() => reject(sessionKilledError()), 0);
+    });
   }
 
   return new Promise((resolve, reject) => {
+    let abortTimeout: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+      if (abortTimeout) {
+        clearTimeout(abortTimeout);
+      }
+    };
     const onAbort = () => {
       signal.removeEventListener("abort", onAbort);
-      reject(sessionKilledError());
+      abortTimeout = setTimeout(() => {
+        abortTimeout = undefined;
+        reject(sessionKilledError());
+      }, 0);
     };
 
     signal.addEventListener("abort", onAbort, { once: true });
     promise.then(
       (value) => {
-        signal.removeEventListener("abort", onAbort);
+        cleanup();
         resolve(value);
       },
       (error: unknown) => {
-        signal.removeEventListener("abort", onAbort);
+        cleanup();
         reject(error);
       }
     );

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -22,6 +22,7 @@ export class AgentSession {
   readonly #listeners = new Set<AgentEventListener>();
   readonly #llm: Llm;
   readonly #history: AgentModelHistory;
+  readonly #onHistoryChange?: OnHistoryChange;
   readonly #inputQueue: QueuedInput[] = [];
   #running = false;
   #activeAbort?: AbortController;
@@ -36,6 +37,7 @@ export class AgentSession {
   constructor(llm: Llm, options?: SessionOptions) {
     this.#llm = llm;
     const { history, onHistoryChange } = options ?? {};
+    this.#onHistoryChange = onHistoryChange;
     this.#history = new AgentModelHistory(
       history,
       onHistoryChange
@@ -152,9 +154,11 @@ export class AgentSession {
         await turnHistoryWrites;
       }
 
-      this.#emit({
-        type: result === "aborted" ? "turn-abort" : "turn-end",
-      });
+      const interrupted = result === "aborted";
+      this.#emit({ type: interrupted ? "turn-abort" : "turn-end" });
+      if (interrupted) {
+        this.#interruptAbort = new AbortController();
+      }
       item.resolve();
     } catch (error) {
       if (this.#killed && isSessionKilledError(error)) {
@@ -165,7 +169,7 @@ export class AgentSession {
       }
 
       if (isSessionInterruptedError(error)) {
-        this.#historyPromiseChain = Promise.resolve();
+        this.#repairHistoryPersistenceAfterInterruptedWait();
         this.#pendingWrites.clear();
         this.#interruptAbort = new AbortController();
         this.#emit({ type: "turn-abort" });
@@ -231,6 +235,26 @@ export class AgentSession {
     );
   }
 
+  #repairHistoryPersistenceAfterInterruptedWait(): void {
+    const onHistoryChange = this.#onHistoryChange;
+    if (!onHistoryChange) {
+      return;
+    }
+
+    const abandonedChain = this.#historyPromiseChain;
+    this.#historyPromiseChain = Promise.resolve();
+    abandonedChain.then(() => {
+      if (this.#killed) {
+        return;
+      }
+
+      this.#enqueueHistoryChange(
+        this.#history.modelSnapshot(),
+        onHistoryChange
+      );
+    });
+  }
+
   async #awaitPendingHistoryWrites(options?: {
     unblockOnInterrupt?: boolean;
     unblockOnKill?: boolean;
@@ -292,7 +316,7 @@ export class AgentSession {
       return await interruptibleWrites;
     } catch (error: unknown) {
       if (isSessionKilledError(error) || isSessionInterruptedError(error)) {
-        await waitForKillRaceSettlements();
+        await waitForAbortRaceSettlements();
 
         if (this.#settledWriteErrors.size > 0) {
           const settledErrors = [...this.#settledWriteErrors];
@@ -369,7 +393,7 @@ function isSessionInterruptedError(error: unknown): boolean {
   return error instanceof Error && error.message === "Session interrupted";
 }
 
-async function waitForKillRaceSettlements(): Promise<void> {
+async function waitForAbortRaceSettlements(): Promise<void> {
   await new Promise<void>((resolve) => {
     setTimeout(resolve, 0);
   });

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -7,6 +7,7 @@ export type SessionInput = UserText;
 
 export interface SessionOptions {
   history?: AgentMessage[];
+  onHistoryChange?: (history: AgentMessage[]) => void | Promise<void>;
 }
 
 interface QueuedInput {
@@ -26,7 +27,14 @@ export class AgentSession {
 
   constructor(llm: Llm, options?: SessionOptions) {
     this.#llm = llm;
-    this.#history = new AgentModelHistory(options?.history);
+    this.#history = new AgentModelHistory(
+      options?.history,
+      options?.onHistoryChange
+        ? () => {
+            options.onHistoryChange?.(this.getHistory());
+          }
+        : undefined
+    );
   }
 
   getHistory(): AgentMessage[] {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -110,55 +110,75 @@ export class AgentSession {
       while (!this.#killed && this.#inputQueue.length > 0) {
         const item = this.#inputQueue.shift();
 
-        if (!item) {
-          continue;
-        }
-
-        this.#activeAbort = new AbortController();
-        const historySnapshot = this.#history.modelSnapshot();
-        this.#pendingWrites.clear();
-
-        try {
-          this.#turnErrorEmitted = false;
-          this.#emit({ type: "turn-start" });
-          this.#history.appendUserInput(item.input);
-
-          const result = await runAgentLoop({
-            emit: (event) => this.#emit(event),
-            history: this.#history,
-            llm: this.#llm,
-            signal: this.#activeAbort.signal,
-          });
-
-          await this.#awaitPendingHistoryWrites();
-
-          this.#emit({
-            type: result === "aborted" ? "turn-abort" : "turn-end",
-          });
-          item.resolve();
-        } catch (error) {
-          this.#history.rollback(historySnapshot);
-          let rejectionError = error;
-
-          try {
-            await this.#awaitPendingHistoryWrites();
-          } catch (rollbackOrWriteError) {
-            rejectionError = mergeTurnAndPersistenceErrors(
-              error,
-              rollbackOrWriteError
-            );
-          }
-
-          this.#emitTurnError(rejectionError);
-          item.reject(rejectionError);
-        } finally {
-          this.#pendingWrites.clear();
-          this.#activeAbort = undefined;
+        if (item) {
+          await this.#processQueuedInput(item);
         }
       }
     } finally {
       this.#running = false;
     }
+  }
+
+  async #processQueuedInput(item: QueuedInput): Promise<void> {
+    this.#activeAbort = new AbortController();
+    const historySnapshot = this.#history.modelSnapshot();
+    this.#pendingWrites.clear();
+
+    try {
+      this.#turnErrorEmitted = false;
+      this.#emit({ type: "turn-start" });
+      this.#history.appendUserInput(item.input);
+      const userHistoryWrite = this.#pendingHistoryWrites();
+      if (userHistoryWrite) {
+        await userHistoryWrite;
+      }
+
+      const result = await runAgentLoop({
+        emit: (event) => this.#emit(event),
+        history: this.#history,
+        llm: this.#llm,
+        signal: this.#activeAbort.signal,
+      });
+
+      const turnHistoryWrites = this.#pendingHistoryWrites();
+      if (turnHistoryWrites) {
+        await turnHistoryWrites;
+      }
+
+      this.#emit({
+        type: result === "aborted" ? "turn-abort" : "turn-end",
+      });
+      item.resolve();
+    } catch (error) {
+      await this.#rollbackAndRejectInput(item, historySnapshot, error);
+    } finally {
+      this.#pendingWrites.clear();
+      this.#activeAbort = undefined;
+    }
+  }
+
+  async #rollbackAndRejectInput(
+    item: QueuedInput,
+    historySnapshot: AgentMessage[],
+    error: unknown
+  ): Promise<void> {
+    this.#history.rollback(historySnapshot);
+    let rejectionError = error;
+
+    try {
+      const rollbackHistoryWrite = this.#pendingHistoryWrites();
+      if (rollbackHistoryWrite) {
+        await rollbackHistoryWrite;
+      }
+    } catch (rollbackOrWriteError) {
+      rejectionError = mergeTurnAndPersistenceErrors(
+        error,
+        rollbackOrWriteError
+      );
+    }
+
+    this.#emitTurnError(rejectionError);
+    item.reject(rejectionError);
   }
 
   #enqueueHistoryChange(
@@ -200,6 +220,14 @@ export class AgentSession {
     if (errors.length > 0) {
       throw combinePersistenceErrors(errors);
     }
+  }
+
+  #pendingHistoryWrites(): Promise<void> | undefined {
+    if (this.#pendingWrites.size === 0) {
+      return;
+    }
+
+    return this.#awaitPendingHistoryWrites();
   }
 
   #emitTurnError(error: unknown): void {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -39,11 +39,9 @@ export class AgentSession {
                 await onHistoryChange(this.getHistory());
               })
               .catch((error: unknown) => {
-                this.#emit({
-                  type: "turn-error",
-                  message: `onHistoryChange failed: ${errorMessage(error)}`,
-                });
-                throw error;
+                throw new Error(
+                  `onHistoryChange failed: ${errorMessage(error)}`
+                );
               });
 
             this.#historyPromiseChain = writePromise.catch(() => {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,13 +1,12 @@
-import type { ModelMessage } from "ai";
 import { runAgentLoop } from "../agent-loop";
-import type { Llm } from "../llm";
+import type { AgentMessage, Llm } from "../llm";
 import type { AgentEvent, AgentEventListener, UserText } from "./events";
 import { AgentModelHistory } from "./history";
 
 export type SessionInput = UserText;
 
 export interface SessionOptions {
-  history?: ModelMessage[];
+  history?: AgentMessage[];
 }
 
 interface QueuedInput {
@@ -30,7 +29,7 @@ export class AgentSession {
     this.#history = new AgentModelHistory(options?.history);
   }
 
-  getHistory(): ModelMessage[] {
+  getHistory(): AgentMessage[] {
     return this.#history.modelSnapshot();
   }
 

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -24,6 +24,8 @@ export class AgentSession {
   #running = false;
   #activeAbort?: AbortController;
   #killed = false;
+  #historyPromiseChain: Promise<void> = Promise.resolve();
+  #pendingWrites: Promise<void>[] = [];
 
   constructor(llm: Llm, options?: SessionOptions) {
     this.#llm = llm;
@@ -31,15 +33,23 @@ export class AgentSession {
     this.#history = new AgentModelHistory(
       history,
       onHistoryChange
-        ? async () => {
-            try {
-              await onHistoryChange(this.getHistory());
-            } catch (error: unknown) {
-              this.#emit({
-                type: "turn-error",
-                message: `onHistoryChange failed: ${errorMessage(error)}`,
+        ? () => {
+            const writePromise = this.#historyPromiseChain
+              .then(async () => {
+                await onHistoryChange(this.getHistory());
+              })
+              .catch((error: unknown) => {
+                this.#emit({
+                  type: "turn-error",
+                  message: `onHistoryChange failed: ${errorMessage(error)}`,
+                });
+                throw error;
               });
-            }
+
+            this.#historyPromiseChain = writePromise.catch(() => {
+              // Catch errors to ensure the chain continues for subsequent writes
+            });
+            this.#pendingWrites.push(writePromise);
           }
         : undefined
     );
@@ -113,6 +123,8 @@ export class AgentSession {
         }
 
         this.#activeAbort = new AbortController();
+        const historySnapshot = this.#history.modelSnapshot();
+        this.#pendingWrites = [];
 
         try {
           this.#emit({ type: "turn-start" });
@@ -124,14 +136,22 @@ export class AgentSession {
             llm: this.#llm,
             signal: this.#activeAbort.signal,
           });
+
+          await Promise.all(this.#pendingWrites);
+
           this.#emit({
             type: result === "aborted" ? "turn-abort" : "turn-end",
           });
           item.resolve();
         } catch (error) {
+          this.#pendingWrites = [];
+          this.#history.rollback(historySnapshot);
+          this.#pendingWrites = [];
+
           this.#emit({ type: "turn-error", message: errorMessage(error) });
           item.reject(error);
         } finally {
+          this.#pendingWrites = [];
           this.#activeAbort = undefined;
         }
       }

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -29,6 +29,7 @@ export class AgentSession {
   #killed = false;
   #historyPromiseChain: Promise<void> = Promise.resolve();
   readonly #pendingWrites = new Set<Promise<void>>();
+  readonly #settledWriteErrors = new Set<unknown>();
   #turnErrorEmitted = false;
 
   constructor(llm: Llm, options?: SessionOptions) {
@@ -119,6 +120,7 @@ export class AgentSession {
     this.#activeAbort = new AbortController();
     const historySnapshot = this.#history.modelSnapshot();
     this.#pendingWrites.clear();
+    this.#settledWriteErrors.clear();
 
     try {
       this.#turnErrorEmitted = false;
@@ -151,7 +153,7 @@ export class AgentSession {
       item.resolve();
     } catch (error) {
       if (this.#killed && isSessionKilledError(error)) {
-        this.#history.rollback(historySnapshot, { notify: false });
+        this.#history.rollback(historySnapshot);
         this.#emit({ type: "turn-abort" });
         item.resolve();
         return;
@@ -208,7 +210,10 @@ export class AgentSession {
     this.#pendingWrites.add(writePromise);
     writePromise.then(
       () => this.#pendingWrites.delete(writePromise),
-      () => this.#pendingWrites.delete(writePromise)
+      (error: unknown) => {
+        this.#settledWriteErrors.add(error);
+        this.#pendingWrites.delete(writePromise);
+      }
     );
   }
 
@@ -220,15 +225,14 @@ export class AgentSession {
     while (this.#pendingWrites.size > 0) {
       const writes = [...this.#pendingWrites];
       const settledWrites = Promise.allSettled(writes);
-      const results = options?.unblockOnKill
-        ? await rejectOnKill(settledWrites, this.#killAbort.signal)
-        : await settledWrites;
+      const results = await this.#settleHistoryWrites(settledWrites, options);
 
       for (const result of results) {
         if (result.status === "rejected") {
           errors.push(result.reason);
         }
       }
+      this.#settledWriteErrors.clear();
     }
 
     if (errors.length > 0) {
@@ -244,6 +248,27 @@ export class AgentSession {
     }
 
     return this.#awaitPendingHistoryWrites(options);
+  }
+
+  async #settleHistoryWrites(
+    writes: Promise<PromiseSettledResult<void>[]>,
+    options?: { unblockOnKill?: boolean }
+  ): Promise<PromiseSettledResult<void>[]> {
+    if (!options?.unblockOnKill) {
+      return writes;
+    }
+
+    try {
+      return await rejectOnKill(writes, this.#killAbort.signal);
+    } catch (error: unknown) {
+      if (isSessionKilledError(error) && this.#settledWriteErrors.size > 0) {
+        const settledErrors = [...this.#settledWriteErrors];
+        this.#settledWriteErrors.clear();
+        throw combinePersistenceErrors(settledErrors);
+      }
+
+      throw error;
+    }
   }
 
   #emitTurnError(error: unknown): void {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -27,13 +27,10 @@ export class AgentSession {
 
   constructor(llm: Llm, options?: SessionOptions) {
     this.#llm = llm;
+    const { history, onHistoryChange } = options ?? {};
     this.#history = new AgentModelHistory(
-      options?.history,
-      options?.onHistoryChange
-        ? () => {
-            options.onHistoryChange?.(this.getHistory());
-          }
-        : undefined
+      history,
+      onHistoryChange ? () => onHistoryChange(this.getHistory()) : undefined
     );
   }
 

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -26,6 +26,7 @@ export class AgentSession {
   #running = false;
   #activeAbort?: AbortController;
   readonly #killAbort = new AbortController();
+  #interruptAbort = new AbortController();
   #killed = false;
   #historyPromiseChain: Promise<void> = Promise.resolve();
   readonly #pendingWrites = new Set<Promise<void>>();
@@ -80,6 +81,7 @@ export class AgentSession {
 
   interrupt(): void {
     this.#activeAbort?.abort();
+    this.#interruptAbort.abort();
   }
 
   kill(): void {
@@ -113,6 +115,7 @@ export class AgentSession {
       }
     } finally {
       this.#running = false;
+      this.#interruptAbort = new AbortController();
     }
   }
 
@@ -128,6 +131,7 @@ export class AgentSession {
       this.#history.appendUserInput(item.input);
       const userHistoryWrite = this.#pendingHistoryWrites({
         unblockOnKill: true,
+        unblockOnInterrupt: true,
       });
       if (userHistoryWrite) {
         await userHistoryWrite;
@@ -142,6 +146,7 @@ export class AgentSession {
 
       const turnHistoryWrites = this.#pendingHistoryWrites({
         unblockOnKill: true,
+        unblockOnInterrupt: true,
       });
       if (turnHistoryWrites) {
         await turnHistoryWrites;
@@ -154,6 +159,15 @@ export class AgentSession {
     } catch (error) {
       if (this.#killed && isSessionKilledError(error)) {
         this.#history.rollback(historySnapshot);
+        this.#emit({ type: "turn-abort" });
+        item.resolve();
+        return;
+      }
+
+      if (isSessionInterruptedError(error)) {
+        this.#historyPromiseChain = Promise.resolve();
+        this.#pendingWrites.clear();
+        this.#interruptAbort = new AbortController();
         this.#emit({ type: "turn-abort" });
         item.resolve();
         return;
@@ -218,6 +232,7 @@ export class AgentSession {
   }
 
   async #awaitPendingHistoryWrites(options?: {
+    unblockOnInterrupt?: boolean;
     unblockOnKill?: boolean;
   }): Promise<void> {
     const errors: unknown[] = [];
@@ -241,6 +256,7 @@ export class AgentSession {
   }
 
   #pendingHistoryWrites(options?: {
+    unblockOnInterrupt?: boolean;
     unblockOnKill?: boolean;
   }): Promise<void> | undefined {
     if (this.#pendingWrites.size === 0) {
@@ -252,16 +268,30 @@ export class AgentSession {
 
   async #settleHistoryWrites(
     writes: Promise<PromiseSettledResult<void>[]>,
-    options?: { unblockOnKill?: boolean }
+    options?: { unblockOnInterrupt?: boolean; unblockOnKill?: boolean }
   ): Promise<PromiseSettledResult<void>[]> {
-    if (!options?.unblockOnKill) {
+    if (!(options?.unblockOnKill || options?.unblockOnInterrupt)) {
       return writes;
     }
 
+    let interruptibleWrites = writes;
+    if (options.unblockOnKill) {
+      interruptibleWrites = rejectOnKill(
+        interruptibleWrites,
+        this.#killAbort.signal
+      );
+    }
+    if (options.unblockOnInterrupt) {
+      interruptibleWrites = rejectOnInterrupt(
+        interruptibleWrites,
+        this.#interruptAbort.signal
+      );
+    }
+
     try {
-      return await rejectOnKill(writes, this.#killAbort.signal);
+      return await interruptibleWrites;
     } catch (error: unknown) {
-      if (isSessionKilledError(error)) {
+      if (isSessionKilledError(error) || isSessionInterruptedError(error)) {
         await waitForKillRaceSettlements();
 
         if (this.#settledWriteErrors.size > 0) {
@@ -331,6 +361,14 @@ function isSessionKilledError(error: unknown): boolean {
   return error instanceof Error && error.message === "Session killed";
 }
 
+function sessionInterruptedError(): Error {
+  return new Error("Session interrupted");
+}
+
+function isSessionInterruptedError(error: unknown): boolean {
+  return error instanceof Error && error.message === "Session interrupted";
+}
+
 async function waitForKillRaceSettlements(): Promise<void> {
   await new Promise<void>((resolve) => {
     setTimeout(resolve, 0);
@@ -338,9 +376,24 @@ async function waitForKillRaceSettlements(): Promise<void> {
 }
 
 function rejectOnKill<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return rejectOnSignal(promise, signal, sessionKilledError);
+}
+
+function rejectOnInterrupt<T>(
+  promise: Promise<T>,
+  signal: AbortSignal
+): Promise<T> {
+  return rejectOnSignal(promise, signal, sessionInterruptedError);
+}
+
+function rejectOnSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+  createError: () => Error
+): Promise<T> {
   if (signal.aborted) {
     return new Promise((_, reject) => {
-      setTimeout(() => reject(sessionKilledError()), 0);
+      setTimeout(() => reject(createError()), 0);
     });
   }
 
@@ -356,7 +409,7 @@ function rejectOnKill<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
       signal.removeEventListener("abort", onAbort);
       abortTimeout = setTimeout(() => {
         abortTimeout = undefined;
-        reject(sessionKilledError());
+        reject(createError());
       }, 0);
     };
 

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -26,6 +26,7 @@ export class AgentSession {
   #killed = false;
   #historyPromiseChain: Promise<void> = Promise.resolve();
   #pendingWrites: Promise<void>[] = [];
+  #turnErrorEmitted = false;
 
   constructor(llm: Llm, options?: SessionOptions) {
     this.#llm = llm;
@@ -39,9 +40,17 @@ export class AgentSession {
                 await onHistoryChange(this.getHistory());
               })
               .catch((error: unknown) => {
-                throw new Error(
-                  `onHistoryChange failed: ${errorMessage(error)}`
-                );
+                const message = `onHistoryChange failed: ${errorMessage(error)}`;
+                if (!this.#turnErrorEmitted) {
+                  this.#turnErrorEmitted = true;
+                  this.#emit({
+                    type: "turn-error",
+                    message,
+                  });
+                }
+                const persistenceError = new Error(message);
+                (persistenceError as any).isPersistenceError = true;
+                throw persistenceError;
               });
 
             this.#historyPromiseChain = writePromise.catch(() => {
@@ -83,7 +92,10 @@ export class AgentSession {
     });
 
     this.#drainInputQueue().catch((error: unknown) => {
-      this.#emit({ type: "turn-error", message: errorMessage(error) });
+      if (!this.#turnErrorEmitted) {
+        this.#turnErrorEmitted = true;
+        this.#emit({ type: "turn-error", message: errorMessage(error) });
+      }
     });
     return queued;
   }
@@ -125,6 +137,7 @@ export class AgentSession {
         this.#pendingWrites = [];
 
         try {
+          this.#turnErrorEmitted = false;
           this.#emit({ type: "turn-start" });
           this.#history.appendUserInput(item.input);
 
@@ -146,7 +159,10 @@ export class AgentSession {
           this.#history.rollback(historySnapshot);
           this.#pendingWrites = [];
 
-          this.#emit({ type: "turn-error", message: errorMessage(error) });
+          if (!this.#turnErrorEmitted) {
+            this.#turnErrorEmitted = true;
+            this.#emit({ type: "turn-error", message: errorMessage(error) });
+          }
           item.reject(error);
         } finally {
           this.#pendingWrites = [];

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -82,7 +82,11 @@ export class AgentSession {
   }
 
   interrupt(): void {
-    this.#activeAbort?.abort();
+    if (!this.#activeAbort) {
+      return;
+    }
+
+    this.#activeAbort.abort();
     this.#interruptAbort.abort();
   }
 


### PR DESCRIPTION
This PR adds support for hydrating AgentSession with caller-owned `history`, exposing a public AgentMessage type alias, and adding a getHistory() snapshot getter to AgentSession. This enables integration with stateful, step-wise custom execution loops such as the Bori backend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds history hydration, a getHistory() snapshot getter, and an onHistoryChange hook to AgentSession for stateful loops and storage sync. Ensures persistence-first, serialized history writes with deterministic snapshots, safe rollback, single turn-error, kill() that unblocks stalled persistence, and interrupt() that unblocks, runs the next turn, and later repairs persistence, while ignoring idle interrupts.

- New Features
  - Agent.createSession(options?: SessionOptions) accepts history and onHistoryChange.
  - AgentSession#getHistory() returns a cloned history snapshot.
  - Export AgentMessage and SessionOptions from `@minpeter/pss-runtime`.

- Bug Fixes
  - Serialize onHistoryChange with mutation-time snapshots; drain queued writes and persist rollback before turn-end/turn-abort or rejection.
  - Persist the user append before model/tool work; on failure, roll back to the pre-turn snapshot and include rollback-persist errors in the final turn-error.
  - kill() unblocks stalled history writes, rolls back in-memory without waiting on stuck I/O, queues rollback persistence, and surfaces any write failures that settle during kill.
  - interrupt() releases stalled history-persistence waits, ignores idle interrupts when no turn is active, resets the interrupt state before the next queued turn, and detaches the abandoned chain while scheduling a latest-snapshot repair once the stalled write resumes.

<sup>Written for commit 4b3cbf888a40be704426481e789acfeb51e6d8df. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/23?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

