### PR TITLE
Accept serializable multimodal runtime inputs

### DIFF
--- a/.changeset/bright-images-send.md
+++ b/.changeset/bright-images-send.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": minor
+---
+
+Add serializable image/file content parts to `agent.send` and session sends, preserving them through runtime-owned session snapshots.

--- a/.changeset/clever-images-learn.md
+++ b/.changeset/clever-images-learn.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Document first-pass image input support in the runtime session/send API.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ for await (const event of conversation.stream()) {
 }
 ```
 
+The runtime `send` API also accepts JSON-serializable multimodal content parts
+for model providers that support them:
+
+```ts
+await agent.send({
+  type: "user-text",
+  text: [
+    { type: "text", text: "What changed in this screenshot?" },
+    { type: "image", image: "data:image/png;base64,...", mediaType: "image/png" },
+  ],
+});
+```
+
 Run the TUI:
 
 ```sh

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -32,6 +32,40 @@ for await (const event of run.stream()) {
 
 `agent.send(...)` is shorthand for `agent.session("default").send(...)`.
 
+For model providers that support multimodal input, send JSON-serializable content
+parts through the same API. String input and `readonly string[]` remain supported
+shortcuts for text-only turns.
+
+```ts
+const run = await agent.send([
+  { type: "text", text: "Describe this UI screenshot." },
+  {
+    type: "image",
+    image: "data:image/png;base64,iVBORw0KGgo...",
+    mediaType: "image/png",
+  },
+]);
+```
+
+File parts use the same JSON-serializable shape when the selected model supports
+file input:
+
+```ts
+await agent.send([
+  { type: "text", text: "Summarize the attached report." },
+  {
+    type: "file",
+    data: "data:application/pdf;base64,JVBERi0x...",
+    filename: "report.pdf",
+    mediaType: "application/pdf",
+  },
+]);
+```
+
+The runtime normalizes and persists these content parts as session continuation
+state; it does not fetch remote media, decode files, or guarantee provider support
+for every media type.
+
 The public transcript protocol is `AgentEvent`: live runs emit runtime-defined
 events through `run.stream()`. Provider/model message history is internal
 continuation state, not a public history API.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -25,11 +25,18 @@ export type {
   AssistantText,
   ToolCall,
   ToolResult,
+  UserMessage,
+  UserMessageContent,
+  UserMessageContentPart,
+  UserMessageFileData,
+  UserMessageFilePart,
+  UserMessageImagePart,
+  UserMessageTextPart,
   UserText,
   UserTextContent,
 } from "./session/events";
 export type { AgentRun } from "./session/run";
-export type { AgentInput } from "./session/session";
+export type { AgentInput, SessionInput, UserInput } from "./session/session";
 export type {
   CommitResult,
   ExpectedSessionVersion,

--- a/packages/runtime/src/session/events.ts
+++ b/packages/runtime/src/session/events.ts
@@ -4,6 +4,43 @@ export interface UserText {
   text: UserTextContent;
   type: "user-text";
 }
+
+export interface UserMessageTextPart {
+  text: string;
+  type: "text";
+}
+
+export interface UserMessageImagePart {
+  image: string;
+  mediaType?: string;
+  type: "image";
+}
+
+export type UserMessageFileData =
+  | string
+  | { data: string; type: "data" }
+  | { reference: Record<string, string>; type: "reference" }
+  | { text: string; type: "text" }
+  | { type: "url"; url: string };
+
+export interface UserMessageFilePart {
+  data: UserMessageFileData;
+  filename?: string;
+  mediaType: string;
+  type: "file";
+}
+
+export type UserMessageContentPart =
+  | UserMessageFilePart
+  | UserMessageImagePart
+  | UserMessageTextPart;
+
+export type UserMessageContent = readonly UserMessageContentPart[];
+
+export interface UserMessage {
+  content: UserMessageContent;
+  type: "user-message";
+}
 export interface AssistantText {
   text: string;
   type: "assistant-text";
@@ -27,7 +64,10 @@ export interface ToolResult {
 
 export type AgentEvent =
   /** User input was accepted into the session queue. */
+  | UserMessage
   | UserText
+  /** User multipart input was accepted into the session queue. */
+  | UserMessage
   /** A queued user input started running as a turn. */
   | { type: "turn-start" }
   /** The active turn was interrupted before normal completion. */

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -1,6 +1,6 @@
 import type { ModelMessage } from "ai";
-import type { UserText } from "./events";
-import { userTextToModelMessage } from "./mapping";
+import { userInputToModelMessage } from "./mapping";
+import type { UserInput } from "./session";
 
 export class AgentModelHistory {
   readonly #modelHistory: ModelMessage[] = [];
@@ -20,8 +20,8 @@ export class AgentModelHistory {
     return structuredClone(this.#modelHistory);
   }
 
-  appendUserInput(input: UserText): void {
-    this.#modelHistory.push(userTextToModelMessage(input));
+  appendUserInput(input: UserInput): void {
+    this.#modelHistory.push(userInputToModelMessage(input));
     this.#triggerChange();
   }
 

--- a/packages/runtime/src/session/mapping.test.ts
+++ b/packages/runtime/src/session/mapping.test.ts
@@ -3,9 +3,14 @@ import {
   assistantMessage,
   toolCallPart,
   toolResultFor,
+  userMessage,
   userText,
 } from "../test-fixtures";
-import { modelMessageToAgentEvents, userTextToModelMessage } from "./mapping";
+import {
+  modelMessageToAgentEvents,
+  userMessageToModelMessage,
+  userTextToModelMessage,
+} from "./mapping";
 
 describe("session mapping", () => {
   it("maps user text to an AI SDK user model message", () => {
@@ -25,6 +30,63 @@ describe("session mapping", () => {
         { type: "text", text: "user message" },
       ],
     });
+  });
+
+  it("maps user image input to a serializable AI SDK file part", () => {
+    expect(
+      userMessageToModelMessage(
+        userMessage([
+          { type: "text", text: "describe this" },
+          {
+            type: "image",
+            image: "iVBORw0KGgo=",
+            mediaType: "image/png",
+          },
+        ])
+      )
+    ).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "describe this" },
+        { type: "file", data: "iVBORw0KGgo=", mediaType: "image/png" },
+      ],
+    });
+  });
+
+  it("maps user file input without non-JSON URL objects", () => {
+    const message = userMessageToModelMessage(
+      userMessage([
+        {
+          type: "file",
+          data: "https://example.com/a.txt",
+          filename: "a.txt",
+          mediaType: "text/plain",
+        },
+        {
+          type: "file",
+          data: { type: "text", text: "inline document" },
+          mediaType: "text/plain",
+        },
+      ])
+    );
+
+    expect(message).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "file",
+          data: "https://example.com/a.txt",
+          filename: "a.txt",
+          mediaType: "text/plain",
+        },
+        {
+          type: "file",
+          data: { type: "text", text: "inline document" },
+          mediaType: "text/plain",
+        },
+      ],
+    });
+    expect(JSON.parse(JSON.stringify(message))).toEqual(message);
   });
 
   it("projects assistant reasoning, text, and tool calls to public agent events", () => {

--- a/packages/runtime/src/session/mapping.ts
+++ b/packages/runtime/src/session/mapping.ts
@@ -10,15 +10,28 @@ import type {
   AssistantText,
   ToolCall,
   ToolResult,
+  UserMessage,
+  UserMessageContent,
+  UserMessageContentPart,
+  UserMessageFileData,
   UserText,
   UserTextContent,
 } from "./events";
+import type { UserInput } from "./session";
 
 type AssistantContentPart = Exclude<AssistantContent, string>[number];
 type ToolContentPart = ToolModelMessage["content"][number];
 type ModelEvent = AssistantReasoning | AssistantText | ToolCall | ToolResult;
 
-// UserText -> AI SDK UserModelMessage
+// UserInput -> AI SDK UserModelMessage
+export function userInputToModelMessage(input: UserInput): UserModelMessage {
+  if (input.type === "user-message") {
+    return userMessageToModelMessage(input);
+  }
+
+  return userTextToModelMessage(input);
+}
+
 export function userTextToModelMessage(input: UserText): UserModelMessage {
   return { role: "user", content: userTextContentToUserContent(input.text) };
 }
@@ -31,6 +44,69 @@ function userTextContentToUserContent(
   }
 
   return text.map((part) => ({ type: "text", text: part }));
+}
+
+export function userMessageToModelMessage(
+  input: UserMessage
+): UserModelMessage {
+  return {
+    role: "user",
+    content: userMessageContentToUserContent(input.content),
+  };
+}
+
+function userMessageContentToUserContent(
+  content: UserMessageContent
+): Exclude<UserModelMessage["content"], string> {
+  return content.map(userMessageContentPartToUserContentPart);
+}
+
+function userMessageContentPartToUserContentPart(
+  part: UserMessageContentPart
+): Exclude<UserModelMessage["content"], string>[number] {
+  if (part.type === "text") {
+    return { type: "text", text: part.text };
+  }
+
+  if (part.type === "image") {
+    return {
+      type: "file",
+      data: part.image,
+      mediaType: part.mediaType ?? "image",
+    };
+  }
+
+  return {
+    type: "file",
+    data: userMessageFileDataToFileData(part.data),
+    mediaType: part.mediaType,
+    ...(part.filename === undefined ? {} : { filename: part.filename }),
+  };
+}
+
+function userMessageFileDataToFileData(
+  data: UserMessageFileData
+): Extract<
+  Exclude<UserModelMessage["content"], string>[number],
+  { type: "file" }
+>["data"] {
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (data.type === "url") {
+    return data.url;
+  }
+
+  if (data.type === "data") {
+    return { type: "data", data: data.data };
+  }
+
+  if (data.type === "reference") {
+    return { type: "reference", reference: { ...data.reference } };
+  }
+
+  return { type: "text", text: data.text };
 }
 
 // AI SDK ModelMessage -> public agent events

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { Agent } from "../agent";
@@ -7,10 +10,12 @@ import {
   eventTypes,
   toolCallPart,
   toolResultFor,
+  userMessage,
   userText,
 } from "../test-fixtures";
 import type { AgentEvent } from "./events";
 import { userTextToModelMessage } from "./mapping";
+import { FileSessionStore } from "./store/file";
 import type { CommitResult, SessionStore, StoredSession } from "./store/types";
 
 const collect = async (run: Awaited<ReturnType<Agent["send"]>>) => {
@@ -124,6 +129,168 @@ describe("Agent session API", () => {
       type: "user-text",
       text: ["context", "hello"],
     });
+  });
+
+  it("agent.send accepts JSON-serializable user content parts", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const agent = await Agent.create({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    });
+
+    const input = [
+      { type: "text", text: "describe this" },
+      { type: "image", image: "iVBORw0KGgo=", mediaType: "image/png" },
+      {
+        type: "file",
+        data: { type: "text", text: "inline document" },
+        filename: "note.txt",
+        mediaType: "text/plain",
+      },
+    ] as const;
+    const events = await collect(await agent.send(input));
+
+    expect(seenHistory).toEqual([
+      [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe this" },
+            { type: "file", data: "iVBORw0KGgo=", mediaType: "image/png" },
+            {
+              type: "file",
+              data: { type: "text", text: "inline document" },
+              filename: "note.txt",
+              mediaType: "text/plain",
+            },
+          ],
+        },
+      ],
+    ]);
+    expect(events[0]).toEqual({
+      type: "user-message",
+      content: input,
+    });
+  });
+
+  it("rejects malformed multipart input before queueing", async () => {
+    const agent = await Agent.create({
+      llm: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+
+    await expect(
+      agent.send([{ type: "image", mediaType: "image/png" }] as never)
+    ).rejects.toThrow(
+      'Agent input content parts must be { type: "text", text }, { type: "image", image }, or { type: "file", data, mediaType }.'
+    );
+  });
+
+  it("rejects malformed explicit user-message input before queueing", async () => {
+    const agent = await Agent.create({
+      llm: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+
+    await expect(
+      agent.send({
+        type: "user-message",
+        content: [{ type: "file", data: "abc" }],
+      } as never)
+    ).rejects.toThrow(
+      'Agent input content parts must be { type: "text", text }, { type: "image", image }, or { type: "file", data, mediaType }.'
+    );
+  });
+
+  it("file session store preserves image content parts across reload", async () => {
+    const input = userMessage([
+      { type: "text", text: "remember this image" },
+      {
+        type: "image",
+        image: "data:image/png;base64,ZmFrZQ==",
+        mediaType: "image/png",
+      },
+      {
+        type: "file",
+        data: { type: "text", text: "inline note" },
+        filename: "note.txt",
+        mediaType: "text/plain",
+      },
+    ]);
+    const directory = await mkdtemp(join(tmpdir(), "pss-runtime-image-store-"));
+    const store = new FileSessionStore(directory);
+
+    const first = await Agent.create({
+      llm: () => Promise.resolve([assistantMessage("stored")]),
+      sessions: { store },
+    });
+    await collect(await first.session("images").send(input));
+
+    const seenHistory: ModelMessage[][] = [];
+    const second = await Agent.create({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+      sessions: { store },
+    });
+
+    await collect(await second.session("images").send("next"));
+
+    expect(seenHistory).toEqual([
+      [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "remember this image" },
+            {
+              type: "file",
+              data: "data:image/png;base64,ZmFrZQ==",
+              mediaType: "image/png",
+            },
+            {
+              type: "file",
+              data: { type: "text", text: "inline note" },
+              filename: "note.txt",
+              mediaType: "text/plain",
+            },
+          ],
+        },
+        assistantMessage("stored"),
+        userTextToModelMessage(userText("next")),
+      ],
+    ]);
+  });
+
+  it("session.send accepts user-message events", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const agent = await Agent.create({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([]);
+      },
+    });
+
+    await collect(
+      await agent.session("custom").send(
+        userMessage([
+          { type: "text", text: "summarize" },
+          { type: "image", image: "iVBORw0KGgo=" },
+        ])
+      )
+    );
+
+    expect(seenHistory).toEqual([
+      [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "summarize" },
+            { type: "file", data: "iVBORw0KGgo=", mediaType: "image" },
+          ],
+        },
+      ],
+    ]);
   });
 
   it("session.send accepts user-text events", async () => {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,13 +1,18 @@
 import { runAgentLoop } from "../agent-loop";
 import type { Llm } from "../llm";
-import type { UserText } from "./events";
+import type { UserMessage, UserMessageContentPart, UserText } from "./events";
 import { AgentModelHistory } from "./history";
 import type { AgentRun } from "./run";
 import { BufferedAgentRun } from "./run";
 import { decodeStoredSessionSnapshot, encodeSessionSnapshot } from "./snapshot";
 import type { SessionStore } from "./store/types";
 
-export type AgentInput = string | readonly string[] | UserText;
+export type UserInput = UserMessage | UserText;
+export type AgentInput =
+  | readonly string[]
+  | readonly UserMessageContentPart[]
+  | string
+  | UserInput;
 export type SessionInput = AgentInput;
 export type { AgentRun } from "./run";
 
@@ -17,7 +22,7 @@ interface SessionPersistenceOptions {
 }
 
 interface QueuedInput {
-  readonly input: UserText;
+  readonly input: UserInput;
   readonly run: BufferedAgentRun;
 }
 
@@ -191,7 +196,7 @@ export class AgentSession {
   }
 }
 
-export function normalizeAgentInput(input: AgentInput): UserText {
+export function normalizeAgentInput(input: AgentInput): UserInput {
   if (typeof input === "string") {
     return {
       type: "user-text",
@@ -206,11 +211,110 @@ export function normalizeAgentInput(input: AgentInput): UserText {
     };
   }
 
+  if (isArrayInput(input)) {
+    assertUserMessageContent(input);
+    return {
+      type: "user-message",
+      content: structuredClone(input) as readonly UserMessageContentPart[],
+    };
+  }
+
+  if (isUserMessage(input)) {
+    assertUserMessageContent(input.content);
+  }
+
   return structuredClone(input);
 }
 
 function isStringArrayInput(input: AgentInput): input is readonly string[] {
+  return isArrayInput(input) && input.every((part) => typeof part === "string");
+}
+
+function isArrayInput(
+  input: AgentInput
+): input is readonly string[] | readonly UserMessageContentPart[] {
   return Array.isArray(input);
+}
+
+function isUserMessage(input: UserInput): input is UserMessage {
+  return input.type === "user-message";
+}
+
+function assertUserMessageContent(
+  input: readonly unknown[]
+): asserts input is readonly UserMessageContentPart[] {
+  for (const part of input) {
+    if (!isUserMessageContentPart(part)) {
+      throw new TypeError(
+        'Agent input content parts must be { type: "text", text }, { type: "image", image }, or { type: "file", data, mediaType }.'
+      );
+    }
+  }
+}
+
+function isUserMessageContentPart(
+  part: unknown
+): part is UserMessageContentPart {
+  if (part === null || typeof part !== "object" || !("type" in part)) {
+    return false;
+  }
+
+  if (part.type === "text") {
+    return "text" in part && typeof part.text === "string";
+  }
+
+  if (part.type === "image") {
+    return (
+      "image" in part &&
+      typeof part.image === "string" &&
+      (!("mediaType" in part) || typeof part.mediaType === "string")
+    );
+  }
+
+  if (part.type === "file") {
+    return (
+      "data" in part &&
+      isUserMessageFileData(part.data) &&
+      "mediaType" in part &&
+      typeof part.mediaType === "string" &&
+      (!("filename" in part) || typeof part.filename === "string")
+    );
+  }
+
+  return false;
+}
+
+function isUserMessageFileData(data: unknown): boolean {
+  if (typeof data === "string") {
+    return true;
+  }
+
+  if (data === null || typeof data !== "object" || !("type" in data)) {
+    return false;
+  }
+
+  if (data.type === "data") {
+    return "data" in data && typeof data.data === "string";
+  }
+
+  if (data.type === "reference") {
+    return (
+      "reference" in data &&
+      data.reference !== null &&
+      typeof data.reference === "object" &&
+      Object.values(data.reference).every((value) => typeof value === "string")
+    );
+  }
+
+  if (data.type === "text") {
+    return "text" in data && typeof data.text === "string";
+  }
+
+  if (data.type === "url") {
+    return "url" in data && typeof data.url === "string";
+  }
+
+  return false;
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/runtime/src/test-fixtures.ts
+++ b/packages/runtime/src/test-fixtures.ts
@@ -1,6 +1,12 @@
 import type { AssistantModelMessage, ToolCallPart, ToolModelMessage } from "ai";
 import type { Llm, LlmOutput } from "./llm";
-import type { AgentEvent, UserText, UserTextContent } from "./session/events";
+import type {
+  AgentEvent,
+  UserMessage,
+  UserMessageContent,
+  UserText,
+  UserTextContent,
+} from "./session/events";
 
 export const assistantMessage = (
   content: AssistantModelMessage["content"]
@@ -54,4 +60,9 @@ export const eventTypes = (events: AgentEvent[]) =>
 export const userText = (text: UserTextContent): UserText => ({
   type: "user-text",
   text,
+});
+
+export const userMessage = (content: UserMessageContent): UserMessage => ({
+  type: "user-message",
+  content,
 });


### PR DESCRIPTION
## Summary

- Add serializable `user-message` text/image/file content parts to `agent.send` / session sends while preserving string and `string[]` shortcuts.
- Map runtime image/file inputs to AI SDK `file` content parts so snapshots stay JSON-serializable and provider internals stay out of the public API.
- Persist image inputs through session snapshots with FileSessionStore reload coverage, add malformed multipart validation, document event extensibility, and add a changeset.

## Verification

- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm verify:release`
- `git diff --check`
- Team runtime: `implement-first-pass-26bd9f1a` terminal with 6/6 tasks completed, 0 pending/in-progress/failed
- Final code review: APPROVE; architect status: CLEAR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds JSON-serializable multimodal input (text/image/file) to `agent.send` and session sends, with inputs persisted across session snapshots and mapped to SDK `file` content without exposing provider internals. Validates and rejects malformed multipart inputs; string and `string[]` inputs remain unchanged.

- **New Features**
  - Accepts `readonly` content parts in `agent.send`/`session.send` or as a `user-message` event: `{ type: "text" }`, `{ type: "image" }`, `{ type: "file" }`.
  - Validates parts before queueing; defaults image `mediaType` when omitted; treats file `url` data as strings and rejects non-serializable inputs (e.g., `URL` instances).
  - Adds `user-message` to `AgentEvent`; exports `UserMessage`, `UserMessageContent*`, `UserInput`, and `SessionInput`. Docs updated with examples.

- **Migration**
  - Use serializable URLs (string form), `data:` URLs, or base64 strings with `mediaType`; do not pass local paths, binary buffers, or `URL` objects.
  - If you switch to multipart sends, handle `user-message` in event consumers. Existing string and `string[]` inputs need no changes.

<sup>Written for commit 718bd8df0192c9faea7295bccd61200587916396. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/35?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

