### PR TITLE
Add runtime tool choice and lifecycle hooks

### DIFF
--- a/.changeset/early-reef-runtime-hooks.md
+++ b/.changeset/early-reef-runtime-hooks.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": minor
+---
+
+Add runtime `toolChoice` configuration and lifecycle hooks for turns and steps.

--- a/.changeset/early-reef-runtime-hooks.md
+++ b/.changeset/early-reef-runtime-hooks.md
@@ -1,5 +1,5 @@
 ---
-"@minpeter/pss-runtime": minor
+"@minpeter/pss-runtime": patch
 ---
 
 Add runtime `toolChoice` configuration and lifecycle hooks for turns and steps.

--- a/packages/runtime/src/agent-loop.test.ts
+++ b/packages/runtime/src/agent-loop.test.ts
@@ -61,6 +61,49 @@ describe("runAgentLoop", () => {
     ]);
   });
 
+  it("calls step hooks around each model loop step", async () => {
+    const hookCalls: string[] = [];
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const toolCall = toolCallPart("call-tool-hooks");
+    const llm = createScriptedLlm([
+      [assistantMessage([toolCall]), toolResultFor(toolCall)],
+      [assistantMessage("DONE")],
+    ]);
+
+    await expect(
+      runAgentLoop({
+        emit: (event) => events.push(event),
+        history,
+        hooks: {
+          afterStep: ({ history: snapshot, result, stepIndex }) => {
+            hookCalls.push(`after:${stepIndex}:${result}:${snapshot.length}`);
+          },
+          beforeStep: ({ history: snapshot, stepIndex }) => {
+            hookCalls.push(`before:${stepIndex}:${snapshot.length}`);
+          },
+        },
+        llm,
+      })
+    ).resolves.toBe("completed");
+
+    expect(eventTypes(events)).toEqual([
+      "step-start",
+      "tool-call",
+      "tool-result",
+      "step-end",
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+    expect(hookCalls).toEqual([
+      "before:0:0",
+      "after:0:continue:2",
+      "before:1:2",
+      "after:1:completed:3",
+    ]);
+  });
+
   it("returns aborted when the LLM rejects after the signal is aborted", async () => {
     const events: AgentEvent[] = [];
     const history = new AgentModelHistory();

--- a/packages/runtime/src/agent-loop.test.ts
+++ b/packages/runtime/src/agent-loop.test.ts
@@ -157,6 +157,60 @@ describe("runAgentLoop", () => {
     ]);
   });
 
+  it("returns aborted before emitting a step when beforeStep aborts", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const controller = new AbortController();
+    let llmCalled = false;
+
+    await expect(
+      runAgentLoop({
+        emit: (event) => events.push(event),
+        history,
+        hooks: {
+          beforeStep: () => {
+            controller.abort();
+          },
+        },
+        llm: () => {
+          llmCalled = true;
+          return Promise.resolve([assistantMessage("UNREACHABLE")]);
+        },
+        signal: controller.signal,
+      })
+    ).resolves.toBe("aborted");
+
+    expect(events).toEqual([]);
+    expect(llmCalled).toBe(false);
+    expect(history.modelSnapshot()).toEqual([]);
+  });
+
+  it("rejects before emitting a step when beforeStep throws", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    let llmCalled = false;
+
+    await expect(
+      runAgentLoop({
+        emit: (event) => events.push(event),
+        history,
+        hooks: {
+          beforeStep: () => {
+            throw new Error("before step failed");
+          },
+        },
+        llm: () => {
+          llmCalled = true;
+          return Promise.resolve([assistantMessage("UNREACHABLE")]);
+        },
+      })
+    ).rejects.toThrow("before step failed");
+
+    expect(events).toEqual([]);
+    expect(llmCalled).toBe(false);
+    expect(history.modelSnapshot()).toEqual([]);
+  });
+
   it("returns aborted when the LLM rejects after the signal is aborted", async () => {
     const events: AgentEvent[] = [];
     const history = new AgentModelHistory();

--- a/packages/runtime/src/agent-loop.test.ts
+++ b/packages/runtime/src/agent-loop.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { runAgentLoop } from "./agent-loop";
-import type { Llm } from "./llm";
+import type { Llm, RuntimeLlmContext } from "./llm";
 import type { AgentEvent } from "./session/events";
 import { AgentModelHistory } from "./session/history";
 import {
@@ -101,6 +101,59 @@ describe("runAgentLoop", () => {
       "after:0:continue:2",
       "before:1:2",
       "after:1:completed:3",
+    ]);
+  });
+
+  it("keeps appended output and continues when afterStep throws", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const toolCall = toolCallPart("call-tool-after-step");
+    const seenHistory: RuntimeLlmContext["history"][] = [];
+    let calls = 0;
+    const llm: Llm = ({ history: snapshot }) => {
+      calls += 1;
+      seenHistory.push([...snapshot]);
+
+      if (calls === 1) {
+        return Promise.resolve([
+          assistantMessage([toolCall]),
+          toolResultFor(toolCall),
+        ]);
+      }
+
+      return Promise.resolve([assistantMessage("DONE")]);
+    };
+
+    await expect(
+      runAgentLoop({
+        emit: (event) => events.push(event),
+        history,
+        hooks: {
+          afterStep: () => {
+            throw new Error("after step failed");
+          },
+        },
+        llm,
+      })
+    ).resolves.toBe("completed");
+
+    expect(eventTypes(events)).toEqual([
+      "step-start",
+      "tool-call",
+      "tool-result",
+      "step-end",
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+    expect(seenHistory[1]).toEqual([
+      assistantMessage([toolCall]),
+      toolResultFor(toolCall),
+    ]);
+    expect(history.modelSnapshot()).toEqual([
+      assistantMessage([toolCall]),
+      toolResultFor(toolCall),
+      assistantMessage("DONE"),
     ]);
   });
 

--- a/packages/runtime/src/agent-loop.ts
+++ b/packages/runtime/src/agent-loop.ts
@@ -52,7 +52,7 @@ export async function runAgentLoop({
       return "aborted";
     }
 
-    await hooks?.afterStep?.({
+    await runAfterStepHook(hooks, {
       history: history.modelSnapshot(),
       result,
       signal,
@@ -66,6 +66,18 @@ export async function runAgentLoop({
 
     stepIndex += 1;
   }
+}
+
+async function runAfterStepHook(
+  hooks: AgentHooks | undefined,
+  context: Parameters<NonNullable<AgentHooks["afterStep"]>>[0]
+): Promise<void> {
+  const hook = hooks?.afterStep;
+  if (!hook) {
+    return;
+  }
+
+  await Promise.allSettled([Promise.resolve().then(() => hook(context))]);
 }
 
 async function readLlmOutput({

--- a/packages/runtime/src/agent-loop.ts
+++ b/packages/runtime/src/agent-loop.ts
@@ -39,6 +39,11 @@ export async function runAgentLoop({
       signal,
       stepIndex,
     });
+
+    if (signal.aborted) {
+      return "aborted";
+    }
+
     emit({ type: "step-start" });
     const output = await readLlmOutput({ history, llm, signal });
 

--- a/packages/runtime/src/agent-loop.ts
+++ b/packages/runtime/src/agent-loop.ts
@@ -1,4 +1,5 @@
 import type { ModelMessage } from "ai";
+import type { AgentHooks, AgentStepResult } from "./hooks";
 import type { Llm, LlmOutput } from "./llm";
 import type { AgentEventListener } from "./session/events";
 import { modelMessageToAgentEvents } from "./session/mapping";
@@ -11,24 +12,33 @@ interface ModelHistory {
 interface RunAgentLoopOptions {
   emit: AgentEventListener;
   history: ModelHistory;
+  hooks?: AgentHooks;
   llm: Llm;
   signal?: AbortSignal;
 }
 
 export type AgentLoopResult = "completed" | "aborted";
-type StepOutputResult = "continue" | "completed" | "aborted";
+type StepOutputResult = AgentStepResult | "aborted";
 
 export async function runAgentLoop({
   emit,
   history,
+  hooks,
   llm,
   signal = new AbortController().signal,
 }: RunAgentLoopOptions): Promise<AgentLoopResult> {
+  let stepIndex = 0;
+
   while (true) {
     if (signal.aborted) {
       return "aborted";
     }
 
+    await hooks?.beforeStep?.({
+      history: history.modelSnapshot(),
+      signal,
+      stepIndex,
+    });
     emit({ type: "step-start" });
     const output = await readLlmOutput({ history, llm, signal });
 
@@ -42,11 +52,19 @@ export async function runAgentLoop({
       return "aborted";
     }
 
+    await hooks?.afterStep?.({
+      history: history.modelSnapshot(),
+      result,
+      signal,
+      stepIndex,
+    });
     emit({ type: "step-end" });
 
     if (result === "completed") {
       return "completed";
     }
+
+    stepIndex += 1;
   }
 }
 

--- a/packages/runtime/src/agent.test.ts
+++ b/packages/runtime/src/agent.test.ts
@@ -11,11 +11,13 @@ const missingModelPattern = /missing options\.model/;
 const missingOptionsPattern = /Agent options are required/;
 
 const acceptsModelOptions: AgentOptions = {
+  hooks: {},
   instructions: "Use the injected model.",
   model: fakeModel,
+  toolChoice: "auto",
   tools: {},
 };
-const acceptsCustomLlmOptions: AgentOptions = { llm: fakeLlm };
+const acceptsCustomLlmOptions: AgentOptions = { hooks: {}, llm: fakeLlm };
 
 // @ts-expect-error custom llm and model options are mutually exclusive.
 const rejectsAmbiguousModelPrecedence: AgentOptions = {

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -1,23 +1,33 @@
 import type { LanguageModel } from "ai";
-import { type AgentTools, createLlm, type Llm } from "./llm";
+import type { AgentHooks } from "./hooks";
+import {
+  type AgentToolChoice,
+  type AgentTools,
+  createLlm,
+  type Llm,
+} from "./llm";
 import type { AgentRun } from "./session/run";
 import { type AgentInput, AgentSession } from "./session/session";
 import { MemorySessionStore } from "./session/store/memory";
 import type { SessionStore } from "./session/store/types";
 
 interface AgentModelOptions {
+  hooks?: AgentHooks;
   instructions?: string;
   llm?: never;
   model: LanguageModel;
   sessions?: AgentSessionOptions;
+  toolChoice?: AgentToolChoice;
   tools?: AgentTools;
 }
 
 interface AgentLlmOptions {
+  hooks?: AgentHooks;
   instructions?: never;
   llm: Llm;
   model?: never;
   sessions?: AgentSessionOptions;
+  toolChoice?: never;
   tools?: never;
 }
 
@@ -34,6 +44,7 @@ export interface SessionHandle {
 export type AgentOptions = AgentModelOptions | AgentLlmOptions;
 
 export class Agent {
+  readonly #hooks?: AgentHooks;
   readonly #llm: Llm;
   readonly #sessions = new Map<string, SessionHandle>();
   readonly #store: SessionStore;
@@ -42,11 +53,13 @@ export class Agent {
     assertAgentOptions(options);
 
     this.#store = options.sessions?.store ?? new MemorySessionStore();
+    this.#hooks = options.hooks;
     this.#llm = hasCustomLlm(options)
       ? options.llm
       : createLlm({
           instructions: options.instructions,
           model: options.model,
+          toolChoice: options.toolChoice,
           tools: options.tools,
         });
   }
@@ -65,7 +78,11 @@ export class Agent {
       return existing;
     }
 
-    const session = new AgentSession(this.#llm, { key, store: this.#store });
+    const session = new AgentSession(
+      this.#llm,
+      { key, store: this.#store },
+      this.#hooks
+    );
     const handle: SessionHandle = {
       interrupt: () => session.interrupt(),
       kill: () => {

--- a/packages/runtime/src/hooks.ts
+++ b/packages/runtime/src/hooks.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage } from "ai";
+import type { RuntimeLlmContext } from "./llm";
 import type { UserInput } from "./session/session";
 
 export type AgentTurnResult = "aborted" | "completed";
@@ -6,7 +6,7 @@ export type AgentStepResult = "completed" | "continue";
 type MaybePromise<T> = PromiseLike<T> | T;
 
 export interface AgentBeforeTurnContext {
-  readonly history: readonly ModelMessage[];
+  readonly history: RuntimeLlmContext["history"];
   readonly input: UserInput;
   readonly signal: AbortSignal;
 }
@@ -16,7 +16,7 @@ export interface AgentAfterTurnContext extends AgentBeforeTurnContext {
 }
 
 export interface AgentBeforeStepContext {
-  readonly history: readonly ModelMessage[];
+  readonly history: RuntimeLlmContext["history"];
   readonly signal: AbortSignal;
   readonly stepIndex: number;
 }

--- a/packages/runtime/src/hooks.ts
+++ b/packages/runtime/src/hooks.ts
@@ -1,0 +1,33 @@
+import type { ModelMessage } from "ai";
+import type { UserInput } from "./session/session";
+
+export type AgentTurnResult = "aborted" | "completed";
+export type AgentStepResult = "completed" | "continue";
+type MaybePromise<T> = PromiseLike<T> | T;
+
+export interface AgentBeforeTurnContext {
+  readonly history: readonly ModelMessage[];
+  readonly input: UserInput;
+  readonly signal: AbortSignal;
+}
+
+export interface AgentAfterTurnContext extends AgentBeforeTurnContext {
+  readonly result: AgentTurnResult;
+}
+
+export interface AgentBeforeStepContext {
+  readonly history: readonly ModelMessage[];
+  readonly signal: AbortSignal;
+  readonly stepIndex: number;
+}
+
+export interface AgentAfterStepContext extends AgentBeforeStepContext {
+  readonly result: AgentStepResult;
+}
+
+export interface AgentHooks {
+  afterStep?(context: AgentAfterStepContext): MaybePromise<void>;
+  afterTurn?(context: AgentAfterTurnContext): MaybePromise<void>;
+  beforeStep?(context: AgentBeforeStepContext): MaybePromise<void>;
+  beforeTurn?(context: AgentBeforeTurnContext): MaybePromise<void>;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -6,8 +6,18 @@ export {
 } from "./agent";
 export { type AgentLoopResult, runAgentLoop } from "./agent-loop";
 export type {
+  AgentAfterStepContext,
+  AgentAfterTurnContext,
+  AgentBeforeStepContext,
+  AgentBeforeTurnContext,
+  AgentHooks,
+  AgentStepResult,
+  AgentTurnResult,
+} from "./hooks";
+export type {
   AgentModel,
   AgentTool,
+  AgentToolChoice,
   AgentToolExecute,
   AgentToolExecutionOptions,
   AgentTools,

--- a/packages/runtime/src/llm.test.ts
+++ b/packages/runtime/src/llm.test.ts
@@ -142,6 +142,23 @@ describe("Agent tool wiring", () => {
     );
   });
 
+  it("passes AgentOptions toolChoice into createLlm/generateText", async () => {
+    const Agent = await loadAgent();
+    const agent = await Agent.create({
+      model: fakeModel,
+      toolChoice: "required",
+    });
+
+    await drainRun(await agent.send(userText("force tool choice")));
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: fakeModel,
+        toolChoice: "required",
+      })
+    );
+  });
+
   it("does not attach product tools by default", async () => {
     const Agent = await loadAgent();
     const agent = await Agent.create({ model: fakeModel });

--- a/packages/runtime/src/llm.test.ts
+++ b/packages/runtime/src/llm.test.ts
@@ -89,6 +89,26 @@ describe("createLlm", () => {
       })
     );
   });
+
+  it("passes configured toolChoice to generateText", async () => {
+    const createLlm = await loadCreateLlm();
+    const signal = new AbortController().signal;
+    const history = [{ role: "user" as const, content: "hello" }];
+    const llm = createLlm({
+      model: fakeModel,
+      toolChoice: "required",
+    });
+
+    await expect(llm({ history, signal })).resolves.toEqual([
+      assistantMessage("DONE"),
+    ]);
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolChoice: "required",
+      })
+    );
+  });
 });
 
 describe("Agent tool wiring", () => {

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -11,6 +11,7 @@ export type AgentToolExecutionOptions = ToolExecutionOptions<unknown>;
 export type AgentToolExecute = NonNullable<Tool["execute"]>;
 export type AgentTool = Tool;
 export type AgentTools = ToolSet;
+export type AgentToolChoice = "auto" | "required";
 export type AgentModel = LanguageModel;
 export type AgentMessage = ModelMessage;
 export type LlmOutput = Awaited<
@@ -28,6 +29,7 @@ export type Llm = (context: LlmContext) => Promise<LlmOutput>;
 export interface CreateLlmOptions {
   instructions?: string;
   model: LanguageModel;
+  toolChoice?: AgentToolChoice;
   tools?: AgentTools;
 }
 
@@ -39,6 +41,7 @@ export type RuntimeLlmOutput = LlmOutput;
 export function createLlm({
   model,
   instructions,
+  toolChoice,
   tools,
 }: CreateLlmOptions): Llm {
   return async ({ history, signal }) => {
@@ -47,6 +50,7 @@ export function createLlm({
       instructions,
       messages: [...history],
       model,
+      toolChoice,
       tools,
     });
 

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -596,6 +596,7 @@ describe("Agent session API", () => {
 
   it("interrupts the active run without aborting queued input", async () => {
     const firstLlmCall = createDeferred();
+    const firstLlmStarted = createDeferred();
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
     const session = (
@@ -604,6 +605,7 @@ describe("Agent session API", () => {
           calls += 1;
           seenHistory.push([...history]);
           if (calls === 1) {
+            firstLlmStarted.resolve();
             await firstLlmCall.promise;
           }
           return [assistantMessage("DONE")];
@@ -616,6 +618,7 @@ describe("Agent session API", () => {
     const firstEvents = collect(firstRun);
     const secondEvents = collect(secondRun);
 
+    await firstLlmStarted.promise;
     session.interrupt();
     firstLlmCall.resolve();
 

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -139,6 +139,52 @@ describe("Agent session API", () => {
     ]);
   });
 
+  it("commits successful output before afterTurn failures", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = await Agent.create({
+      hooks: {
+        afterTurn: () => {
+          throw new Error("after turn failed");
+        },
+      },
+      llm: ({ history }) => {
+        calls += 1;
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage(`DONE ${calls}`)]);
+      },
+    });
+
+    const firstEvents = await collect(
+      await agent.session("after-turn").send("first")
+    );
+    const secondEvents = await collect(
+      await agent.session("after-turn").send("second")
+    );
+
+    expect(eventTypes(firstEvents)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(eventTypes(secondEvents)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(seenHistory[1]).toEqual([
+      userTextToModelMessage(userText("first")),
+      assistantMessage("DONE 1"),
+      userTextToModelMessage(userText("second")),
+    ]);
+  });
+
   it("agent.send accepts multipart string input without lossy joining", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = await Agent.create({

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -109,6 +109,36 @@ describe("Agent session API", () => {
     ]);
   });
 
+  it("calls turn hooks around a queued turn", async () => {
+    const hookCalls: string[] = [];
+    const agent = await Agent.create({
+      hooks: {
+        afterTurn: ({ history, input, result }) => {
+          hookCalls.push(`${input.type}:after:${result}:${history.length}`);
+        },
+        beforeTurn: ({ history, input }) => {
+          hookCalls.push(`${input.type}:before:${history.length}`);
+        },
+      },
+      llm: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+
+    const events = await collect(await agent.send("hello"));
+
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(hookCalls).toEqual([
+      "user-text:before:0",
+      "user-text:after:completed:2",
+    ]);
+  });
+
   it("agent.send accepts multipart string input without lossy joining", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = await Agent.create({

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -163,13 +163,13 @@ export class AgentSession {
         signal: this.#activeAbort.signal,
       });
 
-      await this.#hooks?.afterTurn?.({
+      await this.#commitHistory();
+      await runAfterTurnHook(this.#hooks, {
         history: this.#history.modelSnapshot(),
         input,
         result,
         signal: this.#activeAbort.signal,
       });
-      await this.#commitHistory();
       run.emit({ type: result === "aborted" ? "turn-abort" : "turn-end" });
     } catch (error) {
       if (error instanceof SessionCommitConflictError) {
@@ -213,6 +213,18 @@ export class AgentSession {
 
     this.#storeVersion = result.version;
   }
+}
+
+async function runAfterTurnHook(
+  hooks: AgentHooks | undefined,
+  context: Parameters<NonNullable<AgentHooks["afterTurn"]>>[0]
+): Promise<void> {
+  const hook = hooks?.afterTurn;
+  if (!hook) {
+    return;
+  }
+
+  await Promise.allSettled([Promise.resolve().then(() => hook(context))]);
 }
 
 export function normalizeAgentInput(input: AgentInput): UserInput {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,4 +1,5 @@
 import { runAgentLoop } from "../agent-loop";
+import type { AgentHooks } from "../hooks";
 import type { Llm } from "../llm";
 import type { UserMessage, UserMessageContentPart, UserText } from "./events";
 import { AgentModelHistory } from "./history";
@@ -27,6 +28,7 @@ interface QueuedInput {
 }
 
 export class AgentSession {
+  readonly #hooks?: AgentHooks;
   readonly #inputQueue: QueuedInput[] = [];
   readonly #llm: Llm;
   readonly #persistence: SessionPersistenceOptions;
@@ -38,7 +40,12 @@ export class AgentSession {
   #running = false;
   #storeVersion: string | undefined;
 
-  constructor(llm: Llm, persistence: SessionPersistenceOptions) {
+  constructor(
+    llm: Llm,
+    persistence: SessionPersistenceOptions,
+    hooks?: AgentHooks
+  ) {
+    this.#hooks = hooks;
     this.#llm = llm;
     this.#persistence = persistence;
   }
@@ -139,6 +146,11 @@ export class AgentSession {
     const historySnapshot = this.#history.modelSnapshot();
 
     try {
+      await this.#hooks?.beforeTurn?.({
+        history: this.#history.modelSnapshot(),
+        input,
+        signal: this.#activeAbort.signal,
+      });
       run.emit({ type: "turn-start" });
       this.#history.appendUserInput(input);
       await this.#commitHistory();
@@ -146,10 +158,17 @@ export class AgentSession {
       const result = await runAgentLoop({
         emit: (event) => run.emit(event),
         history: this.#history,
+        hooks: this.#hooks,
         llm: this.#llm,
         signal: this.#activeAbort.signal,
       });
 
+      await this.#hooks?.afterTurn?.({
+        history: this.#history.modelSnapshot(),
+        input,
+        result,
+        signal: this.#activeAbort.signal,
+      });
       await this.#commitHistory();
       run.emit({ type: result === "aborted" ? "turn-abort" : "turn-end" });
     } catch (error) {

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -226,6 +226,20 @@ describe("verifyReleaseArtifacts", () => {
     ]);
   });
 
+  it("rejects raw AI SDK message types from runtime hook declarations", () => {
+    const cwd = createFixture();
+    writeFileSync(
+      join(cwd, "packages", "runtime", "dist", "hooks.d.ts"),
+      'import type { ModelMessage } from "ai";\nexport interface AgentBeforeTurnContext { readonly history: readonly ModelMessage[]; }\n'
+    );
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
+    ).toEqual([
+      "packages/runtime/dist/hooks.d.ts: unauthorized runtime declaration token ModelMessage",
+    ]);
+  });
+
   it("rejects internal runtime message aliases from root declarations", () => {
     const cwd = createFixture();
     writeFileSync(


### PR DESCRIPTION
## Summary
- add init-time runtime `toolChoice` support for `auto` and `required`
- add exported lifecycle hook types for turn and step boundaries
- thread hooks through sessions and agent loop with coverage
- add a runtime changeset

## Verification
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm --filter @minpeter/pss-runtime build`
- manual Agent run verified hook/event order

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime `toolChoice` and lifecycle hooks around turns and steps. `beforeStep` aborts now stop the loop cleanly with no step events or LLM calls.

- New Features
  - `toolChoice` at init via `Agent.create({ model, toolChoice })` (`auto` | `required`), propagated through `createLlm` to `generateText`.
  - Lifecycle hooks: `beforeTurn`/`afterTurn`, `beforeStep`/`afterStep` with typed contexts; exported from `@minpeter/pss-runtime` and accepted via `Agent.create({ hooks })`.
  - Hooks threaded through `Agent`, `AgentSession`, and `runAgentLoop`.

- Bug Fixes
  - Stop the loop when `beforeStep` aborts; emit nothing and skip LLM.
  - Throwing in `beforeStep` rejects before any events; state unchanged.
  - Preserve history and continue when `afterStep` or `afterTurn` throw; output is committed before hooks run.
  - Ensure hook declaration types use runtime aliases only; release check rejects raw `ai` types.

<sup>Written for commit 7eb5f5afcf325c129258059ac99568eb3f22bfd5. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/38?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

