### PR TITLE
Add repository agent instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ dist
 !.env.example
 .turbo
 packages/*/.turbo
-.omo/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Repository Instructions
+
+## Development
+
+- Use `pnpm` for workspace commands.
+
+## Pull Requests and Releases
+
+- Include a Changeset only for changes that should produce a package release or
+  changelog entry, such as user-visible runtime behavior, package-facing APIs,
+  dependency changes that affect consumers, or release process changes.
+- Do not add a Changeset for repository-only maintenance such as agent
+  instructions, local ignore rules, internal notes, or other changes that should
+  not release `@minpeter/pss-runtime` or `@minpeter/pss-coding-agent`.
+- When a Changeset is needed and the user does not explicitly request a `major`,
+  `minor`, or `patch` release level, create a `patch` Changeset by default.
+- Use `pnpm changeset` for interactive Changeset creation when practical;
+  otherwise add a valid markdown file under `.changeset/`.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,7 +3,7 @@
   "root": true,
   "extends": ["ultracite/biome/core"],
   "files": {
-    "includes": ["**/*", "!!**/.omx"]
+    "includes": ["**/*", "!!**/.omo", "!!**/.omx"]
   },
   "overrides": [
     {


### PR DESCRIPTION
## Summary
- add a root AGENTS.md with repo-specific agent guidance
- clarify when Changesets are required and when repo-only maintenance should skip them
- keep local agent state out of formatter/linter scope

## Verification
- pnpm lint

Note: existing unstaged local change in examples/basic.ts was intentionally left out of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a root `AGENTS.md` with repo-specific guidance, including when to create a Changeset vs skip for repo-only maintenance. Updates tooling to keep local agent state out of lint/format (excludes `.omo`/`.omx` in `biome.jsonc`) and removes `.omo/` from `.gitignore`.

<sup>Written for commit f7a0846483eab0016a91136936c0cf0e18f9d487. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/43?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

