### PR TITLE
Accept native AI SDK ToolSet in pss-runtime

### DIFF
--- a/.changeset/native-toolset-runtime.md
+++ b/.changeset/native-toolset-runtime.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Accept AI SDK ToolSet directly for runtime Agent tools.

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -1,21 +1,16 @@
-import type { LanguageModel, ModelMessage } from "ai";
-import { generateText, type ToolSet } from "ai";
+import type {
+  LanguageModel,
+  ModelMessage,
+  Tool,
+  ToolExecutionOptions,
+  ToolSet,
+} from "ai";
+import { generateText } from "ai";
 
-export interface AgentToolExecutionOptions {
-  abortSignal?: AbortSignal;
-  [key: string]: unknown;
-}
-
-export type AgentToolExecute = unknown;
-
-export interface AgentTool {
-  description?: unknown;
-  execute?: AgentToolExecute;
-  inputSchema: unknown;
-  outputSchema?: unknown;
-}
-
-export type AgentTools = Record<string, AgentTool>;
+export type AgentToolExecutionOptions = ToolExecutionOptions<unknown>;
+export type AgentToolExecute = NonNullable<Tool["execute"]>;
+export type AgentTool = Tool;
+export type AgentTools = ToolSet;
 export type AgentModel = LanguageModel;
 export type AgentMessage = ModelMessage;
 export type LlmOutput = Awaited<
@@ -46,15 +41,13 @@ export function createLlm({
   instructions,
   tools,
 }: CreateLlmOptions): Llm {
-  const runtimeTools = tools as ToolSet | undefined;
-
   return async ({ history, signal }) => {
     const { responseMessages } = await generateText({
       abortSignal: signal,
       instructions,
       messages: [...history],
       model,
-      tools: runtimeTools,
+      tools,
     });
 
     return responseMessages;


### PR DESCRIPTION
## Summary
- Make pss-runtime `AgentTools` a direct alias of AI SDK `ToolSet`
- Remove the internal `tools as ToolSet` cast before `generateText`
- Keep the existing exported compatibility type names while aligning them with AI SDK types
- Add a patch changeset for `@minpeter/pss-runtime`

## Why
Bori and other host runtimes already assemble AI SDK ToolSet objects. Accepting ToolSet directly in pss-runtime removes the need for downstream casts like `tools as AgentTools` and keeps the Agent constructor native.

## Verification
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm --filter @minpeter/pss-coding-agent typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept native AI SDK `ToolSet` in `@minpeter/pss-runtime` by aliasing `AgentTools` to it, removing internal casts and matching AI SDK tool types. Host runtimes can now pass tools directly without extra casting.

- **Refactors**
  - `AgentTools` is now a direct alias of AI SDK `ToolSet`; `AgentTool`, `AgentToolExecute`, and `AgentToolExecutionOptions` map to AI SDK `Tool` types.
  - Removed the `tools as ToolSet` cast before `generateText`.
  - Added a patch changeset for `@minpeter/pss-runtime`.

<sup>Written for commit e7ee7ab2228dc40bf354593af2948f2f8162f4ac. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/29?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

