### PR TITLE
Hide runtime internals from root API

### DIFF
--- a/.changeset/hide-runtime-loop.md
+++ b/.changeset/hide-runtime-loop.md
@@ -4,4 +4,4 @@
 
 Hide the internal agent loop runner from the root runtime export and clarify the session store version contract so stores own loaded-session versions while commit payloads carry state only.
 
-Rename the synchronized run event iterator from `run.stream()` to `run.events()` across the runtime API and examples.
+Rename the synchronized run event iterator from `run.stream()` to `run.events()` across the runtime API and examples. This intentionally removes `run.stream()`; replace calls with `run.events()`.

--- a/.changeset/hide-runtime-loop.md
+++ b/.changeset/hide-runtime-loop.md
@@ -3,3 +3,5 @@
 ---
 
 Hide the internal agent loop runner from the root runtime export and clarify the session store version contract so stores own loaded-session versions while commit payloads carry state only.
+
+Rename the synchronized run event iterator from `run.stream()` to `run.events()` across the runtime API and examples.

--- a/.changeset/hide-runtime-loop.md
+++ b/.changeset/hide-runtime-loop.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Hide the internal agent loop runner from the root runtime export and clarify the session store version contract so stores own loaded-session versions while commit payloads carry state only.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ const agent = await Agent.create({
   tools,
 });
 const run = await agent.send("Hello");
-for await (const event of run.stream()) {
+for await (const event of run.events()) {
   console.dir(event, { depth: null });
 }
 ```
 
-`run.stream()` is synchronized and drives the run. Consume it to let the runtime
+`run.events()` is synchronized and drives the run. Consume it to let the runtime
 cross lifecycle boundaries such as `turn-start`, `step-start`, and `step-end`.
 Use `session.send(input)` for a new user turn. If a run is already active, the
 turn is queued until the active run finishes. Use `session.steer(input)` when the
@@ -34,7 +34,7 @@ const session = agent.session("default");
 const run = await session.send("Write a two sentence summary.");
 let addedConstraint = false;
 
-for await (const event of run.stream()) {
+for await (const event of run.events()) {
   if (event.type === "step-end" && !addedConstraint) {
     addedConstraint = true;
     await session.steer("Keep the second sentence under 10 words.");

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -27,7 +27,7 @@ const session = agent.session("default");
 const run = await session.send("Write a short summary.");
 let steered = false;
 
-for await (const event of run.stream()) {
+for await (const event of run.events()) {
   console.log(event);
 
   if (event.type === "step-end" && !steered) {

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -13,14 +13,14 @@ const agent = await Agent.create({
 });
 
 const run = await agent.send("Hello from pss");
-for await (const event of run.stream()) {
+for await (const event of run.events()) {
   console.dir(event, { depth: null });
 }
 ```
 
-`run.stream()` is synchronized and drives the run. The runtime waits at
-`turn-start`, `step-start`, and `step-end` until the stream consumer continues,
-so consume the stream to let the run progress. Use `session.send(input)` for a
+`run.events()` is synchronized and drives the run. The runtime waits at
+`turn-start`, `step-start`, and `step-end` until the events consumer continues,
+so consume the events to let the run progress. Use `session.send(input)` for a
 new user turn and `session.steer(input)` to steer the active run. If no run is
 active, `session.steer(input)` starts a normal run.
 
@@ -29,7 +29,7 @@ const session = agent.session("default");
 const run = await session.send("Explain the latest result.");
 let askedForExample = false;
 
-for await (const event of run.stream()) {
+for await (const event of run.events()) {
   if (event.type === "step-end" && !askedForExample) {
     askedForExample = true;
     await session.steer("Add one concrete example.");

--- a/packages/coding-agent/src/tui-runner.test.ts
+++ b/packages/coding-agent/src/tui-runner.test.ts
@@ -129,8 +129,8 @@ describe("TUI runner", () => {
     expect(session.steer).toHaveBeenCalledWith("extra");
   });
 
-  it("clears stale active runs when stream consumption throws", async () => {
-    const run = createRun([new Error("stream failed")]);
+  it("clears stale active runs when events consumption throws", async () => {
+    const run = createRun([new Error("events failed")]);
     const runner = createTuiRunner({
       addLine: vi.fn(),
       requestRender: vi.fn(),
@@ -188,7 +188,7 @@ describe("TUI runner", () => {
   });
 });
 
-function createRun(events: readonly StreamItem[]): TestRun {
+function createRun(events: readonly EventItem[]): TestRun {
   let eventCount = 0;
   let firstEventReadResolve: (() => void) | undefined;
   let doneResolve: (() => void) | undefined;
@@ -211,7 +211,7 @@ function createRun(events: readonly StreamItem[]): TestRun {
     stop: () => {
       stopped = true;
     },
-    async *stream() {
+    async *events() {
       try {
         for (const item of events) {
           if (stopped) {
@@ -240,14 +240,14 @@ function createRun(events: readonly StreamItem[]): TestRun {
   return run;
 }
 
-type StreamItem = AgentEvent | Error | Promise<AgentEvent>;
+type EventItem = AgentEvent | Error | Promise<AgentEvent>;
 
 interface TestRun {
   readonly done: Promise<void>;
+  events(): AsyncIterable<AgentEvent>;
   readonly eventsRead: (count: number) => Promise<void>;
   readonly firstEventRead: Promise<void>;
   readonly stop: () => void;
-  stream(): AsyncIterable<AgentEvent>;
 }
 
 async function waitUntil(predicate: () => boolean): Promise<void> {

--- a/packages/coding-agent/src/tui-runner.test.ts
+++ b/packages/coding-agent/src/tui-runner.test.ts
@@ -41,11 +41,11 @@ describe("TUI runner", () => {
   });
 
   it("steers active submissions without sending a new turn", async () => {
-    let releaseStream: (() => void) | undefined;
+    let releaseEvent: (() => void) | undefined;
     const run = createRun([
       { text: "initial", type: "user-text" },
       new Promise<AgentEvent>((resolve) => {
-        releaseStream = () => resolve({ type: "turn-end" });
+        releaseEvent = () => resolve({ type: "turn-end" });
       }),
     ]);
     const session = {
@@ -61,7 +61,7 @@ describe("TUI runner", () => {
     runner.submit("initial");
     await run.firstEventRead;
     runner.submit(" extra ");
-    releaseStream?.();
+    releaseEvent?.();
     await run.done;
 
     expect(session.send).toHaveBeenCalledTimes(1);
@@ -148,12 +148,12 @@ describe("TUI runner", () => {
   });
 
   it("clears active runs as soon as terminal turn events render", async () => {
-    let releaseStream: (() => void) | undefined;
+    let releaseEvent: (() => void) | undefined;
     let releaseAfterTerminal: (() => void) | undefined;
     const run = createRun([
       { text: "initial", type: "user-text" },
       new Promise<AgentEvent>((resolve) => {
-        releaseStream = () => resolve({ type: "turn-abort" });
+        releaseEvent = () => resolve({ type: "turn-abort" });
       }),
       new Promise<AgentEvent>((resolve) => {
         releaseAfterTerminal = () => resolve({ type: "step-start" });
@@ -172,7 +172,7 @@ describe("TUI runner", () => {
     await run.firstEventRead;
     expect(runner.activeRun).toBe(run);
 
-    releaseStream?.();
+    releaseEvent?.();
     await run.eventsRead(2);
     await waitUntil(() => runner.activeRun === undefined);
 

--- a/packages/coding-agent/src/tui-runner.ts
+++ b/packages/coding-agent/src/tui-runner.ts
@@ -83,7 +83,7 @@ export function createTuiRunner({
     activeRun = run;
 
     try {
-      for await (const event of run.stream()) {
+      for await (const event of run.events()) {
         const line = formatEvent(event);
         if (line) {
           addLine(line);

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -4,7 +4,7 @@
 
 # @minpeter/pss-runtime
 
-Minimal, platform-agnostic agent runtime with sessions keyed through `run.stream()` and
+Minimal, platform-agnostic agent runtime with sessions keyed through `run.events()` and
 opaque persistence contracts.
 
 ## Core DX
@@ -19,14 +19,14 @@ const agent = await Agent.create({
 });
 
 const run = await agent.send("Hello");
-for await (const event of run.stream()) {
+for await (const event of run.events()) {
   console.log(event);
 }
 ```
 
-`run.stream()` is the run driver. The runtime stops at synchronized lifecycle
-boundaries until the stream consumer asks for the next event, so callers must
-consume the stream for the run to progress. This is what lets code react to
+`run.events()` is the run driver. The runtime stops at synchronized lifecycle
+boundaries until the events consumer asks for the next event, so callers must
+consume the events for the run to progress. This is what lets code react to
 `turn-start`, `step-start`, and `step-end` before the next model snapshot is
 created.
 
@@ -35,8 +35,8 @@ Per-key conversations use `session(key)`:
 ```ts
 const roomSession = agent.session("room:123:user:456");
 const run = await roomSession.send(["Context: user prefers short answers", "Hi"]);
-for await (const event of run.stream()) {
-  // stream events for this single turn
+for await (const event of run.events()) {
+  // events for this single turn
 }
 ```
 
@@ -77,7 +77,7 @@ state; it does not fetch remote media, decode files, or guarantee provider suppo
 for every media type.
 
 The public transcript protocol is `AgentEvent`: live runs emit runtime-defined
-events through `run.stream()`. Provider/model message history is internal
+events through `run.events()`. Provider/model message history is internal
 continuation state, not a public history API.
 
 ## Send and Steer
@@ -92,7 +92,7 @@ values. Active steering emits `runtime-input` events. A `runtime-input` is
 runtime/API-originated input mapped internally to the model's user role. It is
 distinct from human-origin `user-text` and `user-message` events.
 
-Runtime input windows are tied to synchronized stream events:
+Runtime input windows are tied to synchronized events:
 
 - `turn-start`: input is appended after the original turn input and before the first model snapshot.
 - `step-start`: input is appended before that same step's model snapshot.
@@ -106,7 +106,7 @@ const session = agent.session("room:123:user:456");
 const run = await session.send("Draft a short answer.");
 let addedSteer = false;
 
-for await (const event of run.stream()) {
+for await (const event of run.events()) {
   if (event.type === "assistant-text") {
     process.stdout.write(event.text);
   }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -4,8 +4,8 @@
 
 # @minpeter/pss-runtime
 
-Minimal, platform-agnostic agent runtime with sessions keyed through `run.events()` and
-opaque persistence contracts.
+Minimal, platform-agnostic agent runtime with keyed sessions, synchronized
+`run.events()`, and opaque persistence contracts.
 
 ## Core DX
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -131,6 +131,12 @@ Stored session state is an opaque, versioned runtime snapshot for continuation.
 Do not inspect it as a replay log; exact replay should be modeled separately as
 an `AgentEvent` log if that capability is added later.
 
+Custom stores own version generation. `load(key)` returns the opaque `state` with
+the store-minted `version`; `commit(key, { state }, { expectedVersion })` receives
+state only and should reject stale versions by returning `{ ok: false, reason:
+"conflict" }`. On success, the store persists `{ state, version }` and returns the
+new version to the runtime.
+
 ```ts
 import type { SessionStore } from "@minpeter/pss-runtime";
 import { MemorySessionStore } from "@minpeter/pss-runtime/session-store/memory";

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@minpeter/pss-runtime",
   "version": "0.0.9",
-  "description": "Generic agent runtime for sessions, model loops, and event streams.",
+  "description": "Generic agent runtime for sessions, model loops, and synchronized run events.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/runtime/src/agent.test.ts
+++ b/packages/runtime/src/agent.test.ts
@@ -39,8 +39,8 @@ const typeFixtures = [
 ];
 
 const collectRun = async (run: Awaited<ReturnType<Agent["send"]>>) => {
-  for await (const _event of run.stream()) {
-    // Drain the stream so the run can finish.
+  for await (const _event of run.events()) {
+    // Drain the events so the run can finish.
   }
 };
 

--- a/packages/runtime/src/hooks.ts
+++ b/packages/runtime/src/hooks.ts
@@ -1,5 +1,5 @@
 import type { RuntimeLlmContext } from "./llm";
-import type { UserInput } from "./session/session";
+import type { UserInput } from "./session/input";
 
 export type AgentTurnResult = "aborted" | "completed";
 export type AgentStepResult = "completed" | "continue";

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import * as runtime from "./index";
+
+describe("runtime public exports", () => {
+  it("does not expose internal agent loop runner from package root", () => {
+    expect(runtime).not.toHaveProperty("runAgentLoop");
+  });
+});

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
-import * as runtime from "./index";
 
 describe("runtime public exports", () => {
-  it("does not expose internal agent loop runner from package root", () => {
+  it("does not expose internal agent loop runner from package root", async () => {
+    const runtime = await import("./index");
+
     expect(runtime).not.toHaveProperty("runAgentLoop");
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -4,7 +4,6 @@ export {
   type AgentSessionOptions,
   type SessionHandle,
 } from "./agent";
-export { type AgentLoopResult, runAgentLoop } from "./agent-loop";
 export type {
   AgentAfterStepContext,
   AgentAfterTurnContext,
@@ -33,6 +32,7 @@ export type {
   RuntimeInput,
   ToolCall,
   ToolResult,
+  UserInput,
   UserMessage,
   UserMessageContent,
   UserMessageContentPart,
@@ -44,10 +44,11 @@ export type {
   UserTextContent,
 } from "./session/events";
 export type { AgentRun } from "./session/run";
-export type { AgentInput, SessionInput, UserInput } from "./session/session";
+export type { AgentInput, SessionInput } from "./session/input";
 export type {
   CommitResult,
   ExpectedSessionVersion,
+  SessionStoreCommit,
   SessionStore,
   StoredSession,
 } from "./session/store/types";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -43,12 +43,12 @@ export type {
   UserText,
   UserTextContent,
 } from "./session/events";
-export type { AgentRun } from "./session/run";
 export type { AgentInput, SessionInput } from "./session/input";
+export type { AgentRun } from "./session/run";
 export type {
   CommitResult,
   ExpectedSessionVersion,
-  SessionStoreCommit,
   SessionStore,
+  SessionStoreCommit,
   StoredSession,
 } from "./session/store/types";

--- a/packages/runtime/src/llm.test.ts
+++ b/packages/runtime/src/llm.test.ts
@@ -44,8 +44,8 @@ async function loadAgent() {
   return Agent;
 }
 
-async function drainRun(run: { stream(): AsyncIterable<unknown> }) {
-  for await (const _event of run.stream()) {
+async function drainRun(run: { events(): AsyncIterable<unknown> }) {
+  for await (const _event of run.events()) {
     // Drain the run so model calls complete before assertions.
   }
 }

--- a/packages/runtime/src/session/events.test.ts
+++ b/packages/runtime/src/session/events.test.ts
@@ -1,10 +1,15 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
+const sessionImplementationImportPattern = /from "\.\/session"/;
+
 describe("session event protocol boundary", () => {
   it("does not depend on the session implementation module", async () => {
-    const source = await readFile(new URL("./events.ts", import.meta.url), "utf8");
+    const source = await readFile(
+      new URL("./events.ts", import.meta.url),
+      "utf8"
+    );
 
-    expect(source).not.toMatch(/from "\.\/session"/);
+    expect(source).not.toMatch(sessionImplementationImportPattern);
   });
 });

--- a/packages/runtime/src/session/events.test.ts
+++ b/packages/runtime/src/session/events.test.ts
@@ -1,0 +1,10 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("session event protocol boundary", () => {
+  it("does not depend on the session implementation module", async () => {
+    const source = await readFile(new URL("./events.ts", import.meta.url), "utf8");
+
+    expect(source).not.toMatch(/from "\.\/session"/);
+  });
+});

--- a/packages/runtime/src/session/events.ts
+++ b/packages/runtime/src/session/events.ts
@@ -1,48 +1,16 @@
-import type { UserInput } from "./session";
-
-export type UserTextContent = string | readonly string[];
-
-export interface UserText {
-  text: UserTextContent;
-  type: "user-text";
-}
-
-export interface UserMessageTextPart {
-  text: string;
-  type: "text";
-}
-
-export interface UserMessageImagePart {
-  image: string;
-  mediaType?: string;
-  type: "image";
-}
-
-export type UserMessageFileData =
-  | string
-  | { data: string; type: "data" }
-  | { reference: Record<string, string>; type: "reference" }
-  | { text: string; type: "text" }
-  | { type: "url"; url: string };
-
-export interface UserMessageFilePart {
-  data: UserMessageFileData;
-  filename?: string;
-  mediaType: string;
-  type: "file";
-}
-
-export type UserMessageContentPart =
-  | UserMessageFilePart
-  | UserMessageImagePart
-  | UserMessageTextPart;
-
-export type UserMessageContent = readonly UserMessageContentPart[];
-
-export interface UserMessage {
-  content: UserMessageContent;
-  type: "user-message";
-}
+import type { UserInput, UserMessage, UserText } from "./input";
+export type {
+  UserInput,
+  UserMessage,
+  UserMessageContent,
+  UserMessageContentPart,
+  UserMessageFileData,
+  UserMessageFilePart,
+  UserMessageImagePart,
+  UserMessageTextPart,
+  UserText,
+  UserTextContent,
+} from "./input";
 
 export interface RuntimeInput {
   /**

--- a/packages/runtime/src/session/events.ts
+++ b/packages/runtime/src/session/events.ts
@@ -1,4 +1,5 @@
 import type { UserInput, UserMessage, UserText } from "./input";
+
 export type {
   UserInput,
   UserMessage,

--- a/packages/runtime/src/session/history.ts
+++ b/packages/runtime/src/session/history.ts
@@ -1,6 +1,6 @@
 import type { ModelMessage } from "ai";
+import type { UserInput } from "./input";
 import { userInputToModelMessage } from "./mapping";
-import type { UserInput } from "./session";
 
 export class ModelMessageHistory {
   readonly #modelHistory: ModelMessage[] = [];

--- a/packages/runtime/src/session/input.ts
+++ b/packages/runtime/src/session/input.ts
@@ -1,0 +1,51 @@
+export type UserTextContent = string | readonly string[];
+
+export interface UserText {
+  text: UserTextContent;
+  type: "user-text";
+}
+
+export interface UserMessageTextPart {
+  text: string;
+  type: "text";
+}
+
+export interface UserMessageImagePart {
+  image: string;
+  mediaType?: string;
+  type: "image";
+}
+
+export type UserMessageFileData =
+  | string
+  | { data: string; type: "data" }
+  | { reference: Record<string, string>; type: "reference" }
+  | { text: string; type: "text" }
+  | { type: "url"; url: string };
+
+export interface UserMessageFilePart {
+  data: UserMessageFileData;
+  filename?: string;
+  mediaType: string;
+  type: "file";
+}
+
+export type UserMessageContentPart =
+  | UserMessageFilePart
+  | UserMessageImagePart
+  | UserMessageTextPart;
+
+export type UserMessageContent = readonly UserMessageContentPart[];
+
+export interface UserMessage {
+  content: UserMessageContent;
+  type: "user-message";
+}
+
+export type UserInput = UserMessage | UserText;
+export type AgentInput =
+  | readonly string[]
+  | readonly UserMessageContentPart[]
+  | string
+  | UserInput;
+export type SessionInput = AgentInput;

--- a/packages/runtime/src/session/mapping.test.ts
+++ b/packages/runtime/src/session/mapping.test.ts
@@ -12,7 +12,7 @@ import {
   userMessageToModelMessage,
   userTextToModelMessage,
 } from "./mapping";
-import type { UserInput } from "./session";
+import type { UserInput } from "./input";
 
 describe("session mapping", () => {
   it("exposes runtime-input as runtime-originated current-turn input", () => {

--- a/packages/runtime/src/session/mapping.test.ts
+++ b/packages/runtime/src/session/mapping.test.ts
@@ -7,12 +7,12 @@ import {
   userText,
 } from "../test-fixtures";
 import type { AgentEvent, RuntimeInput } from "./events";
+import type { UserInput } from "./input";
 import {
   modelMessageToAgentEvents,
   userMessageToModelMessage,
   userTextToModelMessage,
 } from "./mapping";
-import type { UserInput } from "./input";
 
 describe("session mapping", () => {
   it("exposes runtime-input as runtime-originated current-turn input", () => {

--- a/packages/runtime/src/session/mapping.ts
+++ b/packages/runtime/src/session/mapping.ts
@@ -17,7 +17,7 @@ import type {
   UserText,
   UserTextContent,
 } from "./events";
-import type { UserInput } from "./session";
+import type { UserInput } from "./input";
 
 type AssistantContentPart = Exclude<AssistantContent, string>[number];
 type ToolContentPart = ToolModelMessage["content"][number];

--- a/packages/runtime/src/session/run.test.ts
+++ b/packages/runtime/src/session/run.test.ts
@@ -10,14 +10,14 @@ const expectPending = async (promise: Promise<unknown>) => {
 };
 
 describe("AgentRun", () => {
-  it("delivers events emitted before stream consumption", async () => {
+  it("delivers events emitted before events consumption", async () => {
     const run = new BufferedAgentRun();
     run.emit({ type: "user-text", text: "hello" });
     run.emit({ type: "turn-end" });
     run.close();
 
     const events: AgentEvent[] = [];
-    for await (const event of run.stream()) {
+    for await (const event of run.events()) {
       events.push(event);
     }
 
@@ -27,11 +27,11 @@ describe("AgentRun", () => {
     ]);
   });
 
-  it("delivers events emitted after stream consumption starts", async () => {
+  it("delivers events emitted after events consumption starts", async () => {
     const run = new BufferedAgentRun();
     const events: unknown[] = [];
     const collecting = (async () => {
-      for await (const event of run.stream()) {
+      for await (const event of run.events()) {
         events.push(event);
       }
     })();
@@ -46,7 +46,7 @@ describe("AgentRun", () => {
 
   it("keeps boundary emit pending until the consumer asks for another event", async () => {
     const run = new BufferedAgentRun();
-    const iterator = run.stream()[Symbol.asyncIterator]();
+    const iterator = run.events()[Symbol.asyncIterator]();
 
     const boundary = run.emitBoundary({ type: "step-end" });
     await expect(iterator.next()).resolves.toEqual({
@@ -65,28 +65,30 @@ describe("AgentRun", () => {
     });
   });
 
-  it("rejects duplicate stream readers", () => {
+  it("rejects duplicate events readers", () => {
     const run = new BufferedAgentRun();
-    run.stream();
-    expect(() => run.stream()).toThrow(
-      "AgentRun.stream() can only be consumed once"
+    run.events();
+    expect(() => run.events()).toThrow(
+      "AgentRun.events() can only be consumed once"
     );
   });
 
   it("returns the same iterator for repeated async iterator access", () => {
     const run = new BufferedAgentRun();
-    const stream = run.stream();
+    const eventIterator = run.events();
 
-    expect(stream[Symbol.asyncIterator]()).toBe(stream[Symbol.asyncIterator]());
+    expect(eventIterator[Symbol.asyncIterator]()).toBe(
+      eventIterator[Symbol.asyncIterator]()
+    );
   });
 
   it("rejects concurrent next calls so consumers cannot prefetch", async () => {
     const run = new BufferedAgentRun();
-    const iterator = run.stream()[Symbol.asyncIterator]();
+    const iterator = run.events()[Symbol.asyncIterator]();
 
     const waitingNext = iterator.next();
     await expect(iterator.next()).rejects.toThrow(
-      "AgentRun.stream() does not allow concurrent next() calls"
+      "AgentRun.events() does not allow concurrent next() calls"
     );
 
     run.emit({ type: "turn-start" });
@@ -98,14 +100,14 @@ describe("AgentRun", () => {
 
   it("rejects same-tick prefetch when a boundary event is already queued", async () => {
     const run = new BufferedAgentRun();
-    const iterator = run.stream()[Symbol.asyncIterator]();
+    const iterator = run.events()[Symbol.asyncIterator]();
 
     const boundary = run.emitBoundary({ type: "step-end" });
     const first = iterator.next();
     const second = iterator.next();
 
     await expect(second).rejects.toThrow(
-      "AgentRun.stream() does not allow concurrent next() calls"
+      "AgentRun.events() does not allow concurrent next() calls"
     );
     await expectPending(boundary);
     await expect(first).resolves.toEqual({
@@ -126,7 +128,7 @@ describe("AgentRun", () => {
 
   it("return() settles pending boundary ack and pending next waiter", async () => {
     const run = new BufferedAgentRun();
-    const iterator = run.stream()[Symbol.asyncIterator]();
+    const iterator = run.events()[Symbol.asyncIterator]();
 
     const boundary = run.emitBoundary({ type: "step-start" });
     await expect(iterator.next()).resolves.toEqual({
@@ -146,9 +148,9 @@ describe("AgentRun", () => {
     });
   });
 
-  it("closes and discards queued events when the stream returns early", async () => {
+  it("closes and discards queued events when the events iterator returns early", async () => {
     const run = new BufferedAgentRun();
-    const iterator = run.stream()[Symbol.asyncIterator]();
+    const iterator = run.events()[Symbol.asyncIterator]();
 
     run.emit({ type: "turn-start" });
     await expect(iterator.next()).resolves.toEqual({

--- a/packages/runtime/src/session/run.ts
+++ b/packages/runtime/src/session/run.ts
@@ -1,7 +1,7 @@
 import type { AgentEvent } from "./events";
 
 export interface AgentRun {
-  stream(): AsyncIterable<AgentEvent>;
+  events(): AsyncIterable<AgentEvent>;
 }
 
 interface QueuedEvent {
@@ -20,7 +20,7 @@ export class BufferedAgentRun implements AgentRun {
   #error: unknown;
   #pendingAck: (() => void) | undefined;
   #resultPending = false;
-  #streamStarted = false;
+  #eventsStarted = false;
   #waiter: NextWaiter | undefined;
 
   emit(event: AgentEvent): void {
@@ -63,11 +63,11 @@ export class BufferedAgentRun implements AgentRun {
     waiter.resolve({ done: true, value: undefined });
   }
 
-  stream(): AsyncIterable<AgentEvent> {
-    if (this.#streamStarted) {
-      throw new Error("AgentRun.stream() can only be consumed once");
+  events(): AsyncIterable<AgentEvent> {
+    if (this.#eventsStarted) {
+      throw new Error("AgentRun.events() can only be consumed once");
     }
-    this.#streamStarted = true;
+    this.#eventsStarted = true;
 
     const iterator: AsyncIterableIterator<AgentEvent> = {
       next: () => this.#next(),
@@ -83,7 +83,7 @@ export class BufferedAgentRun implements AgentRun {
   #cancel(): void {
     this.#settleQueuedAcks();
     this.#events.length = 0;
-    this.close(undefined, "stream return");
+    this.close(undefined, "events return");
   }
 
   #enqueue(event: QueuedEvent): void {
@@ -100,7 +100,7 @@ export class BufferedAgentRun implements AgentRun {
   #next(): Promise<IteratorResult<AgentEvent>> {
     if (this.#resultPending || this.#waiter) {
       return Promise.reject(
-        new Error("AgentRun.stream() does not allow concurrent next() calls")
+        new Error("AgentRun.events() does not allow concurrent next() calls")
       );
     }
 

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -16,7 +16,12 @@ import {
 import type { AgentEvent } from "./events";
 import { userTextToModelMessage } from "./mapping";
 import { FileSessionStore } from "./store/file";
-import type { CommitResult, SessionStore, StoredSession } from "./store/types";
+import type {
+  CommitResult,
+  SessionStore,
+  SessionStoreCommit,
+  StoredSession,
+} from "./store/types";
 
 const collect = async (run: Awaited<ReturnType<Agent["send"]>>) => {
   const events: AgentEvent[] = [];
@@ -29,8 +34,8 @@ const collect = async (run: Awaited<ReturnType<Agent["send"]>>) => {
 class SpyStore implements SessionStore {
   readonly commits: Array<{
     key: string;
-    next: StoredSession;
-    version?: string | null;
+    next: SessionStoreCommit;
+    expectedVersion: string | null;
   }> = [];
   loadCount = 0;
   loadGate?: Promise<void>;
@@ -45,15 +50,12 @@ class SpyStore implements SessionStore {
 
   commit(
     key: string,
-    next: StoredSession,
-    options?: { expectedVersion?: string | null }
+    next: SessionStoreCommit,
+    options: { expectedVersion: string | null }
   ): Promise<CommitResult> {
     const current = this.sessions.get(key);
     const currentVersion = current?.version ?? null;
-    if (
-      options?.expectedVersion !== undefined &&
-      options.expectedVersion !== currentVersion
-    ) {
+    if (options.expectedVersion !== currentVersion) {
       return Promise.resolve({ ok: false, reason: "conflict" });
     }
 
@@ -62,7 +64,7 @@ class SpyStore implements SessionStore {
     this.commits.push({
       key,
       next: structuredClone(next),
-      version: options?.expectedVersion,
+      expectedVersion: options.expectedVersion,
     });
     this.sessions.set(key, stored);
     return Promise.resolve({ ok: true, version });
@@ -74,8 +76,8 @@ class ConflictOnceStore extends SpyStore {
 
   override commit(
     key: string,
-    next: StoredSession,
-    options?: { expectedVersion?: string | null }
+    next: SessionStoreCommit,
+    options: { expectedVersion: string | null }
   ): Promise<CommitResult> {
     if (this.conflictNextCommit) {
       this.conflictNextCommit = false;
@@ -92,8 +94,8 @@ class ConflictOnCommitStore extends SpyStore {
 
   override commit(
     key: string,
-    next: StoredSession,
-    options?: { expectedVersion?: string | null }
+    next: SessionStoreCommit,
+    options: { expectedVersion: string | null }
   ): Promise<CommitResult> {
     this.commitCount += 1;
     if (this.commitCount === this.conflictOnCommit) {
@@ -1278,6 +1280,8 @@ describe("Agent session API", () => {
       expect.objectContaining({ history: expect.any(Array), schemaVersion: 1 })
     );
     expect(finalCommit?.next.state).not.toBeInstanceOf(Array);
+    expect(finalCommit?.next).not.toHaveProperty("version");
+    expect(store.commits[0]?.expectedVersion).toBeNull();
   });
 
   it("refreshes stored state after commit conflicts so the handle can recover", async () => {

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -25,7 +25,7 @@ import type {
 
 const collect = async (run: Awaited<ReturnType<Agent["send"]>>) => {
   const events: AgentEvent[] = [];
-  for await (const event of run.stream()) {
+  for await (const event of run.events()) {
     events.push(event);
   }
   return events;
@@ -253,7 +253,7 @@ describe("Agent session API", () => {
     let addedStepStart = false;
     let addedStepEnd = false;
 
-    for await (const event of run.stream()) {
+    for await (const event of run.events()) {
       events.push(event);
       trace.push(`event:${event.type}`);
 
@@ -611,7 +611,7 @@ describe("Agent session API", () => {
     const events: AgentEvent[] = [];
     let injected = false;
 
-    for await (const event of run.stream()) {
+    for await (const event of run.events()) {
       events.push(event);
       if (event.type === "step-end" && !injected) {
         injected = true;
@@ -659,7 +659,7 @@ describe("Agent session API", () => {
     let addedTurnStart = false;
     let addedStepStart = false;
 
-    for await (const event of run.stream()) {
+    for await (const event of run.events()) {
       events.push(event);
       if (event.type === "turn-start" && !addedTurnStart) {
         addedTurnStart = true;
@@ -797,7 +797,7 @@ describe("Agent session API", () => {
     const runtimeInputs: AgentEvent[] = [];
     let added = false;
 
-    for await (const event of run.stream()) {
+    for await (const event of run.events()) {
       if (event.type === "step-start" && !added) {
         added = true;
         await session.steer("first");
@@ -842,7 +842,7 @@ describe("Agent session API", () => {
     const runtimeInputs: AgentEvent[] = [];
     let added = false;
 
-    for await (const event of run.stream()) {
+    for await (const event of run.events()) {
       if (event.type === "step-start" && !added) {
         added = true;
         await Promise.all([
@@ -905,7 +905,7 @@ describe("Agent session API", () => {
     const firstEvents: AgentEvent[] = [];
     let added = false;
     const firstCollecting = (async () => {
-      for await (const event of firstRun.stream()) {
+      for await (const event of firstRun.events()) {
         firstEvents.push(event);
         if (event.type === "step-start" && !added) {
           added = true;
@@ -960,7 +960,7 @@ describe("Agent session API", () => {
     const runtimeInputs: AgentEvent[] = [];
     let added = false;
 
-    for await (const event of run.stream()) {
+    for await (const event of run.events()) {
       if (event.type === "step-start" && !added) {
         added = true;
         await session.steer(input);
@@ -1084,12 +1084,12 @@ describe("Agent session API", () => {
     await expect(session.steer("late")).rejects.toThrow("Session killed");
   });
 
-  it("rejects runtime input after stream return", async () => {
+  it("rejects runtime input after events return", async () => {
     const agent = await Agent.create({
       llm: () => Promise.resolve([assistantMessage("DONE")]),
     });
     const run = await agent.send("initial");
-    const iterator = run.stream()[Symbol.asyncIterator]();
+    const iterator = run.events()[Symbol.asyncIterator]();
 
     await expect(iterator.next()).resolves.toEqual({
       done: false,
@@ -1122,7 +1122,7 @@ describe("Agent session API", () => {
     const events: AgentEvent[] = [];
     let runtimeAdd: Promise<void> | undefined;
 
-    for await (const event of run.stream()) {
+    for await (const event of run.events()) {
       events.push(event);
       if (event.type === "turn-start" && !runtimeAdd) {
         runtimeAdd = session.steer("conflicting runtime").then(() => undefined);

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,15 +1,20 @@
 import { runAgentLoop } from "../agent-loop";
 import type { AgentHooks } from "../hooks";
 import type { Llm } from "../llm";
-import type { RuntimeInput, UserMessage, UserMessageContentPart } from "./events";
+import type {
+  RuntimeInput,
+  UserMessage,
+  UserMessageContentPart,
+} from "./events";
 import { ModelMessageHistory } from "./history";
 import type { AgentInput, UserInput } from "./input";
 import type { AgentRun } from "./run";
 import { BufferedAgentRun } from "./run";
 import { decodeStoredSessionSnapshot, encodeSessionSnapshot } from "./snapshot";
 import type { SessionStore } from "./store/types";
-export type { AgentRun } from "./run";
+
 export type { AgentInput, SessionInput, UserInput } from "./input";
+export type { AgentRun } from "./run";
 
 interface SessionPersistenceOptions {
   readonly key: string;

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,26 +1,15 @@
 import { runAgentLoop } from "../agent-loop";
 import type { AgentHooks } from "../hooks";
 import type { Llm } from "../llm";
-import type {
-  RuntimeInput,
-  UserMessage,
-  UserMessageContentPart,
-  UserText,
-} from "./events";
+import type { RuntimeInput, UserMessage, UserMessageContentPart } from "./events";
 import { ModelMessageHistory } from "./history";
+import type { AgentInput, UserInput } from "./input";
 import type { AgentRun } from "./run";
 import { BufferedAgentRun } from "./run";
 import { decodeStoredSessionSnapshot, encodeSessionSnapshot } from "./snapshot";
 import type { SessionStore } from "./store/types";
-
-export type UserInput = UserMessage | UserText;
-export type AgentInput =
-  | readonly string[]
-  | readonly UserMessageContentPart[]
-  | string
-  | UserInput;
-export type SessionInput = AgentInput;
 export type { AgentRun } from "./run";
+export type { AgentInput, SessionInput, UserInput } from "./input";
 
 interface SessionPersistenceOptions {
   readonly key: string;
@@ -338,7 +327,6 @@ export class AgentSession {
       this.#persistence.key,
       {
         state: encodeSessionSnapshot(this.#history.modelSnapshot()),
-        version: this.#storeVersion,
       },
       { expectedVersion: this.#storeVersion ?? null }
     );

--- a/packages/runtime/src/session/store/file.test.ts
+++ b/packages/runtime/src/session/store/file.test.ts
@@ -19,7 +19,11 @@ describe("FileSessionStore", () => {
     const firstStore = new FileSessionStore(dir);
 
     await expect(
-      firstStore.commit("session:a", { state: { count: 1 } })
+      firstStore.commit(
+        "session:a",
+        { state: { count: 1 } },
+        { expectedVersion: null }
+      )
     ).resolves.toEqual({
       ok: true,
       version: "1",
@@ -34,8 +38,8 @@ describe("FileSessionStore", () => {
   it("isolates distinct keys", async () => {
     const dir = await tempDir();
     const store = new FileSessionStore(dir);
-    await store.commit("a", { state: { key: "a" } });
-    await store.commit("b", { state: { key: "b" } });
+    await store.commit("a", { state: { key: "a" } }, { expectedVersion: null });
+    await store.commit("b", { state: { key: "b" } }, { expectedVersion: null });
 
     await expect(store.load("a")).resolves.toMatchObject({
       state: { key: "a" },
@@ -48,7 +52,7 @@ describe("FileSessionStore", () => {
   it("detects expectedVersion conflicts", async () => {
     const dir = await tempDir();
     const store = new FileSessionStore(dir);
-    await store.commit("key", { state: { value: 1 } });
+    await store.commit("key", { state: { value: 1 } }, { expectedVersion: null });
 
     await expect(
       store.commit("key", { state: { value: 2 } }, { expectedVersion: "stale" })
@@ -58,12 +62,12 @@ describe("FileSessionStore", () => {
   it("serializes expectedVersion checks across concurrent writers", async () => {
     const dir = await tempDir();
     const store = new FileSessionStore(dir);
-    await expect(store.commit("key", { state: { value: 1 } })).resolves.toEqual(
-      {
-        ok: true,
-        version: "1",
-      }
-    );
+    await expect(
+      store.commit("key", { state: { value: 1 } }, { expectedVersion: null })
+    ).resolves.toEqual({
+      ok: true,
+      version: "1",
+    });
 
     const results = await Promise.all([
       store.commit("key", { state: { value: 2 } }, { expectedVersion: "1" }),

--- a/packages/runtime/src/session/store/file.test.ts
+++ b/packages/runtime/src/session/store/file.test.ts
@@ -52,7 +52,11 @@ describe("FileSessionStore", () => {
   it("detects expectedVersion conflicts", async () => {
     const dir = await tempDir();
     const store = new FileSessionStore(dir);
-    await store.commit("key", { state: { value: 1 } }, { expectedVersion: null });
+    await store.commit(
+      "key",
+      { state: { value: 1 } },
+      { expectedVersion: null }
+    );
 
     await expect(
       store.commit("key", { state: { value: 2 } }, { expectedVersion: "stale" })

--- a/packages/runtime/src/session/store/file.ts
+++ b/packages/runtime/src/session/store/file.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { setTimeout } from "node:timers/promises";
-import type { CommitResult, SessionStore, StoredSession } from "./types";
+import type {
+  CommitResult,
+  SessionStore,
+  SessionStoreCommit,
+  StoredSession,
+} from "./types";
 
 const LOCK_POLL_INTERVAL_MS = 10;
 const LOCK_STALE_AFTER_MS = 30_000;
@@ -38,8 +43,8 @@ export class FileSessionStore implements SessionStore {
 
   async commit(
     key: string,
-    next: StoredSession,
-    options?: { expectedVersion?: string | null }
+    next: SessionStoreCommit,
+    options: { expectedVersion: string | null }
   ): Promise<CommitResult> {
     const file = this.#fileForKey(key);
     const lockDirectory = `${file}.lock`;
@@ -49,10 +54,7 @@ export class FileSessionStore implements SessionStore {
       const current = await this.load(key);
       const currentVersion = current?.version ?? null;
 
-      if (
-        options?.expectedVersion !== undefined &&
-        options.expectedVersion !== currentVersion
-      ) {
+      if (options.expectedVersion !== currentVersion) {
         return { ok: false, reason: "conflict" };
       }
 

--- a/packages/runtime/src/session/store/index.ts
+++ b/packages/runtime/src/session/store/index.ts
@@ -2,5 +2,6 @@ export type {
   CommitResult,
   ExpectedSessionVersion,
   SessionStore,
+  SessionStoreCommit,
   StoredSession,
 } from "./types";

--- a/packages/runtime/src/session/store/memory.test.ts
+++ b/packages/runtime/src/session/store/memory.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { MemorySessionStore } from "./memory";
+import type { SessionStoreCommit } from "./types";
 
 describe("MemorySessionStore", () => {
   it("loads null for unknown sessions", async () => {
@@ -28,20 +29,40 @@ describe("MemorySessionStore", () => {
     expect(second).toEqual({ ok: true, version: "2" });
   });
 
-  it("rejects caller-supplied versions in commit payloads", async () => {
-    const store = new MemorySessionStore();
+  it("types commit payloads as state only", () => {
+    type CommitPayloadHasVersion = "version" extends keyof SessionStoreCommit
+      ? true
+      : false;
 
-    await store.commit(
-      "key",
-      // @ts-expect-error stores own versions; callers only commit state.
-      { state: { value: 1 }, version: "caller" },
-      { expectedVersion: null }
-    );
+    expectTypeOf<CommitPayloadHasVersion>().toEqualTypeOf<false>();
+    expectTypeOf<
+      Parameters<MemorySessionStore["commit"]>[1]
+    >().toEqualTypeOf<SessionStoreCommit>();
+  });
+
+  it("does not persist extra runtime payload fields", async () => {
+    const store = new MemorySessionStore();
+    const payload = {
+      state: { value: 1 },
+      ignored: true,
+      version: "caller",
+    } as SessionStoreCommit;
+
+    await store.commit("key", payload, { expectedVersion: null });
+
+    await expect(store.load("key")).resolves.toEqual({
+      state: { value: 1 },
+      version: "1",
+    });
   });
 
   it("detects expectedVersion conflicts", async () => {
     const store = new MemorySessionStore();
-    await store.commit("key", { state: { value: 1 } }, { expectedVersion: null });
+    await store.commit(
+      "key",
+      { state: { value: 1 } },
+      { expectedVersion: null }
+    );
 
     await expect(
       store.commit("key", { state: { value: 2 } }, { expectedVersion: "stale" })
@@ -50,7 +71,11 @@ describe("MemorySessionStore", () => {
 
   it("detects expectedVersion null conflicts for existing sessions", async () => {
     const store = new MemorySessionStore();
-    await store.commit("key", { state: { value: 1 } }, { expectedVersion: null });
+    await store.commit(
+      "key",
+      { state: { value: 1 } },
+      { expectedVersion: null }
+    );
 
     await expect(
       store.commit("key", { state: { value: 2 } }, { expectedVersion: null })

--- a/packages/runtime/src/session/store/memory.test.ts
+++ b/packages/runtime/src/session/store/memory.test.ts
@@ -9,7 +9,11 @@ describe("MemorySessionStore", () => {
   it("commits opaque state and increments versions", async () => {
     const store = new MemorySessionStore();
 
-    const first = await store.commit("key", { state: { value: 1 } });
+    const first = await store.commit(
+      "key",
+      { state: { value: 1 } },
+      { expectedVersion: null }
+    );
     expect(first).toEqual({ ok: true, version: "1" });
     await expect(store.load("key")).resolves.toEqual({
       state: { value: 1 },
@@ -24,9 +28,20 @@ describe("MemorySessionStore", () => {
     expect(second).toEqual({ ok: true, version: "2" });
   });
 
+  it("rejects caller-supplied versions in commit payloads", async () => {
+    const store = new MemorySessionStore();
+
+    await store.commit(
+      "key",
+      // @ts-expect-error stores own versions; callers only commit state.
+      { state: { value: 1 }, version: "caller" },
+      { expectedVersion: null }
+    );
+  });
+
   it("detects expectedVersion conflicts", async () => {
     const store = new MemorySessionStore();
-    await store.commit("key", { state: { value: 1 } });
+    await store.commit("key", { state: { value: 1 } }, { expectedVersion: null });
 
     await expect(
       store.commit("key", { state: { value: 2 } }, { expectedVersion: "stale" })
@@ -35,7 +50,7 @@ describe("MemorySessionStore", () => {
 
   it("detects expectedVersion null conflicts for existing sessions", async () => {
     const store = new MemorySessionStore();
-    await store.commit("key", { state: { value: 1 } });
+    await store.commit("key", { state: { value: 1 } }, { expectedVersion: null });
 
     await expect(
       store.commit("key", { state: { value: 2 } }, { expectedVersion: null })
@@ -45,7 +60,7 @@ describe("MemorySessionStore", () => {
   it("protects committed state from caller mutation", async () => {
     const store = new MemorySessionStore();
     const state = { nested: { value: 1 } };
-    await store.commit("key", { state });
+    await store.commit("key", { state }, { expectedVersion: null });
     state.nested.value = 2;
 
     const loaded = await store.load("key");

--- a/packages/runtime/src/session/store/memory.ts
+++ b/packages/runtime/src/session/store/memory.ts
@@ -29,7 +29,7 @@ export class MemorySessionStore implements SessionStore {
     const versionNumber = (this.#versions.get(key) ?? 0) + 1;
     const version = String(versionNumber);
     this.#versions.set(key, versionNumber);
-    this.#sessions.set(key, structuredClone({ ...next, version }));
+    this.#sessions.set(key, structuredClone({ state: next.state, version }));
     return Promise.resolve({ ok: true, version });
   }
 }

--- a/packages/runtime/src/session/store/memory.ts
+++ b/packages/runtime/src/session/store/memory.ts
@@ -1,4 +1,9 @@
-import type { CommitResult, SessionStore, StoredSession } from "./types";
+import type {
+  CommitResult,
+  SessionStore,
+  SessionStoreCommit,
+  StoredSession,
+} from "./types";
 
 export class MemorySessionStore implements SessionStore {
   readonly #sessions = new Map<string, StoredSession>();
@@ -11,16 +16,13 @@ export class MemorySessionStore implements SessionStore {
 
   commit(
     key: string,
-    next: StoredSession,
-    options?: { expectedVersion?: string | null }
+    next: SessionStoreCommit,
+    options: { expectedVersion: string | null }
   ): Promise<CommitResult> {
     const current = this.#sessions.get(key);
     const currentVersion = current?.version ?? null;
 
-    if (
-      options?.expectedVersion !== undefined &&
-      options.expectedVersion !== currentVersion
-    ) {
+    if (options.expectedVersion !== currentVersion) {
       return Promise.resolve({ ok: false, reason: "conflict" });
     }
 

--- a/packages/runtime/src/session/store/types.ts
+++ b/packages/runtime/src/session/store/types.ts
@@ -1,6 +1,10 @@
 export interface StoredSession {
-  state: unknown;
-  version?: string;
+  readonly state: unknown;
+  readonly version: string;
+}
+
+export interface SessionStoreCommit {
+  readonly state: unknown;
 }
 
 export type CommitResult =
@@ -12,8 +16,8 @@ export type ExpectedSessionVersion = string | null;
 export interface SessionStore {
   commit(
     key: string,
-    next: StoredSession,
-    options?: { expectedVersion?: ExpectedSessionVersion }
+    next: SessionStoreCommit,
+    options: { expectedVersion: ExpectedSessionVersion }
   ): Promise<CommitResult>;
   load(key: string): Promise<StoredSession | null>;
 }

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -32,11 +32,11 @@ const FORBIDDEN_RUNTIME_ROOT_ALIASES = [
 const FORBIDDEN_RUNTIME_PUBLIC_PATTERNS = [
   {
     description: "removed AgentRun.stream() API",
-    pattern: /\bstream\(\): AsyncIterable<AgentEvent>/,
+    pattern: /\bstream\(\): AsyncIterable(?:Iterator)?<AgentEvent>/,
   },
   {
-    description: "removed AgentRun.stream() error string",
-    pattern: /AgentRun\.stream\(\)/,
+    description: "removed AgentRun.stream() member",
+    pattern: /(?:\bstream\(\)\s*\{|AgentRun\.stream\(\))/,
   },
 ];
 

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -29,12 +29,23 @@ const FORBIDDEN_RUNTIME_ROOT_ALIASES = [
   "RunInput",
   "runAgentLoop",
 ];
+const FORBIDDEN_RUNTIME_PUBLIC_PATTERNS = [
+  {
+    description: "removed AgentRun.stream() API",
+    pattern: /\bstream\(\): AsyncIterable<AgentEvent>/,
+  },
+  {
+    description: "removed AgentRun.stream() error string",
+    pattern: /AgentRun\.stream\(\)/,
+  },
+];
 
 const RELATIVE_IMPORT_RE =
   /(?:from\s+["']|import\s*(?:\(\s*)?["'])(\.\.?\/[^"']+)(?:["'])/g;
 const TEST_ARTIFACT_RE =
   /(?:^|[/\\])(?:__tests__|test-fixtures?)(?:[/\\]|\.)|\.(?:test|spec)\.(?:d\.)?[cm]?js$/i;
 const JAVASCRIPT_ARTIFACT_RE = /\.[cm]?js$/;
+const RUNTIME_PUBLIC_ARTIFACT_RE = /\.(?:d\.ts|[cm]?js)$/;
 
 function parseArgs(argv) {
   const options = {
@@ -309,10 +320,32 @@ function findRuntimeDeclarationLeaks({ cwd, packages }) {
     return [];
   }
 
-  return findRuntimeRootDeclarationLeaks({
-    cwd,
-    file: join(packageDistPath(cwd, "runtime"), "index.d.ts"),
-  });
+  return [
+    ...findRuntimeRootDeclarationLeaks({
+      cwd,
+      file: join(packageDistPath(cwd, "runtime"), "index.d.ts"),
+    }),
+    ...findRuntimePublicPatternLeaks({ cwd }),
+  ];
+}
+
+function findRuntimePublicPatternLeaks({ cwd }) {
+  const errors = [];
+  const distPath = packageDistPath(cwd, "runtime");
+  const files = listFiles(distPath, (file) =>
+    RUNTIME_PUBLIC_ARTIFACT_RE.test(file)
+  );
+
+  for (const file of files) {
+    const text = readFileSync(file, "utf8");
+    for (const { description, pattern } of FORBIDDEN_RUNTIME_PUBLIC_PATTERNS) {
+      if (pattern.test(text)) {
+        errors.push(`${relativeToCwd(cwd, file)}: exposes ${description}`);
+      }
+    }
+  }
+
+  return errors;
 }
 
 function findRuntimeRootDeclarationLeaks({ cwd, file }) {

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -22,10 +22,12 @@ const REQUIRED_RUNTIME_ROOT_ALIASES = [
 const FORBIDDEN_RUNTIME_ROOT_ALIASES = [
   "AgentMessage",
   ["Agent", "Model"].join(""),
+  "AgentLoopResult",
   "AgentRunInput",
   "AgentTool",
   "AgentTools",
   "RunInput",
+  "runAgentLoop",
 ];
 
 const RELATIVE_IMPORT_RE =

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -304,7 +304,7 @@ describe("verifyReleaseArtifacts", () => {
       verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
     ).toEqual([
       "packages/runtime/dist/session/run.d.ts: exposes removed AgentRun.stream() API",
-      "packages/runtime/dist/session/run.js: exposes removed AgentRun.stream() error string",
+      "packages/runtime/dist/session/run.js: exposes removed AgentRun.stream() member",
     ]);
   });
 

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -271,6 +271,21 @@ describe("verifyReleaseArtifacts", () => {
     ]);
   });
 
+  it("rejects internal agent loop aliases from root declarations", () => {
+    const cwd = createFixture();
+    writeFileSync(
+      join(cwd, "packages", "runtime", "dist", "index.d.ts"),
+      'export { runAgentLoop, type AgentLoopResult } from "./agent-loop";\nexport type { AgentRun, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput } from "./llm";\n'
+    );
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
+    ).toEqual([
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias AgentLoopResult",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime alias runAgentLoop",
+    ]);
+  });
+
   it("allows direct AI SDK types inside internal runtime declarations", () => {
     const cwd = createFixture();
     writeFileSync(

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -286,6 +286,28 @@ describe("verifyReleaseArtifacts", () => {
     ]);
   });
 
+  it("rejects removed AgentRun stream API from runtime artifacts", () => {
+    const cwd = createFixture();
+    mkdirSync(join(cwd, "packages", "runtime", "dist", "session"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(cwd, "packages", "runtime", "dist", "session", "run.d.ts"),
+      'import type { AgentEvent } from "./events";\nexport interface AgentRun { stream(): AsyncIterable<AgentEvent>; }\n'
+    );
+    writeFileSync(
+      join(cwd, "packages", "runtime", "dist", "session", "run.js"),
+      'throw new Error("AgentRun.stream() can only be consumed once");\n'
+    );
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
+    ).toEqual([
+      "packages/runtime/dist/session/run.d.ts: exposes removed AgentRun.stream() API",
+      "packages/runtime/dist/session/run.js: exposes removed AgentRun.stream() error string",
+    ]);
+  });
+
   it("allows direct AI SDK types inside internal runtime declarations", () => {
     const cwd = createFixture();
     writeFileSync(


### PR DESCRIPTION
## Summary
- hide the internal agent loop runner from the runtime root export while keeping internal module usage intact
- move user input protocol types into a leaf session/input module to break the events/session dependency cycle
- clarify SessionStore version ownership with state-only commit payloads, store-minted versions, docs, tests, and release-artifact guards

## Verification
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build
- pnpm verify:release
- manual run surface check: `run.events()` iterates events and `run.stream` is absent
- manual package-surface checks: built root export keys are ["Agent","createLlm"], root artifacts omit runAgentLoop/AgentLoopResult, MemorySessionStore persists state-only payloads and rejects stale commits

## Review
- 5-agent review completed: goal verification PASS, QA PASS, security PASS, context/code review blockers fixed before push

## Follow-up deferred
- AgentSession responsibility decomposition

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the internal agent loop from the `@minpeter/pss-runtime` root API, formalizes store-owned session versions, and renames the run iterator to `run.events()` for clarity and stronger API boundaries.

- **Refactors**
  - Remove `runAgentLoop` and `AgentLoopResult` from root exports; add release guards and tests for these and the removed `AgentRun.stream()` API.
  - Rename `run.stream()` to `run.events()` across runtime, examples, and docs.
  - Move user input protocol types to `session/input`; `events` re-exports to avoid a dependency cycle.
  - Define `SessionStoreCommit` (state-only) and require store-owned versions; `StoredSession.version` is now required. Update stores, docs, and tests.

- **Migration**
  - Replace `run.stream()` with `run.events()`.
  - Custom `SessionStore` implementations:
    - `load(key)` must return `{ state, version }` (version required).
    - `commit(key, { state }, { expectedVersion })` must generate and return the new version and return `{ ok: false, reason: "conflict" }` on mismatches.
  - If you deep-imported input types from `session/session`, switch to `session/input`. Avoid using `runAgentLoop` from the root API.

<sup>Written for commit 3796df1a40712a3175d3b437551a25130b0b6fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/48?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

