### PR TITLE
Allow submit text arrays for turn context

### DIFF
--- a/.changeset/bright-owls-submit-text-parts.md
+++ b/.changeset/bright-owls-submit-text-parts.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Allow `AgentSession.submit()` user text to be passed as an array of strings for host-rendered per-turn context.

--- a/packages/coding-agent/src/tui.ts
+++ b/packages/coding-agent/src/tui.ts
@@ -6,7 +6,7 @@ import {
   Text,
   TUI,
 } from "@earendil-works/pi-tui";
-import type { AgentEvent } from "@minpeter/pss-runtime";
+import type { AgentEvent, UserTextContent } from "@minpeter/pss-runtime";
 import { Agent } from "@minpeter/pss-runtime";
 import { createCodingAgentModel } from "./model";
 import { tools } from "./tools";
@@ -53,10 +53,13 @@ const addLine = (text: string): void => {
   tui.requestRender();
 };
 
+const formatUserTextContent = (text: UserTextContent): string =>
+  typeof text === "string" ? text : text.join("\n");
+
 const formatEvent = (event: AgentEvent): string | undefined => {
   switch (event.type) {
     case "user-text":
-      return `\x1b[36myou\x1b[0m: ${safeText(event.text)}`;
+      return `\x1b[36myou\x1b[0m: ${safeText(formatUserTextContent(event.text))}`;
     case "assistant-text":
       return `\x1b[32massistant\x1b[0m: ${safeText(event.text)}`;
     case "assistant-reasoning":

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -115,3 +115,18 @@ try {
   unsubscribe();
 }
 ```
+
+`submit()` also accepts `text` as an array of strings. The runtime keeps those
+strings together as one user turn and forwards them to the model as AI SDK text
+content parts, which is useful when the host needs to prepend per-turn context
+without flattening it into the user's visible message.
+
+```ts
+await session.submit({
+  type: "user-text",
+  text: [
+    "Context: user timezone is Asia/Seoul.",
+    "Please remind me tomorrow morning.",
+  ],
+});
+```

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -22,6 +22,7 @@ export type {
   ToolCall,
   ToolResult,
   UserText,
+  UserTextContent,
 } from "./session/events";
 export {
   AgentSession,

--- a/packages/runtime/src/session/events.ts
+++ b/packages/runtime/src/session/events.ts
@@ -1,5 +1,7 @@
+export type UserTextContent = string | readonly string[];
+
 export interface UserText {
-  text: string;
+  text: UserTextContent;
   type: "user-text";
 }
 export interface AssistantText {

--- a/packages/runtime/src/session/mapping.test.ts
+++ b/packages/runtime/src/session/mapping.test.ts
@@ -15,6 +15,18 @@ describe("session mapping", () => {
     });
   });
 
+  it("maps multipart user text to AI SDK text content parts", () => {
+    expect(
+      userTextToModelMessage(userText(["context block", "user message"]))
+    ).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "context block" },
+        { type: "text", text: "user message" },
+      ],
+    });
+  });
+
   it("projects assistant reasoning, text, and tool calls to public agent events", () => {
     const toolCall = toolCallPart("call-tool", "test_tool", {
       query: "latest OpenAI API updates",

--- a/packages/runtime/src/session/mapping.ts
+++ b/packages/runtime/src/session/mapping.ts
@@ -11,6 +11,7 @@ import type {
   ToolCall,
   ToolResult,
   UserText,
+  UserTextContent,
 } from "./events";
 
 type AssistantContentPart = Exclude<AssistantContent, string>[number];
@@ -19,7 +20,17 @@ type ModelEvent = AssistantReasoning | AssistantText | ToolCall | ToolResult;
 
 // UserText -> AI SDK UserModelMessage
 export function userTextToModelMessage(input: UserText): UserModelMessage {
-  return { role: "user", content: input.text };
+  return { role: "user", content: userTextContentToUserContent(input.text) };
+}
+
+function userTextContentToUserContent(
+  text: UserTextContent
+): UserModelMessage["content"] {
+  if (typeof text === "string") {
+    return text;
+  }
+
+  return text.map((part) => ({ type: "text", text: part }));
 }
 
 // AI SDK ModelMessage -> public agent events

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -97,6 +97,32 @@ describe("AgentSession", () => {
     ]);
   });
 
+  it("accepts multipart user text as one submitted turn", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const session = new Agent({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    }).createSession();
+    const events: AgentEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    await session.submit(userText(["per-turn context", "hello"]));
+
+    expect(seenHistory).toEqual([
+      [userTextToModelMessage(userText(["per-turn context", "hello"]))],
+    ]);
+    expect(events[0]).toEqual({
+      type: "user-text",
+      text: ["per-turn context", "hello"],
+    });
+    expect(session.getHistory()).toEqual([
+      userTextToModelMessage(userText(["per-turn context", "hello"])),
+      assistantMessage("DONE"),
+    ]);
+  });
+
   it("emits turn-error and rejects the submitted input when the LLM fails", async () => {
     const session = new Agent({
       llm: () => Promise.reject(new Error("model unavailable")),

--- a/packages/runtime/src/test-fixtures.ts
+++ b/packages/runtime/src/test-fixtures.ts
@@ -1,6 +1,6 @@
 import type { AssistantModelMessage, ToolCallPart, ToolModelMessage } from "ai";
 import type { Llm, LlmOutput } from "./llm";
-import type { AgentEvent, UserText } from "./session/events";
+import type { AgentEvent, UserText, UserTextContent } from "./session/events";
 
 export const assistantMessage = (
   content: AssistantModelMessage["content"]
@@ -51,7 +51,7 @@ export const createScriptedLlm = (outputs: LlmOutput[]): Llm => {
 export const eventTypes = (events: AgentEvent[]) =>
   events.map((event) => event.type);
 
-export const userText = (text: string): UserText => ({
+export const userText = (text: UserTextContent): UserText => ({
   type: "user-text",
   text,
 });


### PR DESCRIPTION
## What changed

- Allows `AgentSession.submit({ type: "user-text", text })` to accept `text` as either a string or an array of strings.
- Maps string arrays to AI SDK user text content parts inside one user turn.
- Exports `UserTextContent` and updates the coding-agent TUI to render the widened user-text event type safely.
- Adds runtime tests and README guidance for host-rendered per-turn context.
- Adds a patch changeset for `@minpeter/pss-runtime`.

## Why

Bori should be able to prepend model-visible per-turn context, such as timezone or recalled context, without making backend-owned identifiers like `agent_id`, `user_id`, or delivery handles part of tool input or prompt plumbing.

## Validation

- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm verify:release`
