### PR TITLE
Keep image input release at patch level

### DIFF
--- a/.changeset/bright-images-send.md
+++ b/.changeset/bright-images-send.md
@@ -1,5 +1,5 @@
 ---
-"@minpeter/pss-runtime": minor
+"@minpeter/pss-runtime": patch
 ---
 
 Add serializable image/file content parts to `agent.send` and session sends, preserving them through runtime-owned session snapshots.


### PR DESCRIPTION
## Summary\n- Change the image input changeset for `@minpeter/pss-runtime` from minor to patch.\n- Leave the merged runtime implementation/docs untouched.\n\n## Validation\n- `corepack pnpm changeset status`\n- `git diff --check`\n\n## Notes\n- This corrects the release classification for PR #35 after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reclassifies the image/file input change for `@minpeter/pss-runtime` from minor to patch by updating the changeset metadata. Leaves the merged implementation and docs as-is, ensuring the release reflects the intended patch scope (follow-up to PR #35).

<sup>Written for commit a6f90fd7c00467deaa2aa94118af11f01c2664fb. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/36?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

