### PR TITLE
Keep runtime transcripts event-only

### DIFF
--- a/.changeset/quiet-hats-obey.md
+++ b/.changeset/quiet-hats-obey.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Keep runtime transcripts event-only while storing session continuation state as an internal versioned snapshot.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 !.env.example
 .turbo
 packages/*/.turbo
+.omo/

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -32,10 +32,18 @@ for await (const event of run.stream()) {
 
 `agent.send(...)` is shorthand for `agent.session("default").send(...)`.
 
+The public transcript protocol is `AgentEvent`: live runs emit runtime-defined
+events through `run.stream()`. Provider/model message history is internal
+continuation state, not a public history API.
+
 ## Session storage and portability
 
 The runtime owns full session state encoding and history compaction semantics.
 Adapters own persistence only through `SessionStore`:
+
+Stored session state is an opaque, versioned runtime snapshot for continuation.
+Do not inspect it as a replay log; exact replay should be modeled separately as
+an `AgentEvent` log if that capability is added later.
 
 ```ts
 import type { SessionStore } from "@minpeter/pss-runtime";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -6,7 +6,6 @@ export {
 } from "./agent";
 export { type AgentLoopResult, runAgentLoop } from "./agent-loop";
 export type {
-  AgentMessage,
   AgentModel,
   AgentTool,
   AgentToolExecute,

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -302,7 +302,7 @@ describe("Agent session API", () => {
     ]);
   });
 
-  it("persists opaque runtime-owned session state through SessionStore", async () => {
+  it("persists versioned runtime-owned session snapshots through SessionStore", async () => {
     const store = new SpyStore();
     const agent = await Agent.create({
       llm: () => Promise.resolve([assistantMessage("DONE")]),
@@ -315,7 +315,7 @@ describe("Agent session API", () => {
     const finalCommit = store.commits.at(-1);
     expect(finalCommit?.key).toBe("spy");
     expect(finalCommit?.next.state).toEqual(
-      expect.objectContaining({ schemaVersion: 1 })
+      expect.objectContaining({ history: expect.any(Array), schemaVersion: 1 })
     );
     expect(finalCommit?.next.state).not.toBeInstanceOf(Array);
   });

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,10 +1,11 @@
 import { runAgentLoop } from "../agent-loop";
-import type { AgentMessage, Llm } from "../llm";
+import type { Llm } from "../llm";
 import type { UserText } from "./events";
 import { AgentModelHistory } from "./history";
 import type { AgentRun } from "./run";
 import { BufferedAgentRun } from "./run";
-import type { SessionStore, StoredSession } from "./store/types";
+import { decodeStoredSessionSnapshot, encodeSessionSnapshot } from "./snapshot";
+import type { SessionStore } from "./store/types";
 
 export type AgentInput = string | readonly string[] | UserText;
 export type SessionInput = AgentInput;
@@ -18,11 +19,6 @@ interface SessionPersistenceOptions {
 interface QueuedInput {
   readonly input: UserText;
   readonly run: BufferedAgentRun;
-}
-
-interface EncodedSessionState {
-  readonly history: AgentMessage[];
-  readonly schemaVersion: 1;
 }
 
 export class AgentSession {
@@ -112,7 +108,7 @@ export class AgentSession {
   async #replaceWithStoredSession(): Promise<void> {
     const stored = await this.#persistence.store.load(this.#persistence.key);
     this.#storeVersion = stored?.version;
-    this.#history = new AgentModelHistory(decodeStoredHistory(stored));
+    this.#history = new AgentModelHistory(decodeStoredSessionSnapshot(stored));
   }
 
   async #drainInputQueue(): Promise<void> {
@@ -180,7 +176,7 @@ export class AgentSession {
     const result = await this.#persistence.store.commit(
       this.#persistence.key,
       {
-        state: encodeHistory(this.#history.modelSnapshot()),
+        state: encodeSessionSnapshot(this.#history.modelSnapshot()),
         version: this.#storeVersion,
       },
       { expectedVersion: this.#storeVersion ?? null }
@@ -215,30 +211,6 @@ export function normalizeAgentInput(input: AgentInput): UserText {
 
 function isStringArrayInput(input: AgentInput): input is readonly string[] {
   return Array.isArray(input);
-}
-
-function encodeHistory(history: AgentMessage[]): EncodedSessionState {
-  return { schemaVersion: 1, history };
-}
-
-function decodeStoredHistory(stored: StoredSession | null): AgentMessage[] {
-  if (!stored) {
-    return [];
-  }
-
-  const state = stored.state;
-  if (
-    state !== null &&
-    typeof state === "object" &&
-    "schemaVersion" in state &&
-    state.schemaVersion === 1 &&
-    "history" in state &&
-    Array.isArray(state.history)
-  ) {
-    return structuredClone(state.history) as AgentMessage[];
-  }
-
-  throw new Error("Unsupported stored session state");
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/runtime/src/session/snapshot.test.ts
+++ b/packages/runtime/src/session/snapshot.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { assistantMessage } from "../test-fixtures";
+import { decodeStoredSessionSnapshot, encodeSessionSnapshot } from "./snapshot";
+
+describe("session snapshot", () => {
+  it("encodes model continuation state as a versioned runtime snapshot", () => {
+    const history = [assistantMessage("DONE")];
+    const snapshot = encodeSessionSnapshot(history);
+
+    expect(snapshot).toEqual({
+      history,
+      schemaVersion: 1,
+    });
+    expect(snapshot.history).not.toBe(history);
+  });
+
+  it("decodes missing sessions to empty continuation state", () => {
+    expect(decodeStoredSessionSnapshot(null)).toEqual([]);
+  });
+
+  it("decodes cloned v1 snapshots from opaque stored state", () => {
+    const history = [assistantMessage("persisted")];
+    const decoded = decodeStoredSessionSnapshot({
+      state: { history, schemaVersion: 1 },
+      version: "1",
+    });
+
+    expect(decoded).toEqual(history);
+    expect(decoded).not.toBe(history);
+  });
+
+  it("rejects unsupported stored session state versions", () => {
+    expect(() =>
+      decodeStoredSessionSnapshot({
+        state: { history: [], schemaVersion: 2 },
+        version: "1",
+      })
+    ).toThrow("Unsupported stored session state");
+  });
+});

--- a/packages/runtime/src/session/snapshot.ts
+++ b/packages/runtime/src/session/snapshot.ts
@@ -1,0 +1,41 @@
+import type { AgentMessage } from "../llm";
+import type { StoredSession } from "./store/types";
+
+export interface AgentSessionSnapshotV1 {
+  readonly history: AgentMessage[];
+  readonly schemaVersion: 1;
+}
+
+export type AgentSessionSnapshot = AgentSessionSnapshotV1;
+
+export function encodeSessionSnapshot(
+  history: AgentMessage[]
+): AgentSessionSnapshot {
+  return { schemaVersion: 1, history: structuredClone(history) };
+}
+
+export function decodeStoredSessionSnapshot(
+  stored: StoredSession | null
+): AgentMessage[] {
+  if (!stored) {
+    return [];
+  }
+
+  const snapshot = stored.state;
+  if (isSessionSnapshotV1(snapshot)) {
+    return structuredClone(snapshot.history);
+  }
+
+  throw new Error("Unsupported stored session state");
+}
+
+function isSessionSnapshotV1(value: unknown): value is AgentSessionSnapshotV1 {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "schemaVersion" in value &&
+    value.schemaVersion === 1 &&
+    "history" in value &&
+    Array.isArray(value.history)
+  );
+}

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -34,6 +34,7 @@ const REQUIRED_RUNTIME_ROOT_ALIASES = [
   "RuntimeLlmContext",
   "RuntimeLlmOutput",
 ];
+const FORBIDDEN_RUNTIME_ROOT_ALIASES = ["AgentMessage"];
 
 const RELATIVE_IMPORT_RE =
   /(?:from\s+["']|import\s*(?:\(\s*)?["'])(\.\.?\/[^"']+)(?:["'])/g;
@@ -335,6 +336,14 @@ function findRuntimeRootDeclarationLeaks({ cwd, file }) {
     (token) =>
       `${relativeToCwd(cwd, file)}: root declaration exposes raw AI SDK token ${token}`
   );
+
+  for (const alias of FORBIDDEN_RUNTIME_ROOT_ALIASES) {
+    if (text.includes(alias)) {
+      errors.push(
+        `${relativeToCwd(cwd, file)}: root declaration exposes internal runtime alias ${alias}`
+      );
+    }
+  }
 
   for (const alias of REQUIRED_RUNTIME_ROOT_ALIASES) {
     if (!text.includes(alias)) {

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -226,6 +226,20 @@ describe("verifyReleaseArtifacts", () => {
     ]);
   });
 
+  it("rejects internal runtime message aliases from root declarations", () => {
+    const cwd = createFixture();
+    writeFileSync(
+      join(cwd, "packages", "runtime", "dist", "index.d.ts"),
+      'export type { AgentMessage, AgentModel, AgentTools, RuntimeCreateLlmOptions, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+    );
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
+    ).toEqual([
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentMessage",
+    ]);
+  });
+
   it("allows raw AI SDK types inside allowlisted internal runtime declarations", () => {
     const cwd = createFixture();
     writeFileSync(


### PR DESCRIPTION
## Summary
- add an internal versioned session snapshot codec for runtime continuation state
- remove the root AgentMessage export and document AgentEvent as the public transcript protocol
- guard release declarations against re-exporting AgentMessage from the runtime root
- ignore local .omo metadata

## Verification
- pnpm --filter @minpeter/pss-runtime test
- pnpm --filter @minpeter/pss-runtime typecheck
- pnpm verify:release --package runtime
- pnpm typecheck
- pnpm build
- pnpm test
- changed-file ultracite check passed
- Oracle ultrawork verification: <promise>VERIFIED</promise>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep runtime transcripts event-only and move session persistence to versioned, opaque snapshots. Removed `AgentMessage` from the runtime root API and enforced a release check that forbids exposing it.

- **New Features**
  - Added internal v1 session snapshot codec; sessions persist/restore from snapshots, not raw messages; rejects unsupported versions; docs and tests updated.
  - Made `AgentEvent` the public transcript; release check prevents `AgentMessage` from leaking in root declarations.
  - Ignored local `.omo/` metadata.

- **Migration**
  - Stop importing `AgentMessage` from `@minpeter/pss-runtime`; use `run.stream()` and `AgentEvent` for transcripts.
  - Treat stored session state as opaque continuation snapshots; do not read it as a replay log.

<sup>Written for commit dcb597a1a69f819ba35d7ff7eec8f96f47729ba0. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

