### PR TITLE
Update repository agent preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,11 @@
 
 ## Pull Requests and Releases
 
-- Include a Changeset only for changes that should produce a package release or
-  changelog entry, such as user-visible runtime behavior, package-facing APIs,
-  dependency changes that affect consumers, or release process changes.
-- Do not add a Changeset for repository-only maintenance such as agent
-  instructions, local ignore rules, internal notes, or other changes that should
-  not release `@minpeter/pss-runtime` or `@minpeter/pss-coding-agent`.
-- When a Changeset is needed and the user does not explicitly request a `major`,
-  `minor`, or `patch` release level, create a `patch` Changeset by default.
-- Use `pnpm changeset` for interactive Changeset creation when practical;
-  otherwise add a valid markdown file under `.changeset/`.
+- Include a Changeset only for changes that should produce a package release or changelog entry, such as user-visible runtime behavior, package-facing APIs, dependency changes that affect consumers, or release process changes.
+- Do not add a Changeset for repository-only maintenance such as agent instructions, local ignore rules, internal notes, or other changes that should not release `@minpeter/pss-runtime` or `@minpeter/pss-coding-agent`.
+- When a Changeset is needed and the user does not explicitly request a `major`, `minor`, or `patch` release level, create a `patch` Changeset by default.
+- Use `pnpm changeset` for interactive Changeset creation when practical; otherwise add a valid markdown file under `.changeset/`.
+
+## User Preferences
+
+- For `@minpeter/pss-runtime` examples/docs, do not use `@minpeter/pss-coding-agent`; use generic models, custom LLM stubs, or direct runtime APIs instead.


### PR DESCRIPTION
## Summary
- Keep AGENTS.md bullets on single lines
- Add a user preference that pss-runtime examples/docs should not depend on pss-coding-agent

## Testing
- Not run; documentation-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized AGENTS.md bullets to single lines. Added a user preference: `@minpeter/pss-runtime` examples/docs should not use `@minpeter/pss-coding-agent`; use generic models, custom LLM stubs, or direct runtime APIs instead.

<sup>Written for commit c4a0940ff3a170024d438eb9bc29a7d67fc18e43. Summary will update on new commits. <a href="https://cubic.dev/pr/minpeter/pss-next/pull/44?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

