### PR TITLE
Document runtime event delivery for Cloudflare hosts

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -54,7 +54,12 @@ Objects, where a long-lived session mirrors history into Durable Object Storage,
 SQLite, or another caller-owned store.
 
 ```ts
-import { Agent, type AgentMessage, type AgentSession } from "@minpeter/pss-runtime";
+import {
+  Agent,
+  type AgentEvent,
+  type AgentMessage,
+  type AgentSession,
+} from "@minpeter/pss-runtime";
 
 export class AgentDurableObject {
   private agent: Agent;
@@ -69,21 +74,47 @@ export class AgentDurableObject {
     });
   }
 
-  async fetch(request: Request) {
-    if (!this.session) {
-      const history =
-        (await this.storage.get<AgentMessage[]>("history")) ?? [];
-
-      this.session = this.agent.createSession({
-        history,
-        onHistoryChange: async (nextHistory) => {
-          await this.storage.put("history", nextHistory);
-        },
-      });
+  private async getSession() {
+    if (this.session) {
+      return this.session;
     }
 
-    // Process the incoming request (e.g. submit user text and stream back events).
-    // ...
+    const history =
+      (await this.storage.get<AgentMessage[]>("history")) ?? [];
+
+    this.session = this.agent.createSession({
+      history,
+      onHistoryChange: async (nextHistory) => {
+        await this.storage.put("history", nextHistory);
+      },
+    });
+    return this.session;
+  }
+
+  async fetch(request: Request) {
+    const { message } = await request.json<{ message: string }>();
+    const session = await this.getSession();
+    let responseText = "";
+
+    const unsubscribe = session.subscribe((event: AgentEvent) => {
+      if (event.type === "assistant-text") {
+        // In a real Worker, write this to a TransformStream, WebSocket, or
+        // channel-specific delivery queue. This also receives text emitted
+        // before a tool call in the same model step.
+        responseText += event.text;
+      }
+    });
+
+    try {
+      await session.submit({ type: "user-text", text: message });
+    } finally {
+      unsubscribe();
+    }
+
+    return Response.json({
+      history: session.getHistory(),
+      response: responseText,
+    });
   }
 }
 ```
@@ -103,7 +134,7 @@ const unsubscribe = session.subscribe((event) => {
       process.stdout.write(event.text);
       break;
     case "tool-call":
-      console.log(`\nCalling tool: ${event.name}`);
+      console.log(`\nCalling tool: ${event.toolName}`);
       break;
   }
 });
@@ -115,6 +146,25 @@ try {
   unsubscribe();
 }
 ```
+
+Visible assistant text is emitted as `assistant-text` events in model-message
+order. If a single assistant model message contains both a text part and a
+tool-call part, subscribers receive the text first and the tool call afterward:
+
+```txt
+step-start
+assistant-text   // visible text before the tool call
+tool-call
+tool-result      // if the LLM adapter returns tool results for that step
+step-end
+step-start       // the next loop iteration after tool results are appended
+...
+```
+
+Hosts that deliver “pre-tool” bubbles should subscribe to `assistant-text`
+events instead of reconstructing partial messages from history. Use
+`getHistory()` after `submit()` for durable snapshots, memory indexing, or other
+post-turn inspection.
 
 `submit()` also accepts `text` as an array of strings. The runtime keeps those
 strings together as one user turn and forwards them to the model as AI SDK text

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -97,6 +97,56 @@ describe("AgentSession", () => {
     ]);
   });
 
+  it("emits assistant text before tool-call events from the same model message", async () => {
+    let calls = 0;
+    const toolCall = toolCallPart("call-tool-loop-1");
+    const session = new Agent({
+      llm: () => {
+        calls += 1;
+
+        if (calls === 1) {
+          return Promise.resolve([
+            assistantMessage([
+              { type: "text", text: "Let me check that." },
+              toolCall,
+            ]),
+            toolResultFor(toolCall),
+          ]);
+        }
+
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    }).createSession();
+    const events: AgentEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    await session.submit(userText("check"));
+
+    expect(events).toEqual([
+      { type: "user-text", text: "check" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "assistant-text", text: "Let me check that." },
+      {
+        type: "tool-call",
+        input: {},
+        toolCallId: "call-tool-loop-1",
+        toolName: "test_tool",
+      },
+      {
+        type: "tool-result",
+        output: { type: "json", value: {} },
+        toolCallId: "call-tool-loop-1",
+        toolName: "test_tool",
+      },
+      { type: "step-end" },
+      { type: "step-start" },
+      { type: "assistant-text", text: "DONE" },
+      { type: "step-end" },
+      { type: "turn-end" },
+    ]);
+  });
+
   it("accepts multipart user text as one submitted turn", async () => {
     const seenHistory: ModelMessage[][] = [];
     const session = new Agent({


### PR DESCRIPTION
## Summary

- expand the runtime README Cloudflare Durable Object example to show session event subscription, assistant-text delivery, submit, and getHistory usage\n- document the assistant-text before tool-call event ordering contract for pre-tool bubble delivery\n- add a regression test that locks assistant text -> tool-call -> tool-result ordering when a single assistant model message contains text plus a tool call\n\n## Tests\n- pnpm --filter @minpeter/pss-runtime lint\n- pnpm --filter @minpeter/pss-runtime test\n- pnpm --filter @minpeter/pss-runtime typecheck\n- git diff --check\n\n## Notes\n- Docs/test-only; no runtime API change and no changeset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the Cloudflare Durable Object guide in `@minpeter/pss-runtime` to show session subscription, assistant-text delivery, submit, and getHistory, and documented that assistant-text is emitted before a tool call in the same model step. Added a regression test that locks assistant-text -> tool-call -> tool-result ordering; docs/tests only, no runtime API changes.

<sup>Written for commit 7a519e8bb2f569d170a40dcefa9386e89571d7dd. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/27?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

