### PR TITLE
Add current-turn runtime input stream

### DIFF
--- a/.changeset/current-turn-runtime-input.md
+++ b/.changeset/current-turn-runtime-input.md
@@ -3,4 +3,6 @@
 "@minpeter/pss-coding-agent": patch
 ---
 
-Document the synchronized run stream driver, current-turn runtime input API, and TUI active-run input behavior.
+Replace the public current-turn input API with `session.steer(input)` and keep
+`session.send(input)` as the new-turn queue. Active TUI submissions now steer the
+current run through the session API.

--- a/.changeset/current-turn-runtime-input.md
+++ b/.changeset/current-turn-runtime-input.md
@@ -1,6 +1,6 @@
 ---
-"@minpeter/pss-runtime": minor
-"@minpeter/pss-coding-agent": minor
+"@minpeter/pss-runtime": patch
+"@minpeter/pss-coding-agent": patch
 ---
 
 Document the synchronized run stream driver, current-turn runtime input API, and TUI active-run input behavior.

--- a/.changeset/current-turn-runtime-input.md
+++ b/.changeset/current-turn-runtime-input.md
@@ -1,0 +1,6 @@
+---
+"@minpeter/pss-runtime": minor
+"@minpeter/pss-coding-agent": minor
+---
+
+Document the synchronized run stream driver, current-turn runtime input API, and TUI active-run input behavior.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Small agent runtime workspace.
 
-- `@minpeter/pss-runtime` — runtime, sessions, model loop.
-- `@minpeter/pss-coding-agent` — web tools, model wiring, and the `pss` TUI.
+- `@minpeter/pss-runtime`: runtime, sessions, model loop.
+- `@minpeter/pss-coding-agent`: web tools, model wiring, and the `pss` TUI.
 
 ## Use
 
@@ -17,11 +17,41 @@ const agent = await Agent.create({
   model: createCodingAgentModel(),
   tools,
 });
-const conversation = await agent.send("Hello");
-for await (const event of conversation.stream()) {
+const run = await agent.send("Hello");
+for await (const event of run.stream()) {
   console.dir(event, { depth: null });
 }
 ```
+
+`run.stream()` is synchronized and drives the run. Consume it to let the runtime
+cross lifecycle boundaries such as `turn-start`, `step-start`, and `step-end`.
+At those boundaries, code can add current-turn input with `run.input.add(input)`.
+It accepts the same input shapes as `session.send(input)`, but it only works for
+the active turn.
+
+```ts
+const session = agent.session("default");
+const run = await session.send("Write a two sentence summary.");
+let addedConstraint = false;
+
+for await (const event of run.stream()) {
+  if (event.type === "step-end" && !addedConstraint) {
+    addedConstraint = true;
+    await run.input.add("Keep the second sentence under 10 words.");
+  }
+}
+```
+
+The guard matters. `step-end` runtime input asks the runtime to continue the
+current turn before the next model snapshot, even after final-looking assistant
+text. Adding input on every `step-end` can keep a turn running indefinitely.
+
+Use `session.send(input)` to start or enqueue a new turn. Use `run.input.add()`
+only inside the current run's input windows. After `turn-end`, `turn-error`,
+`turn-abort`, stream `return()`, or `kill()`, it rejects and never enqueues a new
+turn. Runtime additions appear as `runtime-input` events: runtime/API-originated
+input mapped internally to the model's user role, separate from human
+`user-text` and `user-message` events.
 
 The runtime `send` API also accepts JSON-serializable multimodal content parts
 for model providers that support them:
@@ -48,6 +78,9 @@ or install it:
 pnpm add -g @minpeter/pss-coding-agent
 pss
 ```
+
+In the `pss` TUI, submitting while a run is active adds runtime input to that
+current run. Submitting while idle starts a normal new turn.
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ for await (const event of run.stream()) {
 
 `run.stream()` is synchronized and drives the run. Consume it to let the runtime
 cross lifecycle boundaries such as `turn-start`, `step-start`, and `step-end`.
-At those boundaries, code can add current-turn input with `run.input.add(input)`.
-It accepts the same input shapes as `session.send(input)`, but it only works for
-the active turn.
+Use `session.send(input)` for a new user turn. If a run is already active, the
+turn is queued until the active run finishes. Use `session.steer(input)` when the
+input should steer the active run; if no run is active, it starts a normal run.
 
 ```ts
 const session = agent.session("default");
@@ -37,7 +37,7 @@ let addedConstraint = false;
 for await (const event of run.stream()) {
   if (event.type === "step-end" && !addedConstraint) {
     addedConstraint = true;
-    await run.input.add("Keep the second sentence under 10 words.");
+    await session.steer("Keep the second sentence under 10 words.");
   }
 }
 ```
@@ -46,12 +46,9 @@ The guard matters. `step-end` runtime input asks the runtime to continue the
 current turn before the next model snapshot, even after final-looking assistant
 text. Adding input on every `step-end` can keep a turn running indefinitely.
 
-Use `session.send(input)` to start or enqueue a new turn. Use `run.input.add()`
-only inside the current run's input windows. After `turn-end`, `turn-error`,
-`turn-abort`, stream `return()`, or `kill()`, it rejects and never enqueues a new
-turn. Runtime additions appear as `runtime-input` events: runtime/API-originated
-input mapped internally to the model's user role, separate from human
-`user-text` and `user-message` events.
+Steering additions appear as `runtime-input` events: runtime/API-originated input
+mapped internally to the model's user role, separate from human `user-text` and
+`user-message` events.
 
 The runtime `send` API also accepts JSON-serializable multimodal content parts
 for model providers that support them:
@@ -79,8 +76,8 @@ pnpm add -g @minpeter/pss-coding-agent
 pss
 ```
 
-In the `pss` TUI, submitting while a run is active adds runtime input to that
-current run. Submitting while idle starts a normal new turn.
+In the `pss` TUI, submitting while a run is active steers the current run.
+Submitting while idle starts a normal new turn.
 
 ## Develop
 

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -16,6 +16,6 @@ for await (const event of run.stream()) {
 
   if (event.type === "step-end" && !askedForSource) {
     askedForSource = true;
-    await run.input.add("Include the most relevant source you found.");
+    await session.steer("Include the most relevant source you found.");
   }
 }

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -7,7 +7,15 @@ const agent = await Agent.create({
   model: createCodingAgentModel(),
   tools,
 });
-const run = await agent.send("Find information about minpeter.");
+const session = agent.session("default");
+const run = await session.send("Find information about minpeter.");
+let askedForSource = false;
+
 for await (const event of run.stream()) {
   console.dir(event, { depth: null });
+
+  if (event.type === "step-end" && !askedForSource) {
+    askedForSource = true;
+    await run.input.add("Include the most relevant source you found.");
+  }
 }

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -20,9 +20,9 @@ for await (const event of run.stream()) {
 
 `run.stream()` is synchronized and drives the run. The runtime waits at
 `turn-start`, `step-start`, and `step-end` until the stream consumer continues,
-so consume the stream to let the run progress. During those current-turn input
-windows, `run.input.add(input)` accepts the same input shapes as
-`session.send(input)` and inserts input into the active turn only.
+so consume the stream to let the run progress. Use `session.send(input)` for a
+new user turn and `session.steer(input)` to steer the active run. If no run is
+active, `session.steer(input)` starts a normal run.
 
 ```ts
 const session = agent.session("default");
@@ -32,7 +32,7 @@ let askedForExample = false;
 for await (const event of run.stream()) {
   if (event.type === "step-end" && !askedForExample) {
     askedForExample = true;
-    await run.input.add("Add one concrete example.");
+    await session.steer("Add one concrete example.");
   }
 }
 ```
@@ -45,8 +45,7 @@ turn running indefinitely.
 Runtime additions emit `runtime-input`: runtime/API-originated input mapped
 internally to the model's user role, separate from human `user-text` and
 `user-message` events. `session.send(input)` starts or enqueues a new turn;
-`run.input.add(input)` is current-turn-only and rejects after `turn-end`,
-`turn-error`, `turn-abort`, stream `return()`, or `kill()`.
+`session.steer(input)` steers the active run or starts a normal run when idle.
 
 ## CLI
 
@@ -62,9 +61,9 @@ pss
 Bin aliases: `pss`, `pss-coding-agent`.
 
 When the TUI is idle, submitting text starts a normal `session.send()` turn. When
-a run is active, submitting text calls `activeRun.input.add(trimmed)` so the text
-lands in the current run and renders as dim `runtime: ...` input instead of a
-new human turn.
+a run is active, submitting text calls `session.steer(trimmed)` so the text lands
+in the current run and renders as dim `runtime: ...` input instead of a new human
+turn.
 
 ## Env
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -18,6 +18,36 @@ for await (const event of run.stream()) {
 }
 ```
 
+`run.stream()` is synchronized and drives the run. The runtime waits at
+`turn-start`, `step-start`, and `step-end` until the stream consumer continues,
+so consume the stream to let the run progress. During those current-turn input
+windows, `run.input.add(input)` accepts the same input shapes as
+`session.send(input)` and inserts input into the active turn only.
+
+```ts
+const session = agent.session("default");
+const run = await session.send("Explain the latest result.");
+let askedForExample = false;
+
+for await (const event of run.stream()) {
+  if (event.type === "step-end" && !askedForExample) {
+    askedForExample = true;
+    await run.input.add("Add one concrete example.");
+  }
+}
+```
+
+Guard `step-end` additions. Runtime input added at `step-end` intentionally
+continues the current turn before the next model snapshot, even if the assistant
+already printed final-looking text. Adding input on every `step-end` can keep the
+turn running indefinitely.
+
+Runtime additions emit `runtime-input`: runtime/API-originated input mapped
+internally to the model's user role, separate from human `user-text` and
+`user-message` events. `session.send(input)` starts or enqueues a new turn;
+`run.input.add(input)` is current-turn-only and rejects after `turn-end`,
+`turn-error`, `turn-abort`, stream `return()`, or `kill()`.
+
 ## CLI
 
 ```sh
@@ -30,6 +60,11 @@ pss
 ```
 
 Bin aliases: `pss`, `pss-coding-agent`.
+
+When the TUI is idle, submitting text starts a normal `session.send()` turn. When
+a run is active, submitting text calls `activeRun.input.add(trimmed)` so the text
+lands in the current run and renders as dim `runtime: ...` input instead of a
+new human turn.
 
 ## Env
 

--- a/packages/coding-agent/src/tui-runner.test.ts
+++ b/packages/coding-agent/src/tui-runner.test.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, AgentRun } from "@minpeter/pss-runtime";
+import type { AgentEvent } from "@minpeter/pss-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createTuiRunner, formatEvent } from "./tui-runner";
 
@@ -21,7 +21,10 @@ describe("TUI runner", () => {
       { text: "hello", type: "user-text" },
       { type: "turn-end" },
     ]);
-    const session = { send: vi.fn().mockResolvedValue(run) };
+    const session = {
+      send: vi.fn().mockResolvedValue(run),
+      steer: vi.fn().mockResolvedValue(run),
+    };
     const lines: string[] = [];
     const runner = createTuiRunner({
       addLine: (line) => lines.push(line),
@@ -37,7 +40,7 @@ describe("TUI runner", () => {
     expect(runner.activeRun).toBeUndefined();
   });
 
-  it("adds active submissions to the current run without sending a new turn", async () => {
+  it("steers active submissions without sending a new turn", async () => {
     let releaseStream: (() => void) | undefined;
     const run = createRun([
       { text: "initial", type: "user-text" },
@@ -45,7 +48,10 @@ describe("TUI runner", () => {
         releaseStream = () => resolve({ type: "turn-end" });
       }),
     ]);
-    const session = { send: vi.fn().mockResolvedValue(run) };
+    const session = {
+      send: vi.fn().mockResolvedValue(run),
+      steer: vi.fn().mockResolvedValue(run),
+    };
     const runner = createTuiRunner({
       addLine: vi.fn(),
       requestRender: vi.fn(),
@@ -59,8 +65,33 @@ describe("TUI runner", () => {
     await run.done;
 
     expect(session.send).toHaveBeenCalledTimes(1);
-    expect(run.addInput).toHaveBeenCalledWith("extra");
+    expect(session.steer).toHaveBeenCalledWith("extra");
     expect(runner.activeRun).toBeUndefined();
+  });
+
+  it("renders active steering errors", async () => {
+    const run = createRun([
+      { text: "initial", type: "user-text" },
+      new Promise<AgentEvent>(() => undefined),
+    ]);
+    const lines: string[] = [];
+    const session = {
+      send: vi.fn().mockResolvedValue(run),
+      steer: vi.fn().mockRejectedValue(new Error("cannot steer")),
+    };
+    const runner = createTuiRunner({
+      addLine: (line) => lines.push(line),
+      requestRender: vi.fn(),
+      session,
+    });
+
+    runner.submit("initial");
+    await run.firstEventRead;
+    runner.submit(" extra ");
+    await waitUntil(() => lines.includes("\x1b[31merror\x1b[0m: cannot steer"));
+    run.stop();
+
+    expect(session.steer).toHaveBeenCalledWith("extra");
   });
 
   it("clears stale active runs when stream consumption throws", async () => {
@@ -68,7 +99,10 @@ describe("TUI runner", () => {
     const runner = createTuiRunner({
       addLine: vi.fn(),
       requestRender: vi.fn(),
-      session: { send: vi.fn().mockResolvedValue(run) },
+      session: {
+        send: vi.fn().mockResolvedValue(run),
+        steer: vi.fn().mockResolvedValue(run),
+      },
     });
 
     runner.submit("hello");
@@ -93,7 +127,10 @@ describe("TUI runner", () => {
     const runner = createTuiRunner({
       addLine: vi.fn(),
       requestRender: vi.fn(),
-      session: { send: vi.fn().mockResolvedValue(run) },
+      session: {
+        send: vi.fn().mockResolvedValue(run),
+        steer: vi.fn().mockResolvedValue(run),
+      },
     });
 
     runner.submit("initial");
@@ -111,7 +148,6 @@ describe("TUI runner", () => {
 });
 
 function createRun(events: readonly StreamItem[]): TestRun {
-  const addInput = vi.fn().mockResolvedValue(undefined);
   let eventCount = 0;
   let firstEventReadResolve: (() => void) | undefined;
   let doneResolve: (() => void) | undefined;
@@ -125,14 +161,12 @@ function createRun(events: readonly StreamItem[]): TestRun {
   });
 
   const run: TestRun = {
-    addInput,
     done,
     eventsRead: (count) =>
       eventCount >= count
         ? Promise.resolve()
         : new Promise<void>((resolve) => eventWaiters.set(count, resolve)),
     firstEventRead,
-    input: { add: addInput },
     stop: () => {
       stopped = true;
     },
@@ -167,12 +201,12 @@ function createRun(events: readonly StreamItem[]): TestRun {
 
 type StreamItem = AgentEvent | Error | Promise<AgentEvent>;
 
-interface TestRun extends AgentRun {
-  readonly addInput: ReturnType<typeof vi.fn>;
+interface TestRun {
   readonly done: Promise<void>;
   readonly eventsRead: (count: number) => Promise<void>;
   readonly firstEventRead: Promise<void>;
   readonly stop: () => void;
+  stream(): AsyncIterable<AgentEvent>;
 }
 
 async function waitUntil(predicate: () => boolean): Promise<void> {

--- a/packages/coding-agent/src/tui-runner.test.ts
+++ b/packages/coding-agent/src/tui-runner.test.ts
@@ -69,6 +69,41 @@ describe("TUI runner", () => {
     expect(runner.activeRun).toBeUndefined();
   });
 
+  it("consumes a distinct run returned by active steering", async () => {
+    let releaseActive: (() => void) | undefined;
+    const activeRun = createRun([
+      { text: "initial", type: "user-text" },
+      new Promise<AgentEvent>((resolve) => {
+        releaseActive = () => resolve({ type: "turn-end" });
+      }),
+    ]);
+    const fallbackRun = createRun([
+      { text: "fallback", type: "user-text" },
+      { type: "turn-end" },
+    ]);
+    const lines: string[] = [];
+    const session = {
+      send: vi.fn().mockResolvedValue(activeRun),
+      steer: vi.fn().mockResolvedValue(fallbackRun),
+    };
+    const runner = createTuiRunner({
+      addLine: (line) => lines.push(line),
+      requestRender: vi.fn(),
+      session,
+    });
+
+    runner.submit("initial");
+    await activeRun.firstEventRead;
+    runner.submit(" fallback ");
+    await fallbackRun.done;
+    releaseActive?.();
+    await activeRun.done;
+
+    expect(session.steer).toHaveBeenCalledWith("fallback");
+    expect(lines).toContain("\x1b[36myou\x1b[0m: fallback");
+    expect(runner.activeRun).toBeUndefined();
+  });
+
   it("renders active steering errors", async () => {
     const run = createRun([
       { text: "initial", type: "user-text" },

--- a/packages/coding-agent/src/tui-runner.test.ts
+++ b/packages/coding-agent/src/tui-runner.test.ts
@@ -17,7 +17,10 @@ describe("TUI runner", () => {
   });
 
   it("starts idle submissions with session.send and consumes the run", async () => {
-    const run = createRun([{ text: "hello", type: "user-text" }, { type: "turn-end" }]);
+    const run = createRun([
+      { text: "hello", type: "user-text" },
+      { type: "turn-end" },
+    ]);
     const session = { send: vi.fn().mockResolvedValue(run) };
     const lines: string[] = [];
     const runner = createTuiRunner({
@@ -133,7 +136,7 @@ function createRun(events: readonly StreamItem[]): TestRun {
     stop: () => {
       stopped = true;
     },
-    stream: async function* () {
+    async *stream() {
       try {
         for (const item of events) {
           if (stopped) {

--- a/packages/coding-agent/src/tui-runner.test.ts
+++ b/packages/coding-agent/src/tui-runner.test.ts
@@ -1,0 +1,183 @@
+import type { AgentEvent, AgentRun } from "@minpeter/pss-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { createTuiRunner, formatEvent } from "./tui-runner";
+
+describe("TUI runner", () => {
+  it("renders runtime input distinctly from human input", () => {
+    expect(formatEvent({ text: "hello", type: "user-text" })).toBe(
+      "\x1b[36myou\x1b[0m: hello"
+    );
+    expect(
+      formatEvent({
+        input: { text: "extra", type: "user-text" },
+        placement: "step-end",
+        type: "runtime-input",
+      })
+    ).toBe("\x1b[2mruntime: extra\x1b[0m");
+  });
+
+  it("starts idle submissions with session.send and consumes the run", async () => {
+    const run = createRun([{ text: "hello", type: "user-text" }, { type: "turn-end" }]);
+    const session = { send: vi.fn().mockResolvedValue(run) };
+    const lines: string[] = [];
+    const runner = createTuiRunner({
+      addLine: (line) => lines.push(line),
+      requestRender: vi.fn(),
+      session,
+    });
+
+    runner.submit(" hello ");
+    await run.done;
+
+    expect(session.send).toHaveBeenCalledWith("hello");
+    expect(lines).toContain("\x1b[36myou\x1b[0m: hello");
+    expect(runner.activeRun).toBeUndefined();
+  });
+
+  it("adds active submissions to the current run without sending a new turn", async () => {
+    let releaseStream: (() => void) | undefined;
+    const run = createRun([
+      { text: "initial", type: "user-text" },
+      new Promise<AgentEvent>((resolve) => {
+        releaseStream = () => resolve({ type: "turn-end" });
+      }),
+    ]);
+    const session = { send: vi.fn().mockResolvedValue(run) };
+    const runner = createTuiRunner({
+      addLine: vi.fn(),
+      requestRender: vi.fn(),
+      session,
+    });
+
+    runner.submit("initial");
+    await run.firstEventRead;
+    runner.submit(" extra ");
+    releaseStream?.();
+    await run.done;
+
+    expect(session.send).toHaveBeenCalledTimes(1);
+    expect(run.addInput).toHaveBeenCalledWith("extra");
+    expect(runner.activeRun).toBeUndefined();
+  });
+
+  it("clears stale active runs when stream consumption throws", async () => {
+    const run = createRun([new Error("stream failed")]);
+    const runner = createTuiRunner({
+      addLine: vi.fn(),
+      requestRender: vi.fn(),
+      session: { send: vi.fn().mockResolvedValue(run) },
+    });
+
+    runner.submit("hello");
+    await run.done;
+    await waitUntil(() => runner.activeRun === undefined);
+
+    expect(runner.activeRun).toBeUndefined();
+  });
+
+  it("clears active runs as soon as terminal turn events render", async () => {
+    let releaseStream: (() => void) | undefined;
+    let releaseAfterTerminal: (() => void) | undefined;
+    const run = createRun([
+      { text: "initial", type: "user-text" },
+      new Promise<AgentEvent>((resolve) => {
+        releaseStream = () => resolve({ type: "turn-abort" });
+      }),
+      new Promise<AgentEvent>((resolve) => {
+        releaseAfterTerminal = () => resolve({ type: "step-start" });
+      }),
+    ]);
+    const runner = createTuiRunner({
+      addLine: vi.fn(),
+      requestRender: vi.fn(),
+      session: { send: vi.fn().mockResolvedValue(run) },
+    });
+
+    runner.submit("initial");
+    await run.firstEventRead;
+    expect(runner.activeRun).toBe(run);
+
+    releaseStream?.();
+    await run.eventsRead(2);
+    await waitUntil(() => runner.activeRun === undefined);
+
+    expect(runner.activeRun).toBeUndefined();
+    releaseAfterTerminal?.();
+    await run.done;
+  });
+});
+
+function createRun(events: readonly StreamItem[]): TestRun {
+  const addInput = vi.fn().mockResolvedValue(undefined);
+  let eventCount = 0;
+  let firstEventReadResolve: (() => void) | undefined;
+  let doneResolve: (() => void) | undefined;
+  const eventWaiters = new Map<number, () => void>();
+  let stopped = false;
+  const firstEventRead = new Promise<void>((resolve) => {
+    firstEventReadResolve = resolve;
+  });
+  const done = new Promise<void>((resolve) => {
+    doneResolve = resolve;
+  });
+
+  const run: TestRun = {
+    addInput,
+    done,
+    eventsRead: (count) =>
+      eventCount >= count
+        ? Promise.resolve()
+        : new Promise<void>((resolve) => eventWaiters.set(count, resolve)),
+    firstEventRead,
+    input: { add: addInput },
+    stop: () => {
+      stopped = true;
+    },
+    stream: async function* () {
+      try {
+        for (const item of events) {
+          if (stopped) {
+            return;
+          }
+          const event = await item;
+          if (event instanceof Error) {
+            throw event;
+          }
+          eventCount += 1;
+          firstEventReadResolve?.();
+          for (const [count, resolve] of eventWaiters) {
+            if (eventCount >= count) {
+              eventWaiters.delete(count);
+              resolve();
+            }
+          }
+          yield event;
+        }
+      } finally {
+        doneResolve?.();
+      }
+    },
+  };
+
+  return run;
+}
+
+type StreamItem = AgentEvent | Error | Promise<AgentEvent>;
+
+interface TestRun extends AgentRun {
+  readonly addInput: ReturnType<typeof vi.fn>;
+  readonly done: Promise<void>;
+  readonly eventsRead: (count: number) => Promise<void>;
+  readonly firstEventRead: Promise<void>;
+  readonly stop: () => void;
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}

--- a/packages/coding-agent/src/tui-runner.ts
+++ b/packages/coding-agent/src/tui-runner.ts
@@ -18,7 +18,7 @@ import {
 export interface TuiRunnerOptions {
   readonly addLine: (text: string) => void;
   readonly requestRender: () => void;
-  readonly session: Pick<SessionHandle, "send">;
+  readonly session: Pick<SessionHandle, "send" | "steer">;
 }
 
 export interface TuiRunner {
@@ -107,7 +107,7 @@ export function createTuiRunner({
 
     const run = activeRun;
     if (run) {
-      run.input.add(trimmed).catch((error: unknown) => {
+      session.steer(trimmed).catch((error: unknown) => {
         addLine(`\x1b[31merror\x1b[0m: ${safeText(errorMessage(error))}`);
       });
       return;

--- a/packages/coding-agent/src/tui-runner.ts
+++ b/packages/coding-agent/src/tui-runner.ts
@@ -23,8 +23,8 @@ export interface TuiRunnerOptions {
 
 export interface TuiRunner {
   readonly activeRun: AgentRun | undefined;
-  consumeRun(run: AgentRun): Promise<void>;
   clearActiveRun(run?: AgentRun): void;
+  consumeRun(run: AgentRun): Promise<void>;
   submit(text: string): void;
 }
 

--- a/packages/coding-agent/src/tui-runner.ts
+++ b/packages/coding-agent/src/tui-runner.ts
@@ -107,9 +107,16 @@ export function createTuiRunner({
 
     const run = activeRun;
     if (run) {
-      session.steer(trimmed).catch((error: unknown) => {
-        addLine(`\x1b[31merror\x1b[0m: ${safeText(errorMessage(error))}`);
-      });
+      session
+        .steer(trimmed)
+        .then((nextRun) => {
+          if (nextRun !== run) {
+            return consumeRun(nextRun);
+          }
+        })
+        .catch((error: unknown) => {
+          addLine(`\x1b[31merror\x1b[0m: ${safeText(errorMessage(error))}`);
+        });
       return;
     }
 

--- a/packages/coding-agent/src/tui-runner.ts
+++ b/packages/coding-agent/src/tui-runner.ts
@@ -1,0 +1,197 @@
+import type {
+  AgentEvent,
+  AgentRun,
+  SessionHandle,
+  UserInput,
+  UserMessage,
+  UserMessageContentPart,
+  UserTextContent,
+} from "@minpeter/pss-runtime";
+import {
+  formatToolCallForTui,
+  formatToolResultForTui,
+  safeInlineText,
+  safeText,
+  truncateDetail,
+} from "./tui-tool-printer";
+
+export interface TuiRunnerOptions {
+  readonly addLine: (text: string) => void;
+  readonly requestRender: () => void;
+  readonly session: Pick<SessionHandle, "send">;
+}
+
+export interface TuiRunner {
+  readonly activeRun: AgentRun | undefined;
+  consumeRun(run: AgentRun): Promise<void>;
+  clearActiveRun(run?: AgentRun): void;
+  submit(text: string): void;
+}
+
+const dimText = "\x1b[2m";
+const resetText = "\x1b[0m";
+
+export const formatUserTextContent = (text: UserTextContent): string =>
+  typeof text === "string" ? text : text.join("\n");
+
+export const formatEvent = (event: AgentEvent): string | undefined => {
+  switch (event.type) {
+    case "user-text":
+      return `\x1b[36myou\x1b[0m: ${safeText(formatUserTextContent(event.text))}`;
+    case "user-message":
+      return `\x1b[36myou\x1b[0m: ${safeText(formatUserMessageContent(event))}`;
+    case "runtime-input":
+      return `${dimText}runtime: ${safeText(formatRuntimeInput(event.input))}${resetText}`;
+    case "assistant-text":
+      return `\x1b[32massistant\x1b[0m: ${safeText(event.text)}`;
+    case "assistant-reasoning":
+      return `\x1b[35mreasoning\x1b[0m: ${truncateDetail(safeInlineText(event.text), 240)}`;
+    case "tool-call":
+      return `\x1b[33mtool\x1b[0m ${formatToolCallForTui(event)}`;
+    case "tool-result":
+      return `\x1b[33mtool result\x1b[0m ${formatToolResultForTui(event)}`;
+    case "turn-start":
+      return `${dimText}running...${resetText}`;
+    case "turn-abort":
+      return `${dimText}interrupted${resetText}`;
+    case "turn-error":
+      return `\x1b[31merror\x1b[0m: ${safeText(event.message)}`;
+    case "turn-end":
+      return `${dimText}done${resetText}`;
+    case "step-start":
+    case "step-end":
+      return;
+    default:
+      return;
+  }
+};
+
+export function createTuiRunner({
+  addLine,
+  requestRender,
+  session,
+}: TuiRunnerOptions): TuiRunner {
+  let activeRun: AgentRun | undefined;
+
+  const clearActiveRun = (run?: AgentRun): void => {
+    if (run === undefined || activeRun === run) {
+      activeRun = undefined;
+    }
+  };
+
+  const consumeRun = async (run: AgentRun): Promise<void> => {
+    activeRun = run;
+
+    try {
+      for await (const event of run.stream()) {
+        const line = formatEvent(event);
+        if (line) {
+          addLine(line);
+        }
+
+        if (isTerminalTurnEvent(event)) {
+          clearActiveRun(run);
+        }
+      }
+    } finally {
+      clearActiveRun(run);
+    }
+  };
+
+  const submit = (text: string): void => {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      requestRender();
+      return;
+    }
+
+    const run = activeRun;
+    if (run) {
+      run.input.add(trimmed).catch((error: unknown) => {
+        addLine(`\x1b[31merror\x1b[0m: ${safeText(errorMessage(error))}`);
+      });
+      return;
+    }
+
+    session
+      .send(trimmed)
+      .then((nextRun) => consumeRun(nextRun))
+      .catch((error: unknown) => {
+        addLine(`\x1b[31merror\x1b[0m: ${safeText(errorMessage(error))}`);
+      });
+  };
+
+  return {
+    get activeRun() {
+      return activeRun;
+    },
+    clearActiveRun,
+    consumeRun,
+    submit,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatRuntimeInput(input: UserInput): string {
+  if (isUserText(input)) {
+    return formatUserTextContent(input.text);
+  }
+
+  if (isUserMessage(input)) {
+    return formatUserMessageContent(input);
+  }
+
+  return safeInlineText(String(input));
+}
+
+function formatUserMessageContent(message: UserMessage): string {
+  return message.content.map(formatUserMessagePart).join("\n");
+}
+
+function formatUserMessagePart(part: UserMessageContentPart): string {
+  switch (part.type) {
+    case "text":
+      return part.text;
+    case "image":
+      return `[image ${part.mediaType ?? "unknown"}]`;
+    case "file":
+      return `[file ${part.filename ?? part.mediaType}]`;
+    default:
+      return "[input]";
+  }
+}
+
+function isTerminalTurnEvent(event: AgentEvent): boolean {
+  return (
+    event.type === "turn-end" ||
+    event.type === "turn-error" ||
+    event.type === "turn-abort"
+  );
+}
+
+function isUserMessage(input: unknown): input is UserMessage {
+  return (
+    typeof input === "object" &&
+    input !== null &&
+    "type" in input &&
+    input.type === "user-message" &&
+    "content" in input &&
+    Array.isArray(input.content)
+  );
+}
+
+function isUserText(
+  input: unknown
+): input is { text: UserTextContent; type: "user-text" } {
+  return (
+    typeof input === "object" &&
+    input !== null &&
+    "type" in input &&
+    input.type === "user-text" &&
+    "text" in input &&
+    (typeof input.text === "string" || Array.isArray(input.text))
+  );
+}

--- a/packages/coding-agent/src/tui.ts
+++ b/packages/coding-agent/src/tui.ts
@@ -6,19 +6,13 @@ import {
   Text,
   TUI,
 } from "@earendil-works/pi-tui";
-import type { AgentEvent, UserTextContent } from "@minpeter/pss-runtime";
 import { Agent } from "@minpeter/pss-runtime";
 import { FileSessionStore } from "@minpeter/pss-runtime/session-store/file";
 import { createCodingAgentModel } from "./model";
 import { resolveCodingAgentSessionConfig } from "./session-config";
 import { tools } from "./tools";
-import {
-  formatToolCallForTui,
-  formatToolResultForTui,
-  safeInlineText,
-  safeText,
-  truncateDetail,
-} from "./tui-tool-printer";
+import { createTuiRunner } from "./tui-runner";
+import { safeInlineText } from "./tui-tool-printer";
 
 const sessionConfig = resolveCodingAgentSessionConfig();
 const agent = await Agent.create({
@@ -59,60 +53,15 @@ const addLine = (text: string): void => {
   tui.requestRender();
 };
 
-const formatUserTextContent = (text: UserTextContent): string =>
-  typeof text === "string" ? text : text.join("\n");
+const runner = createTuiRunner({
+  addLine,
+  requestRender: () => tui.requestRender(),
+  session,
+});
 
-const formatEvent = (event: AgentEvent): string | undefined => {
-  switch (event.type) {
-    case "user-text":
-      return `\x1b[36myou\x1b[0m: ${safeText(formatUserTextContent(event.text))}`;
-    case "assistant-text":
-      return `\x1b[32massistant\x1b[0m: ${safeText(event.text)}`;
-    case "assistant-reasoning":
-      return `\x1b[35mreasoning\x1b[0m: ${truncateDetail(safeInlineText(event.text), 240)}`;
-    case "tool-call":
-      return `\x1b[33mtool\x1b[0m ${formatToolCallForTui(event)}`;
-    case "tool-result":
-      return `\x1b[33mtool result\x1b[0m ${formatToolResultForTui(event)}`;
-    case "turn-start":
-      return "\x1b[2mrunning...\x1b[0m";
-    case "turn-abort":
-      return "\x1b[2minterrupted\x1b[0m";
-    case "turn-error":
-      return `\x1b[31merror\x1b[0m: ${safeText(event.message)}`;
-    case "turn-end":
-      return "\x1b[2mdone\x1b[0m";
-    case "step-start":
-    case "step-end":
-      return;
-    default:
-      return;
-  }
-};
 input.onSubmit = (text) => {
   input.setValue("");
-
-  const trimmed = text.trim();
-  if (!trimmed) {
-    tui.requestRender();
-    return;
-  }
-
-  session
-    .send(trimmed)
-    .then((run) => run.stream())
-    .then(async (stream) => {
-      for await (const event of stream) {
-        const line = formatEvent(event);
-        if (line) {
-          addLine(line);
-        }
-      }
-    })
-    .catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : String(error);
-      addLine(`\x1b[31merror\x1b[0m: ${safeText(message)}`);
-    });
+  runner.submit(text);
 };
 
 const removeInputListener = tui.addInputListener((data) => {
@@ -128,6 +77,7 @@ const removeInputListener = tui.addInputListener((data) => {
 
   removeInputListener();
   session.kill();
+  runner.clearActiveRun();
   tui.stop();
   finish();
   return { consume: true };

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -20,6 +20,12 @@ for await (const event of run.stream()) {
 }
 ```
 
+`run.stream()` is the run driver. The runtime stops at synchronized lifecycle
+boundaries until the stream consumer asks for the next event, so callers must
+consume the stream for the run to progress. This is what lets code react to
+`turn-start`, `step-start`, and `step-end` before the next model snapshot is
+created.
+
 Per-key conversations use `session(key)`:
 
 ```ts
@@ -69,6 +75,52 @@ for every media type.
 The public transcript protocol is `AgentEvent`: live runs emit runtime-defined
 events through `run.stream()`. Provider/model message history is internal
 continuation state, not a public history API.
+
+## Current-turn runtime input
+
+Use `session.send(input)` to start or enqueue a new turn. It never merges into an
+active run. Use `run.input.add(input)` only when you are handling the current
+run's stream and want the active turn to see more input before the next model
+snapshot.
+
+`run.input.add(input)` accepts the same input shapes as `session.send(input)`:
+strings, arrays of strings, `{ type: "user-text", text }`, and multipart
+`{ type: "user-message", content }` values. The runtime emits those additions as
+`runtime-input` events. A `runtime-input` is runtime/API-originated input mapped
+internally to the model's user role. It is distinct from human-origin
+`user-text` and `user-message` events.
+
+Runtime input windows are tied to synchronized stream events:
+
+- `turn-start`: input is appended after the original turn input and before the first model snapshot.
+- `step-start`: input is appended before that same step's model snapshot.
+- `step-end`: input is appended before the next step and intentionally continues the current turn, even if the assistant text looked final.
+
+Guard `step-end` insertion with a one-shot flag or a real condition. Adding input
+on every `step-end` can keep the turn running indefinitely.
+
+```ts
+const session = agent.session("room:123:user:456");
+const run = await session.send("Draft a short answer.");
+let addedFollowUp = false;
+
+for await (const event of run.stream()) {
+  if (event.type === "assistant-text") {
+    process.stdout.write(event.text);
+  }
+
+  if (event.type === "step-end" && !addedFollowUp) {
+    addedFollowUp = true;
+    await run.input.add("Also mention the main tradeoff.");
+  }
+}
+```
+
+`run.input.add()` resolves when the input is accepted into the current run's
+pending input path. It does not wait for a later model snapshot. After a terminal
+state, current-turn input is closed: `turn-end`, `turn-error`, `turn-abort`,
+stream `return()`, and `kill()` all make later `run.input.add()` calls reject.
+Rejected runtime input never enqueues a new turn.
 
 ## Session storage and portability
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -76,19 +76,17 @@ The public transcript protocol is `AgentEvent`: live runs emit runtime-defined
 events through `run.stream()`. Provider/model message history is internal
 continuation state, not a public history API.
 
-## Current-turn runtime input
+## Send and Steer
 
-Use `session.send(input)` to start or enqueue a new turn. It never merges into an
-active run. Use `run.input.add(input)` only when you are handling the current
-run's stream and want the active turn to see more input before the next model
-snapshot.
+Use `session.send(input)` for a new user turn. If a run is already active, the
+turn is queued until the active run finishes. Use `session.steer(input)` when the
+input should steer the active run; if no run is active, it starts a normal run.
 
-`run.input.add(input)` accepts the same input shapes as `session.send(input)`:
-strings, arrays of strings, `{ type: "user-text", text }`, and multipart
-`{ type: "user-message", content }` values. The runtime emits those additions as
-`runtime-input` events. A `runtime-input` is runtime/API-originated input mapped
-internally to the model's user role. It is distinct from human-origin
-`user-text` and `user-message` events.
+Both APIs accept the same input shapes: strings, arrays of strings,
+`{ type: "user-text", text }`, and multipart `{ type: "user-message", content }`
+values. Active steering emits `runtime-input` events. A `runtime-input` is
+runtime/API-originated input mapped internally to the model's user role. It is
+distinct from human-origin `user-text` and `user-message` events.
 
 Runtime input windows are tied to synchronized stream events:
 
@@ -102,25 +100,23 @@ on every `step-end` can keep the turn running indefinitely.
 ```ts
 const session = agent.session("room:123:user:456");
 const run = await session.send("Draft a short answer.");
-let addedFollowUp = false;
+let addedSteer = false;
 
 for await (const event of run.stream()) {
   if (event.type === "assistant-text") {
     process.stdout.write(event.text);
   }
 
-  if (event.type === "step-end" && !addedFollowUp) {
-    addedFollowUp = true;
-    await run.input.add("Also mention the main tradeoff.");
+  if (event.type === "step-end" && !addedSteer) {
+    addedSteer = true;
+    await session.steer("Also mention the main tradeoff.");
   }
 }
 ```
 
-`run.input.add()` resolves when the input is accepted into the current run's
-pending input path. It does not wait for a later model snapshot. After a terminal
-state, current-turn input is closed: `turn-end`, `turn-error`, `turn-abort`,
-stream `return()`, and `kill()` all make later `run.input.add()` calls reject.
-Rejected runtime input never enqueues a new turn.
+`session.steer()` resolves when the input is accepted into the active run's
+pending steering path or, when idle, when a new run is scheduled. It does not wait
+for a later model snapshot.
 
 ## Session storage and portability
 

--- a/packages/runtime/src/agent-loop.test.ts
+++ b/packages/runtime/src/agent-loop.test.ts
@@ -5,11 +5,24 @@ import type { AgentEvent } from "./session/events";
 import { AgentModelHistory } from "./session/history";
 import {
   assistantMessage,
+  createDeferred,
   createScriptedLlm,
   eventTypes,
   toolCallPart,
   toolResultFor,
 } from "./test-fixtures";
+
+const nextMicrotask = () =>
+  new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+const waitFor = async (condition: () => boolean) => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+    await nextMicrotask();
+  }
+};
 
 describe("runAgentLoop", () => {
   it("continues after assistant messages request any tool", async () => {
@@ -28,7 +41,7 @@ describe("runAgentLoop", () => {
     ]);
 
     await expect(
-      runAgentLoop({ emit: (event) => events.push(event), history, llm })
+      runAgentLoop({ emit: (event) => void events.push(event), history, llm })
     ).resolves.toBe("completed");
 
     expect(events).toEqual([
@@ -72,7 +85,7 @@ describe("runAgentLoop", () => {
 
     await expect(
       runAgentLoop({
-        emit: (event) => events.push(event),
+        emit: (event) => void events.push(event),
         history,
         llm: abortingLlm,
         signal: controller.signal,
@@ -94,7 +107,7 @@ describe("runAgentLoop", () => {
 
     await expect(
       runAgentLoop({
-        emit: (event) => events.push(event),
+        emit: (event) => void events.push(event),
         history,
         llm: emptyAbortingLlm,
         signal: controller.signal,
@@ -103,5 +116,207 @@ describe("runAgentLoop", () => {
 
     expect(eventTypes(events)).toEqual(["step-start"]);
     expect(history.modelSnapshot()).toEqual([]);
+  });
+
+  it("does not call the LLM until the awaited step-start boundary resolves", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const stepStart = createDeferred();
+    let llmCalls = 0;
+    const llm: Llm = () => {
+      llmCalls += 1;
+      return Promise.resolve([assistantMessage("DONE")]);
+    };
+
+    const result = runAgentLoop({
+      emit: (event) => {
+        void events.push(event);
+        if (event.type === "step-start") {
+          return stepStart.promise;
+        }
+      },
+      history,
+      llm,
+    });
+
+    await nextMicrotask();
+
+    expect(eventTypes(events)).toEqual(["step-start"]);
+    expect(llmCalls).toBe(0);
+
+    stepStart.resolve();
+
+    await expect(result).resolves.toBe("completed");
+    expect(llmCalls).toBe(1);
+    expect(eventTypes(events)).toEqual([
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+  });
+
+  it("does not start the next LLM call until the awaited step-end boundary resolves", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const firstStepEnd = createDeferred();
+    const toolCall = toolCallPart("call-tool-1");
+    let llmCalls = 0;
+    let stepEndCount = 0;
+    const llm = createScriptedLlm([
+      [assistantMessage([toolCall]), toolResultFor(toolCall)],
+      [assistantMessage("DONE")],
+    ]);
+    const countingLlm: Llm = (context) => {
+      llmCalls += 1;
+      return llm(context);
+    };
+
+    const result = runAgentLoop({
+      emit: (event) => {
+        void events.push(event);
+        if (event.type === "step-end") {
+          stepEndCount += 1;
+          if (stepEndCount === 1) {
+            return firstStepEnd.promise;
+          }
+        }
+      },
+      history,
+      llm: countingLlm,
+    });
+
+    await waitFor(() => eventTypes(events).includes("step-end"));
+
+    expect(llmCalls).toBe(1);
+    expect(eventTypes(events)).toEqual([
+      "step-start",
+      "tool-call",
+      "tool-result",
+      "step-end",
+    ]);
+
+    firstStepEnd.resolve();
+
+    await expect(result).resolves.toBe("completed");
+    expect(llmCalls).toBe(2);
+    expect(eventTypes(events)).toEqual([
+      "step-start",
+      "tool-call",
+      "tool-result",
+      "step-end",
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+  });
+
+  it("does not complete until the awaited final step-end boundary resolves", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const stepEnd = createDeferred();
+    const llm = createScriptedLlm([[assistantMessage("DONE")]]);
+    let settled = false;
+
+    const result = runAgentLoop({
+      emit: (event) => {
+        void events.push(event);
+        if (event.type === "step-end") {
+          return stepEnd.promise;
+        }
+      },
+      history,
+      llm,
+    }).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    await waitFor(() => eventTypes(events).includes("step-end"));
+
+    expect(eventTypes(events)).toEqual([
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+    expect(settled).toBe(false);
+
+    stepEnd.resolve();
+
+    await expect(result).resolves.toBe("completed");
+    expect(settled).toBe(true);
+  });
+
+  it("continues after step-end boundary input even without a tool call", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    let llmCalls = 0;
+    let stepEndCount = 0;
+    const llm = createScriptedLlm([
+      [assistantMessage("This could be final.")],
+      [assistantMessage("DONE")],
+    ]);
+    const countingLlm: Llm = (context) => {
+      llmCalls += 1;
+      return llm(context);
+    };
+
+    await expect(
+      runAgentLoop({
+        emit: (event) => {
+          void events.push(event);
+          if (event.type === "step-end") {
+            stepEndCount += 1;
+            return { runtimeInputAdded: stepEndCount === 1 };
+          }
+        },
+        history,
+        llm: countingLlm,
+      })
+    ).resolves.toBe("completed");
+
+    expect(llmCalls).toBe(2);
+    expect(eventTypes(events)).toEqual([
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+    expect(history.modelSnapshot()).toEqual([
+      assistantMessage("This could be final."),
+      assistantMessage("DONE"),
+    ]);
+  });
+
+  it("returns aborted when aborted while waiting for a boundary", async () => {
+    const events: AgentEvent[] = [];
+    const history = new AgentModelHistory();
+    const controller = new AbortController();
+    const stepStart = createDeferred();
+    let llmCalls = 0;
+    const llm: Llm = () => {
+      llmCalls += 1;
+      return Promise.resolve([assistantMessage("DONE")]);
+    };
+
+    const result = runAgentLoop({
+      emit: (event) => {
+        void events.push(event);
+        if (event.type === "step-start") {
+          return stepStart.promise;
+        }
+      },
+      history,
+      llm,
+      signal: controller.signal,
+    });
+
+    await nextMicrotask();
+    controller.abort();
+
+    await expect(result).resolves.toBe("aborted");
+    expect(eventTypes(events)).toEqual(["step-start"]);
+    expect(llmCalls).toBe(0);
   });
 });

--- a/packages/runtime/src/agent-loop.test.ts
+++ b/packages/runtime/src/agent-loop.test.ts
@@ -12,6 +12,8 @@ import {
   toolResultFor,
 } from "./test-fixtures";
 
+const noBoundaryDecision = undefined;
+
 const nextMicrotask = () =>
   new Promise<void>((resolve) => queueMicrotask(() => resolve()));
 
@@ -41,7 +43,13 @@ describe("runAgentLoop", () => {
     ]);
 
     await expect(
-      runAgentLoop({ emit: (event) => void events.push(event), history, llm })
+      runAgentLoop({
+        emit: (event) => {
+          events.push(event);
+        },
+        history,
+        llm,
+      })
     ).resolves.toBe("completed");
 
     expect(events).toEqual([
@@ -85,7 +93,9 @@ describe("runAgentLoop", () => {
 
     await expect(
       runAgentLoop({
-        emit: (event) => void events.push(event),
+        emit: (event) => {
+          events.push(event);
+        },
         history,
         llm: abortingLlm,
         signal: controller.signal,
@@ -107,7 +117,9 @@ describe("runAgentLoop", () => {
 
     await expect(
       runAgentLoop({
-        emit: (event) => void events.push(event),
+        emit: (event) => {
+          events.push(event);
+        },
         history,
         llm: emptyAbortingLlm,
         signal: controller.signal,
@@ -130,10 +142,11 @@ describe("runAgentLoop", () => {
 
     const result = runAgentLoop({
       emit: (event) => {
-        void events.push(event);
+        events.push(event);
         if (event.type === "step-start") {
-          return stepStart.promise;
+          return stepStart.promise.then(() => noBoundaryDecision);
         }
+        return noBoundaryDecision;
       },
       history,
       llm,
@@ -173,13 +186,14 @@ describe("runAgentLoop", () => {
 
     const result = runAgentLoop({
       emit: (event) => {
-        void events.push(event);
+        events.push(event);
         if (event.type === "step-end") {
           stepEndCount += 1;
           if (stepEndCount === 1) {
-            return firstStepEnd.promise;
+            return firstStepEnd.promise.then(() => noBoundaryDecision);
           }
         }
+        return noBoundaryDecision;
       },
       history,
       llm: countingLlm,
@@ -219,10 +233,11 @@ describe("runAgentLoop", () => {
 
     const result = runAgentLoop({
       emit: (event) => {
-        void events.push(event);
+        events.push(event);
         if (event.type === "step-end") {
-          return stepEnd.promise;
+          return stepEnd.promise.then(() => noBoundaryDecision);
         }
+        return noBoundaryDecision;
       },
       history,
       llm,
@@ -263,7 +278,7 @@ describe("runAgentLoop", () => {
     await expect(
       runAgentLoop({
         emit: (event) => {
-          void events.push(event);
+          events.push(event);
           if (event.type === "step-end") {
             stepEndCount += 1;
             return { runtimeInputAdded: stepEndCount === 1 };
@@ -302,10 +317,11 @@ describe("runAgentLoop", () => {
 
     const result = runAgentLoop({
       emit: (event) => {
-        void events.push(event);
+        events.push(event);
         if (event.type === "step-start") {
-          return stepStart.promise;
+          return stepStart.promise.then(() => noBoundaryDecision);
         }
+        return noBoundaryDecision;
       },
       history,
       llm,

--- a/packages/runtime/src/agent-loop.ts
+++ b/packages/runtime/src/agent-loop.ts
@@ -1,6 +1,6 @@
 import type { ModelMessage } from "ai";
 import type { Llm, LlmOutput } from "./llm";
-import type { AgentEventListener } from "./session/events";
+import type { AgentEvent, AgentEventListener } from "./session/events";
 import { modelMessageToAgentEvents } from "./session/mapping";
 
 interface ModelHistory {
@@ -9,13 +9,23 @@ interface ModelHistory {
 }
 
 interface RunAgentLoopOptions {
-  emit: AgentEventListener;
+  emit: AgentLoopEventListener;
   history: ModelHistory;
   llm: Llm;
   signal?: AbortSignal;
 }
 
 export type AgentLoopResult = "completed" | "aborted";
+type AgentLoopBoundaryEvent = Extract<
+  AgentEvent,
+  { type: "step-end" } | { type: "step-start" }
+>;
+interface AgentLoopBoundaryDecision {
+  readonly runtimeInputAdded?: boolean;
+}
+type AgentLoopEventListener = (
+  event: AgentEvent
+) => AgentLoopBoundaryDecision | Promise<AgentLoopBoundaryDecision | void> | void;
 type StepOutputResult = "continue" | "completed" | "aborted";
 
 export async function runAgentLoop({
@@ -29,7 +39,16 @@ export async function runAgentLoop({
       return "aborted";
     }
 
-    emit({ type: "step-start" });
+    const stepStartDecision = await emitBoundary({
+      emit,
+      event: { type: "step-start" },
+      signal,
+    });
+
+    if (stepStartDecision === "aborted") {
+      return "aborted";
+    }
+
     const output = await readLlmOutput({ history, llm, signal });
 
     if (output === "aborted") {
@@ -42,12 +61,66 @@ export async function runAgentLoop({
       return "aborted";
     }
 
-    emit({ type: "step-end" });
+    const stepEndDecision = await emitBoundary({
+      emit,
+      event: { type: "step-end" },
+      signal,
+    });
 
-    if (result === "completed") {
+    if (stepEndDecision === "aborted") {
+      return "aborted";
+    }
+
+    // Runtime input after step-end intentionally forces another inference step,
+    // even after final-looking assistant text. Unconditional insertion on every
+    // step-end can create an unbounded loop.
+    if (result === "completed" && !stepEndDecision?.runtimeInputAdded) {
       return "completed";
     }
   }
+}
+
+async function emitBoundary({
+  emit,
+  event,
+  signal,
+}: Pick<RunAgentLoopOptions, "emit"> & {
+  event: AgentLoopBoundaryEvent;
+  signal: AbortSignal;
+}): Promise<AgentLoopBoundaryDecision | "aborted" | void> {
+  if (signal.aborted) {
+    return "aborted";
+  }
+
+  const abort = createAbortBoundary(signal);
+  try {
+    return await Promise.race([Promise.resolve(emit(event)), abort.promise]);
+  } catch (error) {
+    if (signal.aborted) {
+      return "aborted";
+    }
+
+    throw error;
+  } finally {
+    abort.dispose();
+  }
+}
+
+function createAbortBoundary(signal: AbortSignal): {
+  dispose: () => void;
+  promise: Promise<"aborted">;
+} {
+  let dispose = () => {
+    return;
+  };
+
+  const promise = new Promise<"aborted">((resolve) => {
+    const onAbort = () => resolve("aborted");
+    dispose = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  return { dispose, promise };
 }
 
 async function readLlmOutput({
@@ -73,7 +146,7 @@ function appendStepOutput({
   history,
   output,
   signal,
-}: Pick<RunAgentLoopOptions, "emit" | "history"> & {
+}: { emit: AgentEventListener; history: ModelHistory } & {
   output: LlmOutput;
   signal: AbortSignal;
 }): StepOutputResult {

--- a/packages/runtime/src/agent-loop.ts
+++ b/packages/runtime/src/agent-loop.ts
@@ -25,7 +25,10 @@ interface AgentLoopBoundaryDecision {
 }
 type AgentLoopEventListener = (
   event: AgentEvent
-) => AgentLoopBoundaryDecision | Promise<AgentLoopBoundaryDecision | void> | void;
+) =>
+  | AgentLoopBoundaryDecision
+  | Promise<AgentLoopBoundaryDecision | undefined>
+  | undefined;
 type StepOutputResult = "continue" | "completed" | "aborted";
 
 export async function runAgentLoop({
@@ -87,7 +90,7 @@ async function emitBoundary({
 }: Pick<RunAgentLoopOptions, "emit"> & {
   event: AgentLoopBoundaryEvent;
   signal: AbortSignal;
-}): Promise<AgentLoopBoundaryDecision | "aborted" | void> {
+}): Promise<AgentLoopBoundaryDecision | "aborted" | undefined> {
   if (signal.aborted) {
     return "aborted";
   }
@@ -110,9 +113,7 @@ function createAbortBoundary(signal: AbortSignal): {
   dispose: () => void;
   promise: Promise<"aborted">;
 } {
-  let dispose = () => {
-    return;
-  };
+  let dispose: () => void = () => undefined;
 
   const promise = new Promise<"aborted">((resolve) => {
     const onAbort = () => resolve("aborted");

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -39,6 +39,7 @@ export interface SessionHandle {
   interrupt(): void;
   kill(): void;
   send(input: AgentInput): Promise<AgentRun>;
+  steer(input: AgentInput): Promise<AgentRun>;
 }
 
 export type AgentOptions = AgentModelOptions | AgentLlmOptions;
@@ -90,6 +91,7 @@ export class Agent {
         this.#sessions.delete(key);
       },
       send: (input) => session.send(input),
+      steer: (input) => session.steer(input),
     };
     this.#sessions.set(key, handle);
     return handle;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -36,7 +36,7 @@ export type {
   UserText,
   UserTextContent,
 } from "./session/events";
-export type { AgentRun } from "./session/run";
+export type { AgentRun, AgentRunInput, RunInput } from "./session/run";
 export type { AgentInput, SessionInput, UserInput } from "./session/session";
 export type {
   CommitResult,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -23,6 +23,7 @@ export type {
   AgentEventListener,
   AssistantReasoning,
   AssistantText,
+  RuntimeInput,
   ToolCall,
   ToolResult,
   UserMessage,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -46,7 +46,7 @@ export type {
   UserText,
   UserTextContent,
 } from "./session/events";
-export type { AgentRun, AgentRunInput, RunInput } from "./session/run";
+export type { AgentRun } from "./session/run";
 export type { AgentInput, SessionInput, UserInput } from "./session/session";
 export type {
   CommitResult,

--- a/packages/runtime/src/session/events.ts
+++ b/packages/runtime/src/session/events.ts
@@ -1,3 +1,5 @@
+import type { UserInput } from "./session";
+
 export type UserTextContent = string | readonly string[];
 
 export interface UserText {
@@ -41,6 +43,17 @@ export interface UserMessage {
   content: UserMessageContent;
   type: "user-message";
 }
+
+export interface RuntimeInput {
+  /**
+   * Runtime/API-originated model input inserted into the current turn.
+   * This is distinct from human-originated user-text and user-message input.
+   */
+  input: UserInput;
+  placement: "turn-start" | "step-start" | "step-end";
+  type: "runtime-input";
+}
+
 export interface AssistantText {
   text: string;
   type: "assistant-text";
@@ -64,10 +77,11 @@ export interface ToolResult {
 
 export type AgentEvent =
   /** User input was accepted into the session queue. */
-  | UserMessage
   | UserText
   /** User multipart input was accepted into the session queue. */
   | UserMessage
+  /** Runtime/API-originated input inserted into the current turn, not human input. */
+  | RuntimeInput
   /** A queued user input started running as a turn. */
   | { type: "turn-start" }
   /** The active turn was interrupted before normal completion. */

--- a/packages/runtime/src/session/mapping.test.ts
+++ b/packages/runtime/src/session/mapping.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   assistantMessage,
   toolCallPart,
@@ -11,8 +11,31 @@ import {
   userMessageToModelMessage,
   userTextToModelMessage,
 } from "./mapping";
+import type { AgentEvent, RuntimeInput } from "./events";
+import type { UserInput } from "./session";
 
 describe("session mapping", () => {
+  it("exposes runtime-input as runtime-originated current-turn input", () => {
+    const input = userText("runtime hint");
+    const event: RuntimeInput = {
+      type: "runtime-input",
+      input,
+      placement: "step-start",
+    };
+    const observed: AgentEvent = event;
+
+    if (observed.type !== "runtime-input") {
+      throw new Error("expected runtime-input event");
+    }
+
+    expectTypeOf(observed.input).toEqualTypeOf<UserInput>();
+    expectTypeOf(observed.placement).toEqualTypeOf<
+      "turn-start" | "step-start" | "step-end"
+    >();
+    expect(observed.input).toEqual(input);
+    expect(observed.placement).toBe("step-start");
+  });
+
   it("maps user text to an AI SDK user model message", () => {
     expect(userTextToModelMessage(userText("hello"))).toEqual({
       role: "user",
@@ -177,5 +200,14 @@ describe("session mapping", () => {
     expect(
       modelMessageToAgentEvents(userTextToModelMessage(userText("hi")))
     ).toEqual([]);
+  });
+
+  it("does not project runtime-input from model output", () => {
+    const eventTypes = modelMessageToAgentEvents(
+      assistantMessage("runtime-input")
+    ).map((event) => event.type);
+
+    expect(eventTypes).toEqual(["assistant-text"]);
+    expect(eventTypes).not.toContain("runtime-input");
   });
 });

--- a/packages/runtime/src/session/mapping.test.ts
+++ b/packages/runtime/src/session/mapping.test.ts
@@ -6,12 +6,12 @@ import {
   userMessage,
   userText,
 } from "../test-fixtures";
+import type { AgentEvent, RuntimeInput } from "./events";
 import {
   modelMessageToAgentEvents,
   userMessageToModelMessage,
   userTextToModelMessage,
 } from "./mapping";
-import type { AgentEvent, RuntimeInput } from "./events";
 import type { UserInput } from "./session";
 
 describe("session mapping", () => {

--- a/packages/runtime/src/session/run.test.ts
+++ b/packages/runtime/src/session/run.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "./events";
 import { BufferedAgentRun } from "./run";
 
+const expectPending = async (promise: Promise<unknown>) => {
+  const marker = Symbol("pending");
+  await expect(Promise.race([promise, Promise.resolve(marker)])).resolves.toBe(
+    marker
+  );
+};
+
 describe("AgentRun", () => {
-  it("buffers events emitted before stream consumption", async () => {
+  it("delivers events emitted before stream consumption", async () => {
     const run = new BufferedAgentRun();
     run.emit({ type: "user-text", text: "hello" });
     run.emit({ type: "turn-end" });
@@ -37,10 +44,31 @@ describe("AgentRun", () => {
     expect(events).toEqual([{ type: "turn-start" }, { type: "turn-end" }]);
   });
 
+  it("keeps boundary emit pending until the consumer asks for another event", async () => {
+    const run = new BufferedAgentRun();
+    const iterator = run.stream()[Symbol.asyncIterator]();
+
+    const boundary = run.emitBoundary({ type: "step-end" });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "step-end" },
+    });
+    await expectPending(boundary);
+
+    const nextEvent = iterator.next();
+    await boundary;
+    run.emit({ type: "turn-end" });
+
+    await expect(nextEvent).resolves.toEqual({
+      done: false,
+      value: { type: "turn-end" },
+    });
+  });
+
   it("rejects duplicate stream readers", () => {
     const run = new BufferedAgentRun();
     run.stream();
-    expect(() => run.stream()).toThrow("can only be consumed once");
+    expect(() => run.stream()).toThrow("AgentRun.stream() can only be consumed once");
   });
 
   it("returns the same iterator for repeated async iterator access", () => {
@@ -50,7 +78,94 @@ describe("AgentRun", () => {
     expect(stream[Symbol.asyncIterator]()).toBe(stream[Symbol.asyncIterator]());
   });
 
-  it("closes and discards buffered events when the stream returns early", async () => {
+  it("rejects concurrent next calls so consumers cannot prefetch", async () => {
+    const run = new BufferedAgentRun();
+    const iterator = run.stream()[Symbol.asyncIterator]();
+
+    const waitingNext = iterator.next();
+    await expect(iterator.next()).rejects.toThrow(
+      "AgentRun.stream() does not allow concurrent next() calls"
+    );
+
+    run.emit({ type: "turn-start" });
+    await expect(waitingNext).resolves.toEqual({
+      done: false,
+      value: { type: "turn-start" },
+    });
+  });
+
+  it("rejects same-tick prefetch when a boundary event is already queued", async () => {
+    const run = new BufferedAgentRun();
+    const iterator = run.stream()[Symbol.asyncIterator]();
+
+    const boundary = run.emitBoundary({ type: "step-end" });
+    const first = iterator.next();
+    const second = iterator.next();
+
+    await expect(second).rejects.toThrow(
+      "AgentRun.stream() does not allow concurrent next() calls"
+    );
+    await expectPending(boundary);
+    await expect(first).resolves.toEqual({
+      done: false,
+      value: { type: "step-end" },
+    });
+    await expectPending(boundary);
+
+    const afterHandling = iterator.next();
+    await boundary;
+    run.emit({ type: "turn-end" });
+
+    await expect(afterHandling).resolves.toEqual({
+      done: false,
+      value: { type: "turn-end" },
+    });
+  });
+
+  it("return() settles pending boundary ack and pending next waiter", async () => {
+    const run = new BufferedAgentRun();
+    const iterator = run.stream()[Symbol.asyncIterator]();
+
+    const boundary = run.emitBoundary({ type: "step-start" });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "step-start" },
+    });
+    const waitingNext = iterator.next();
+
+    await expect(iterator.return?.()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    await expect(boundary).resolves.toBeUndefined();
+    await expect(waitingNext).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it("delegates input.add to the injected handler", async () => {
+    const addInput = vi.fn(async (_input: unknown) => undefined);
+    const run = new BufferedAgentRun({ addInput });
+    const input = { type: "user-text", text: "runtime" };
+
+    await expect(run.input.add(input)).resolves.toBeUndefined();
+
+    expect(addInput).toHaveBeenCalledWith(input);
+  });
+
+  it("rejects input.add after close without delegating", async () => {
+    const addInput = vi.fn(async (_input: unknown) => undefined);
+    const run = new BufferedAgentRun({ addInput });
+    run.close();
+
+    await expect(run.input.add("runtime")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after the run is closed"
+    );
+    expect(addInput).not.toHaveBeenCalled();
+  });
+
+  it("closes and discards queued events when the stream returns early", async () => {
     const run = new BufferedAgentRun();
     const iterator = run.stream()[Symbol.asyncIterator]();
 

--- a/packages/runtime/src/session/run.test.ts
+++ b/packages/runtime/src/session/run.test.ts
@@ -165,6 +165,17 @@ describe("AgentRun", () => {
     expect(addInput).not.toHaveBeenCalled();
   });
 
+  it("rejects input.add with a deterministic terminal close reason", async () => {
+    const addInput = vi.fn(async (_input: unknown) => undefined);
+    const run = new BufferedAgentRun({ addInput });
+    run.close(undefined, "turn-end");
+
+    await expect(run.input.add("runtime")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after turn-end"
+    );
+    expect(addInput).not.toHaveBeenCalled();
+  });
+
   it("closes and discards queued events when the stream returns early", async () => {
     const run = new BufferedAgentRun();
     const iterator = run.stream()[Symbol.asyncIterator]();
@@ -186,5 +197,8 @@ describe("AgentRun", () => {
       done: true,
       value: undefined,
     });
+    await expect(run.input.add("runtime")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after stream return"
+    );
   });
 });

--- a/packages/runtime/src/session/run.test.ts
+++ b/packages/runtime/src/session/run.test.ts
@@ -147,7 +147,7 @@ describe("AgentRun", () => {
   it("delegates input.add to the injected handler", async () => {
     const addInput = vi.fn(async (_input: unknown) => undefined);
     const run = new BufferedAgentRun({ addInput });
-    const input = { type: "user-text", text: "runtime" };
+    const input = { type: "user-text", text: "runtime" } as const;
 
     await expect(run.input.add(input)).resolves.toBeUndefined();
 

--- a/packages/runtime/src/session/run.test.ts
+++ b/packages/runtime/src/session/run.test.ts
@@ -68,7 +68,9 @@ describe("AgentRun", () => {
   it("rejects duplicate stream readers", () => {
     const run = new BufferedAgentRun();
     run.stream();
-    expect(() => run.stream()).toThrow("AgentRun.stream() can only be consumed once");
+    expect(() => run.stream()).toThrow(
+      "AgentRun.stream() can only be consumed once"
+    );
   });
 
   it("returns the same iterator for repeated async iterator access", () => {

--- a/packages/runtime/src/session/run.test.ts
+++ b/packages/runtime/src/session/run.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { AgentEvent } from "./events";
 import { BufferedAgentRun } from "./run";
 
@@ -146,38 +146,6 @@ describe("AgentRun", () => {
     });
   });
 
-  it("delegates input.add to the injected handler", async () => {
-    const addInput = vi.fn(async (_input: unknown) => undefined);
-    const run = new BufferedAgentRun({ addInput });
-    const input = { type: "user-text", text: "runtime" } as const;
-
-    await expect(run.input.add(input)).resolves.toBeUndefined();
-
-    expect(addInput).toHaveBeenCalledWith(input);
-  });
-
-  it("rejects input.add after close without delegating", async () => {
-    const addInput = vi.fn(async (_input: unknown) => undefined);
-    const run = new BufferedAgentRun({ addInput });
-    run.close();
-
-    await expect(run.input.add("runtime")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after the run is closed"
-    );
-    expect(addInput).not.toHaveBeenCalled();
-  });
-
-  it("rejects input.add with a deterministic terminal close reason", async () => {
-    const addInput = vi.fn(async (_input: unknown) => undefined);
-    const run = new BufferedAgentRun({ addInput });
-    run.close(undefined, "turn-end");
-
-    await expect(run.input.add("runtime")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after turn-end"
-    );
-    expect(addInput).not.toHaveBeenCalled();
-  });
-
   it("closes and discards queued events when the stream returns early", async () => {
     const run = new BufferedAgentRun();
     const iterator = run.stream()[Symbol.asyncIterator]();
@@ -199,8 +167,5 @@ describe("AgentRun", () => {
       done: true,
       value: undefined,
     });
-    await expect(run.input.add("runtime")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after stream return"
-    );
   });
 });

--- a/packages/runtime/src/session/run.ts
+++ b/packages/runtime/src/session/run.ts
@@ -1,31 +1,72 @@
 import type { AgentEvent } from "./events";
 
+export type RunInput = unknown;
+
+export interface AgentRunInput {
+  add(input: RunInput): Promise<void>;
+}
+
 export interface AgentRun {
+  readonly input: AgentRunInput;
   stream(): AsyncIterable<AgentEvent>;
 }
 
+interface AgentRunOptions {
+  readonly addInput?: (input: RunInput) => Promise<void> | void;
+}
+
+interface QueuedEvent {
+  readonly ack?: () => void;
+  readonly event: AgentEvent;
+}
+
+interface NextWaiter {
+  readonly reject: (error: unknown) => void;
+  readonly resolve: (value: IteratorResult<AgentEvent>) => void;
+}
+
 export class BufferedAgentRun implements AgentRun {
-  readonly #events: AgentEvent[] = [];
-  readonly #waiters: Array<{
-    reject: (error: unknown) => void;
-    resolve: (value: IteratorResult<AgentEvent>) => void;
-  }> = [];
+  readonly #events: QueuedEvent[] = [];
+  readonly #inputHandler: (input: RunInput) => Promise<void> | void;
   #closed = false;
   #error: unknown;
+  #pendingAck: (() => void) | undefined;
+  #resultPending = false;
   #streamStarted = false;
+  #waiter: NextWaiter | undefined;
+
+  readonly input: AgentRunInput = {
+    add: async (input) => {
+      if (this.#closed) {
+        throw new Error(
+          "AgentRun.input.add() cannot be used after the run is closed"
+        );
+      }
+
+      await this.#inputHandler(input);
+    },
+  };
+
+  constructor(options: AgentRunOptions = {}) {
+    this.#inputHandler = options.addInput ?? (() => undefined);
+  }
 
   emit(event: AgentEvent): void {
     if (this.#closed) {
       return;
     }
 
-    const waiter = this.#waiters.shift();
-    if (waiter) {
-      waiter.resolve({ done: false, value: event });
-      return;
+    this.#enqueue({ event: structuredClone(event) });
+  }
+
+  emitBoundary(event: AgentEvent): Promise<void> {
+    if (this.#closed) {
+      return Promise.resolve();
     }
 
-    this.#events.push(structuredClone(event));
+    return new Promise((resolve) => {
+      this.#enqueue({ ack: resolve, event: structuredClone(event) });
+    });
   }
 
   close(error?: unknown): void {
@@ -35,19 +76,19 @@ export class BufferedAgentRun implements AgentRun {
 
     this.#closed = true;
     this.#error = error;
+    this.#settlePendingAck();
 
-    while (this.#waiters.length > 0) {
-      const waiter = this.#waiters.shift();
-      if (!waiter) {
-        continue;
-      }
-
-      if (error) {
-        waiter.reject(error);
-      } else {
-        waiter.resolve({ done: true, value: undefined });
-      }
+    if (!this.#waiter) {
+      return;
     }
+
+    const waiter = this.#waiter;
+    this.#waiter = undefined;
+    if (error) {
+      waiter.reject(error);
+      return;
+    }
+    waiter.resolve({ done: true, value: undefined });
   }
 
   stream(): AsyncIterable<AgentEvent> {
@@ -68,14 +109,34 @@ export class BufferedAgentRun implements AgentRun {
   }
 
   #cancel(): void {
+    this.#settleQueuedAcks();
     this.#events.length = 0;
     this.close();
   }
 
+  #enqueue(event: QueuedEvent): void {
+    const waiter = this.#waiter;
+    if (waiter) {
+      this.#waiter = undefined;
+      this.#deliver(waiter.resolve, event);
+      return;
+    }
+
+    this.#events.push(event);
+  }
+
   #next(): Promise<IteratorResult<AgentEvent>> {
+    if (this.#resultPending || this.#waiter) {
+      return Promise.reject(
+        new Error("AgentRun.stream() does not allow concurrent next() calls")
+      );
+    }
+
+    this.#settlePendingAck();
+
     const event = this.#events.shift();
     if (event) {
-      return Promise.resolve({ done: false, value: event });
+      return new Promise((resolve) => this.#deliver(resolve, event));
     }
 
     if (this.#closed) {
@@ -86,7 +147,31 @@ export class BufferedAgentRun implements AgentRun {
     }
 
     return new Promise((resolve, reject) => {
-      this.#waiters.push({ reject, resolve });
+      this.#waiter = { reject, resolve };
     });
+  }
+
+  #deliver(
+    resolve: (value: IteratorResult<AgentEvent>) => void,
+    { ack, event }: QueuedEvent
+  ): void {
+    this.#resultPending = true;
+    queueMicrotask(() => {
+      this.#resultPending = false;
+    });
+    this.#pendingAck = ack;
+    resolve({ done: false, value: event });
+  }
+
+  #settlePendingAck(): void {
+    const ack = this.#pendingAck;
+    this.#pendingAck = undefined;
+    ack?.();
+  }
+
+  #settleQueuedAcks(): void {
+    for (const event of this.#events) {
+      event.ack?.();
+    }
   }
 }

--- a/packages/runtime/src/session/run.ts
+++ b/packages/runtime/src/session/run.ts
@@ -1,6 +1,7 @@
 import type { AgentEvent } from "./events";
+import type { AgentInput } from "./session";
 
-export type RunInput = unknown;
+export type RunInput = AgentInput;
 
 export interface AgentRunInput {
   add(input: RunInput): Promise<void>;

--- a/packages/runtime/src/session/run.ts
+++ b/packages/runtime/src/session/run.ts
@@ -40,7 +40,9 @@ export class BufferedAgentRun implements AgentRun {
   readonly input: AgentRunInput = {
     add: async (input) => {
       if (this.#closed) {
-        throw new Error(`AgentRun.input.add() cannot be used after ${this.#closedReason}`);
+        throw new Error(
+          `AgentRun.input.add() cannot be used after ${this.#closedReason}`
+        );
       }
 
       await this.#inputHandler(input);

--- a/packages/runtime/src/session/run.ts
+++ b/packages/runtime/src/session/run.ts
@@ -1,19 +1,7 @@
 import type { AgentEvent } from "./events";
-import type { AgentInput } from "./session";
-
-export type RunInput = AgentInput;
-
-export interface AgentRunInput {
-  add(input: RunInput): Promise<void>;
-}
 
 export interface AgentRun {
-  readonly input: AgentRunInput;
   stream(): AsyncIterable<AgentEvent>;
-}
-
-interface AgentRunOptions {
-  readonly addInput?: (input: RunInput) => Promise<void> | void;
 }
 
 interface QueuedEvent {
@@ -28,30 +16,12 @@ interface NextWaiter {
 
 export class BufferedAgentRun implements AgentRun {
   readonly #events: QueuedEvent[] = [];
-  readonly #inputHandler: (input: RunInput) => Promise<void> | void;
   #closed = false;
-  #closedReason = "the run is closed";
   #error: unknown;
   #pendingAck: (() => void) | undefined;
   #resultPending = false;
   #streamStarted = false;
   #waiter: NextWaiter | undefined;
-
-  readonly input: AgentRunInput = {
-    add: async (input) => {
-      if (this.#closed) {
-        throw new Error(
-          `AgentRun.input.add() cannot be used after ${this.#closedReason}`
-        );
-      }
-
-      await this.#inputHandler(input);
-    },
-  };
-
-  constructor(options: AgentRunOptions = {}) {
-    this.#inputHandler = options.addInput ?? (() => undefined);
-  }
 
   emit(event: AgentEvent): void {
     if (this.#closed) {
@@ -71,13 +41,12 @@ export class BufferedAgentRun implements AgentRun {
     });
   }
 
-  close(error?: unknown, reason = "the run is closed"): void {
+  close(error?: unknown, _reason = "the run is closed"): void {
     if (this.#closed) {
       return;
     }
 
     this.#closed = true;
-    this.#closedReason = reason;
     this.#error = error;
     this.#settlePendingAck();
 

--- a/packages/runtime/src/session/run.ts
+++ b/packages/runtime/src/session/run.ts
@@ -30,6 +30,7 @@ export class BufferedAgentRun implements AgentRun {
   readonly #events: QueuedEvent[] = [];
   readonly #inputHandler: (input: RunInput) => Promise<void> | void;
   #closed = false;
+  #closedReason = "the run is closed";
   #error: unknown;
   #pendingAck: (() => void) | undefined;
   #resultPending = false;
@@ -39,9 +40,7 @@ export class BufferedAgentRun implements AgentRun {
   readonly input: AgentRunInput = {
     add: async (input) => {
       if (this.#closed) {
-        throw new Error(
-          "AgentRun.input.add() cannot be used after the run is closed"
-        );
+        throw new Error(`AgentRun.input.add() cannot be used after ${this.#closedReason}`);
       }
 
       await this.#inputHandler(input);
@@ -70,12 +69,13 @@ export class BufferedAgentRun implements AgentRun {
     });
   }
 
-  close(error?: unknown): void {
+  close(error?: unknown, reason = "the run is closed"): void {
     if (this.#closed) {
       return;
     }
 
     this.#closed = true;
+    this.#closedReason = reason;
     this.#error = error;
     this.#settlePendingAck();
 
@@ -112,7 +112,7 @@ export class BufferedAgentRun implements AgentRun {
   #cancel(): void {
     this.#settleQueuedAcks();
     this.#events.length = 0;
-    this.close();
+    this.close(undefined, "stream return");
   }
 
   #enqueue(event: QueuedEvent): void {

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -86,6 +86,24 @@ class ConflictOnceStore extends SpyStore {
   }
 }
 
+class ConflictOnCommitStore extends SpyStore {
+  commitCount = 0;
+  conflictOnCommit = 1;
+
+  override commit(
+    key: string,
+    next: StoredSession,
+    options?: { expectedVersion?: string | null }
+  ): Promise<CommitResult> {
+    this.commitCount += 1;
+    if (this.commitCount === this.conflictOnCommit) {
+      return Promise.resolve({ ok: false, reason: "conflict" });
+    }
+
+    return super.commit(key, next, options);
+  }
+}
+
 describe("Agent session API", () => {
   it("agent.send accepts string input and streams one run", async () => {
     const seenHistory: ModelMessage[][] = [];
@@ -486,6 +504,317 @@ describe("Agent session API", () => {
         userTextToModelMessage(userText("second")),
       ],
     ]);
+  });
+
+  it("runtime input preserves FIFO order for concurrent additions in one window", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const agent = await Agent.create({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    });
+    const run = await agent.send("initial");
+    const runtimeInputs: AgentEvent[] = [];
+    let added = false;
+
+    for await (const event of run.stream()) {
+      if (event.type === "step-start" && !added) {
+        added = true;
+        await Promise.all([
+          run.input.add("first"),
+          run.input.add("second"),
+          run.input.add("third"),
+        ]);
+      }
+      if (event.type === "runtime-input") {
+        runtimeInputs.push(event);
+      }
+    }
+
+    expect(runtimeInputs).toEqual([
+      {
+        type: "runtime-input",
+        input: { type: "user-text", text: "first" },
+        placement: "step-start",
+      },
+      {
+        type: "runtime-input",
+        input: { type: "user-text", text: "second" },
+        placement: "step-start",
+      },
+      {
+        type: "runtime-input",
+        input: { type: "user-text", text: "third" },
+        placement: "step-start",
+      },
+    ]);
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("initial")),
+        userTextToModelMessage(userText("first")),
+        userTextToModelMessage(userText("second")),
+        userTextToModelMessage(userText("third")),
+      ],
+    ]);
+  });
+
+  it("keeps queued session.send input as a separate turn while runtime input affects the active turn", async () => {
+    const stepGate = createDeferred();
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const session = (
+      await Agent.create({
+        llm: async ({ history }) => {
+          calls += 1;
+          seenHistory.push([...history]);
+          if (calls === 1) {
+            await stepGate.promise;
+            return [assistantMessage("ACTIVE")];
+          }
+          return [assistantMessage("QUEUED")];
+        },
+      })
+    ).session("queue-separation");
+    const firstRun = await session.send("first");
+    const secondRun = await session.send("second");
+    const firstEvents: AgentEvent[] = [];
+    let added = false;
+    const firstCollecting = (async () => {
+      for await (const event of firstRun.stream()) {
+        firstEvents.push(event);
+        if (event.type === "step-start" && !added) {
+          added = true;
+          await firstRun.input.add("extra");
+          stepGate.resolve();
+        }
+      }
+    })();
+    const secondEvents = collect(secondRun);
+
+    await Promise.all([firstCollecting, secondEvents]);
+
+    expect(firstEvents).toContainEqual({
+      type: "runtime-input",
+      input: { type: "user-text", text: "extra" },
+      placement: "step-start",
+    });
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("first")),
+        userTextToModelMessage(userText("extra")),
+      ],
+      [
+        userTextToModelMessage(userText("first")),
+        userTextToModelMessage(userText("extra")),
+        assistantMessage("ACTIVE"),
+        userTextToModelMessage(userText("second")),
+      ],
+    ]);
+  });
+
+  it("normalizes multipart image and file runtime input like session.send", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const agent = await Agent.create({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    });
+    const input = [
+      { type: "text", text: "describe this" },
+      { type: "image", image: "iVBORw0KGgo=", mediaType: "image/png" },
+      {
+        type: "file",
+        data: { type: "text", text: "inline document" },
+        filename: "note.txt",
+        mediaType: "text/plain",
+      },
+    ] as const;
+    const run = await agent.send("initial");
+    const runtimeInputs: AgentEvent[] = [];
+    let added = false;
+
+    for await (const event of run.stream()) {
+      if (event.type === "step-start" && !added) {
+        added = true;
+        await run.input.add(input);
+      }
+      if (event.type === "runtime-input") {
+        runtimeInputs.push(event);
+      }
+    }
+
+    expect(runtimeInputs).toEqual([
+      {
+        type: "runtime-input",
+        input: { type: "user-message", content: input },
+        placement: "step-start",
+      },
+    ]);
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("initial")),
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe this" },
+            { type: "file", data: "iVBORw0KGgo=", mediaType: "image/png" },
+            {
+              type: "file",
+              data: { type: "text", text: "inline document" },
+              filename: "note.txt",
+              mediaType: "text/plain",
+            },
+          ],
+        },
+      ],
+    ]);
+  });
+
+  it("rejects runtime input after turn-end without enqueueing a new session turn", async () => {
+    let calls = 0;
+    const agent = await Agent.create({
+      llm: () => {
+        calls += 1;
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    });
+    const run = await agent.send("initial");
+
+    await collect(run);
+
+    await expect(run.input.add("late")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after turn-end"
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("rejects runtime input after model turn-error without enqueueing a new session turn", async () => {
+    let calls = 0;
+    const agent = await Agent.create({
+      llm: () => {
+        calls += 1;
+        return Promise.reject(new Error("model unavailable"));
+      },
+    });
+    const run = await agent.send("initial");
+
+    expect(eventTypes(await collect(run))).toContain("turn-error");
+
+    await expect(run.input.add("late")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after turn-error"
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("rejects runtime input after interrupt turn-abort and does not hang", async () => {
+    const llmStarted = createDeferred();
+    const llmGate = createDeferred();
+    const session = (
+      await Agent.create({
+        llm: async () => {
+          llmStarted.resolve();
+          await llmGate.promise;
+          return [assistantMessage("DONE")];
+        },
+      })
+    ).session("interrupt-terminal");
+    const run = await session.send("initial");
+    const events = collect(run);
+
+    await llmStarted.promise;
+    session.interrupt();
+    llmGate.resolve();
+
+    expect(eventTypes(await events)).toContain("turn-abort");
+    await expect(run.input.add("late")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after turn-abort"
+    );
+  });
+
+  it("rejects runtime input after kill and settles queued runs", async () => {
+    const llmStarted = createDeferred();
+    const llmGate = createDeferred();
+    const session = (
+      await Agent.create({
+        llm: async () => {
+          llmStarted.resolve();
+          await llmGate.promise;
+          return [assistantMessage("DONE")];
+        },
+      })
+    ).session("kill-terminal");
+    const firstRun = await session.send("first");
+    const secondRun = await session.send("second");
+    const firstEvents = collect(firstRun);
+    const secondEvents = collect(secondRun);
+
+    await llmStarted.promise;
+    session.kill();
+    llmGate.resolve();
+
+    expect(eventTypes(await firstEvents)).toContain("turn-abort");
+    expect(eventTypes(await secondEvents)).toEqual(["user-text", "turn-error"]);
+    await expect(firstRun.input.add("late")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after Session killed"
+    );
+    await expect(secondRun.input.add("late")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after Session killed"
+    );
+  });
+
+  it("rejects runtime input after stream return", async () => {
+    const agent = await Agent.create({
+      llm: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+    const run = await agent.send("initial");
+    const iterator = run.stream()[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "user-text", text: "initial" },
+    });
+    await expect(iterator.return?.()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    await expect(run.input.add("late")).rejects.toThrow(
+      "AgentRun.input.add() cannot be used after stream return"
+    );
+  });
+
+  it("emits and propagates runtime input commit conflicts without using the conflicted snapshot", async () => {
+    const store = new ConflictOnCommitStore();
+    store.conflictOnCommit = 2;
+    const seenHistory: ModelMessage[][] = [];
+    const session = (
+      await Agent.create({
+        llm: ({ history }) => {
+          seenHistory.push([...history]);
+          return Promise.resolve([assistantMessage("DONE")]);
+        },
+        sessions: { store },
+      })
+    ).session("runtime-conflict");
+    const run = await session.send("initial");
+    const events: AgentEvent[] = [];
+    let runtimeAdd: Promise<void> | undefined;
+
+    for await (const event of run.stream()) {
+      events.push(event);
+      if (event.type === "turn-start" && !runtimeAdd) {
+        runtimeAdd = run.input.add("conflicting runtime");
+      }
+    }
+
+    await expect(runtimeAdd).resolves.toBeUndefined();
+    expect(events).toContainEqual({
+      type: "turn-error",
+      message: 'Session "runtime-conflict" commit conflict',
+    });
+    expect(seenHistory).toEqual([]);
   });
 
   it("emits turn-error in the run when the LLM fails", async () => {

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -342,6 +342,152 @@ describe("Agent session API", () => {
     ]);
   });
 
+  it("runtime input at step-end continues the current turn with appended user input", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = await Agent.create({
+      llm: ({ history }) => {
+        calls += 1;
+        seenHistory.push([...history]);
+        return Promise.resolve([
+          assistantMessage(calls === 1 ? "This could be final." : "DONE"),
+        ]);
+      },
+    });
+    const run = await agent.send("initial user");
+    const events: AgentEvent[] = [];
+    let injected = false;
+
+    for await (const event of run.stream()) {
+      events.push(event);
+      if (event.type === "step-end" && !injected) {
+        injected = true;
+        await run.input.add("extra");
+      }
+    }
+
+    expect(seenHistory).toEqual([
+      [userTextToModelMessage(userText("initial user"))],
+      [
+        userTextToModelMessage(userText("initial user")),
+        assistantMessage("This could be final."),
+        userTextToModelMessage(userText("extra")),
+      ],
+    ]);
+    expect(events).toEqual([
+      { type: "user-text", text: "initial user" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "assistant-text", text: "This could be final." },
+      { type: "step-end" },
+      {
+        type: "runtime-input",
+        input: { type: "user-text", text: "extra" },
+        placement: "step-end",
+      },
+      { type: "step-start" },
+      { type: "assistant-text", text: "DONE" },
+      { type: "step-end" },
+      { type: "turn-end" },
+    ]);
+  });
+
+  it("runtime input at turn-start and step-start is visible before the first LLM snapshot", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const agent = await Agent.create({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    });
+    const run = await agent.send("original");
+    const events: AgentEvent[] = [];
+    let addedTurnStart = false;
+    let addedStepStart = false;
+
+    for await (const event of run.stream()) {
+      events.push(event);
+      if (event.type === "turn-start" && !addedTurnStart) {
+        addedTurnStart = true;
+        await run.input.add("turn runtime");
+      }
+      if (event.type === "step-start" && !addedStepStart) {
+        addedStepStart = true;
+        await run.input.add("step runtime");
+      }
+    }
+
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("original")),
+        userTextToModelMessage(userText("turn runtime")),
+        userTextToModelMessage(userText("step runtime")),
+      ],
+    ]);
+    expect(events).toEqual([
+      { type: "user-text", text: "original" },
+      { type: "turn-start" },
+      {
+        type: "runtime-input",
+        input: { type: "user-text", text: "turn runtime" },
+        placement: "turn-start",
+      },
+      { type: "step-start" },
+      {
+        type: "runtime-input",
+        input: { type: "user-text", text: "step runtime" },
+        placement: "step-start",
+      },
+      { type: "assistant-text", text: "DONE" },
+      { type: "step-end" },
+      { type: "turn-end" },
+    ]);
+  });
+
+  it("runtime input preserves FIFO order for multiple additions in one window", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const agent = await Agent.create({
+      llm: ({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      },
+    });
+    const run = await agent.send("initial");
+    const runtimeInputs: AgentEvent[] = [];
+    let added = false;
+
+    for await (const event of run.stream()) {
+      if (event.type === "step-start" && !added) {
+        added = true;
+        await run.input.add("first");
+        await run.input.add("second");
+      }
+      if (event.type === "runtime-input") {
+        runtimeInputs.push(event);
+      }
+    }
+
+    expect(runtimeInputs).toEqual([
+      {
+        type: "runtime-input",
+        input: { type: "user-text", text: "first" },
+        placement: "step-start",
+      },
+      {
+        type: "runtime-input",
+        input: { type: "user-text", text: "second" },
+        placement: "step-start",
+      },
+    ]);
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("initial")),
+        userTextToModelMessage(userText("first")),
+        userTextToModelMessage(userText("second")),
+      ],
+    ]);
+  });
+
   it("emits turn-error in the run when the LLM fails", async () => {
     const agent = await Agent.create({
       llm: () => Promise.reject(new Error("model unavailable")),
@@ -520,6 +666,7 @@ describe("Agent session API", () => {
 
   it("interrupts the active run without aborting queued input", async () => {
     const firstLlmCall = createDeferred();
+    const firstLlmStarted = createDeferred();
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
     const session = (
@@ -528,6 +675,7 @@ describe("Agent session API", () => {
           calls += 1;
           seenHistory.push([...history]);
           if (calls === 1) {
+            firstLlmStarted.resolve();
             await firstLlmCall.promise;
           }
           return [assistantMessage("DONE")];
@@ -540,6 +688,7 @@ describe("Agent session API", () => {
     const firstEvents = collect(firstRun);
     const secondEvents = collect(secondRun);
 
+    await firstLlmStarted.promise;
     session.interrupt();
     firstLlmCall.resolve();
 

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -257,17 +257,17 @@ describe("Agent session API", () => {
 
       if (event.type === "turn-start" && !addedTurnStart) {
         addedTurnStart = true;
-        await run.input.add("turn runtime");
+        await session.steer("turn runtime");
       }
 
       if (event.type === "step-start" && !addedStepStart) {
         addedStepStart = true;
-        await run.input.add("step runtime");
+        await session.steer("step runtime");
       }
 
       if (event.type === "step-end" && !addedStepEnd) {
         addedStepEnd = true;
-        await run.input.add("step-end runtime");
+        await session.steer("step-end runtime");
       }
     }
 
@@ -592,7 +592,7 @@ describe("Agent session API", () => {
     ]);
   });
 
-  it("runtime input at step-end continues the current turn with appended user input", async () => {
+  it("active session.steer at step-end continues the current turn with appended user input", async () => {
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
     const agent = await Agent.create({
@@ -604,7 +604,8 @@ describe("Agent session API", () => {
         ]);
       },
     });
-    const run = await agent.send("initial user");
+    const session = agent.session("step-end-steer");
+    const run = await session.send("initial user");
     const events: AgentEvent[] = [];
     let injected = false;
 
@@ -612,7 +613,7 @@ describe("Agent session API", () => {
       events.push(event);
       if (event.type === "step-end" && !injected) {
         injected = true;
-        await run.input.add("extra");
+        await session.steer("extra");
       }
     }
 
@@ -642,7 +643,7 @@ describe("Agent session API", () => {
     ]);
   });
 
-  it("runtime input at turn-start and step-start is visible before the first LLM snapshot", async () => {
+  it("active session.steer at turn-start and step-start is visible before the first LLM snapshot", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = await Agent.create({
       llm: ({ history }) => {
@@ -650,7 +651,8 @@ describe("Agent session API", () => {
         return Promise.resolve([assistantMessage("DONE")]);
       },
     });
-    const run = await agent.send("original");
+    const session = agent.session("early-steer");
+    const run = await session.send("original");
     const events: AgentEvent[] = [];
     let addedTurnStart = false;
     let addedStepStart = false;
@@ -659,11 +661,11 @@ describe("Agent session API", () => {
       events.push(event);
       if (event.type === "turn-start" && !addedTurnStart) {
         addedTurnStart = true;
-        await run.input.add("turn runtime");
+        await session.steer("turn runtime");
       }
       if (event.type === "step-start" && !addedStepStart) {
         addedStepStart = true;
-        await run.input.add("step runtime");
+        await session.steer("step runtime");
       }
     }
 
@@ -694,7 +696,93 @@ describe("Agent session API", () => {
     ]);
   });
 
-  it("runtime input preserves FIFO order for multiple additions in one window", async () => {
+  it("drains hook steering at turn-start, step-start, and step-end but not afterTurn", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    let afterTurnRun:
+      | Promise<Awaited<ReturnType<typeof session.steer>>>
+      | undefined;
+    let afterTurnSteered = false;
+    let step = 0;
+    let session: ReturnType<Agent["session"]>;
+    const agent = await Agent.create({
+      hooks: {
+        afterStep: async ({ stepIndex }) => {
+          if (stepIndex === 0) {
+            await session.steer("after step steer");
+          }
+        },
+        afterTurn: () => {
+          if (!afterTurnSteered) {
+            afterTurnSteered = true;
+            afterTurnRun = session.steer("after turn steer");
+          }
+        },
+        beforeStep: async ({ stepIndex }) => {
+          if (stepIndex === 0) {
+            await session.steer("before step steer");
+          }
+        },
+        beforeTurn: async () => {
+          await session.steer("before turn steer");
+        },
+      },
+      llm: ({ history }) => {
+        step += 1;
+        seenHistory.push([...history]);
+        return Promise.resolve([
+          assistantMessage(step === 1 ? "This could be final." : "DONE"),
+        ]);
+      },
+    });
+    session = agent.session("hook-steer");
+
+    const events = await collect(await session.send("original"));
+
+    expect(events).toContainEqual({
+      input: { type: "user-text", text: "before turn steer" },
+      placement: "turn-start",
+      type: "runtime-input",
+    });
+    expect(events).toContainEqual({
+      input: { type: "user-text", text: "before step steer" },
+      placement: "step-start",
+      type: "runtime-input",
+    });
+    expect(events).toContainEqual({
+      input: { type: "user-text", text: "after step steer" },
+      placement: "step-end",
+      type: "runtime-input",
+    });
+    expect(events).not.toContainEqual({
+      input: { type: "user-text", text: "after turn steer" },
+      placement: "step-end",
+      type: "runtime-input",
+    });
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("original")),
+        userTextToModelMessage(userText("before turn steer")),
+        userTextToModelMessage(userText("before step steer")),
+      ],
+      [
+        userTextToModelMessage(userText("original")),
+        userTextToModelMessage(userText("before turn steer")),
+        userTextToModelMessage(userText("before step steer")),
+        assistantMessage("This could be final."),
+        userTextToModelMessage(userText("after step steer")),
+      ],
+    ]);
+    if (!afterTurnRun) {
+      throw new Error("expected afterTurn steer to start a new run");
+    }
+    const afterTurnEvents = await collect(await afterTurnRun);
+    expect(afterTurnEvents[0]).toEqual({
+      text: "after turn steer",
+      type: "user-text",
+    });
+  });
+
+  it("active session.steer preserves FIFO order for multiple additions in one window", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = await Agent.create({
       llm: ({ history }) => {
@@ -702,15 +790,16 @@ describe("Agent session API", () => {
         return Promise.resolve([assistantMessage("DONE")]);
       },
     });
-    const run = await agent.send("initial");
+    const session = agent.session("steer-fifo");
+    const run = await session.send("initial");
     const runtimeInputs: AgentEvent[] = [];
     let added = false;
 
     for await (const event of run.stream()) {
       if (event.type === "step-start" && !added) {
         added = true;
-        await run.input.add("first");
-        await run.input.add("second");
+        await session.steer("first");
+        await session.steer("second");
       }
       if (event.type === "runtime-input") {
         runtimeInputs.push(event);
@@ -738,7 +827,7 @@ describe("Agent session API", () => {
     ]);
   });
 
-  it("runtime input preserves FIFO order for concurrent additions in one window", async () => {
+  it("active session.steer preserves FIFO order for concurrent additions in one window", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = await Agent.create({
       llm: ({ history }) => {
@@ -746,7 +835,8 @@ describe("Agent session API", () => {
         return Promise.resolve([assistantMessage("DONE")]);
       },
     });
-    const run = await agent.send("initial");
+    const session = agent.session("steer-concurrent-fifo");
+    const run = await session.send("initial");
     const runtimeInputs: AgentEvent[] = [];
     let added = false;
 
@@ -754,9 +844,9 @@ describe("Agent session API", () => {
       if (event.type === "step-start" && !added) {
         added = true;
         await Promise.all([
-          run.input.add("first"),
-          run.input.add("second"),
-          run.input.add("third"),
+          session.steer("first"),
+          session.steer("second"),
+          session.steer("third"),
         ]);
       }
       if (event.type === "runtime-input") {
@@ -791,7 +881,7 @@ describe("Agent session API", () => {
     ]);
   });
 
-  it("keeps queued session.send input as a separate turn while runtime input affects the active turn", async () => {
+  it("keeps active session.send input as a separate turn while session.steer affects the active turn", async () => {
     const stepGate = createDeferred();
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
@@ -817,7 +907,7 @@ describe("Agent session API", () => {
         firstEvents.push(event);
         if (event.type === "step-start" && !added) {
           added = true;
-          await firstRun.input.add("extra");
+          await session.steer("extra");
           stepGate.resolve();
         }
       }
@@ -845,7 +935,7 @@ describe("Agent session API", () => {
     ]);
   });
 
-  it("normalizes multipart image and file runtime input like session.send", async () => {
+  it("normalizes multipart image and file session.steer input like session.send", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = await Agent.create({
       llm: ({ history }) => {
@@ -863,14 +953,15 @@ describe("Agent session API", () => {
         mediaType: "text/plain",
       },
     ] as const;
-    const run = await agent.send("initial");
+    const session = agent.session("multipart-steer");
+    const run = await session.send("initial");
     const runtimeInputs: AgentEvent[] = [];
     let added = false;
 
     for await (const event of run.stream()) {
       if (event.type === "step-start" && !added) {
         added = true;
-        await run.input.add(input);
+        await session.steer(input);
       }
       if (event.type === "runtime-input") {
         runtimeInputs.push(event);
@@ -904,7 +995,7 @@ describe("Agent session API", () => {
     ]);
   });
 
-  it("rejects runtime input after turn-end without enqueueing a new session turn", async () => {
+  it("idle session.steer starts a new run after turn-end", async () => {
     let calls = 0;
     const agent = await Agent.create({
       llm: () => {
@@ -912,17 +1003,16 @@ describe("Agent session API", () => {
         return Promise.resolve([assistantMessage("DONE")]);
       },
     });
-    const run = await agent.send("initial");
+    const session = agent.session("idle-steer-after-turn-end");
+    const run = await session.send("initial");
 
     await collect(run);
 
-    await expect(run.input.add("late")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after turn-end"
-    );
-    expect(calls).toBe(1);
+    await collect(await session.steer("late"));
+    expect(calls).toBe(2);
   });
 
-  it("rejects runtime input after model turn-error without enqueueing a new session turn", async () => {
+  it("idle session.steer starts a new run after model turn-error", async () => {
     let calls = 0;
     const agent = await Agent.create({
       llm: () => {
@@ -930,17 +1020,18 @@ describe("Agent session API", () => {
         return Promise.reject(new Error("model unavailable"));
       },
     });
-    const run = await agent.send("initial");
+    const session = agent.session("idle-steer-after-turn-error");
+    const run = await session.send("initial");
 
     expect(eventTypes(await collect(run))).toContain("turn-error");
 
-    await expect(run.input.add("late")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after turn-error"
+    expect(eventTypes(await collect(await session.steer("late")))).toContain(
+      "turn-error"
     );
-    expect(calls).toBe(1);
+    expect(calls).toBe(2);
   });
 
-  it("rejects runtime input after interrupt turn-abort and does not hang", async () => {
+  it("idle session.steer starts a new run after interrupt turn-abort", async () => {
     const llmStarted = createDeferred();
     const llmGate = createDeferred();
     const session = (
@@ -960,8 +1051,8 @@ describe("Agent session API", () => {
     llmGate.resolve();
 
     expect(eventTypes(await events)).toContain("turn-abort");
-    await expect(run.input.add("late")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after turn-abort"
+    expect(eventTypes(await collect(await session.steer("late")))).toContain(
+      "turn-end"
     );
   });
 
@@ -988,12 +1079,7 @@ describe("Agent session API", () => {
 
     expect(eventTypes(await firstEvents)).toContain("turn-abort");
     expect(eventTypes(await secondEvents)).toEqual(["user-text", "turn-error"]);
-    await expect(firstRun.input.add("late")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after Session killed"
-    );
-    await expect(secondRun.input.add("late")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after Session killed"
-    );
+    await expect(session.steer("late")).rejects.toThrow("Session killed");
   });
 
   it("rejects runtime input after stream return", async () => {
@@ -1012,8 +1098,8 @@ describe("Agent session API", () => {
       value: undefined,
     });
 
-    await expect(run.input.add("late")).rejects.toThrow(
-      "AgentRun.input.add() cannot be used after stream return"
+    expect(eventTypes(await collect(await agent.send("late")))).toContain(
+      "turn-end"
     );
   });
 
@@ -1037,7 +1123,7 @@ describe("Agent session API", () => {
     for await (const event of run.stream()) {
       events.push(event);
       if (event.type === "turn-start" && !runtimeAdd) {
-        runtimeAdd = run.input.add("conflicting runtime");
+        runtimeAdd = session.steer("conflicting runtime").then(() => undefined);
       }
     }
 

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -33,6 +33,7 @@ interface QueuedInput {
 }
 
 type RuntimeInputPlacement = RuntimeInput["placement"];
+const noBoundaryDecision = undefined;
 
 interface QueuedRuntimeInput {
   readonly input: UserInput;
@@ -41,8 +42,8 @@ interface QueuedRuntimeInput {
 
 interface RuntimeInputState {
   closedReason?: string;
-  placement?: RuntimeInputPlacement;
   pending: Promise<void>;
+  placement?: RuntimeInputPlacement;
   readonly queue: QueuedRuntimeInput[];
 }
 
@@ -75,7 +76,10 @@ export class AgentSession {
       throw sessionKilledError();
     }
 
-    const runtimeInput: RuntimeInputState = { pending: Promise.resolve(), queue: [] };
+    const runtimeInput: RuntimeInputState = {
+      pending: Promise.resolve(),
+      queue: [],
+    };
     const acceptedInput = normalizeAgentInput(input);
     const run = new BufferedAgentRun({
       addInput: (input) => this.#addRuntimeInput(runtimeInput, input),
@@ -104,7 +108,10 @@ export class AgentSession {
 
     this.#killed = true;
     this.#activeAbort?.abort();
-    this.#closeRuntimeInput(this.#activeRuntimeInput, sessionKilledError().message);
+    this.#closeRuntimeInput(
+      this.#activeRuntimeInput,
+      sessionKilledError().message
+    );
 
     while (this.#inputQueue.length > 0) {
       const item = this.#inputQueue.shift();
@@ -204,7 +211,7 @@ export class AgentSession {
             if (event.type === "step-end") {
               return { runtimeInputAdded };
             }
-            return;
+            return noBoundaryDecision;
           }
 
           run.emit(event);
@@ -278,11 +285,9 @@ export class AgentSession {
     runtimeInput: RuntimeInputState | undefined,
     reason = "the run reached a terminal state"
   ): void {
-    if (!runtimeInput?.closedReason) {
-      if (runtimeInput) {
-        runtimeInput.closedReason = reason;
-        runtimeInput.placement = undefined;
-      }
+    if (!runtimeInput?.closedReason && runtimeInput) {
+      runtimeInput.closedReason = reason;
+      runtimeInput.placement = undefined;
     }
   }
 
@@ -340,9 +345,11 @@ function shiftRuntimeInput(
   runtimeInput: RuntimeInputState,
   placement: RuntimeInputPlacement
 ): QueuedRuntimeInput | undefined {
-  const index = runtimeInput.queue.findIndex((input) => input.placement === placement);
+  const index = runtimeInput.queue.findIndex(
+    (input) => input.placement === placement
+  );
   if (index === -1) {
-    return undefined;
+    return;
   }
 
   return runtimeInput.queue.splice(index, 1)[0];

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -40,7 +40,9 @@ interface QueuedRuntimeInput {
 }
 
 interface RuntimeInputState {
+  closedReason?: string;
   placement?: RuntimeInputPlacement;
+  pending: Promise<void>;
   readonly queue: QueuedRuntimeInput[];
 }
 
@@ -49,6 +51,7 @@ export class AgentSession {
   readonly #llm: Llm;
   readonly #persistence: SessionPersistenceOptions;
   #activeAbort?: AbortController;
+  #activeRuntimeInput?: RuntimeInputState;
   #history = new AgentModelHistory();
   #killed = false;
   #loadPromise?: Promise<void>;
@@ -72,21 +75,10 @@ export class AgentSession {
       throw sessionKilledError();
     }
 
-    const runtimeInput: RuntimeInputState = { queue: [] };
+    const runtimeInput: RuntimeInputState = { pending: Promise.resolve(), queue: [] };
     const acceptedInput = normalizeAgentInput(input);
     const run = new BufferedAgentRun({
-      addInput: (input) => {
-        if (!runtimeInput.placement) {
-          throw new Error(
-            "AgentRun.input.add() can only be used during an active run input window"
-          );
-        }
-
-        runtimeInput.queue.push({
-          input: normalizeAgentInput(input),
-          placement: runtimeInput.placement,
-        });
-      },
+      addInput: (input) => this.#addRuntimeInput(runtimeInput, input),
     });
     run.emit(acceptedInput);
     this.#inputQueue.push({
@@ -112,14 +104,16 @@ export class AgentSession {
 
     this.#killed = true;
     this.#activeAbort?.abort();
+    this.#closeRuntimeInput(this.#activeRuntimeInput, sessionKilledError().message);
 
     while (this.#inputQueue.length > 0) {
       const item = this.#inputQueue.shift();
+      this.#closeRuntimeInput(item?.runtimeInput, sessionKilledError().message);
       item?.run.emit({
         type: "turn-error",
         message: sessionKilledError().message,
       });
-      item?.run.close();
+      item?.run.close(undefined, sessionKilledError().message);
     }
   }
 
@@ -176,6 +170,7 @@ export class AgentSession {
     runtimeInput,
   }: QueuedInput): Promise<void> {
     this.#activeAbort = new AbortController();
+    this.#activeRuntimeInput = runtimeInput;
     const historySnapshot = this.#history.modelSnapshot();
 
     try {
@@ -220,10 +215,13 @@ export class AgentSession {
       });
 
       await this.#commitHistory();
-      run.emit({ type: result === "aborted" ? "turn-abort" : "turn-end" });
+      const terminalEvent = result === "aborted" ? "turn-abort" : "turn-end";
+      run.emit({ type: terminalEvent });
+      this.#closeRuntimeInput(runtimeInput, terminalEvent);
     } catch (error) {
       if (error instanceof SessionCommitConflictError) {
         run.emit({ type: "turn-error", message: error.message });
+        this.#closeRuntimeInput(runtimeInput, "a session commit conflict");
         this.#activeAbort = undefined;
         return;
       }
@@ -238,13 +236,53 @@ export class AgentSession {
             rollbackError
           )}`,
         });
+        this.#closeRuntimeInput(runtimeInput, "turn-error");
         this.#activeAbort = undefined;
         return;
       }
       run.emit({ type: "turn-error", message: errorMessage(error) });
+      this.#closeRuntimeInput(runtimeInput, "turn-error");
     } finally {
+      this.#closeRuntimeInput(runtimeInput);
       this.#activeAbort = undefined;
-      run.close();
+      this.#activeRuntimeInput = undefined;
+      run.close(undefined, runtimeInput.closedReason);
+    }
+  }
+
+  #addRuntimeInput(
+    runtimeInput: RuntimeInputState,
+    input: AgentInput
+  ): Promise<void> {
+    const next = runtimeInput.pending.then(() => {
+      if (runtimeInput.closedReason) {
+        throw runtimeInputClosedError(runtimeInput.closedReason);
+      }
+
+      if (!runtimeInput.placement) {
+        throw new Error(
+          "AgentRun.input.add() can only be used during an active run input window"
+        );
+      }
+
+      runtimeInput.queue.push({
+        input: normalizeAgentInput(input),
+        placement: runtimeInput.placement,
+      });
+    });
+    runtimeInput.pending = next.catch(() => undefined);
+    return next;
+  }
+
+  #closeRuntimeInput(
+    runtimeInput: RuntimeInputState | undefined,
+    reason = "the run reached a terminal state"
+  ): void {
+    if (!runtimeInput?.closedReason) {
+      if (runtimeInput) {
+        runtimeInput.closedReason = reason;
+        runtimeInput.placement = undefined;
+      }
     }
   }
 
@@ -441,6 +479,10 @@ function errorMessage(error: unknown): string {
 
 function sessionKilledError(): Error {
   return new Error("Session killed");
+}
+
+function runtimeInputClosedError(reason: string): Error {
+  return new Error(`AgentRun.input.add() cannot be used after ${reason}`);
 }
 
 class SessionCommitConflictError extends Error {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,6 +1,11 @@
 import { runAgentLoop } from "../agent-loop";
 import type { Llm } from "../llm";
-import type { UserMessage, UserMessageContentPart, UserText } from "./events";
+import type {
+  RuntimeInput,
+  UserMessage,
+  UserMessageContentPart,
+  UserText,
+} from "./events";
 import { AgentModelHistory } from "./history";
 import type { AgentRun } from "./run";
 import { BufferedAgentRun } from "./run";
@@ -24,6 +29,19 @@ interface SessionPersistenceOptions {
 interface QueuedInput {
   readonly input: UserInput;
   readonly run: BufferedAgentRun;
+  readonly runtimeInput: RuntimeInputState;
+}
+
+type RuntimeInputPlacement = RuntimeInput["placement"];
+
+interface QueuedRuntimeInput {
+  readonly input: UserInput;
+  readonly placement: RuntimeInputPlacement;
+}
+
+interface RuntimeInputState {
+  placement?: RuntimeInputPlacement;
+  readonly queue: QueuedRuntimeInput[];
 }
 
 export class AgentSession {
@@ -54,10 +72,28 @@ export class AgentSession {
       throw sessionKilledError();
     }
 
+    const runtimeInput: RuntimeInputState = { queue: [] };
     const acceptedInput = normalizeAgentInput(input);
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentRun({
+      addInput: (input) => {
+        if (!runtimeInput.placement) {
+          throw new Error(
+            "AgentRun.input.add() can only be used during an active run input window"
+          );
+        }
+
+        runtimeInput.queue.push({
+          input: normalizeAgentInput(input),
+          placement: runtimeInput.placement,
+        });
+      },
+    });
     run.emit(acceptedInput);
-    this.#inputQueue.push({ input: structuredClone(acceptedInput), run });
+    this.#inputQueue.push({
+      input: structuredClone(acceptedInput),
+      run,
+      runtimeInput,
+    });
     this.#drainInputQueue().catch((error: unknown) => {
       run.emit({ type: "turn-error", message: errorMessage(error) });
       run.close();
@@ -134,17 +170,50 @@ export class AgentSession {
     }
   }
 
-  async #processQueuedInput({ input, run }: QueuedInput): Promise<void> {
+  async #processQueuedInput({
+    input,
+    run,
+    runtimeInput,
+  }: QueuedInput): Promise<void> {
     this.#activeAbort = new AbortController();
     const historySnapshot = this.#history.modelSnapshot();
 
     try {
-      run.emit({ type: "turn-start" });
+      await this.#withRuntimeInputWindow(
+        runtimeInput,
+        "turn-start",
+        async () => {
+          await run.emitBoundary({ type: "turn-start" });
+        }
+      );
       this.#history.appendUserInput(input);
       await this.#commitHistory();
+      await this.#drainRuntimeInput(run, runtimeInput, "turn-start");
 
       const result = await runAgentLoop({
-        emit: (event) => run.emit(event),
+        emit: async (event) => {
+          if (event.type === "step-start" || event.type === "step-end") {
+            await this.#withRuntimeInputWindow(
+              runtimeInput,
+              event.type,
+              async () => {
+                await run.emitBoundary(event);
+              }
+            );
+            const runtimeInputAdded = await this.#drainRuntimeInput(
+              run,
+              runtimeInput,
+              event.type
+            );
+
+            if (event.type === "step-end") {
+              return { runtimeInputAdded };
+            }
+            return;
+          }
+
+          run.emit(event);
+        },
         history: this.#history,
         llm: this.#llm,
         signal: this.#activeAbort.signal,
@@ -155,6 +224,7 @@ export class AgentSession {
     } catch (error) {
       if (error instanceof SessionCommitConflictError) {
         run.emit({ type: "turn-error", message: error.message });
+        this.#activeAbort = undefined;
         return;
       }
 
@@ -168,12 +238,13 @@ export class AgentSession {
             rollbackError
           )}`,
         });
+        this.#activeAbort = undefined;
         return;
       }
       run.emit({ type: "turn-error", message: errorMessage(error) });
     } finally {
-      run.close();
       this.#activeAbort = undefined;
+      run.close();
     }
   }
 
@@ -194,6 +265,49 @@ export class AgentSession {
 
     this.#storeVersion = result.version;
   }
+
+  async #withRuntimeInputWindow<T>(
+    runtimeInput: RuntimeInputState,
+    placement: RuntimeInputPlacement,
+    callback: () => Promise<T>
+  ): Promise<T> {
+    runtimeInput.placement = placement;
+    try {
+      return await callback();
+    } finally {
+      runtimeInput.placement = undefined;
+    }
+  }
+
+  async #drainRuntimeInput(
+    run: BufferedAgentRun,
+    runtimeInput: RuntimeInputState,
+    placement: RuntimeInputPlacement
+  ): Promise<boolean> {
+    let added = false;
+    let next = shiftRuntimeInput(runtimeInput, placement);
+    while (next) {
+      added = true;
+      run.emit({ type: "runtime-input", input: next.input, placement });
+      this.#history.appendUserInput(next.input);
+      await this.#commitHistory();
+      next = shiftRuntimeInput(runtimeInput, placement);
+    }
+
+    return added;
+  }
+}
+
+function shiftRuntimeInput(
+  runtimeInput: RuntimeInputState,
+  placement: RuntimeInputPlacement
+): QueuedRuntimeInput | undefined {
+  const index = runtimeInput.queue.findIndex((input) => input.placement === placement);
+  if (index === -1) {
+    return undefined;
+  }
+
+  return runtimeInput.queue.splice(index, 1)[0];
 }
 
 export function normalizeAgentInput(input: AgentInput): UserInput {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -46,6 +46,7 @@ interface RuntimeInputState {
   pending: Promise<void>;
   placement?: RuntimeInputPlacement;
   readonly queue: QueuedRuntimeInput[];
+  steerPlacement?: RuntimeInputPlacement;
 }
 
 export class AgentSession {
@@ -54,6 +55,7 @@ export class AgentSession {
   readonly #llm: Llm;
   readonly #persistence: SessionPersistenceOptions;
   #activeAbort?: AbortController;
+  #activeRun?: BufferedAgentRun;
   #activeRuntimeInput?: RuntimeInputState;
   #history = new AgentModelHistory();
   #killed = false;
@@ -88,9 +90,7 @@ export class AgentSession {
       queue: [],
     };
     const acceptedInput = normalizeAgentInput(input);
-    const run = new BufferedAgentRun({
-      addInput: (input) => this.#addRuntimeInput(runtimeInput, input),
-    });
+    const run = new BufferedAgentRun();
     run.emit(acceptedInput);
     this.#inputQueue.push({
       input: structuredClone(acceptedInput),
@@ -101,6 +101,21 @@ export class AgentSession {
       run.emit({ type: "turn-error", message: errorMessage(error) });
       run.close();
     });
+    return run;
+  }
+
+  async steer(input: AgentInput): Promise<AgentRun> {
+    if (this.#killed) {
+      throw sessionKilledError();
+    }
+
+    const runtimeInput = this.#activeRuntimeInput;
+    const run = this.#activeRun;
+    if (!(runtimeInput && run)) {
+      return this.send(input);
+    }
+
+    await this.#addSteeringInput(runtimeInput, input);
     return run;
   }
 
@@ -183,16 +198,24 @@ export class AgentSession {
     run,
     runtimeInput,
   }: QueuedInput): Promise<void> {
-    this.#activeAbort = new AbortController();
+    const activeAbort = new AbortController();
+    this.#activeAbort = activeAbort;
+    this.#activeRun = run;
     this.#activeRuntimeInput = runtimeInput;
     const historySnapshot = this.#history.modelSnapshot();
 
     try {
-      await this.#hooks?.beforeTurn?.({
-        history: this.#history.modelSnapshot(),
-        input,
-        signal: this.#activeAbort.signal,
-      });
+      await this.#withSteeringPlacement(
+        runtimeInput,
+        "turn-start",
+        async () => {
+          await this.#hooks?.beforeTurn?.({
+            history: this.#history.modelSnapshot(),
+            input,
+            signal: activeAbort.signal,
+          });
+        }
+      );
       await this.#withRuntimeInputWindow(
         runtimeInput,
         "turn-start",
@@ -229,21 +252,23 @@ export class AgentSession {
           run.emit(event);
         },
         history: this.#history,
-        hooks: this.#hooks,
+        hooks: this.#hooksForRuntimeInput(runtimeInput),
         llm: this.#llm,
-        signal: this.#activeAbort.signal,
+        signal: activeAbort.signal,
       });
 
       await this.#commitHistory();
       const terminalEvent = result === "aborted" ? "turn-abort" : "turn-end";
+      this.#closeRuntimeInput(runtimeInput, terminalEvent);
+      this.#activeRuntimeInput = undefined;
+      this.#activeRun = undefined;
       await runAfterTurnHook(this.#hooks, {
         history: this.#history.modelSnapshot(),
         input,
         result,
-        signal: this.#activeAbort.signal,
+        signal: activeAbort.signal,
       });
       run.emit({ type: terminalEvent });
-      this.#closeRuntimeInput(runtimeInput, terminalEvent);
     } catch (error) {
       if (error instanceof SessionCommitConflictError) {
         run.emit({ type: "turn-error", message: error.message });
@@ -271,12 +296,13 @@ export class AgentSession {
     } finally {
       this.#closeRuntimeInput(runtimeInput);
       this.#activeAbort = undefined;
+      this.#activeRun = undefined;
       this.#activeRuntimeInput = undefined;
       run.close(undefined, runtimeInput.closedReason);
     }
   }
 
-  #addRuntimeInput(
+  #addSteeringInput(
     runtimeInput: RuntimeInputState,
     input: AgentInput
   ): Promise<void> {
@@ -285,15 +311,10 @@ export class AgentSession {
         throw runtimeInputClosedError(runtimeInput.closedReason);
       }
 
-      if (!runtimeInput.placement) {
-        throw new Error(
-          "AgentRun.input.add() can only be used during an active run input window"
-        );
-      }
-
       runtimeInput.queue.push({
         input: normalizeAgentInput(input),
-        placement: runtimeInput.placement,
+        placement:
+          runtimeInput.steerPlacement ?? runtimeInput.placement ?? "step-end",
       });
     });
     runtimeInput.pending = next.catch(() => undefined);
@@ -333,12 +354,50 @@ export class AgentSession {
     placement: RuntimeInputPlacement,
     callback: () => Promise<T>
   ): Promise<T> {
+    const previousSteerPlacement = runtimeInput.steerPlacement;
     runtimeInput.placement = placement;
+    runtimeInput.steerPlacement = placement;
     try {
       return await callback();
     } finally {
       runtimeInput.placement = undefined;
+      runtimeInput.steerPlacement = previousSteerPlacement;
     }
+  }
+
+  async #withSteeringPlacement<T>(
+    runtimeInput: RuntimeInputState,
+    placement: RuntimeInputPlacement,
+    callback: () => Promise<T>
+  ): Promise<T> {
+    const previousSteerPlacement = runtimeInput.steerPlacement;
+    runtimeInput.steerPlacement = placement;
+    try {
+      return await callback();
+    } finally {
+      runtimeInput.steerPlacement = previousSteerPlacement;
+    }
+  }
+
+  #hooksForRuntimeInput(
+    runtimeInput: RuntimeInputState
+  ): AgentHooks | undefined {
+    const hooks = this.#hooks;
+    if (!hooks) {
+      return;
+    }
+
+    return {
+      ...hooks,
+      afterStep: (context) =>
+        this.#withSteeringPlacement(runtimeInput, "step-end", async () => {
+          await hooks.afterStep?.(context);
+        }),
+      beforeStep: (context) =>
+        this.#withSteeringPlacement(runtimeInput, "step-start", async () => {
+          await hooks.beforeStep?.(context);
+        }),
+    };
   }
 
   async #drainRuntimeInput(
@@ -520,7 +579,7 @@ function sessionKilledError(): Error {
 }
 
 function runtimeInputClosedError(reason: string): Error {
-  return new Error(`AgentRun.input.add() cannot be used after ${reason}`);
+  return new Error(`session.steer() cannot be used after ${reason}`);
 }
 
 class SessionCommitConflictError extends Error {

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -27,9 +27,12 @@ const RUNTIME_DECLARATION_ALLOWLIST = new Set([
   "session/mapping.d.ts",
 ]);
 const REQUIRED_RUNTIME_ROOT_ALIASES = [
+  "AgentRunInput",
   "AgentModel",
   "AgentTools",
+  "RunInput",
   "RuntimeCreateLlmOptions",
+  "RuntimeInput",
   "RuntimeLlm",
   "RuntimeLlmContext",
   "RuntimeLlmOutput",

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -27,17 +27,20 @@ const RUNTIME_DECLARATION_ALLOWLIST = new Set([
   "session/mapping.d.ts",
 ]);
 const REQUIRED_RUNTIME_ROOT_ALIASES = [
-  "AgentRunInput",
   "AgentModel",
+  "AgentRun",
   "AgentTools",
-  "RunInput",
   "RuntimeCreateLlmOptions",
   "RuntimeInput",
   "RuntimeLlm",
   "RuntimeLlmContext",
   "RuntimeLlmOutput",
 ];
-const FORBIDDEN_RUNTIME_ROOT_ALIASES = ["AgentMessage"];
+const FORBIDDEN_RUNTIME_ROOT_ALIASES = [
+  "AgentMessage",
+  "AgentRunInput",
+  "RunInput",
+];
 
 const RELATIVE_IMPORT_RE =
   /(?:from\s+["']|import\s*(?:\(\s*)?["'])(\.\.?\/[^"']+)(?:["'])/g;

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -16,6 +16,8 @@ import {
 
 const cliBinReadFailurePattern =
   /^packages\/coding-agent\/bin\/pss\.js: cannot read CLI bin target /;
+const runtimeRootDeclaration =
+  'export type { AgentModel, AgentRunInput, AgentTools, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n';
 
 let tempRoots = [];
 
@@ -46,7 +48,7 @@ function createFixture() {
     );
     const declaration =
       packageName === "runtime"
-        ? 'export type { AgentModel, AgentTools, RuntimeCreateLlmOptions, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+        ? runtimeRootDeclaration
         : "export declare const ok: true;\n";
     writeFileSync(
       join(cwd, "packages", packageName, "dist", "index.d.ts"),
@@ -216,7 +218,7 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'import type { LanguageModel } from "ai";\nexport type AgentModel = LanguageModel;\nexport type { AgentTools, RuntimeCreateLlmOptions, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      'import type { LanguageModel } from "ai";\nexport type AgentModel = LanguageModel;\nexport type { AgentRunInput, AgentTools, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
     );
 
     expect(
@@ -230,7 +232,7 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'export type { AgentMessage, AgentModel, AgentTools, RuntimeCreateLlmOptions, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      'export type { AgentMessage, AgentModel, AgentRunInput, AgentTools, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
     );
 
     expect(
@@ -244,7 +246,7 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'export type { AgentModel, AgentTools, RuntimeCreateLlmOptions, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      runtimeRootDeclaration
     );
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "llm.d.ts"),
@@ -268,8 +270,11 @@ describe("verifyReleaseArtifacts", () => {
     );
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
       "packages/runtime/dist/index.d.ts: root declaration exposes raw AI SDK token LanguageModel",
+      "packages/runtime/dist/index.d.ts: missing explicit runtime alias AgentRunInput",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias AgentTools",
+      "packages/runtime/dist/index.d.ts: missing explicit runtime alias RunInput",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeCreateLlmOptions",
+      "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeInput",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeLlm",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeLlmContext",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeLlmOutput",

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -17,7 +17,7 @@ import {
 const cliBinReadFailurePattern =
   /^packages\/coding-agent\/bin\/pss\.js: cannot read CLI bin target /;
 const runtimeRootDeclaration =
-  'export type { AgentModel, AgentRunInput, AgentTools, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n';
+  'export type { AgentModel, AgentRun, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n';
 
 let tempRoots = [];
 
@@ -218,7 +218,7 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'import type { LanguageModel } from "ai";\nexport type AgentModel = LanguageModel;\nexport type { AgentRunInput, AgentTools, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      'import type { LanguageModel } from "ai";\nexport type AgentModel = LanguageModel;\nexport type { AgentRun, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
     );
 
     expect(
@@ -246,13 +246,28 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'export type { AgentMessage, AgentModel, AgentRunInput, AgentTools, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      'export type { AgentMessage, AgentModel, AgentRun, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
     );
 
     expect(
       verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
     ).toEqual([
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentMessage",
+    ]);
+  });
+
+  it("rejects removed runtime input aliases from root declarations", () => {
+    const cwd = createFixture();
+    writeFileSync(
+      join(cwd, "packages", "runtime", "dist", "index.d.ts"),
+      'export type { AgentModel, AgentRun, AgentRunInput, AgentTools, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+    );
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
+    ).toEqual([
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentRunInput",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias RunInput",
     ]);
   });
 
@@ -284,9 +299,8 @@ describe("verifyReleaseArtifacts", () => {
     );
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
       "packages/runtime/dist/index.d.ts: root declaration exposes raw AI SDK token LanguageModel",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime alias AgentRunInput",
+      "packages/runtime/dist/index.d.ts: missing explicit runtime alias AgentRun",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias AgentTools",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime alias RunInput",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeCreateLlmOptions",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeInput",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeLlm",


### PR DESCRIPTION
## Summary
- Replaces the old public run-handle current-turn input surface with `session.steer(input)`. Active `session.steer()` steers the current run; idle `session.steer()` starts a normal run.
- Keeps `session.send(input)` as the new-turn API. If a run is active, `send()` queues a separate later turn and never merges into the active run.
- Removes the old run-handle mutation surface and its removed input alias exports; `AgentRun` is now stream-only.
- Updates the TUI so idle submissions call `session.send()` and active submissions call `session.steer()`, including the idle-fallback case where `steer()` returns a distinct run.
- Tightens runtime, TUI, and release-artifact tests around lifecycle placement, FIFO steering, send-vs-steer separation, multipart input, terminal/kill behavior, and removed alias checks.

## Client code shape
The clean runtime client shape is: call `session.send()` for new user turns, call `session.steer()` for current-run steering, and always consume the returned run stream.

```ts
import { Agent } from "@minpeter/pss-runtime";

const agent = await Agent.create({
  model,
  instructions: "Answer briefly.",
});

const session = agent.session("default");
const run = await session.send("Write a short summary.");
let steered = false;

for await (const event of run.stream()) {
  if (event.type === "assistant-text") {
    process.stdout.write(event.text);
  }

  if (event.type === "step-end" && !steered) {
    steered = true;
    await session.steer("Also mention the main tradeoff.");
  }
}
```

For chat/TUI-style clients, consume a distinct run returned by `steer()` because idle fallback starts a normal run:

```ts
import type { AgentRun } from "@minpeter/pss-runtime";

let activeRun: AgentRun | undefined;

async function submit(text: string) {
  const input = text.trim();
  if (!input) {
    return;
  }

  const currentRun = activeRun;
  const run = currentRun
    ? await session.steer(input)
    : await session.send(input);

  if (run !== currentRun) {
    void consumeRun(run);
  }
}

async function consumeRun(run: AgentRun) {
  activeRun = run;

  try {
    for await (const event of run.stream()) {
      render(event);

      if (
        event.type === "turn-end" ||
        event.type === "turn-error" ||
        event.type === "turn-abort"
      ) {
        activeRun = undefined;
      }
    }
  } finally {
    if (activeRun === run) {
      activeRun = undefined;
    }
  }
}
```

## API and release notes
- `run.stream()` must still be consumed to drive synchronized run boundaries (`turn-start`, `step-start`, `step-end`).
- Use `session.send(input)` for new user turns. Active sends remain queued as separate runs.
- Use `session.steer(input)` when input should affect the current active run. It accepts the same input shapes as `session.send(input)`.
- Steering at `turn-start`, `step-start`, and `step-end` emits `runtime-input` events and maps internally to model user-role input.
- `afterTurn` is after current-run steering is closed; `session.steer()` there starts/queues a new normal run.
- Guard `step-end` steering with a real condition or one-shot flag because it intentionally continues the current turn and can otherwise loop indefinitely.
- Changeset included: `.changeset/current-turn-runtime-input.md`.

## Verification
- `pnpm vitest run packages/runtime/src/session/session.test.ts packages/runtime/src/session/run.test.ts`: 42 tests passed.
- `pnpm vitest run packages/coding-agent/src/tui-runner.test.ts`: 7 tests passed.
- `pnpm vitest run scripts/verify-release-artifacts.test.mjs`: 16 tests passed.
- `pnpm typecheck`: passed.
- `pnpm test`: passed.
- `pnpm lint`: passed.
- `pnpm build && pnpm verify:release`: passed.
- Manual SDK QA confirmed active `session.steer("extra")` emitted `runtime-input:step-start:extra`, while active `session.send("second")` remained a separate run after the first terminal event.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synchronized `run.stream()` driver and a current-turn steering API via `session.steer()` so apps can inject input during the active run; the TUI now steers active runs, while idle submissions start new turns.

- New Features
  - Synchronized `run.stream()`; the run only crosses `turn-start`, `step-start`, and `step-end` when the stream is consumed, and the LLM call waits for those boundaries.
  - `session.steer(input)` steers the active run during `turn-start`/`step-start`/`step-end`; accepts the same shapes as `session.send(input)`, is FIFO within a window, and starts a normal run when idle.
  - Emits `runtime-input` events with insertion placement; commit conflicts surface as `turn-error`.
  - TUI: active submissions call `session.steer()` and render as dim `runtime: ...`; if `steer()` returns a different run it is now consumed; idle submissions still call `session.send()`; active runs clear on terminal events or stream errors.
  - Runtime exports: `@minpeter/pss-runtime` now exports `RuntimeInput`; release verifier requires `AgentRun`/`RuntimeInput` and blocks removed input aliases.

- Migration
  - Move old run-handle input injection call sites to `session.steer()`.
  - Drive runs by consuming `run.stream()`; a stream allows a single consumer and no concurrent `next()` calls.
  - Use `session.send()` for new turns; guard `step-end` steering to avoid loops.
  - Steering is rejected after `kill()`; when idle it starts a normal run.

<sup>Written for commit db41a1fadc65411eed08081f2f0b263a6ffa08c6. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/40?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->