### PR TITLE
Document steer mutation boundaries

### DIFF
--- a/.changeset/steady-ravens-breathe.md
+++ b/.changeset/steady-ravens-breathe.md
@@ -1,0 +1,6 @@
+---
+"@minpeter/pss-runtime": patch
+"@minpeter/pss-coding-agent": patch
+---
+
+Document `events()` and `session.steer()` as backpressured mutation boundaries and add a coding-agent guardrail for turn-start steering.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ for await (const event of run.events()) {
 
 `run.events()` is synchronized and drives the run. Consume it to let the runtime
 cross lifecycle boundaries such as `turn-start`, `step-start`, and `step-end`.
+These are backpressured mutation boundaries, not notification-only events: the
+runtime does not cross the boundary until the events consumer asks for the next
+event.
 Use `session.send(input)` for a new user turn. If a run is already active, the
 turn is queued until the active run finishes. Use `session.steer(input)` when the
 input should steer the active run; if no run is active, it starts a normal run.
@@ -45,6 +48,9 @@ for await (const event of run.events()) {
 The guard matters. `step-end` runtime input asks the runtime to continue the
 current turn before the next model snapshot, even after final-looking assistant
 text. Adding input on every `step-end` can keep a turn running indefinitely.
+
+To affect the first model call, finish `await session.steer(...)` inside the
+`turn-start` handler before continuing event iteration.
 
 Steering additions appear as `runtime-input` events: runtime/API-originated input
 mapped internally to the model's user role, separate from human `user-text` and

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ current turn before the next model snapshot, even after final-looking assistant
 text. Adding input on every `step-end` can keep a turn running indefinitely.
 
 To affect the first model call, finish `await session.steer(...)` inside the
-`turn-start` handler before continuing event iteration.
+`turn-start` handler before continuing event iteration. `turn-start` is an
+awaited mutation boundary, not a notification-only event.
 
 Steering additions appear as `runtime-input` events: runtime/API-originated input
 mapped internally to the model's user role, separate from human `user-text` and

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -20,8 +20,9 @@ for await (const event of run.events()) {
 
 `run.events()` is synchronized and drives the run. The runtime waits at
 `turn-start`, `step-start`, and `step-end` until the events consumer continues,
-so consume the events to let the run progress. Use `session.send(input)` for a
-new user turn and `session.steer(input)` to steer the active run. If no run is
+so consume the events to let the run progress. These are backpressured mutation
+boundaries, not notification-only events. Use `session.send(input)` for a new
+user turn and `session.steer(input)` to steer the active run. If no run is
 active, `session.steer(input)` starts a normal run.
 
 ```ts
@@ -46,6 +47,8 @@ Runtime additions emit `runtime-input`: runtime/API-originated input mapped
 internally to the model's user role, separate from human `user-text` and
 `user-message` events. `session.send(input)` starts or enqueues a new turn;
 `session.steer(input)` steers the active run or starts a normal run when idle.
+To affect the first model call, finish `await session.steer(...)` inside the
+`turn-start` handler before continuing event iteration.
 
 ## CLI
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -48,7 +48,8 @@ internally to the model's user role, separate from human `user-text` and
 `user-message` events. `session.send(input)` starts or enqueues a new turn;
 `session.steer(input)` steers the active run or starts a normal run when idle.
 To affect the first model call, finish `await session.steer(...)` inside the
-`turn-start` handler before continuing event iteration.
+`turn-start` handler before continuing event iteration. `turn-start` is an
+awaited mutation boundary, not a notification-only event.
 
 ## CLI
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run",
+    "test": "NODE_OPTIONS=--conditions=@minpeter/pss-source vitest run",
     "lint": "ultracite check ."
   },
   "dependencies": {

--- a/packages/coding-agent/src/runtime-steer.integration.test.ts
+++ b/packages/coding-agent/src/runtime-steer.integration.test.ts
@@ -1,0 +1,31 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { Agent, type RuntimeLlm } from "../../runtime/src";
+
+describe("coding-agent runtime steering integration", () => {
+  it("puts awaited turn-start steering in the first model history", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const llm: RuntimeLlm = ({ history }) => {
+      seenHistory.push([...history]);
+      return Promise.resolve([{ role: "assistant", content: "DONE" }]);
+    };
+    const agent = await Agent.create({ llm });
+    const session = agent.session("bori-turn-context");
+    const run = await session.send("original prompt");
+    let addedTurnContext = false;
+
+    for await (const event of run.events()) {
+      if (event.type === "turn-start" && !addedTurnContext) {
+        addedTurnContext = true;
+        await session.steer("turnContext: prefer concise answer");
+      }
+    }
+
+    expect(seenHistory).toEqual([
+      [
+        { role: "user", content: "original prompt" },
+        { role: "user", content: "turnContext: prefer concise answer" },
+      ],
+    ]);
+  });
+});

--- a/packages/coding-agent/src/runtime-steer.integration.test.ts
+++ b/packages/coding-agent/src/runtime-steer.integration.test.ts
@@ -1,6 +1,6 @@
+import { Agent, type RuntimeLlm } from "@minpeter/pss-runtime";
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
-import { Agent, type RuntimeLlm } from "../../runtime/src";
 
 describe("coding-agent runtime steering integration", () => {
   it("puts awaited turn-start steering in the first model history", async () => {

--- a/packages/coding-agent/tsconfig.json
+++ b/packages/coding-agent/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "customConditions": ["@minpeter/pss-source"],
     "noEmit": true
   },
   "include": ["src/**/*.ts"]

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@minpeter/pss-runtime": resolve(
+        import.meta.dirname,
+        "../runtime/src/index.ts"
+      ),
+    },
+  },
+});

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -26,8 +26,9 @@ for await (const event of run.events()) {
 
 `run.events()` is the run driver. The runtime stops at synchronized lifecycle
 boundaries until the events consumer asks for the next event, so callers must
-consume the events for the run to progress. This is what lets code react to
-`turn-start`, `step-start`, and `step-end` before the next model snapshot is
+consume the events for the run to progress. These boundaries are backpressured
+mutation boundaries, not notification-only events. This is what lets code react
+to `turn-start`, `step-start`, and `step-end` before the next model snapshot is
 created.
 
 Per-key conversations use `session(key)`:
@@ -97,6 +98,10 @@ Runtime input windows are tied to synchronized events:
 - `turn-start`: input is appended after the original turn input and before the first model snapshot.
 - `step-start`: input is appended before that same step's model snapshot.
 - `step-end`: input is appended before the next step and intentionally continues the current turn, even if the assistant text looked final.
+
+`turn-start` is a backpressured mutation boundary. To affect the first model
+call, finish `await session.steer(...)` inside the `turn-start` handler before
+continuing event iteration.
 
 Guard `step-end` insertion with a one-shot flag or a real condition. Adding input
 on every `step-end` can keep the turn running indefinitely.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -101,7 +101,8 @@ Runtime input windows are tied to synchronized events:
 
 `turn-start` is a backpressured mutation boundary. To affect the first model
 call, finish `await session.steer(...)` inside the `turn-start` handler before
-continuing event iteration.
+continuing event iteration. `turn-start` is an awaited mutation boundary, not a
+notification-only event.
 
 Guard `step-end` insertion with a one-shot flag or a real condition. Adding input
 on every `step-end` can keep the turn running indefinitely.


### PR DESCRIPTION
## Summary
- document run.events() lifecycle points as backpressured mutation boundaries, not notification-only events
- clarify that turn-start steering must await session.steer(...) before continuing event iteration to affect the first model call
- add a coding-agent integration guardrail using real pss-runtime Agent/session and an LLM history spy

## Verification
- RED: pnpm --filter @minpeter/pss-coding-agent test -- runtime-steer.integration.test.ts failed with the first model history including turnContext while the assertion omitted it
- GREEN: pnpm --filter @minpeter/pss-coding-agent test -- runtime-steer.integration.test.ts
- GREEN: pnpm --filter @minpeter/pss-runtime test -- src/session/session.test.ts
- GREEN: pnpm test
- GREEN: pnpm typecheck
- GREEN: pnpm build
- GREEN: pnpm lint
- LSP diagnostics clean on packages/coding-agent/src/runtime-steer.integration.test.ts

Reviewer gate: APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies in the READMEs that `run.events()` lifecycle points are backpressured mutation boundaries and that `turn-start` steering must await `session.steer(...)` before continuing event iteration to affect the first model call. Adds an integration guardrail in `@minpeter/pss-coding-agent` that verifies the awaited `turn-start` input appears in the first model history, and stabilizes tests by aliasing `@minpeter/pss-runtime` to source and enabling the `@minpeter/pss-source` condition.

<sup>Written for commit c9b7b0d003cb254ac3a86fc37dbeee0b4022e875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/52?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

