### PR TITLE
Expose provider options on runtime agents

### DIFF
--- a/.changeset/runtime-provider-options.md
+++ b/.changeset/runtime-provider-options.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Allow provider-specific options to pass through the native Agent/createLlm model loop.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -18,6 +18,21 @@ Pass a caller-owned `LanguageModel` through `model`, or pass a custom `llm`.
 Product tools are intentionally not included; pass tools from a separate package
 when constructing an `Agent`.
 
+Provider-specific options can be passed through without replacing the runtime's
+default model loop:
+
+```ts
+const agent = new Agent({
+  instructions: "Answer briefly.",
+  model,
+  providerOptions: {
+    openaiCompatible: {
+      reasoningEffort: "low",
+    },
+  },
+});
+```
+
 ## Session history
 
 Use `history` when the caller already owns the stored model-message history and

--- a/packages/runtime/src/agent.test.ts
+++ b/packages/runtime/src/agent.test.ts
@@ -13,6 +13,7 @@ const missingOptionsPattern = /Agent options are required/;
 const acceptsModelOptions: AgentOptions = {
   instructions: "Use the injected model.",
   model: fakeModel,
+  providerOptions: { openaiCompatible: { reasoningEffort: "low" } },
   tools: {},
 };
 const acceptsCustomLlmOptions: AgentOptions = { llm: fakeLlm };
@@ -26,6 +27,7 @@ const rejectsAmbiguousModelPrecedence: AgentOptions = {
 // @ts-expect-error custom llm bypasses createLlm-only options such as tools.
 const rejectsIgnoredCreateLlmOptions: AgentOptions = {
   llm: fakeLlm,
+  providerOptions: {},
   tools: {},
 };
 

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -6,6 +6,7 @@ interface AgentModelOptions {
   instructions?: string;
   llm?: never;
   model: LanguageModel;
+  providerOptions?: Parameters<typeof createLlm>[0]["providerOptions"];
   tools?: AgentTools;
 }
 
@@ -13,6 +14,7 @@ interface AgentLlmOptions {
   instructions?: never;
   llm: Llm;
   model?: never;
+  providerOptions?: never;
   tools?: never;
 }
 
@@ -29,6 +31,7 @@ export class Agent {
       : createLlm({
           instructions: options.instructions,
           model: options.model,
+          providerOptions: options.providerOptions,
           tools: options.tools,
         });
   }

--- a/packages/runtime/src/llm.test.ts
+++ b/packages/runtime/src/llm.test.ts
@@ -61,11 +61,15 @@ describe("createLlm", () => {
   it("passes injected tools to generateText", async () => {
     const createLlm = await loadCreateLlm();
     const injectedTools = { injected: createNoopTool() } satisfies AgentTools;
+    const providerOptions = {
+      openaiCompatible: { reasoningEffort: "low" },
+    };
     const signal = new AbortController().signal;
     const history = [{ role: "user" as const, content: "hello" }];
     const llm = createLlm({
       instructions: "test instructions",
       model: fakeModel,
+      providerOptions,
       tools: injectedTools,
     });
 
@@ -79,6 +83,7 @@ describe("createLlm", () => {
         instructions: "test instructions",
         messages: history,
         model: fakeModel,
+        providerOptions,
         tools: injectedTools,
       })
     );
@@ -101,8 +106,12 @@ describe("Agent tool wiring", () => {
   it("passes injected AgentOptions tools into createLlm/generateText", async () => {
     const Agent = await loadAgent();
     const injectedTools = { injected: createNoopTool() } satisfies AgentTools;
+    const providerOptions = {
+      openaiCompatible: { reasoningEffort: "low" },
+    };
     const session = new Agent({
       model: fakeModel,
+      providerOptions,
       tools: injectedTools,
     }).createSession();
 
@@ -111,6 +120,7 @@ describe("Agent tool wiring", () => {
     expect(generateTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         model: fakeModel,
+        providerOptions,
         tools: injectedTools,
       })
     );

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -33,6 +33,7 @@ export type Llm = (context: LlmContext) => Promise<LlmOutput>;
 export interface CreateLlmOptions {
   instructions?: string;
   model: LanguageModel;
+  providerOptions?: Parameters<typeof generateText>[0]["providerOptions"];
   tools?: AgentTools;
 }
 
@@ -44,6 +45,7 @@ export type RuntimeLlmOutput = LlmOutput;
 export function createLlm({
   model,
   instructions,
+  providerOptions,
   tools,
 }: CreateLlmOptions): Llm {
   const runtimeTools = tools as ToolSet | undefined;
@@ -54,6 +56,7 @@ export function createLlm({
       instructions,
       messages: [...history],
       model,
+      providerOptions,
       tools: runtimeTools,
     });
 


### PR DESCRIPTION
## Summary\n- add providerOptions to @minpeter/pss-runtime createLlm and model-backed Agent options\n- forward providerOptions into AI SDK generateText on the native runtime model path\n- keep custom llm mode mutually exclusive with createLlm-only options\n- document providerOptions usage and add a patch changeset\n\n## Why\nBori currently needs a custom RuntimeLlm wrapper only to pass OpenAI-compatible reasoning effort. This lets hosts stay on the native Agent({ model, instructions, tools, providerOptions }) path instead.\n\n## Tests\n- pnpm --filter @minpeter/pss-runtime lint\n- pnpm --filter @minpeter/pss-runtime test\n- pnpm --filter @minpeter/pss-runtime typecheck\n- pnpm build\n- pnpm verify:release\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `providerOptions` on runtime agents and `createLlm` in `@minpeter/pss-runtime`. This forwards provider-specific options to the native model path so hosts like Bori can set OpenAI-compatible reasoning effort without custom LLM wrappers.

- New Features
  - Add `providerOptions` to `Agent({ model })` and `createLlm`, forwarding to `generateText`.
  - Keep `llm` mode mutually exclusive with `createLlm`-only options.
  - Update README, add tests, and include a patch changeset.

<sup>Written for commit 0fa7076ca651a628e5995d06e584442b029cde45. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

