### PR TITLE
Make coding-agent TUI import-safe

### DIFF
--- a/.changeset/clean-tui-runtime-types.md
+++ b/.changeset/clean-tui-runtime-types.md
@@ -1,0 +1,6 @@
+---
+"@minpeter/pss-coding-agent": patch
+"@minpeter/pss-runtime": patch
+---
+
+Make the coding-agent TUI subpath import-safe, correct multimodal docs, and tighten public runtime type aliases.

--- a/.changeset/clean-tui-runtime-types.md
+++ b/.changeset/clean-tui-runtime-types.md
@@ -3,4 +3,4 @@
 "@minpeter/pss-runtime": patch
 ---
 
-Make the coding-agent TUI subpath import-safe, correct multimodal docs, and tighten public runtime type aliases.
+Make the coding-agent TUI subpath import-safe, correct multimodal docs, and remove redundant runtime type aliases.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Small agent runtime workspace.
 
 ```ts
 import { tools } from "@minpeter/pss-coding-agent";
-import { createCodingAgentModel } from "@minpeter/pss-coding-agent/model";
+import { createCodingLanguageModel } from "@minpeter/pss-coding-agent/model";
 import { Agent } from "@minpeter/pss-runtime";
 
 const agent = await Agent.create({
   instructions: "Keep every answer under 3 lines.",
-  model: createCodingAgentModel(),
+  model: createCodingLanguageModel(),
   tools,
 });
 const run = await agent.send("Hello");

--- a/README.md
+++ b/README.md
@@ -54,13 +54,10 @@ The runtime `send` API also accepts JSON-serializable multimodal content parts
 for model providers that support them:
 
 ```ts
-await agent.send({
-  type: "user-text",
-  text: [
-    { type: "text", text: "What changed in this screenshot?" },
-    { type: "image", image: "data:image/png;base64,...", mediaType: "image/png" },
-  ],
-});
+await agent.send([
+  { type: "text", text: "What changed in this screenshot?" },
+  { type: "image", image: "data:image/png;base64,...", mediaType: "image/png" },
+]);
 ```
 
 Run the TUI:

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -4,11 +4,11 @@ Web tools, model wiring, and the `pss` TUI for pss-next.
 
 ```ts
 import { tools } from "@minpeter/pss-coding-agent";
-import { createCodingAgentModel } from "@minpeter/pss-coding-agent/model";
+import { createCodingLanguageModel } from "@minpeter/pss-coding-agent/model";
 import { Agent } from "@minpeter/pss-runtime";
 
 const agent = await Agent.create({
-  model: createCodingAgentModel(),
+  model: createCodingLanguageModel(),
   tools,
 });
 

--- a/packages/coding-agent/bin/pss.js
+++ b/packages/coding-agent/bin/pss.js
@@ -1,2 +1,4 @@
 #!/usr/bin/env node
-import "../dist/tui.js";
+import { startTui } from "../dist/tui.js";
+
+await startTui();

--- a/packages/coding-agent/src/model.test.ts
+++ b/packages/coding-agent/src/model.test.ts
@@ -75,9 +75,9 @@ describe("createOpenAICompatibleModelFromEnv", () => {
     process.env.AI_API_KEY = " dotenv-token ";
     process.env.AI_BASE_URL = " https://dotenv.test/v1 ";
     process.env.AI_MODEL = " dotenv-model ";
-    const { createCodingAgentModel } = await import("./model");
+    const { createCodingLanguageModel } = await import("./model");
 
-    const model = createCodingAgentModel({
+    const model = createCodingLanguageModel({
       override: false,
       providerName: "dotenv-provider",
       quiet: false,

--- a/packages/coding-agent/src/model.ts
+++ b/packages/coding-agent/src/model.ts
@@ -1,5 +1,5 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import type { AgentModel } from "@minpeter/pss-runtime";
+import type { LanguageModel } from "ai";
 import { config } from "dotenv";
 import {
   type CodingAgentRuntimeEnv,
@@ -20,7 +20,7 @@ export interface CreateOpenAICompatibleModelFromDotenvOptions {
 export function createOpenAICompatibleModelFromEnv({
   providerName = "custom",
   runtimeEnv = process.env,
-}: CreateOpenAICompatibleModelFromEnvOptions = {}): AgentModel {
+}: CreateOpenAICompatibleModelFromEnvOptions = {}): LanguageModel {
   const env = readOpenAICompatibleModelEnv({ runtimeEnv });
   const provider = createOpenAICompatible({
     name: providerName,
@@ -35,7 +35,7 @@ export function createCodingAgentModel({
   override = true,
   providerName = "custom",
   quiet = true,
-}: CreateOpenAICompatibleModelFromDotenvOptions = {}): AgentModel {
+}: CreateOpenAICompatibleModelFromDotenvOptions = {}): LanguageModel {
   config({ override, quiet });
 
   return createOpenAICompatibleModelFromEnv({

--- a/packages/coding-agent/src/model.ts
+++ b/packages/coding-agent/src/model.ts
@@ -31,7 +31,7 @@ export function createOpenAICompatibleModelFromEnv({
   return provider(env.AI_MODEL);
 }
 
-export function createCodingAgentModel({
+export function createCodingLanguageModel({
   override = true,
   providerName = "custom",
   quiet = true,

--- a/packages/coding-agent/src/model.ts
+++ b/packages/coding-agent/src/model.ts
@@ -1,5 +1,5 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import type { LanguageModel } from "ai";
+import type { AgentModel } from "@minpeter/pss-runtime";
 import { config } from "dotenv";
 import {
   type CodingAgentRuntimeEnv,
@@ -20,7 +20,7 @@ export interface CreateOpenAICompatibleModelFromDotenvOptions {
 export function createOpenAICompatibleModelFromEnv({
   providerName = "custom",
   runtimeEnv = process.env,
-}: CreateOpenAICompatibleModelFromEnvOptions = {}): LanguageModel {
+}: CreateOpenAICompatibleModelFromEnvOptions = {}): AgentModel {
   const env = readOpenAICompatibleModelEnv({ runtimeEnv });
   const provider = createOpenAICompatible({
     name: providerName,
@@ -35,7 +35,7 @@ export function createCodingAgentModel({
   override = true,
   providerName = "custom",
   quiet = true,
-}: CreateOpenAICompatibleModelFromDotenvOptions = {}): LanguageModel {
+}: CreateOpenAICompatibleModelFromDotenvOptions = {}): AgentModel {
   config({ override, quiet });
 
   return createOpenAICompatibleModelFromEnv({

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -1,10 +1,10 @@
-import type { AgentTools } from "@minpeter/pss-runtime";
+import type { ToolSet } from "ai";
 import { webFetchTool as defaultWebFetchTool } from "./web-fetch";
 import { webSearchTool as defaultWebSearchTool } from "./web-search";
 
 export const tools = {
   web_fetch: defaultWebFetchTool,
   web_search: defaultWebSearchTool,
-} satisfies AgentTools;
+} satisfies ToolSet;
 
 export type DefaultTools = typeof tools;

--- a/packages/coding-agent/src/tui-runner.test.ts
+++ b/packages/coding-agent/src/tui-runner.test.ts
@@ -180,6 +180,12 @@ describe("TUI runner", () => {
     releaseAfterTerminal?.();
     await run.done;
   });
+
+  it("fails waitUntil assertions when the predicate never passes", async () => {
+    await expect(waitUntil(() => false)).rejects.toThrow(
+      "Timed out waiting for TUI runner test condition"
+    );
+  });
 });
 
 function createRun(events: readonly StreamItem[]): TestRun {
@@ -252,4 +258,6 @@ async function waitUntil(predicate: () => boolean): Promise<void> {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
+
+  throw new Error("Timed out waiting for TUI runner test condition");
 }

--- a/packages/coding-agent/src/tui.ts
+++ b/packages/coding-agent/src/tui.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   Container,
   Input,
@@ -14,76 +16,88 @@ import { tools } from "./tools";
 import { createTuiRunner } from "./tui-runner";
 import { safeInlineText } from "./tui-tool-printer";
 
-const sessionConfig = resolveCodingAgentSessionConfig();
-const agent = await Agent.create({
-  instructions:
-    "Answer in 2 short sentences and 280 characters or fewer unless the user explicitly asks for detail. Avoid headings.",
-  model: createCodingAgentModel(),
-  sessions: {
-    store: new FileSessionStore(sessionConfig.directory),
-  },
-  tools,
-});
-const session = agent.session(sessionConfig.key);
+export async function startTui(): Promise<void> {
+  const sessionConfig = resolveCodingAgentSessionConfig();
+  const agent = await Agent.create({
+    instructions:
+      "Answer in 2 short sentences and 280 characters or fewer unless the user explicitly asks for detail. Avoid headings.",
+    model: createCodingAgentModel(),
+    sessions: {
+      store: new FileSessionStore(sessionConfig.directory),
+    },
+    tools,
+  });
+  const session = agent.session(sessionConfig.key);
 
-const terminal = new ProcessTerminal();
-const tui = new TUI(terminal);
+  const terminal = new ProcessTerminal();
+  const tui = new TUI(terminal);
 
-const chat = new Container();
-const input = new Input();
+  const chat = new Container();
+  const input = new Input();
 
-tui.addChild(
-  new Text(
-    `\x1b[1mpss-next\x1b[0m \x1b[2m(session ${safeInlineText(sessionConfig.key)} · Esc to interrupt · Ctrl-C to quit)\x1b[0m`,
-    1,
-    0
-  )
-);
-tui.addChild(chat);
-tui.addChild(input);
-tui.setFocus(input);
+  tui.addChild(
+    new Text(
+      `\x1b[1mpss-next\x1b[0m \x1b[2m(session ${safeInlineText(sessionConfig.key)} · Esc to interrupt · Ctrl-C to quit)\x1b[0m`,
+      1,
+      0
+    )
+  );
+  tui.addChild(chat);
+  tui.addChild(input);
+  tui.setFocus(input);
 
-let finish: () => void;
-const done = new Promise<void>((resolve) => {
-  finish = resolve;
-});
+  let finish: () => void;
+  const done = new Promise<void>((resolveDone) => {
+    finish = resolveDone;
+  });
 
-const addLine = (text: string): void => {
-  chat.addChild(new Text(text, 1, 0));
-  tui.requestRender();
-};
+  const addLine = (text: string): void => {
+    chat.addChild(new Text(text, 1, 0));
+    tui.requestRender();
+  };
 
-const runner = createTuiRunner({
-  addLine,
-  requestRender: () => tui.requestRender(),
-  session,
-});
+  const runner = createTuiRunner({
+    addLine,
+    requestRender: () => tui.requestRender(),
+    session,
+  });
 
-input.onSubmit = (text) => {
-  input.setValue("");
-  runner.submit(text);
-};
+  input.onSubmit = (text) => {
+    input.setValue("");
+    runner.submit(text);
+  };
 
-const removeInputListener = tui.addInputListener((data) => {
-  // Avoid input.onEscape because pi-tui maps both Escape and Ctrl-C to it.
-  if (matchesKey(data, "escape")) {
-    session.interrupt();
+  const removeInputListener = tui.addInputListener((data) => {
+    // Avoid input.onEscape because pi-tui maps both Escape and Ctrl-C to it.
+    if (matchesKey(data, "escape")) {
+      session.interrupt();
+      return { consume: true };
+    }
+
+    if (!matchesKey(data, "ctrl+c")) {
+      return;
+    }
+
+    removeInputListener();
+    session.kill();
+    runner.clearActiveRun();
+    tui.stop();
+    finish();
     return { consume: true };
-  }
+  });
 
-  if (!matchesKey(data, "ctrl+c")) {
-    return;
-  }
+  tui.start();
+  tui.requestRender();
 
-  removeInputListener();
-  session.kill();
-  runner.clearActiveRun();
-  tui.stop();
-  finish();
-  return { consume: true };
-});
+  await done;
+}
 
-tui.start();
-tui.requestRender();
+function isMainModule(moduleUrl: string, argvPath = process.argv[1]): boolean {
+  return (
+    argvPath !== undefined && moduleUrl === pathToFileURL(resolve(argvPath)).href
+  );
+}
 
-await done;
+if (isMainModule(import.meta.url)) {
+  await startTui();
+}

--- a/packages/coding-agent/src/tui.ts
+++ b/packages/coding-agent/src/tui.ts
@@ -94,7 +94,8 @@ export async function startTui(): Promise<void> {
 
 function isMainModule(moduleUrl: string, argvPath = process.argv[1]): boolean {
   return (
-    argvPath !== undefined && moduleUrl === pathToFileURL(resolve(argvPath)).href
+    argvPath !== undefined &&
+    moduleUrl === pathToFileURL(resolve(argvPath)).href
   );
 }
 

--- a/packages/coding-agent/src/tui.ts
+++ b/packages/coding-agent/src/tui.ts
@@ -10,7 +10,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { Agent } from "@minpeter/pss-runtime";
 import { FileSessionStore } from "@minpeter/pss-runtime/session-store/file";
-import { createCodingAgentModel } from "./model";
+import { createCodingLanguageModel } from "./model";
 import { resolveCodingAgentSessionConfig } from "./session-config";
 import { tools } from "./tools";
 import { createTuiRunner } from "./tui-runner";
@@ -21,7 +21,7 @@ export async function startTui(): Promise<void> {
   const agent = await Agent.create({
     instructions:
       "Answer in 2 short sentences and 280 characters or fewer unless the user explicitly asks for detail. Avoid headings.",
-    model: createCodingAgentModel(),
+    model: createCodingLanguageModel(),
     sessions: {
       store: new FileSessionStore(sessionConfig.directory),
     },

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -48,7 +48,7 @@
 
   - Add `history` hydration via `SessionOptions` in `Agent.createSession()` and `AgentSession` constructor.
   - Introduce `getHistory()` to retrieve the current snapshot of the agent's message history.
-  - Add `onHistoryChange` lifecycle callback hook to `AgentSession` (and underlying `AgentModelHistory`) to observe and persist serialized mutation-time history snapshots.
+  - Add `onHistoryChange` lifecycle callback hook to `AgentSession` (and underlying model history) to observe and persist serialized mutation-time history snapshots.
   - Keep `kill()` from hanging active turns that are waiting on stalled history persistence.
   - Export `AgentMessage` globally from `@minpeter/pss-runtime` for clean external representation of internal AI SDK message structures.
 

--- a/packages/runtime/src/agent-loop.test.ts
+++ b/packages/runtime/src/agent-loop.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { runAgentLoop } from "./agent-loop";
 import type { Llm, RuntimeLlmContext } from "./llm";
 import type { AgentEvent } from "./session/events";
-import { AgentModelHistory } from "./session/history";
+import { ModelMessageHistory } from "./session/history";
 import {
   assistantMessage,
   createDeferred,
@@ -29,7 +29,7 @@ const waitFor = async (condition: () => boolean) => {
 describe("runAgentLoop", () => {
   it("continues after assistant messages request any tool", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const toolCall = toolCallPart("call-tool-1");
     const llm = createScriptedLlm([
       [
@@ -85,7 +85,7 @@ describe("runAgentLoop", () => {
   it("calls step hooks around each model loop step", async () => {
     const hookCalls: string[] = [];
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const toolCall = toolCallPart("call-tool-hooks");
     const llm = createScriptedLlm([
       [assistantMessage([toolCall]), toolResultFor(toolCall)],
@@ -129,7 +129,7 @@ describe("runAgentLoop", () => {
 
   it("keeps appended output and continues when afterStep throws", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const toolCall = toolCallPart("call-tool-after-step");
     const seenHistory: RuntimeLlmContext["history"][] = [];
     let calls = 0;
@@ -184,7 +184,7 @@ describe("runAgentLoop", () => {
 
   it("returns aborted before emitting a step when beforeStep aborts", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const controller = new AbortController();
     let llmCalled = false;
 
@@ -214,7 +214,7 @@ describe("runAgentLoop", () => {
 
   it("rejects before emitting a step when beforeStep throws", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     let llmCalled = false;
 
     await expect(
@@ -242,7 +242,7 @@ describe("runAgentLoop", () => {
 
   it("returns aborted when the LLM rejects after the signal is aborted", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const controller = new AbortController();
     const abortingLlm: Llm = () => {
       controller.abort();
@@ -266,7 +266,7 @@ describe("runAgentLoop", () => {
 
   it("returns aborted when the LLM resolves empty output after the signal is aborted", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const controller = new AbortController();
     const emptyAbortingLlm: Llm = () => {
       controller.abort();
@@ -290,7 +290,7 @@ describe("runAgentLoop", () => {
 
   it("does not call the LLM until the awaited step-start boundary resolves", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const stepStart = createDeferred();
     let llmCalls = 0;
     const llm: Llm = () => {
@@ -328,7 +328,7 @@ describe("runAgentLoop", () => {
 
   it("does not start the next LLM call until the awaited step-end boundary resolves", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const firstStepEnd = createDeferred();
     const toolCall = toolCallPart("call-tool-1");
     let llmCalls = 0;
@@ -384,7 +384,7 @@ describe("runAgentLoop", () => {
 
   it("does not complete until the awaited final step-end boundary resolves", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const stepEnd = createDeferred();
     const llm = createScriptedLlm([[assistantMessage("DONE")]]);
     let settled = false;
@@ -421,7 +421,7 @@ describe("runAgentLoop", () => {
 
   it("continues after step-end boundary input even without a tool call", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     let llmCalls = 0;
     let stepEndCount = 0;
     const llm = createScriptedLlm([
@@ -464,7 +464,7 @@ describe("runAgentLoop", () => {
 
   it("returns aborted when aborted while waiting for a boundary", async () => {
     const events: AgentEvent[] = [];
-    const history = new AgentModelHistory();
+    const history = new ModelMessageHistory();
     const controller = new AbortController();
     const stepStart = createDeferred();
     let llmCalls = 0;

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -1,10 +1,6 @@
 import type { LanguageModel, ToolSet } from "ai";
 import type { AgentHooks } from "./hooks";
-import {
-  type AgentToolChoice,
-  createLlm,
-  type Llm,
-} from "./llm";
+import { type AgentToolChoice, createLlm, type Llm } from "./llm";
 import type { AgentRun } from "./session/run";
 import { type AgentInput, AgentSession } from "./session/session";
 import { MemorySessionStore } from "./session/store/memory";

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -10,7 +10,7 @@ import { type AgentInput, AgentSession } from "./session/session";
 import { MemorySessionStore } from "./session/store/memory";
 import type { SessionStore } from "./session/store/types";
 
-interface AgentModelOptions {
+interface AgentLanguageModelOptions {
   hooks?: AgentHooks;
   instructions?: string;
   llm?: never;
@@ -41,7 +41,7 @@ export interface SessionHandle {
   steer(input: AgentInput): Promise<AgentRun>;
 }
 
-export type AgentOptions = AgentModelOptions | AgentLlmOptions;
+export type AgentOptions = AgentLanguageModelOptions | AgentLlmOptions;
 
 export class Agent {
   readonly #hooks?: AgentHooks;

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -1,8 +1,7 @@
+import type { LanguageModel, ToolSet } from "ai";
 import type { AgentHooks } from "./hooks";
 import {
-  type AgentModel,
   type AgentToolChoice,
-  type AgentTools,
   createLlm,
   type Llm,
 } from "./llm";
@@ -15,10 +14,10 @@ interface AgentModelOptions {
   hooks?: AgentHooks;
   instructions?: string;
   llm?: never;
-  model: AgentModel;
+  model: LanguageModel;
   sessions?: AgentSessionOptions;
   toolChoice?: AgentToolChoice;
-  tools?: AgentTools;
+  tools?: ToolSet;
 }
 
 interface AgentLlmOptions {

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -1,6 +1,6 @@
-import type { LanguageModel } from "ai";
 import type { AgentHooks } from "./hooks";
 import {
+  type AgentModel,
   type AgentToolChoice,
   type AgentTools,
   createLlm,
@@ -15,7 +15,7 @@ interface AgentModelOptions {
   hooks?: AgentHooks;
   instructions?: string;
   llm?: never;
-  model: LanguageModel;
+  model: AgentModel;
   sessions?: AgentSessionOptions;
   toolChoice?: AgentToolChoice;
   tools?: AgentTools;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -15,12 +15,9 @@ export type {
   AgentTurnResult,
 } from "./hooks";
 export type {
-  AgentModel,
-  AgentTool,
   AgentToolChoice,
   AgentToolExecute,
   AgentToolExecutionOptions,
-  AgentTools,
   LlmOutputPart,
   RuntimeCreateLlmOptions,
   RuntimeLlm,

--- a/packages/runtime/src/llm.test.ts
+++ b/packages/runtime/src/llm.test.ts
@@ -1,7 +1,6 @@
-import type { LanguageModel } from "ai";
+import type { LanguageModel, ToolSet } from "ai";
 import { jsonSchema, tool } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentTools } from "./llm";
 import { assistantMessage, userText } from "./test-fixtures";
 
 const { generateTextMock } = vi.hoisted(() => ({
@@ -66,7 +65,7 @@ describe("createLlm", () => {
 
   it("passes injected tools to generateText", async () => {
     const createLlm = await loadCreateLlm();
-    const injectedTools = { injected: createNoopTool() } satisfies AgentTools;
+    const injectedTools = { injected: createNoopTool() } satisfies ToolSet;
     const signal = new AbortController().signal;
     const history = [{ role: "user" as const, content: "hello" }];
     const llm = createLlm({
@@ -126,7 +125,7 @@ describe("Agent tool wiring", () => {
 
   it("passes injected AgentOptions tools into createLlm/generateText", async () => {
     const Agent = await loadAgent();
-    const injectedTools = { injected: createNoopTool() } satisfies AgentTools;
+    const injectedTools = { injected: createNoopTool() } satisfies ToolSet;
     const agent = await Agent.create({
       model: fakeModel,
       tools: injectedTools,

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -9,11 +9,7 @@ import { generateText } from "ai";
 
 export type AgentToolExecutionOptions = ToolExecutionOptions<unknown>;
 export type AgentToolExecute = NonNullable<Tool["execute"]>;
-export type AgentTool<Input = unknown, Output = unknown> = Tool<Input, Output>;
-export type AgentTools = ToolSet;
 export type AgentToolChoice = "auto" | "required";
-export type AgentModel = LanguageModel;
-export type AgentMessage = ModelMessage;
 export type LlmOutput = Awaited<
   ReturnType<typeof generateText>
 >["responseMessages"];
@@ -28,9 +24,9 @@ export type Llm = (context: LlmContext) => Promise<LlmOutput>;
 
 export interface CreateLlmOptions {
   instructions?: string;
-  model: AgentModel;
+  model: LanguageModel;
   toolChoice?: AgentToolChoice;
-  tools?: AgentTools;
+  tools?: ToolSet;
 }
 
 export type RuntimeCreateLlmOptions = CreateLlmOptions;

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -9,7 +9,7 @@ import { generateText } from "ai";
 
 export type AgentToolExecutionOptions = ToolExecutionOptions<unknown>;
 export type AgentToolExecute = NonNullable<Tool["execute"]>;
-export type AgentTool = Tool;
+export type AgentTool<Input = unknown, Output = unknown> = Tool<Input, Output>;
 export type AgentTools = ToolSet;
 export type AgentToolChoice = "auto" | "required";
 export type AgentModel = LanguageModel;
@@ -28,7 +28,7 @@ export type Llm = (context: LlmContext) => Promise<LlmOutput>;
 
 export interface CreateLlmOptions {
   instructions?: string;
-  model: LanguageModel;
+  model: AgentModel;
   toolChoice?: AgentToolChoice;
   tools?: AgentTools;
 }

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -2,7 +2,7 @@ import type { ModelMessage } from "ai";
 import { userInputToModelMessage } from "./mapping";
 import type { UserInput } from "./session";
 
-export class AgentModelHistory {
+export class ModelMessageHistory {
   readonly #modelHistory: ModelMessage[] = [];
   readonly #onChange?: (snapshot: ModelMessage[]) => void;
 

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -172,7 +172,9 @@ export class AgentSession {
   async #replaceWithStoredSession(): Promise<void> {
     const stored = await this.#persistence.store.load(this.#persistence.key);
     this.#storeVersion = stored?.version;
-    this.#history = new ModelMessageHistory(decodeStoredSessionSnapshot(stored));
+    this.#history = new ModelMessageHistory(
+      decodeStoredSessionSnapshot(stored)
+    );
   }
 
   async #drainInputQueue(): Promise<void> {

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -7,7 +7,7 @@ import type {
   UserMessageContentPart,
   UserText,
 } from "./events";
-import { AgentModelHistory } from "./history";
+import { ModelMessageHistory } from "./history";
 import type { AgentRun } from "./run";
 import { BufferedAgentRun } from "./run";
 import { decodeStoredSessionSnapshot, encodeSessionSnapshot } from "./snapshot";
@@ -57,7 +57,7 @@ export class AgentSession {
   #activeAbort?: AbortController;
   #activeRun?: BufferedAgentRun;
   #activeRuntimeInput?: RuntimeInputState;
-  #history = new AgentModelHistory();
+  #history = new ModelMessageHistory();
   #killed = false;
   #loadPromise?: Promise<void>;
   #loaded = false;
@@ -172,7 +172,7 @@ export class AgentSession {
   async #replaceWithStoredSession(): Promise<void> {
     const stored = await this.#persistence.store.load(this.#persistence.key);
     this.#storeVersion = stored?.version;
-    this.#history = new AgentModelHistory(decodeStoredSessionSnapshot(stored));
+    this.#history = new ModelMessageHistory(decodeStoredSessionSnapshot(stored));
   }
 
   async #drainInputQueue(): Promise<void> {

--- a/packages/runtime/src/session/snapshot.ts
+++ b/packages/runtime/src/session/snapshot.ts
@@ -1,22 +1,22 @@
-import type { AgentMessage } from "../llm";
+import type { ModelMessage } from "ai";
 import type { StoredSession } from "./store/types";
 
 export interface AgentSessionSnapshotV1 {
-  readonly history: AgentMessage[];
+  readonly history: ModelMessage[];
   readonly schemaVersion: 1;
 }
 
 export type AgentSessionSnapshot = AgentSessionSnapshotV1;
 
 export function encodeSessionSnapshot(
-  history: AgentMessage[]
+  history: ModelMessage[]
 ): AgentSessionSnapshot {
   return { schemaVersion: 1, history: structuredClone(history) };
 }
 
 export function decodeStoredSessionSnapshot(
   stored: StoredSession | null
-): AgentMessage[] {
+): ModelMessage[] {
   if (!stored) {
     return [];
   }

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -21,7 +21,7 @@ const REQUIRED_RUNTIME_ROOT_ALIASES = [
 ];
 const FORBIDDEN_RUNTIME_ROOT_ALIASES = [
   "AgentMessage",
-  "AgentModel",
+  ["Agent", "Model"].join(""),
   "AgentRunInput",
   "AgentTool",
   "AgentTools",

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -11,25 +11,8 @@ const REQUIRED_PACKAGE_BINS = {
     "pss-coding-agent": "./bin/pss.js",
   },
 };
-const RAW_RUNTIME_DECLARATION_TOKENS = [
-  "LanguageModel",
-  "ToolSet",
-  "ModelMessage",
-  "AssistantModelMessage",
-  "ToolModelMessage",
-  "generateText",
-];
-const RUNTIME_DECLARATION_ALLOWLIST = new Set([
-  "agent.d.ts",
-  "agent-loop.d.ts",
-  "llm.d.ts",
-  "session/history.d.ts",
-  "session/mapping.d.ts",
-]);
 const REQUIRED_RUNTIME_ROOT_ALIASES = [
-  "AgentModel",
   "AgentRun",
-  "AgentTools",
   "RuntimeCreateLlmOptions",
   "RuntimeInput",
   "RuntimeLlm",
@@ -38,7 +21,10 @@ const REQUIRED_RUNTIME_ROOT_ALIASES = [
 ];
 const FORBIDDEN_RUNTIME_ROOT_ALIASES = [
   "AgentMessage",
+  "AgentModel",
   "AgentRunInput",
+  "AgentTool",
+  "AgentTools",
   "RunInput",
 ];
 
@@ -321,30 +307,18 @@ function findRuntimeDeclarationLeaks({ cwd, packages }) {
     return [];
   }
 
-  const runtimeDist = packageDistPath(cwd, "runtime");
-  const declarationFiles = listFiles(runtimeDist, (file) =>
-    file.endsWith(".d.ts")
-  );
-  const rootDeclarationPath = join(runtimeDist, "index.d.ts");
-
-  return declarationFiles.flatMap((file) =>
-    file === rootDeclarationPath
-      ? findRuntimeRootDeclarationLeaks({ cwd, file })
-      : findRuntimeInternalDeclarationLeaks({ cwd, file, runtimeDist })
-  );
+  return findRuntimeRootDeclarationLeaks({
+    cwd,
+    file: join(packageDistPath(cwd, "runtime"), "index.d.ts"),
+  });
 }
 
 function findRuntimeRootDeclarationLeaks({ cwd, file }) {
   const text = readFileSync(file, "utf8");
-  const errors = RAW_RUNTIME_DECLARATION_TOKENS.filter((token) =>
-    text.includes(token)
-  ).map(
-    (token) =>
-      `${relativeToCwd(cwd, file)}: root declaration exposes raw AI SDK token ${token}`
-  );
+  const errors = [];
 
   for (const alias of FORBIDDEN_RUNTIME_ROOT_ALIASES) {
-    if (text.includes(alias)) {
+    if (hasDeclarationToken(text, alias)) {
       errors.push(
         `${relativeToCwd(cwd, file)}: root declaration exposes internal runtime alias ${alias}`
       );
@@ -358,23 +332,15 @@ function findRuntimeRootDeclarationLeaks({ cwd, file }) {
       );
     }
   }
-
   return errors;
 }
 
-function findRuntimeInternalDeclarationLeaks({ cwd, file, runtimeDist }) {
-  const relative = relativeToCwd(runtimeDist, file);
-  if (RUNTIME_DECLARATION_ALLOWLIST.has(relative)) {
-    return [];
-  }
+function hasDeclarationToken(text, token) {
+  return new RegExp(`\\b${escapeRegExp(token)}\\b`).test(text);
+}
 
-  const text = readFileSync(file, "utf8");
-  return RAW_RUNTIME_DECLARATION_TOKENS.filter((token) =>
-    text.includes(token)
-  ).map(
-    (token) =>
-      `${relativeToCwd(cwd, file)}: unauthorized runtime declaration token ${token}`
-  );
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function relativeToCwd(cwd, file) {

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -17,7 +17,7 @@ import {
 const cliBinReadFailurePattern =
   /^packages\/coding-agent\/bin\/pss\.js: cannot read CLI bin target /;
 const runtimeRootDeclaration =
-  'export type { AgentModel, AgentRun, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n';
+  'export type { AgentRun, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n';
 
 let tempRoots = [];
 
@@ -214,21 +214,19 @@ describe("verifyReleaseArtifacts", () => {
     );
   });
 
-  it("rejects raw AI SDK canary types from runtime public declarations", () => {
+  it("allows direct AI SDK types in runtime public declarations", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'import type { LanguageModel } from "ai";\nexport type AgentModel = LanguageModel;\nexport type { AgentRun, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      'import type { LanguageModel, ToolSet } from "ai";\nexport interface AgentOptions { model: LanguageModel; tools?: ToolSet; }\nexport type { AgentRun, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
     );
 
     expect(
       verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
-    ).toEqual([
-      "packages/runtime/dist/index.d.ts: root declaration exposes raw AI SDK token LanguageModel",
-    ]);
+    ).toEqual([]);
   });
 
-  it("rejects raw AI SDK message types from runtime hook declarations", () => {
+  it("allows direct AI SDK message types in internal runtime declarations", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "hooks.d.ts"),
@@ -237,22 +235,23 @@ describe("verifyReleaseArtifacts", () => {
 
     expect(
       verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
-    ).toEqual([
-      "packages/runtime/dist/hooks.d.ts: unauthorized runtime declaration token ModelMessage",
-    ]);
+    ).toEqual([]);
   });
 
-  it("rejects internal runtime message aliases from root declarations", () => {
+  it("rejects redundant runtime AI SDK aliases from root declarations", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'export type { AgentMessage, AgentModel, AgentRun, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      'export type { AgentMessage, AgentModel, AgentRun, AgentTool, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
     );
 
     expect(
       verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
     ).toEqual([
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentMessage",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentModel",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentTool",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentTools",
     ]);
   });
 
@@ -260,7 +259,7 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'export type { AgentModel, AgentRun, AgentRunInput, AgentTools, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      'export type { AgentRun, AgentRunInput, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
     );
 
     expect(
@@ -271,7 +270,7 @@ describe("verifyReleaseArtifacts", () => {
     ]);
   });
 
-  it("allows raw AI SDK types inside allowlisted internal runtime declarations", () => {
+  it("allows direct AI SDK types inside internal runtime declarations", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
@@ -279,7 +278,7 @@ describe("verifyReleaseArtifacts", () => {
     );
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "llm.d.ts"),
-      'import type { LanguageModel } from "ai";\nexport type AgentModel = LanguageModel;\nexport type { AgentTools, RuntimeCreateLlmOptions, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      'import type { LanguageModel, ToolSet } from "ai";\nexport interface CreateLlmOptions { model: LanguageModel; tools?: ToolSet; }\n'
     );
 
     expect(
@@ -298,9 +297,8 @@ describe("verifyReleaseArtifacts", () => {
       []
     );
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
-      "packages/runtime/dist/index.d.ts: root declaration exposes raw AI SDK token LanguageModel",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentModel",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias AgentRun",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime alias AgentTools",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeCreateLlmOptions",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeInput",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeLlm",

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -16,6 +16,7 @@ import {
 
 const cliBinReadFailurePattern =
   /^packages\/coding-agent\/bin\/pss\.js: cannot read CLI bin target /;
+const removedModelAlias = ["Agent", "Model"].join("");
 const runtimeRootDeclaration =
   'export type { AgentRun, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n';
 
@@ -242,14 +243,14 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'export type { AgentMessage, AgentModel, AgentRun, AgentTool, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+      `export type { AgentMessage, ${removedModelAlias}, AgentRun, AgentTool, AgentTools, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n`
     );
 
     expect(
       verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
     ).toEqual([
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentMessage",
-      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentModel",
+      `packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias ${removedModelAlias}`,
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentTool",
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentTools",
     ]);
@@ -290,14 +291,13 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'import type { LanguageModel } from "ai";\nexport type AgentModel = LanguageModel;\n'
+      'import type { LanguageModel } from "ai";\nexport interface AgentOptions { model: LanguageModel; }\n'
     );
 
     expect(verifyReleaseArtifacts({ cwd, packages: ["coding-agent"] })).toEqual(
       []
     );
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
-      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentModel",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias AgentRun",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeCreateLlmOptions",
       "packages/runtime/dist/index.d.ts: missing explicit runtime alias RuntimeInput",


### PR DESCRIPTION
## Summary
- correct the root multimodal runtime send example
- make the coding-agent TUI subpath import-safe by exporting startTui and calling it from the bin entrypoint
- remove redundant runtime aliases for AI SDK model/tool/message types and use AI SDK types directly
- make the TUI runner waitUntil test helper fail on timeout
- add a patch changeset

## Verification
- pnpm --filter @minpeter/pss-coding-agent test
- pnpm --filter @minpeter/pss-runtime test
- pnpm exec vitest run scripts/*.test.mjs
- pnpm typecheck
- pnpm build
- pnpm verify:release
- pnpm test
- node --input-type=module -e 'const mod = await import("./packages/coding-agent/dist/tui.js"); if (typeof mod.startTui !== "function") throw new Error("missing startTui export"); console.log("tui import safe")'