### PR TITLE
Add multimodal look_at CLI support

### DIFF
--- a/.changeset/look-at-images.md
+++ b/.changeset/look-at-images.md
@@ -1,0 +1,8 @@
+---
+"@minpeter/pss-runtime": patch
+"@minpeter/pss-coding-agent": patch
+---
+
+Add a runtime `look_at` helper for routing image inspection through a dedicated model.
+
+Add coding-agent `PSS_LOOK_AT_*` environment configuration and Ctrl+V image attachment support in the TUI.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,31 @@ await agent.send([
 ]);
 ```
 
+For text first models, delegate image inspection through the runtime
+`createLookAtLlm` helper. It wraps your main model with a `look_at` tool, gives
+the main model image handles instead of raw media, and sends the original image
+only to a vision-capable model when that tool runs.
+
+```ts
+import { Agent, createLookAtLlm } from "@minpeter/pss-runtime";
+
+const agent = await Agent.create({
+  llm: createLookAtLlm({
+    model: mainModel,
+    visionModel,
+  }),
+});
+
+await agent.send([
+  { type: "text", text: "What is unusual in this screenshot?" },
+  { type: "image", image: "data:image/png;base64,...", mediaType: "image/png" },
+]);
+```
+
+You can also pass your own custom `llm` or call the direct runtime APIs with a
+model that already accepts media parts. The runtime package doesn't require the
+coding agent package for image delegation.
+
 Run the TUI:
 
 ```sh

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -65,10 +65,41 @@ a run is active, submitting text calls `session.steer(trimmed)` so the text land
 in the current run and renders as dim `runtime: ...` input instead of a new human
 turn.
 
+Press `Ctrl+V` to attach one PNG or JPEG image from the clipboard to the current
+draft. Press `Enter` to submit the draft text plus any attachment through the
+runtime's multipart input. If a run is active, the multipart draft steers that
+run; otherwise it starts a new turn.
+
+Attachment and error lines only show metadata such as `[attached image/png]` or a
+short clipboard message. They don't print raw data URIs. Automated tests mock
+clipboard and platform behavior; real runtime support depends on the available OS
+clipboard command backend. macOS uses `pngpaste`, Linux Wayland uses `wl-paste`,
+and Linux X11 uses `xclip` when the matching display environment is present.
+
+When look-at vision calls fail, the injected tool returns a concise bounded tool
+error such as `Vision model failed` and the session continues.
+
 ## Env
 
-Set `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL` for the model.
+Set `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL` for the main model.
 Set `TINYFISH_API_KEY` before using `web_search` or `web_fetch`.
+
+Set `PSS_LOOK_AT_MODEL` to enable image inspection through the runtime
+`look_at` tool. When it is unset or empty, `look_at` is disabled. The `look_at` model
+uses these exact env vars:
+
+- `PSS_LOOK_AT_MODEL`: vision model id. Required to enable `look_at`.
+- `PSS_LOOK_AT_BASE_URL`: vision provider base URL. Defaults to `AI_BASE_URL`, then `https://apis.opengateway.ai/v1`.
+- `PSS_LOOK_AT_API_KEY`: vision provider API key. Defaults to `AI_API_KEY` after look-at is enabled.
+- `PSS_LOOK_AT_MAX_OUTPUT_CHARS`: maximum text returned by one vision tool result. Default: `2000`.
+- `PSS_LOOK_AT_MAX_IMAGE_BYTES`: maximum image size accepted by look-at. Default: `10485760`.
+
+Example:
+
+```sh
+PSS_LOOK_AT_MODEL=vision-model-id pss
+PSS_LOOK_AT_MODEL=vision-model-id PSS_LOOK_AT_BASE_URL=https://example.invalid/v1 pss
+```
 
 The TUI persists runtime-owned session state to files by default:
 

--- a/packages/coding-agent/src/clipboard-image.test.ts
+++ b/packages/coding-agent/src/clipboard-image.test.ts
@@ -1,0 +1,235 @@
+import type { UserMessageImagePart } from "@minpeter/pss-runtime";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ClipboardImageReader,
+  type ClipboardImageReadResult,
+  createClipboardImageReader,
+  readClipboardImagePart,
+} from "./clipboard-image";
+
+const fakePngBytes = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const fakeJpegBytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xdb]);
+const dataUri = (mediaType: string, bytes: Uint8Array) =>
+  `data:${mediaType};base64,${Buffer.from(bytes).toString("base64")}`;
+
+describe("ClipboardImageReader", () => {
+  it("converts fake PNG bytes into a runtime image part", async () => {
+    const reader = fakeReader({
+      image: fakePngBytes,
+      mediaType: "image/png",
+      type: "image",
+    });
+
+    const result = await readClipboardImagePart({ reader });
+
+    expect(reader.read).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      image: dataUri("image/png", fakePngBytes),
+      mediaType: "image/png",
+      type: "image",
+    } satisfies UserMessageImagePart);
+  });
+
+  it("converts fake JPEG bytes into a runtime image part", async () => {
+    const reader = fakeReader({
+      image: fakeJpegBytes,
+      mediaType: "image/jpeg",
+      type: "image",
+    });
+
+    await expect(readClipboardImagePart({ reader })).resolves.toEqual({
+      image: dataUri("image/jpeg", fakeJpegBytes),
+      mediaType: "image/jpeg",
+      type: "image",
+    } satisfies UserMessageImagePart);
+  });
+
+  it("reports an empty clipboard as a nonfatal no-image result", async () => {
+    const reader = fakeReader({
+      reason: "clipboard_image_not_found",
+      type: "no-image",
+    });
+
+    await expect(readClipboardImagePart({ reader })).resolves.toEqual({
+      message: "Clipboard does not contain a PNG or JPEG image.",
+      reason: "clipboard_image_not_found",
+      type: "no-image",
+    });
+  });
+
+  it("reports unsupported or headless environments without throwing", async () => {
+    const reader = fakeReader({
+      message: "No supported clipboard image reader is available.",
+      reason: "clipboard_image_unsupported_platform",
+      type: "error",
+    });
+
+    await expect(readClipboardImagePart({ reader })).resolves.toEqual({
+      message: "No supported clipboard image reader is available.",
+      reason: "clipboard_image_unsupported_platform",
+      type: "error",
+    });
+  });
+
+  it("rejects unsupported clipboard media types before creating a data URI", async () => {
+    const reader = fakeReader({
+      image: Uint8Array.from([0x47, 0x49, 0x46]),
+      mediaType: "image/gif",
+      type: "image",
+    });
+
+    await expect(readClipboardImagePart({ reader })).resolves.toEqual({
+      mediaType: "image/gif",
+      message: "Clipboard image media type image/gif is not supported.",
+      reason: "clipboard_image_unsupported_media_type",
+      type: "error",
+    });
+  });
+
+  it("rejects images over the default 10 MiB limit", async () => {
+    const reader = fakeReader({
+      byteLength: 10_485_761,
+      image: new Uint8Array(10_485_761),
+      mediaType: "image/png",
+      type: "image",
+    });
+
+    await expect(readClipboardImagePart({ reader })).resolves.toEqual({
+      byteLength: 10_485_761,
+      maxByteLength: 10_485_760,
+      message:
+        "Clipboard image is 10485761 bytes, exceeding the 10485760 byte limit.",
+      reason: "clipboard_image_too_large",
+      type: "error",
+    });
+  });
+
+  it("uses injected subprocess runners only in tests and never probes the real clipboard", async () => {
+    const pngpasteOutput = Buffer.from(
+      Buffer.from(fakePngBytes).toString("base64")
+    );
+    const run = vi.fn().mockResolvedValue({
+      stdout: pngpasteOutput,
+    });
+    const reader = createClipboardImageReader({
+      platform: "darwin",
+      run,
+    });
+
+    const result = await readClipboardImagePart({ reader });
+
+    expect(run).toHaveBeenCalledWith({
+      args: ["-b"],
+      command: "pngpaste",
+      input: undefined,
+      outputEncoding: "base64",
+    });
+    expect(result).toEqual({
+      image: dataUri("image/png", fakePngBytes),
+      mediaType: "image/png",
+      type: "image",
+    } satisfies UserMessageImagePart);
+  });
+
+  it("decodes macOS pngpaste base64 text into PNG bytes", async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: `${Buffer.from(fakePngBytes).toString("base64")}\n`,
+    });
+    const reader = createClipboardImageReader({
+      platform: "darwin",
+      run,
+    });
+
+    await expect(readClipboardImagePart({ reader })).resolves.toEqual({
+      image: dataUri("image/png", fakePngBytes),
+      mediaType: "image/png",
+      type: "image",
+    } satisfies UserMessageImagePart);
+  });
+
+  it("selects wl-paste for Linux Wayland sessions", async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: Buffer.from(fakePngBytes),
+    });
+    const reader = createClipboardImageReader({
+      env: { WAYLAND_DISPLAY: "wayland-1" },
+      platform: "linux",
+      run,
+    });
+
+    await readClipboardImagePart({ reader });
+
+    expect(run).toHaveBeenCalledWith({
+      args: ["--type", "image/png"],
+      command: "wl-paste",
+      input: undefined,
+      mediaType: "image/png",
+      outputEncoding: "bytes",
+    });
+  });
+
+  it("selects xclip for Linux X11 sessions", async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: Buffer.from(fakePngBytes),
+    });
+    const reader = createClipboardImageReader({
+      env: { DISPLAY: ":0" },
+      platform: "linux",
+      run,
+    });
+
+    await readClipboardImagePart({ reader });
+
+    expect(run).toHaveBeenCalledWith({
+      args: ["-selection", "clipboard", "-t", "image/png", "-o"],
+      command: "xclip",
+      input: undefined,
+      mediaType: "image/png",
+      outputEncoding: "bytes",
+    });
+  });
+
+  it("reports headless Linux without running a command", async () => {
+    const run = vi.fn();
+    const reader = createClipboardImageReader({
+      env: {},
+      platform: "linux",
+      run,
+    });
+
+    await expect(readClipboardImagePart({ reader })).resolves.toEqual({
+      message:
+        "No supported clipboard image reader is available. Set WAYLAND_DISPLAY or DISPLAY and install wl-paste or xclip.",
+      reason: "clipboard_image_unsupported_platform",
+      type: "error",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("reports missing clipboard commands without throwing", async () => {
+    const run = vi.fn().mockRejectedValue(
+      Object.assign(new Error("missing"), {
+        code: "ENOENT",
+      })
+    );
+    const reader = createClipboardImageReader({
+      platform: "darwin",
+      run,
+    });
+
+    await expect(readClipboardImagePart({ reader })).resolves.toEqual({
+      message:
+        "Clipboard image reader command pngpaste was not found. Install it and try again.",
+      reason: "clipboard_image_command_missing",
+      type: "error",
+    });
+  });
+});
+
+function fakeReader(result: ClipboardImageReadResult): ClipboardImageReader {
+  return {
+    read: vi.fn().mockResolvedValue(result),
+  };
+}

--- a/packages/coding-agent/src/clipboard-image.ts
+++ b/packages/coding-agent/src/clipboard-image.ts
@@ -1,0 +1,327 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { UserMessageImagePart } from "@minpeter/pss-runtime";
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_CLIPBOARD_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+
+export type ClipboardImageMediaType = "image/jpeg" | "image/png";
+
+export type ClipboardImageReadResult =
+  | ClipboardImageErrorResult
+  | ClipboardImageNoImageResult
+  | ClipboardImageSuccessResult;
+
+export interface ClipboardImageSuccessResult {
+  readonly byteLength?: number;
+  readonly image: Uint8Array;
+  readonly mediaType: string;
+  readonly type: "image";
+}
+
+export interface ClipboardImageNoImageResult {
+  readonly message?: string;
+  readonly reason: "clipboard_image_not_found";
+  readonly type: "no-image";
+}
+
+export interface ClipboardImageErrorResult {
+  readonly byteLength?: number;
+  readonly maxByteLength?: number;
+  readonly mediaType?: string;
+  readonly message: string;
+  readonly reason:
+    | "clipboard_image_command_missing"
+    | "clipboard_image_too_large"
+    | "clipboard_image_unsupported_media_type"
+    | "clipboard_image_unsupported_platform";
+  readonly type: "error";
+}
+
+export interface ClipboardImageReader {
+  read(): Promise<ClipboardImageReadResult>;
+}
+
+export interface ClipboardImageCommand {
+  readonly args: readonly string[];
+  readonly command: string;
+  readonly input?: Uint8Array;
+  readonly mediaType?: ClipboardImageMediaType;
+  readonly outputEncoding?: "base64" | "bytes";
+}
+
+export interface ClipboardImageCommandResult {
+  readonly stdout: Buffer | Uint8Array | string;
+}
+
+export type ClipboardImageCommandRunner = (
+  command: ClipboardImageCommand
+) => Promise<ClipboardImageCommandResult>;
+
+export interface CreateClipboardImageReaderOptions {
+  readonly env?: ClipboardImageEnv;
+  readonly platform?: NodeJS.Platform | string;
+  readonly run?: ClipboardImageCommandRunner;
+  readonly runCommand?: ClipboardImageCommandRunner;
+}
+
+export interface ReadClipboardImagePartOptions {
+  readonly maxByteLength?: number;
+  readonly reader?: ClipboardImageReader;
+}
+
+type ClipboardImageEnv = Record<string, string | undefined>;
+
+type ReadClipboardImagePartResult =
+  | ClipboardImageErrorResult
+  | ClipboardImageNoImageResult
+  | UserMessageImagePart;
+
+export async function readClipboardImagePart(
+  options: ReadClipboardImagePartOptions = {}
+): Promise<ReadClipboardImagePartResult> {
+  const result = await (options.reader ?? createClipboardImageReader()).read();
+
+  if (result.type !== "image") {
+    return normalizeNonImageResult(result);
+  }
+
+  const mediaType = readSupportedMediaType(result.mediaType);
+
+  if (!mediaType) {
+    return {
+      mediaType: result.mediaType,
+      message: `Clipboard image media type ${result.mediaType} is not supported.`,
+      reason: "clipboard_image_unsupported_media_type",
+      type: "error",
+    };
+  }
+
+  const byteLength = result.byteLength ?? result.image.byteLength;
+  const maxByteLength =
+    options.maxByteLength ?? DEFAULT_CLIPBOARD_IMAGE_MAX_BYTES;
+
+  if (byteLength > maxByteLength) {
+    return {
+      byteLength,
+      maxByteLength,
+      message: `Clipboard image is ${byteLength} bytes, exceeding the ${maxByteLength} byte limit.`,
+      reason: "clipboard_image_too_large",
+      type: "error",
+    };
+  }
+
+  return {
+    image: `data:${mediaType};base64,${Buffer.from(result.image).toString(
+      "base64"
+    )}`,
+    mediaType,
+    type: "image",
+  };
+}
+
+export function createClipboardImageReader(
+  options: CreateClipboardImageReaderOptions = {}
+): ClipboardImageReader {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const command = selectClipboardImageCommand(platform, env);
+  const run = options.run ?? options.runCommand ?? runClipboardImageCommand;
+
+  return {
+    async read() {
+      if (!command) {
+        return unsupportedPlatformResult(platform);
+      }
+
+      try {
+        const output = await run(command);
+        const image = toUint8Array(
+          output.stdout,
+          command.outputEncoding ?? "bytes"
+        );
+
+        if (image.byteLength === 0) {
+          return noImageResult();
+        }
+
+        const mediaType = detectImageMediaType(image) ?? command.mediaType;
+
+        if (!mediaType) {
+          return {
+            mediaType: "application/octet-stream",
+            message:
+              "Clipboard image media type application/octet-stream is not supported.",
+            reason: "clipboard_image_unsupported_media_type",
+            type: "error",
+          };
+        }
+
+        return {
+          image,
+          mediaType,
+          type: "image",
+        };
+      } catch (error) {
+        return commandErrorResult(error, command.command);
+      }
+    },
+  };
+}
+
+function selectClipboardImageCommand(
+  platform: NodeJS.Platform | string,
+  env: ClipboardImageEnv
+): ClipboardImageCommand | undefined {
+  if (platform === "darwin") {
+    return {
+      args: ["-b"],
+      command: "pngpaste",
+      input: undefined,
+      outputEncoding: "base64",
+    };
+  }
+
+  if (platform !== "linux") {
+    return;
+  }
+
+  if (nonEmpty(env.WAYLAND_DISPLAY)) {
+    return {
+      args: ["--type", "image/png"],
+      command: "wl-paste",
+      input: undefined,
+      mediaType: "image/png",
+      outputEncoding: "bytes",
+    };
+  }
+
+  if (nonEmpty(env.DISPLAY)) {
+    return {
+      args: ["-selection", "clipboard", "-t", "image/png", "-o"],
+      command: "xclip",
+      input: undefined,
+      mediaType: "image/png",
+      outputEncoding: "bytes",
+    };
+  }
+
+  return;
+}
+
+async function runClipboardImageCommand(
+  command: ClipboardImageCommand
+): Promise<ClipboardImageCommandResult> {
+  const { stdout } = await execFileAsync(command.command, [...command.args], {
+    encoding: "buffer",
+    maxBuffer: DEFAULT_CLIPBOARD_IMAGE_MAX_BYTES + 1,
+  });
+
+  return { stdout };
+}
+
+function commandErrorResult(
+  error: unknown,
+  command: string
+): ClipboardImageErrorResult | ClipboardImageNoImageResult {
+  if (isMissingCommandError(error)) {
+    return {
+      message: `Clipboard image reader command ${command} was not found. Install it and try again.`,
+      reason: "clipboard_image_command_missing",
+      type: "error",
+    };
+  }
+
+  return noImageResult();
+}
+
+function detectImageMediaType(
+  image: Uint8Array
+): ClipboardImageMediaType | undefined {
+  if (
+    image[0] === 0x89 &&
+    image[1] === 0x50 &&
+    image[2] === 0x4e &&
+    image[3] === 0x47 &&
+    image[4] === 0x0d &&
+    image[5] === 0x0a &&
+    image[6] === 0x1a &&
+    image[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+
+  if (image[0] === 0xff && image[1] === 0xd8 && image[2] === 0xff) {
+    return "image/jpeg";
+  }
+
+  return;
+}
+
+function isMissingCommandError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
+
+function normalizeNonImageResult(
+  result: ClipboardImageErrorResult | ClipboardImageNoImageResult
+): ClipboardImageErrorResult | ClipboardImageNoImageResult {
+  if (result.type === "no-image" && !result.message) {
+    return noImageResult();
+  }
+
+  return result;
+}
+
+function noImageResult(): ClipboardImageNoImageResult {
+  return {
+    message: "Clipboard does not contain a PNG or JPEG image.",
+    reason: "clipboard_image_not_found",
+    type: "no-image",
+  };
+}
+
+function nonEmpty(value: string | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function readSupportedMediaType(
+  mediaType: string
+): ClipboardImageMediaType | undefined {
+  return mediaType === "image/png" || mediaType === "image/jpeg"
+    ? mediaType
+    : undefined;
+}
+
+function toUint8Array(
+  value: Buffer | Uint8Array | string,
+  outputEncoding: "base64" | "bytes"
+): Uint8Array {
+  if (outputEncoding === "base64") {
+    return Buffer.from(Buffer.from(value).toString("utf8").trim(), "base64");
+  }
+
+  if (typeof value === "string") {
+    return Buffer.from(value);
+  }
+
+  return value;
+}
+
+function unsupportedPlatformResult(
+  platform: NodeJS.Platform | string
+): ClipboardImageErrorResult {
+  return {
+    message:
+      platform === "linux"
+        ? "No supported clipboard image reader is available. Set WAYLAND_DISPLAY or DISPLAY and install wl-paste or xclip."
+        : "No supported clipboard image reader is available.",
+    reason: "clipboard_image_unsupported_platform",
+    type: "error",
+  };
+}

--- a/packages/coding-agent/src/env.test.ts
+++ b/packages/coding-agent/src/env.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_LOOK_AT_MAX_IMAGE_BYTES,
+  DEFAULT_LOOK_AT_MAX_OUTPUT_CHARS,
   DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
   DEFAULT_OPENAI_COMPATIBLE_MODEL_ID,
+  readLookAtModelEnv,
   readOpenAICompatibleModelEnv,
   readTinyFishApiKeyPoolFromEnv,
 } from "./env";
@@ -9,6 +12,8 @@ import {
 const aiApiKeyPattern = /AI_API_KEY/;
 const aiBaseUrlPattern = /AI_BASE_URL/;
 const tinyFishApiKeyPattern = /TINYFISH_API_KEY/;
+const lookAtMaxOutputCharsPattern = /PSS_LOOK_AT_MAX_OUTPUT_CHARS/;
+const lookAtMaxImageBytesPattern = /PSS_LOOK_AT_MAX_IMAGE_BYTES/;
 
 describe("coding-agent env validation", () => {
   it("validates and normalizes OpenAI-compatible model env", () => {
@@ -64,6 +69,103 @@ describe("coding-agent env validation", () => {
         },
       })
     ).toThrow(tinyFishApiKeyPattern);
+  });
+
+  it("disables look_at config when the look_at model is absent", () => {
+    expect(
+      readLookAtModelEnv({
+        runtimeEnv: {
+          AI_API_KEY: "ai-token",
+          AI_BASE_URL: "https://llm.test/v1",
+        },
+      })
+    ).toEqual({
+      enabled: false,
+      model: undefined,
+      baseUrl: undefined,
+      apiKey: undefined,
+      maxOutputChars: DEFAULT_LOOK_AT_MAX_OUTPUT_CHARS,
+      maxImageBytes: DEFAULT_LOOK_AT_MAX_IMAGE_BYTES,
+    });
+  });
+
+  it("validates explicit look_at model env", () => {
+    expect(
+      readLookAtModelEnv({
+        runtimeEnv: {
+          PSS_LOOK_AT_MODEL: " vision-model ",
+          PSS_LOOK_AT_BASE_URL: " https://vision.test/v1 ",
+          PSS_LOOK_AT_API_KEY: " vision-token ",
+          PSS_LOOK_AT_MAX_OUTPUT_CHARS: " 4096 ",
+          PSS_LOOK_AT_MAX_IMAGE_BYTES: " 2097152 ",
+        },
+      })
+    ).toEqual({
+      enabled: true,
+      model: "vision-model",
+      baseUrl: "https://vision.test/v1",
+      apiKey: "vision-token",
+      maxOutputChars: 4096,
+      maxImageBytes: 2_097_152,
+    });
+  });
+
+  it("inherits look_at base URL and API key from AI env", () => {
+    expect(
+      readLookAtModelEnv({
+        runtimeEnv: {
+          AI_API_KEY: " ai-token ",
+          AI_BASE_URL: " https://llm.test/v1 ",
+          PSS_LOOK_AT_MODEL: " vision-model ",
+        },
+      })
+    ).toMatchObject({
+      enabled: true,
+      model: "vision-model",
+      baseUrl: "https://llm.test/v1",
+      apiKey: "ai-token",
+    });
+  });
+
+  it("defaults look_at numeric limits", () => {
+    expect(
+      readLookAtModelEnv({
+        runtimeEnv: {
+          AI_API_KEY: "ai-token",
+          AI_BASE_URL: "https://llm.test/v1",
+          PSS_LOOK_AT_MODEL: "vision-model",
+        },
+      })
+    ).toMatchObject({
+      maxOutputChars: 2000,
+      maxImageBytes: 10_485_760,
+    });
+  });
+
+  it("fails look_at env validation when max output chars is invalid", () => {
+    expect(() =>
+      readLookAtModelEnv({
+        runtimeEnv: {
+          AI_API_KEY: "ai-token",
+          AI_BASE_URL: "https://llm.test/v1",
+          PSS_LOOK_AT_MODEL: "vision-model",
+          PSS_LOOK_AT_MAX_OUTPUT_CHARS: "0",
+        },
+      })
+    ).toThrow(lookAtMaxOutputCharsPattern);
+  });
+
+  it("fails look_at env validation when max image bytes is invalid", () => {
+    expect(() =>
+      readLookAtModelEnv({
+        runtimeEnv: {
+          AI_API_KEY: "ai-token",
+          AI_BASE_URL: "https://llm.test/v1",
+          PSS_LOOK_AT_MODEL: "vision-model",
+          PSS_LOOK_AT_MAX_IMAGE_BYTES: "not-a-number",
+        },
+      })
+    ).toThrow(lookAtMaxImageBytesPattern);
   });
 
   it("does not mutate the caller-provided runtime env object", () => {

--- a/packages/coding-agent/src/env.ts
+++ b/packages/coding-agent/src/env.ts
@@ -4,10 +4,30 @@ import { z } from "zod";
 export const DEFAULT_OPENAI_COMPATIBLE_BASE_URL =
   "https://apis.opengateway.ai/v1";
 export const DEFAULT_OPENAI_COMPATIBLE_MODEL_ID = "minimax/MiniMax-M2.7";
+export const DEFAULT_LOOK_AT_MAX_OUTPUT_CHARS = 2000;
+export const DEFAULT_LOOK_AT_MAX_IMAGE_BYTES = 10_485_760;
 const TINYFISH_API_KEY_ERROR =
   "TINYFISH_API_KEY is required to use the built-in TinyFish web tools.";
 
 export type CodingAgentRuntimeEnv = Record<string, string | undefined>;
+
+export type LookAtModelEnv =
+  | {
+      apiKey: string;
+      baseUrl: string;
+      enabled: true;
+      maxImageBytes: number;
+      maxOutputChars: number;
+      model: string;
+    }
+  | {
+      apiKey: undefined;
+      baseUrl: undefined;
+      enabled: false;
+      maxImageBytes: number;
+      maxOutputChars: number;
+      model: undefined;
+    };
 
 interface ReadCodingAgentEnvOptions {
   runtimeEnv?: CodingAgentRuntimeEnv;
@@ -32,6 +52,63 @@ export function readOpenAICompatibleModelEnv({
         .default(DEFAULT_OPENAI_COMPATIBLE_MODEL_ID),
     },
   });
+}
+
+export function readLookAtModelEnv({
+  runtimeEnv = process.env,
+}: ReadCodingAgentEnvOptions = {}): LookAtModelEnv {
+  const candidate = { ...runtimeEnv };
+  const model = emptyStringAsUndefined(candidate.PSS_LOOK_AT_MODEL);
+
+  if (model === undefined) {
+    return {
+      enabled: false as const,
+      model: undefined,
+      baseUrl: undefined,
+      apiKey: undefined,
+      maxOutputChars: DEFAULT_LOOK_AT_MAX_OUTPUT_CHARS,
+      maxImageBytes: DEFAULT_LOOK_AT_MAX_IMAGE_BYTES,
+    };
+  }
+
+  const env = createEnv({
+    emptyStringAsUndefined: true,
+    onValidationError: failEnvValidation(
+      "look_at model environment validation failed."
+    ),
+    runtimeEnv: {
+      ...candidate,
+      PSS_LOOK_AT_API_KEY:
+        emptyStringAsUndefined(candidate.PSS_LOOK_AT_API_KEY) ??
+        candidate.AI_API_KEY,
+      PSS_LOOK_AT_BASE_URL:
+        emptyStringAsUndefined(candidate.PSS_LOOK_AT_BASE_URL) ??
+        candidate.AI_BASE_URL,
+    },
+    server: {
+      PSS_LOOK_AT_API_KEY: z.string().trim().min(1),
+      PSS_LOOK_AT_BASE_URL: z
+        .url()
+        .trim()
+        .default(DEFAULT_OPENAI_COMPATIBLE_BASE_URL),
+      PSS_LOOK_AT_MAX_IMAGE_BYTES: positiveIntegerFromEnv(
+        DEFAULT_LOOK_AT_MAX_IMAGE_BYTES
+      ),
+      PSS_LOOK_AT_MAX_OUTPUT_CHARS: positiveIntegerFromEnv(
+        DEFAULT_LOOK_AT_MAX_OUTPUT_CHARS
+      ),
+      PSS_LOOK_AT_MODEL: z.string().trim().min(1),
+    },
+  });
+
+  return {
+    enabled: true as const,
+    model: env.PSS_LOOK_AT_MODEL,
+    baseUrl: env.PSS_LOOK_AT_BASE_URL,
+    apiKey: env.PSS_LOOK_AT_API_KEY,
+    maxOutputChars: env.PSS_LOOK_AT_MAX_OUTPUT_CHARS,
+    maxImageBytes: env.PSS_LOOK_AT_MAX_IMAGE_BYTES,
+  };
 }
 
 export function readTinyFishApiKeyPoolFromEnv({
@@ -75,4 +152,32 @@ function failEnvValidation(prefix: string) {
 
     throw new Error(`${prefix} ${summary}`.trim());
   };
+}
+
+function emptyStringAsUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed === undefined || trimmed.length === 0 ? undefined : trimmed;
+}
+
+function positiveIntegerFromEnv(defaultValue: number) {
+  return z
+    .string()
+    .trim()
+    .optional()
+    .transform((value, ctx) => {
+      if (value === undefined) {
+        return defaultValue;
+      }
+
+      const parsed = Number(value);
+      if (!(Number.isInteger(parsed) && parsed > 0)) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Expected a positive integer.",
+        });
+        return z.NEVER;
+      }
+
+      return parsed;
+    });
 }

--- a/packages/coding-agent/src/look-at-integration.test.ts
+++ b/packages/coding-agent/src/look-at-integration.test.ts
@@ -1,0 +1,159 @@
+import { Agent, createLookAtLlm } from "@minpeter/pss-runtime";
+import type { LanguageModel } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClipboardImageReader } from "./clipboard-image";
+import { createTuiRunner } from "./tui-runner";
+
+const { generateTextMock } = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+}));
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+
+  return {
+    ...actual,
+    generateText: generateTextMock,
+  };
+});
+
+const mainModel = { provider: "test", modelId: "main" } as LanguageModel;
+const visionModel = { provider: "test", modelId: "vision" } as LanguageModel;
+const pngBytes = Buffer.from("red-square-fixture");
+const dataImageNeedle = ["data", "image"].join(":");
+const pngDataUri = `${dataImageNeedle}/png;base64,${pngBytes.toString("base64")}`;
+
+describe("look_at image delegation through the coding-agent TUI path", () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+  });
+
+  it("keeps raw image data out of main model and TUI output while delegating to vision", async () => {
+    generateTextMock.mockImplementation(async (options) => {
+      if (options.model === visionModel) {
+        return { text: "a red square" };
+      }
+
+      const callIndex = generateTextMock.mock.calls.filter(
+        ([callOptions]) => callOptions.model === mainModel
+      ).length;
+
+      if (callIndex === 1) {
+        const toolCall = {
+          type: "tool-call" as const,
+          toolCallId: "call-look-at-1",
+          toolName: "look_at",
+          input: { imageId: "image_1", question: "What is in this image?" },
+        };
+        const toolResult = await options.tools.look_at.execute(toolCall.input, {
+          abortSignal: options.abortSignal,
+          messages: [],
+          toolCallId: toolCall.toolCallId,
+        });
+
+        return {
+          responseMessages: [
+            { role: "assistant", content: [toolCall] },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: toolCall.toolCallId,
+                  toolName: toolCall.toolName,
+                  output: { type: "json", value: toolResult },
+                },
+              ],
+            },
+          ],
+        };
+      }
+
+      const visionText = findVisionText(options.messages);
+      if (visionText) {
+        return {
+          responseMessages: [
+            {
+              role: "assistant",
+              content: `The vision result is ${visionText}.`,
+            },
+          ],
+        };
+      }
+
+      return {
+        responseMessages: [
+          { role: "assistant", content: "The vision result was unavailable." },
+        ],
+      };
+    });
+
+    const llm = createLookAtLlm({ model: mainModel, visionModel });
+    const agent = await Agent.create({ llm });
+    const lines: string[] = [];
+    const runner = createTuiRunner({
+      addLine: (line) => lines.push(line),
+      clipboardImageReader: createClipboardImageReader(),
+      requestRender: vi.fn(),
+      session: agent.session("look-at-integration"),
+    });
+
+    await runner.attachClipboardImage();
+    runner.submit("What is in this image?");
+    await waitUntil(() => lines.some((line) => line.includes("a red square")));
+    await waitUntil(() => runner.activeRun === undefined);
+
+    const mainCalls = generateTextMock.mock.calls
+      .map(([options]) => options)
+      .filter((options) => options.model === mainModel);
+    const visionCalls = generateTextMock.mock.calls
+      .map(([options]) => options)
+      .filter((options) => options.model === visionModel);
+
+    expect(mainCalls).toHaveLength(2);
+    expect(visionCalls).toHaveLength(1);
+    expect(JSON.stringify(mainCalls)).toContain("[image image_1 image/png]");
+    expect(JSON.stringify(mainCalls)).not.toContain(dataImageNeedle);
+    expect(JSON.stringify(mainCalls)).not.toContain(pngDataUri);
+    expect(visionCalls[0].messages).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is in this image?" },
+          { type: "file", data: pngDataUri, mediaType: "image/png" },
+        ],
+      },
+    ]);
+    expect(lines).toContain("\x1b[2m[attached image/png]\x1b[0m");
+    expect(lines.some((line) => line.includes("a red square"))).toBe(true);
+    expect(JSON.stringify(lines)).not.toContain(dataImageNeedle);
+  });
+});
+
+function findVisionText(messages: unknown): string | undefined {
+  const text = JSON.stringify(messages);
+  return text.includes("a red square") ? "a red square" : undefined;
+}
+
+function createClipboardImageReader(): ClipboardImageReader {
+  return {
+    read: () =>
+      Promise.resolve({
+        image: pngBytes,
+        mediaType: "image/png",
+        type: "image",
+      }),
+  };
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  throw new Error("Timed out waiting for look_at integration test condition");
+}

--- a/packages/coding-agent/src/model.test.ts
+++ b/packages/coding-agent/src/model.test.ts
@@ -1,12 +1,17 @@
-import type { LanguageModel } from "ai";
+import type { LanguageModel, ToolSet } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createOpenAICompatibleMock, dotenvConfigMock, providerMock } =
-  vi.hoisted(() => ({
-    createOpenAICompatibleMock: vi.fn(),
-    dotenvConfigMock: vi.fn(),
-    providerMock: vi.fn(),
-  }));
+const {
+  createLookAtLlmMock,
+  createOpenAICompatibleMock,
+  dotenvConfigMock,
+  providerMock,
+} = vi.hoisted(() => ({
+  createLookAtLlmMock: vi.fn(),
+  createOpenAICompatibleMock: vi.fn(),
+  dotenvConfigMock: vi.fn(),
+  providerMock: vi.fn(),
+}));
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: createOpenAICompatibleMock,
@@ -16,8 +21,19 @@ vi.mock("dotenv", () => ({
   config: dotenvConfigMock,
 }));
 
+vi.mock("@minpeter/pss-runtime", () => ({
+  createLookAtLlm: createLookAtLlmMock,
+}));
+
 describe("createOpenAICompatibleModelFromEnv", () => {
-  const aiEnvKeys = ["AI_API_KEY", "AI_BASE_URL", "AI_MODEL"] as const;
+  const aiEnvKeys = [
+    "AI_API_KEY",
+    "AI_BASE_URL",
+    "AI_MODEL",
+    "PSS_LOOK_AT_API_KEY",
+    "PSS_LOOK_AT_BASE_URL",
+    "PSS_LOOK_AT_MODEL",
+  ] as const;
   const originalEnv = Object.fromEntries(
     aiEnvKeys.map((key) => [key, process.env[key]])
   ) as Record<(typeof aiEnvKeys)[number], string | undefined>;
@@ -38,6 +54,8 @@ describe("createOpenAICompatibleModelFromEnv", () => {
     vi.resetModules();
     restoreAiEnv();
     dotenvConfigMock.mockReset();
+    createLookAtLlmMock.mockReset();
+    createLookAtLlmMock.mockReturnValue({ runtime: "llm" });
     providerMock.mockReset();
     providerMock.mockReturnValue({
       provider: "test",
@@ -94,5 +112,117 @@ describe("createOpenAICompatibleModelFromEnv", () => {
     });
     expect(providerMock).toHaveBeenCalledWith("dotenv-model");
     expect(model).toEqual({ provider: "test" });
+  });
+
+  it("does not create a look_at vision model when look_at env is disabled", async () => {
+    const { createLookAtVisionModelFromEnv } = await import("./model");
+
+    const model = createLookAtVisionModelFromEnv({
+      runtimeEnv: {
+        AI_API_KEY: "ai-token",
+        AI_BASE_URL: "https://llm.test/v1",
+      },
+    });
+
+    expect(dotenvConfigMock).not.toHaveBeenCalled();
+    expect(createOpenAICompatibleMock).not.toHaveBeenCalled();
+    expect(model).toBeUndefined();
+  });
+
+  it("builds a look_at vision model from explicit look_at env", async () => {
+    const { createLookAtVisionModelFromEnv } = await import("./model");
+
+    const model = createLookAtVisionModelFromEnv({
+      providerName: "vision-provider",
+      runtimeEnv: {
+        PSS_LOOK_AT_API_KEY: " vision-token ",
+        PSS_LOOK_AT_BASE_URL: " https://vision.test/v1 ",
+        PSS_LOOK_AT_MODEL: " vision-model ",
+      },
+    });
+
+    expect(dotenvConfigMock).not.toHaveBeenCalled();
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith({
+      name: "vision-provider",
+      apiKey: "vision-token",
+      baseURL: "https://vision.test/v1",
+    });
+    expect(providerMock).toHaveBeenCalledWith("vision-model");
+    expect(model).toEqual({ provider: "test" });
+  });
+
+  it("inherits look_at provider credentials from AI env", async () => {
+    const { createLookAtVisionModelFromEnv } = await import("./model");
+
+    const model = createLookAtVisionModelFromEnv({
+      runtimeEnv: {
+        AI_API_KEY: " ai-token ",
+        AI_BASE_URL: " https://llm.test/v1 ",
+        PSS_LOOK_AT_MODEL: " vision-model ",
+      },
+    });
+
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith({
+      name: "look_at",
+      apiKey: "ai-token",
+      baseURL: "https://llm.test/v1",
+    });
+    expect(providerMock).toHaveBeenCalledWith("vision-model");
+    expect(model).toEqual({ provider: "test" });
+  });
+
+  it("builds a runtime look_at LLM with the main model and tools", async () => {
+    const { createLookAtLlmFromEnv } = await import("./model");
+    const mainModel = { provider: "main" } as unknown as LanguageModel;
+    const webTools = {
+      web_search: { description: "search" },
+    } as unknown as ToolSet;
+
+    const llm = createLookAtLlmFromEnv({
+      instructions: "answer briefly",
+      model: mainModel,
+      runtimeEnv: {
+        AI_API_KEY: " ai-token ",
+        AI_BASE_URL: " https://llm.test/v1 ",
+        PSS_LOOK_AT_MAX_IMAGE_BYTES: "1234",
+        PSS_LOOK_AT_MAX_OUTPUT_CHARS: "567",
+        PSS_LOOK_AT_MODEL: " vision-model ",
+      },
+      tools: webTools,
+    });
+
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith({
+      name: "look_at",
+      apiKey: "ai-token",
+      baseURL: "https://llm.test/v1",
+    });
+    expect(providerMock).toHaveBeenCalledWith("vision-model");
+    expect(createLookAtLlmMock).toHaveBeenCalledWith({
+      instructions: "answer briefly",
+      maxImageBytes: 1234,
+      maxOutputChars: 567,
+      model: mainModel,
+      toolChoice: undefined,
+      tools: webTools,
+      visionModel: { provider: "test" },
+    });
+    expect(llm).toEqual({ runtime: "llm" });
+  });
+
+  it("does not build a runtime look_at LLM when look_at env is disabled", async () => {
+    const { createLookAtLlmFromEnv } = await import("./model");
+    const mainModel = { provider: "main" } as unknown as LanguageModel;
+
+    const llm = createLookAtLlmFromEnv({
+      model: mainModel,
+      runtimeEnv: {
+        AI_API_KEY: "ai-token",
+        AI_BASE_URL: "https://llm.test/v1",
+      },
+    });
+
+    expect(createOpenAICompatibleMock).not.toHaveBeenCalled();
+    expect(createLookAtLlmMock).not.toHaveBeenCalled();
+    expect(llm).toBeUndefined();
   });
 });

--- a/packages/coding-agent/src/model.ts
+++ b/packages/coding-agent/src/model.ts
@@ -1,8 +1,14 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import type { LanguageModel } from "ai";
+import {
+  type AgentToolChoice,
+  createLookAtLlm,
+  type RuntimeLlm,
+} from "@minpeter/pss-runtime";
+import type { LanguageModel, ToolSet } from "ai";
 import { config } from "dotenv";
 import {
   type CodingAgentRuntimeEnv,
+  readLookAtModelEnv,
   readOpenAICompatibleModelEnv,
 } from "./env";
 
@@ -17,6 +23,15 @@ export interface CreateOpenAICompatibleModelFromDotenvOptions {
   quiet?: boolean;
 }
 
+export interface CreateLookAtLlmFromEnvOptions {
+  instructions?: string;
+  model: LanguageModel;
+  providerName?: string;
+  runtimeEnv?: CodingAgentRuntimeEnv;
+  toolChoice?: AgentToolChoice;
+  tools?: ToolSet;
+}
+
 export function createOpenAICompatibleModelFromEnv({
   providerName = "custom",
   runtimeEnv = process.env,
@@ -29,6 +44,59 @@ export function createOpenAICompatibleModelFromEnv({
   });
 
   return provider(env.AI_MODEL);
+}
+
+export function createLookAtVisionModelFromEnv({
+  providerName = "look_at",
+  runtimeEnv = process.env,
+}: CreateOpenAICompatibleModelFromEnvOptions = {}): LanguageModel | undefined {
+  const env = readLookAtModelEnv({ runtimeEnv });
+
+  if (!env.enabled) {
+    return;
+  }
+
+  const provider = createOpenAICompatible({
+    name: providerName,
+    apiKey: env.apiKey,
+    baseURL: env.baseUrl,
+  });
+
+  return provider(env.model);
+}
+
+export function createLookAtLlmFromEnv({
+  instructions,
+  model,
+  providerName,
+  runtimeEnv = process.env,
+  toolChoice,
+  tools,
+}: CreateLookAtLlmFromEnvOptions): RuntimeLlm | undefined {
+  const env = readLookAtModelEnv({ runtimeEnv });
+
+  if (!env.enabled) {
+    return;
+  }
+
+  const visionModel = createLookAtVisionModelFromEnv({
+    providerName,
+    runtimeEnv,
+  });
+
+  if (visionModel === undefined) {
+    throw new Error("look_at vision model configuration is disabled.");
+  }
+
+  return createLookAtLlm({
+    instructions,
+    maxImageBytes: env.maxImageBytes,
+    maxOutputChars: env.maxOutputChars,
+    model,
+    toolChoice,
+    tools,
+    visionModel,
+  });
 }
 
 export function createCodingLanguageModel({

--- a/packages/coding-agent/src/tui-runner.test.ts
+++ b/packages/coding-agent/src/tui-runner.test.ts
@@ -1,8 +1,32 @@
-import type { AgentEvent } from "@minpeter/pss-runtime";
+import type { AgentEvent, UserMessageImagePart } from "@minpeter/pss-runtime";
 import { describe, expect, it, vi } from "vitest";
+import type {
+  ClipboardImageReader,
+  ClipboardImageReadResult,
+} from "./clipboard-image";
+import { resolveStartTuiClipboardImageReader } from "./tui";
 import { createTuiRunner, formatEvent } from "./tui-runner";
 
+const pngPart: UserMessageImagePart = {
+  image: dataUri("image/png", "fake"),
+  mediaType: "image/png",
+  type: "image",
+};
+const pngClipboardResult: ClipboardImageReadResult = {
+  image: Buffer.from("fake"),
+  mediaType: "image/png",
+  type: "image",
+};
+
 describe("TUI runner", () => {
+  it("uses an injected startTui clipboard reader without constructing the default", () => {
+    const reader = createClipboardImageReader([pngClipboardResult]);
+
+    expect(
+      resolveStartTuiClipboardImageReader({ clipboardImageReader: reader })
+    ).toBe(reader);
+  });
+
   it("renders runtime input distinctly from human input", () => {
     expect(formatEvent({ text: "hello", type: "user-text" })).toBe(
       "\x1b[36myou\x1b[0m: hello"
@@ -28,6 +52,7 @@ describe("TUI runner", () => {
     const lines: string[] = [];
     const runner = createTuiRunner({
       addLine: (line) => lines.push(line),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
       requestRender: vi.fn(),
       session,
     });
@@ -54,6 +79,7 @@ describe("TUI runner", () => {
     };
     const runner = createTuiRunner({
       addLine: vi.fn(),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
       requestRender: vi.fn(),
       session,
     });
@@ -88,6 +114,7 @@ describe("TUI runner", () => {
     };
     const runner = createTuiRunner({
       addLine: (line) => lines.push(line),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
       requestRender: vi.fn(),
       session,
     });
@@ -116,6 +143,7 @@ describe("TUI runner", () => {
     };
     const runner = createTuiRunner({
       addLine: (line) => lines.push(line),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
       requestRender: vi.fn(),
       session,
     });
@@ -133,6 +161,7 @@ describe("TUI runner", () => {
     const run = createRun([new Error("events failed")]);
     const runner = createTuiRunner({
       addLine: vi.fn(),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
       requestRender: vi.fn(),
       session: {
         send: vi.fn().mockResolvedValue(run),
@@ -161,6 +190,7 @@ describe("TUI runner", () => {
     ]);
     const runner = createTuiRunner({
       addLine: vi.fn(),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
       requestRender: vi.fn(),
       session: {
         send: vi.fn().mockResolvedValue(run),
@@ -185,6 +215,170 @@ describe("TUI runner", () => {
     await expect(waitUntil(() => false)).rejects.toThrow(
       "Timed out waiting for TUI runner test condition"
     );
+  });
+
+  it("attaches clipboard images without submitting until Enter", async () => {
+    const run = createRun([
+      {
+        type: "user-message",
+        content: [{ text: "describe", type: "text" }, pngPart],
+      },
+      { type: "turn-end" },
+    ]);
+    const session = {
+      send: vi.fn().mockResolvedValue(run),
+      steer: vi.fn().mockResolvedValue(run),
+    };
+    const lines: string[] = [];
+    const runner = createTuiRunner({
+      addLine: (line) => lines.push(line),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
+      requestRender: vi.fn(),
+      session,
+    });
+
+    await runner.attachClipboardImage();
+
+    expect(session.send).not.toHaveBeenCalled();
+    expect(lines).toContain("\x1b[2m[attached image/png]\x1b[0m");
+
+    runner.submit(" describe ");
+    await run.done;
+
+    expect(session.send).toHaveBeenCalledWith([
+      { text: "describe", type: "text" },
+      pngPart,
+    ]);
+    expect(lines).toContain("\x1b[36myou\x1b[0m: describe\n[image image/png]");
+  });
+
+  it("steers active submissions with text and attached images", async () => {
+    let releaseEvent: (() => void) | undefined;
+    const run = createRun([
+      { text: "initial", type: "user-text" },
+      new Promise<AgentEvent>((resolve) => {
+        releaseEvent = () => resolve({ type: "turn-end" });
+      }),
+    ]);
+    const session = {
+      send: vi.fn().mockResolvedValue(run),
+      steer: vi.fn().mockResolvedValue(run),
+    };
+    const runner = createTuiRunner({
+      addLine: vi.fn(),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
+      requestRender: vi.fn(),
+      session,
+    });
+
+    runner.submit("initial");
+    await run.firstEventRead;
+    await runner.attachClipboardImage();
+    runner.submit(" extra ");
+    releaseEvent?.();
+    await run.done;
+
+    expect(session.steer).toHaveBeenCalledWith([
+      { text: "extra", type: "text" },
+      pngPart,
+    ]);
+  });
+
+  it("submits image-only drafts and clears attachments after submit", async () => {
+    const run = createRun([{ type: "turn-end" }]);
+    const session = {
+      send: vi.fn().mockResolvedValue(run),
+      steer: vi.fn().mockResolvedValue(run),
+    };
+    const requestRender = vi.fn();
+    const runner = createTuiRunner({
+      addLine: vi.fn(),
+      clipboardImageReader: createClipboardImageReader([pngClipboardResult]),
+      requestRender,
+      session,
+    });
+
+    await runner.attachClipboardImage();
+    runner.submit("  ");
+    await run.done;
+    runner.submit("  ");
+
+    expect(session.send).toHaveBeenCalledWith([pngPart]);
+    expect(session.send).toHaveBeenCalledTimes(1);
+    expect(requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps draft attachments when clipboard has no supported image", async () => {
+    const run = createRun([{ type: "turn-end" }]);
+    const session = {
+      send: vi.fn().mockResolvedValue(run),
+      steer: vi.fn().mockResolvedValue(run),
+    };
+    const lines: string[] = [];
+    const runner = createTuiRunner({
+      addLine: (line) => lines.push(line),
+      clipboardImageReader: createClipboardImageReader([
+        pngClipboardResult,
+        {
+          message: "Clipboard does not contain a PNG or JPEG image.",
+          reason: "clipboard_image_not_found",
+          type: "no-image",
+        },
+      ]),
+      requestRender: vi.fn(),
+      session,
+    });
+
+    await runner.attachClipboardImage();
+    await runner.attachClipboardImage();
+    runner.submit("describe");
+    await run.done;
+
+    expect(lines).toContain(
+      "\x1b[2mClipboard does not contain a PNG or JPEG image.\x1b[0m"
+    );
+    expect(session.send).toHaveBeenCalledWith([
+      { text: "describe", type: "text" },
+      pngPart,
+    ]);
+  });
+
+  it("appends multiple clipboard image attachments", async () => {
+    const jpegPart: UserMessageImagePart = {
+      image: dataUri("image/jpeg", "fake2"),
+      mediaType: "image/jpeg",
+      type: "image",
+    };
+    const jpegClipboardResult: ClipboardImageReadResult = {
+      image: Buffer.from("fake2"),
+      mediaType: "image/jpeg",
+      type: "image",
+    };
+    const run = createRun([{ type: "turn-end" }]);
+    const session = {
+      send: vi.fn().mockResolvedValue(run),
+      steer: vi.fn().mockResolvedValue(run),
+    };
+    const runner = createTuiRunner({
+      addLine: vi.fn(),
+      clipboardImageReader: createClipboardImageReader([
+        pngClipboardResult,
+        jpegClipboardResult,
+      ]),
+      requestRender: vi.fn(),
+      session,
+    });
+
+    await runner.attachClipboardImage();
+    await runner.attachClipboardImage();
+    runner.submit("compare");
+    await run.done;
+
+    expect(session.send).toHaveBeenCalledWith([
+      { text: "compare", type: "text" },
+      pngPart,
+      jpegPart,
+    ]);
   });
 });
 
@@ -248,6 +442,31 @@ interface TestRun {
   readonly eventsRead: (count: number) => Promise<void>;
   readonly firstEventRead: Promise<void>;
   readonly stop: () => void;
+}
+
+function createClipboardImageReader(
+  results: readonly ClipboardImageReadResult[]
+): ClipboardImageReader {
+  let index = 0;
+  return {
+    read: () => {
+      const result = results[index] ?? results.at(-1);
+      index += 1;
+      if (!result) {
+        return Promise.resolve({
+          message: "Clipboard does not contain a PNG or JPEG image.",
+          reason: "clipboard_image_not_found",
+          type: "no-image",
+        });
+      }
+
+      return Promise.resolve(result);
+    },
+  };
+}
+
+function dataUri(mediaType: string, text: string): string {
+  return `data:${mediaType};base64,${Buffer.from(text).toString("base64")}`;
 }
 
 async function waitUntil(predicate: () => boolean): Promise<void> {

--- a/packages/coding-agent/src/tui-runner.ts
+++ b/packages/coding-agent/src/tui-runner.ts
@@ -5,8 +5,11 @@ import type {
   UserInput,
   UserMessage,
   UserMessageContentPart,
+  UserMessageImagePart,
   UserTextContent,
 } from "@minpeter/pss-runtime";
+import type { ClipboardImageReader } from "./clipboard-image";
+import { readClipboardImagePart } from "./clipboard-image";
 import {
   formatToolCallForTui,
   formatToolResultForTui,
@@ -17,12 +20,14 @@ import {
 
 export interface TuiRunnerOptions {
   readonly addLine: (text: string) => void;
+  readonly clipboardImageReader: ClipboardImageReader;
   readonly requestRender: () => void;
   readonly session: Pick<SessionHandle, "send" | "steer">;
 }
 
 export interface TuiRunner {
   readonly activeRun: AgentRun | undefined;
+  attachClipboardImage(): Promise<void>;
   clearActiveRun(run?: AgentRun): void;
   consumeRun(run: AgentRun): Promise<void>;
   submit(text: string): void;
@@ -68,10 +73,12 @@ export const formatEvent = (event: AgentEvent): string | undefined => {
 
 export function createTuiRunner({
   addLine,
+  clipboardImageReader,
   requestRender,
   session,
 }: TuiRunnerOptions): TuiRunner {
   let activeRun: AgentRun | undefined;
+  let draftImageParts: UserMessageImagePart[] = [];
 
   const clearActiveRun = (run?: AgentRun): void => {
     if (run === undefined || activeRun === run) {
@@ -98,17 +105,32 @@ export function createTuiRunner({
     }
   };
 
+  const attachClipboardImage = async (): Promise<void> => {
+    const part = await readClipboardImagePart({ reader: clipboardImageReader });
+
+    if (part.type !== "image") {
+      addLine(`${dimText}${safeText(part.message ?? part.reason)}${resetText}`);
+      return;
+    }
+
+    draftImageParts = [...draftImageParts, part];
+    addLine(`${dimText}[attached ${part.mediaType ?? "image"}]${resetText}`);
+  };
+
   const submit = (text: string): void => {
     const trimmed = text.trim();
-    if (!trimmed) {
+    if (!trimmed && draftImageParts.length === 0) {
       requestRender();
       return;
     }
 
+    const input = buildSubmittedInput(trimmed, draftImageParts);
+    draftImageParts = [];
+
     const run = activeRun;
     if (run) {
       session
-        .steer(trimmed)
+        .steer(input)
         .then((nextRun) => {
           if (nextRun !== run) {
             return consumeRun(nextRun);
@@ -121,7 +143,7 @@ export function createTuiRunner({
     }
 
     session
-      .send(trimmed)
+      .send(input)
       .then((nextRun) => consumeRun(nextRun))
       .catch((error: unknown) => {
         addLine(`\x1b[31merror\x1b[0m: ${safeText(errorMessage(error))}`);
@@ -132,10 +154,22 @@ export function createTuiRunner({
     get activeRun() {
       return activeRun;
     },
+    attachClipboardImage,
     clearActiveRun,
     consumeRun,
     submit,
   };
+}
+
+function buildSubmittedInput(
+  text: string,
+  imageParts: readonly UserMessageImagePart[]
+): string | readonly UserMessageContentPart[] {
+  if (imageParts.length === 0) {
+    return text;
+  }
+
+  return text ? [{ text, type: "text" }, ...imageParts] : [...imageParts];
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/coding-agent/src/tui.ts
+++ b/packages/coding-agent/src/tui.ts
@@ -10,23 +10,50 @@ import {
 } from "@earendil-works/pi-tui";
 import { Agent } from "@minpeter/pss-runtime";
 import { FileSessionStore } from "@minpeter/pss-runtime/session-store/file";
-import { createCodingLanguageModel } from "./model";
+import type { ClipboardImageReader } from "./clipboard-image";
+import { createClipboardImageReader } from "./clipboard-image";
+import { createCodingLanguageModel, createLookAtLlmFromEnv } from "./model";
 import { resolveCodingAgentSessionConfig } from "./session-config";
 import { tools } from "./tools";
 import { createTuiRunner } from "./tui-runner";
 import { safeInlineText } from "./tui-tool-printer";
 
-export async function startTui(): Promise<void> {
+export interface StartTuiOptions {
+  readonly clipboardImageReader?: ClipboardImageReader;
+}
+
+export function resolveStartTuiClipboardImageReader(
+  options: StartTuiOptions = {}
+): ClipboardImageReader {
+  return options.clipboardImageReader ?? createClipboardImageReader();
+}
+
+export async function startTui(options: StartTuiOptions = {}): Promise<void> {
   const sessionConfig = resolveCodingAgentSessionConfig();
-  const agent = await Agent.create({
-    instructions:
-      "Answer in 2 short sentences and 280 characters or fewer unless the user explicitly asks for detail. Avoid headings.",
-    model: createCodingLanguageModel(),
-    sessions: {
-      store: new FileSessionStore(sessionConfig.directory),
-    },
+  const agentInstructions =
+    "Answer in 2 short sentences and 280 characters or fewer unless the user explicitly asks for detail. Avoid headings.";
+  const sessions = {
+    store: new FileSessionStore(sessionConfig.directory),
+  };
+  const mainModel = createCodingLanguageModel();
+  const lookAtLlm = createLookAtLlmFromEnv({
+    instructions: agentInstructions,
+    model: mainModel,
     tools,
   });
+  const agent = await Agent.create(
+    lookAtLlm
+      ? {
+          llm: lookAtLlm,
+          sessions,
+        }
+      : {
+          instructions: agentInstructions,
+          model: mainModel,
+          sessions,
+          tools,
+        }
+  );
   const session = agent.session(sessionConfig.key);
 
   const terminal = new ProcessTerminal();
@@ -58,6 +85,7 @@ export async function startTui(): Promise<void> {
 
   const runner = createTuiRunner({
     addLine,
+    clipboardImageReader: resolveStartTuiClipboardImageReader(options),
     requestRender: () => tui.requestRender(),
     session,
   });
@@ -71,6 +99,15 @@ export async function startTui(): Promise<void> {
     // Avoid input.onEscape because pi-tui maps both Escape and Ctrl-C to it.
     if (matchesKey(data, "escape")) {
       session.interrupt();
+      return { consume: true };
+    }
+
+    if (matchesKey(data, "ctrl+v")) {
+      runner.attachClipboardImage().catch((error: unknown) => {
+        addLine(
+          `\x1b[31merror\x1b[0m: ${safeInlineText(error instanceof Error ? error.message : String(error))}`
+        );
+      });
       return { consume: true };
     }
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -72,9 +72,54 @@ await agent.send([
 ]);
 ```
 
-The runtime normalizes and persists these content parts as session continuation
-state; it does not fetch remote media, decode files, or guarantee provider support
-for every media type.
+The runtime normalizes and persists these content parts as canonical session
+continuation state; it does not fetch remote media, decode files, or guarantee
+provider support for every media type.
+
+## Image delegation with `createLookAtLlm`
+
+Use `createLookAtLlm` when the main model should reason over text while a
+separate vision capable model inspects attached images on demand. The helper
+plugs into the existing custom `llm` seam and injects a `look_at` tool.
+
+```ts
+import { Agent, createLookAtLlm } from "@minpeter/pss-runtime";
+import { createTextModel, createVisionModel } from "./models";
+
+const agent = await Agent.create({
+  llm: createLookAtLlm({
+    model: createTextModel(),
+    visionModel: createVisionModel(),
+  }),
+});
+
+const run = await agent.send([
+  { type: "text", text: "Describe the problem shown here." },
+  { type: "image", image: "data:image/png;base64,...", mediaType: "image/png" },
+]);
+```
+
+The main model receives sanitized history for that call: allowed image parts are
+replaced with handles such as `[image image_1 image/png]`, oversized or
+unsupported media is replaced with short omission text, and embedded image data
+URLs in text are redacted. The canonical session history still preserves the
+original media parts for continuation and future tool calls.
+
+Options:
+
+- `model`: main language model that receives sanitized history and the injected tool.
+- `visionModel`: model used by the `look_at` tool to inspect one original image handle.
+- `tools`: extra tools to expose beside `look_at`; the helper rejects a name conflict.
+- `toolName`: custom tool name. Default: `look_at`.
+- `toolChoice`: forwarded to the main model call.
+- `instructions`: forwarded to the main model call.
+- `allowedMediaTypes`: image media types that can become handles. Default: `image/png`, `image/jpeg`.
+- `maxImageBytes`: byte limit for each image before the main model sees an omission marker. Default: `10485760`.
+- `maxOutputChars`: maximum vision result text returned by the tool. Default: `2000`.
+
+The vision call submits the original media part to `visionModel`. Choose a
+provider and model that support those submitted media parts. For example, image
+file parts require provider support for the mapped file or image input shape.
 
 The public transcript protocol is `AgentEvent`: live runs emit runtime-defined
 events through `run.events()`. Provider/model message history is internal

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -24,6 +24,14 @@ export type {
   RuntimeLlmOutput,
 } from "./llm";
 export { createLlm } from "./llm";
+export {
+  type CreateLookAtLlmOptions,
+  createLookAtLlm,
+  DEFAULT_LOOK_AT_ALLOWED_MEDIA_TYPES,
+  DEFAULT_LOOK_AT_MAX_IMAGE_BYTES,
+  DEFAULT_LOOK_AT_MAX_OUTPUT_CHARS,
+  DEFAULT_LOOK_AT_TOOL_NAME,
+} from "./look-at";
 export type {
   AgentEvent,
   AgentEventListener,

--- a/packages/runtime/src/look-at.test.ts
+++ b/packages/runtime/src/look-at.test.ts
@@ -1,0 +1,336 @@
+import type { LanguageModel, ToolSet } from "ai";
+import { jsonSchema, tool } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Agent, createLookAtLlm } from "./index";
+import { assistantMessage, userText } from "./test-fixtures";
+
+const { generateTextMock } = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+}));
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+
+  return {
+    ...actual,
+    generateText: generateTextMock,
+  };
+});
+
+const fakeModel = {} as LanguageModel;
+const fakeVisionModel = {
+  provider: "test",
+  modelId: "vision",
+} as LanguageModel;
+const LOOK_AT_CONFLICT_PATTERN = /look_at.*conflict/i;
+const dataImageUrl = (mediaType: string, payload = "ZmFrZQ==") =>
+  `data:${mediaType};base64,${payload}`;
+
+const createNoopTool = () =>
+  tool({
+    description: "No-op test tool.",
+    execute: () => ({}),
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    }),
+    outputSchema: jsonSchema({
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    }),
+  });
+
+async function drainRun(run: { events(): AsyncIterable<unknown> }) {
+  let eventCount = 0;
+  for await (const _event of run.events()) {
+    eventCount += 1;
+  }
+  return eventCount;
+}
+
+describe("createLookAtLlm", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  it("is exported from the public runtime source index", () => {
+    expect(createLookAtLlm).toEqual(expect.any(Function));
+  });
+
+  it("returns an LLM accepted by Agent.create through the custom llm seam", async () => {
+    const llm = createLookAtLlm({
+      model: fakeModel,
+      visionModel: fakeVisionModel,
+    });
+
+    const agent = await Agent.create({ llm });
+
+    await drainRun(
+      await agent.send(userText("describe the available context"))
+    );
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: fakeModel,
+      })
+    );
+  });
+
+  it("passes caller options through while adding the default look_at tool", async () => {
+    const injectedTools = { injected: createNoopTool() } satisfies ToolSet;
+    const signal = new AbortController().signal;
+    const history = [{ role: "user" as const, content: "hello" }];
+    const llm = createLookAtLlm({
+      allowedMediaTypes: ["image/png", "application/pdf"],
+      instructions: "test instructions",
+      maxImageBytes: 1024,
+      maxOutputChars: 2000,
+      model: fakeModel,
+      toolChoice: "required",
+      tools: injectedTools,
+      visionModel: fakeVisionModel,
+    });
+
+    await expect(llm({ history, signal })).resolves.toEqual([
+      assistantMessage("DONE"),
+    ]);
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: signal,
+        instructions: "test instructions",
+        messages: history,
+        model: fakeModel,
+        toolChoice: "required",
+        tools: expect.objectContaining({
+          injected: injectedTools.injected,
+          look_at: expect.any(Object),
+        }),
+      })
+    );
+  });
+
+  it("supports a custom look_at tool name", async () => {
+    const signal = new AbortController().signal;
+    const llm = createLookAtLlm({
+      model: fakeModel,
+      toolName: "inspect_media",
+      visionModel: fakeVisionModel,
+    });
+
+    await llm({
+      history: [{ role: "user", content: "hello" }],
+      signal,
+    });
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.objectContaining({
+          inspect_media: expect.any(Object),
+        }),
+      })
+    );
+  });
+
+  it("rejects caller tools that conflict with the default look_at tool name", () => {
+    expect(() =>
+      createLookAtLlm({
+        model: fakeModel,
+        tools: { look_at: createNoopTool() },
+        visionModel: fakeVisionModel,
+      })
+    ).toThrow(LOOK_AT_CONFLICT_PATTERN);
+  });
+
+  it("sanitizes supported images into scoped handles for the main model", async () => {
+    const originalImage = dataImageUrl("image/png");
+    const unsupportedImage = dataImageUrl("image/gif");
+    const fileData = "raw text file content";
+    const history = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "describe this" },
+          {
+            type: "file" as const,
+            data: originalImage,
+            mediaType: "image/png",
+          },
+          {
+            type: "file" as const,
+            data: unsupportedImage,
+            mediaType: "image/gif",
+          },
+          { type: "file" as const, data: fileData, mediaType: "text/plain" },
+        ],
+      },
+    ];
+    const llm = createLookAtLlm({
+      model: fakeModel,
+      visionModel: fakeVisionModel,
+    });
+
+    await llm({ history, signal: new AbortController().signal });
+
+    const mainCall = generateTextMock.mock.calls[0][0];
+    expect(mainCall.messages).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "text", text: "[image image_1 image/png]" },
+          { type: "text", text: "[image omitted: media type not allowed]" },
+          { type: "text", text: "[file omitted]" },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(mainCall.messages)).not.toContain(originalImage);
+    expect(JSON.stringify(mainCall.messages)).not.toContain(unsupportedImage);
+    expect(JSON.stringify(mainCall.messages)).not.toContain(fileData);
+    expect(history[0].content[1]).toEqual({
+      type: "file",
+      data: originalImage,
+      mediaType: "image/png",
+    });
+  });
+
+  it("omits oversized supported images before creating handles", async () => {
+    const imageData = dataImageUrl("image/png");
+    const llm = createLookAtLlm({
+      maxImageBytes: 1,
+      model: fakeModel,
+      visionModel: fakeVisionModel,
+    });
+
+    await llm({
+      history: [
+        {
+          role: "user",
+          content: [{ type: "file", data: imageData, mediaType: "image/png" }],
+        },
+      ],
+      signal: new AbortController().signal,
+    });
+
+    const mainCall = generateTextMock.mock.calls[0][0];
+    expect(mainCall.messages[0].content).toEqual([
+      { type: "text", text: "[image omitted: too large]" },
+    ]);
+  });
+
+  it("sanitizes data image text markers in existing text content", async () => {
+    const llm = createLookAtLlm({
+      model: fakeModel,
+      visionModel: fakeVisionModel,
+    });
+
+    await llm({
+      history: [{ role: "user", content: `see ${dataImageUrl("image/png")}` }],
+      signal: new AbortController().signal,
+    });
+
+    const mainCall = generateTextMock.mock.calls[0][0];
+    expect(mainCall.messages).toEqual([
+      { role: "user", content: "see [image data omitted]" },
+    ]);
+  });
+
+  it("look_at calls the vision model with original image data and truncates output", async () => {
+    const signal = new AbortController().signal;
+    const imageData = dataImageUrl("image/png");
+    generateTextMock
+      .mockResolvedValueOnce({ responseMessages: [assistantMessage("DONE")] })
+      .mockResolvedValueOnce({ text: "abcdef" });
+    const llm = createLookAtLlm({
+      maxOutputChars: 3,
+      model: fakeModel,
+      visionModel: fakeVisionModel,
+    });
+
+    await llm({
+      history: [
+        {
+          role: "user",
+          content: [{ type: "file", data: imageData, mediaType: "image/png" }],
+        },
+      ],
+      signal,
+    });
+
+    const lookAtTool = generateTextMock.mock.calls[0][0].tools.look_at;
+    await expect(
+      lookAtTool.execute(
+        { imageId: "image_1", question: "what is shown?" },
+        { toolCallId: "call", messages: [], abortSignal: signal }
+      )
+    ).resolves.toEqual({
+      imageId: "image_1",
+      ok: true,
+      text: "abc…[truncated]",
+      truncated: true,
+    });
+    expect(generateTextMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        abortSignal: signal,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "what is shown?" },
+              { type: "file", data: imageData, mediaType: "image/png" },
+            ],
+          },
+        ],
+        model: fakeVisionModel,
+      })
+    );
+  });
+
+  it("look_at returns bounded safe errors for unknown handles and vision failures", async () => {
+    generateTextMock
+      .mockResolvedValueOnce({ responseMessages: [assistantMessage("DONE")] })
+      .mockRejectedValueOnce(new Error("raw provider secret details"));
+    const llm = createLookAtLlm({
+      model: fakeModel,
+      visionModel: fakeVisionModel,
+    });
+
+    await llm({
+      history: [
+        {
+          role: "user",
+          content: [{ type: "file", data: "ZmFrZQ==", mediaType: "image/png" }],
+        },
+      ],
+      signal: new AbortController().signal,
+    });
+
+    const lookAtTool = generateTextMock.mock.calls[0][0].tools.look_at;
+    await expect(
+      lookAtTool.execute(
+        { imageId: "missing", question: "what?" },
+        { toolCallId: "call", messages: [] }
+      )
+    ).resolves.toEqual({
+      imageId: "missing",
+      error: { code: "unknown_image", message: "Unknown image handle" },
+      ok: false,
+    });
+    await expect(
+      lookAtTool.execute(
+        { imageId: "image_1", question: "what?" },
+        { toolCallId: "call", messages: [] }
+      )
+    ).resolves.toEqual({
+      imageId: "image_1",
+      error: { code: "vision_model_error", message: "Vision model failed" },
+      ok: false,
+    });
+  });
+});

--- a/packages/runtime/src/look-at.ts
+++ b/packages/runtime/src/look-at.ts
@@ -1,0 +1,401 @@
+import type {
+  LanguageModel,
+  ModelMessage,
+  SystemModelMessage,
+  ToolSet,
+} from "ai";
+import { generateText, jsonSchema, tool } from "ai";
+import type { AgentToolChoice, Llm, LlmOutput } from "./llm";
+
+export const DEFAULT_LOOK_AT_TOOL_NAME = "look_at";
+export const DEFAULT_LOOK_AT_MAX_OUTPUT_CHARS = 2000;
+export const DEFAULT_LOOK_AT_MAX_IMAGE_BYTES = 10_485_760;
+export const DEFAULT_LOOK_AT_ALLOWED_MEDIA_TYPES = [
+  "image/png",
+  "image/jpeg",
+] as const;
+
+const TRUNCATED_SUFFIX = "…[truncated]";
+const IMAGE_DATA_URL_PATTERN = new RegExp(
+  ["data:", "image/[^\\s)\\]}]+"].join(""),
+  "gi"
+);
+const BASE64_DATA_URL_PATTERN = /^data:[^,]*;base64,([a-z0-9+/=\r\n]+)$/i;
+const BASE64_LINE_BREAK_PATTERN = /[\r\n]/g;
+
+export interface CreateLookAtLlmOptions {
+  allowedMediaTypes?: readonly string[];
+  instructions?: string;
+  maxImageBytes?: number;
+  maxOutputChars?: number;
+  model: LanguageModel;
+  toolChoice?: AgentToolChoice;
+  toolName?: string;
+  tools?: ToolSet;
+  visionModel: LanguageModel;
+}
+
+interface ImageHandle {
+  readonly id: string;
+  readonly mediaType: string;
+  readonly part: Record<string, unknown>;
+}
+
+type SanitizedContentPart =
+  | { text: string; type: "text" }
+  | Record<string, unknown>;
+
+type LookAtResult =
+  | { imageId: string; ok: true; text: string; truncated: boolean }
+  | { error: { code: string; message: string }; imageId?: string; ok: false };
+
+export function createLookAtLlm({
+  allowedMediaTypes = DEFAULT_LOOK_AT_ALLOWED_MEDIA_TYPES,
+  instructions,
+  maxImageBytes = DEFAULT_LOOK_AT_MAX_IMAGE_BYTES,
+  maxOutputChars = DEFAULT_LOOK_AT_MAX_OUTPUT_CHARS,
+  model,
+  toolChoice,
+  toolName = DEFAULT_LOOK_AT_TOOL_NAME,
+  tools,
+  visionModel,
+}: CreateLookAtLlmOptions): Llm {
+  if (tools && toolName in tools) {
+    throw new Error(
+      `${toolName} tool conflict: createLookAtLlm injects this tool`
+    );
+  }
+
+  const allowedMediaTypeSet = new Set(allowedMediaTypes);
+
+  return async ({ history, signal }) => {
+    const handles = new Map<string, ImageHandle>();
+    const messages = sanitizeMessages(history, {
+      allowedMediaTypeSet,
+      handles,
+      maxImageBytes,
+    });
+
+    const lookAtTool = createLookAtTool({
+      handles,
+      maxOutputChars,
+      signal,
+      visionModel,
+    });
+
+    const { responseMessages } = await generateText({
+      abortSignal: signal,
+      instructions,
+      messages,
+      model,
+      toolChoice,
+      tools: { ...(tools ?? {}), [toolName]: lookAtTool },
+    });
+
+    return responseMessages as LlmOutput;
+  };
+}
+
+function sanitizeMessages(
+  history: readonly ModelMessage[],
+  options: {
+    allowedMediaTypeSet: ReadonlySet<string>;
+    handles: Map<string, ImageHandle>;
+    maxImageBytes: number;
+  }
+): ModelMessage[] {
+  return history.map((message) => sanitizeMessage(message, options));
+}
+
+function sanitizeMessage(
+  message: ModelMessage,
+  options: {
+    allowedMediaTypeSet: ReadonlySet<string>;
+    handles: Map<string, ImageHandle>;
+    maxImageBytes: number;
+  }
+): ModelMessage {
+  if (message.role === "system") {
+    return sanitizeSystemMessage(message);
+  }
+
+  if (message.role === "tool") {
+    return {
+      ...message,
+      content: message.content.map((part) =>
+        sanitizeContentPart(part, options)
+      ),
+    } as ModelMessage;
+  }
+
+  if (typeof message.content === "string") {
+    return { ...message, content: sanitizeText(message.content) };
+  }
+
+  return {
+    ...message,
+    content: message.content.map((part) => sanitizeContentPart(part, options)),
+  } as ModelMessage;
+}
+
+function sanitizeSystemMessage(
+  message: SystemModelMessage
+): SystemModelMessage {
+  return { ...message, content: sanitizeText(message.content) };
+}
+
+function sanitizeContentPart(
+  part: unknown,
+  options: {
+    allowedMediaTypeSet: ReadonlySet<string>;
+    handles: Map<string, ImageHandle>;
+    maxImageBytes: number;
+  }
+): SanitizedContentPart {
+  if (!isRecord(part)) {
+    return { type: "text", text: "[unsupported content part omitted]" };
+  }
+
+  if (part.type === "text") {
+    return { ...part, text: sanitizeText(String(part.text ?? "")) };
+  }
+
+  if (part.type === "image" || part.type === "file") {
+    const imagePart = imageHandleCandidate(part, options);
+    if (!imagePart.ok) {
+      return { type: "text", text: `[${imagePart.reason}]` };
+    }
+
+    const id = `image_${options.handles.size + 1}`;
+    options.handles.set(id, {
+      id,
+      mediaType: imagePart.mediaType,
+      part: { ...part },
+    });
+
+    return {
+      type: "text",
+      text: `[image ${id} ${imagePart.mediaType}]`,
+    };
+  }
+
+  return sanitizeUnknownValue(part) as SanitizedContentPart;
+}
+
+function sanitizeUnknownValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return sanitizeText(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sanitizeUnknownValue);
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        sanitizeUnknownValue(entry),
+      ])
+    );
+  }
+
+  return value;
+}
+
+function sanitizeText(text: string): string {
+  return text.replace(IMAGE_DATA_URL_PATTERN, "[image data omitted]");
+}
+
+function imageHandleCandidate(
+  part: Record<string, unknown>,
+  options: {
+    allowedMediaTypeSet: ReadonlySet<string>;
+    maxImageBytes: number;
+  }
+):
+  | { mediaType: string; ok: true }
+  | {
+      ok: false;
+      reason:
+        | "image omitted: media type not allowed"
+        | "image omitted: unsupported data"
+        | "image omitted: too large"
+        | "file omitted";
+    } {
+  const mediaType =
+    typeof part.mediaType === "string" ? part.mediaType : "image";
+  const data = part.type === "image" ? part.image : part.data;
+
+  if (part.type === "file" && !mediaType.startsWith("image/")) {
+    return { ok: false, reason: "file omitted" };
+  }
+
+  if (!options.allowedMediaTypeSet.has(mediaType)) {
+    return { ok: false, reason: "image omitted: media type not allowed" };
+  }
+
+  const size = contentByteLength(data);
+  if (size === undefined) {
+    return { ok: false, reason: "image omitted: unsupported data" };
+  }
+
+  if (size > options.maxImageBytes) {
+    return { ok: false, reason: "image omitted: too large" };
+  }
+
+  return { mediaType, ok: true };
+}
+
+function contentByteLength(value: unknown): number | undefined {
+  if (typeof value === "string") {
+    return (
+      dataUrlDecodedByteLength(value) ??
+      new TextEncoder().encode(value).byteLength
+    );
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return value.byteLength;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return value.byteLength;
+  }
+
+  if (isRecord(value) && value.type === "data") {
+    return contentByteLength(value.data);
+  }
+
+  return;
+}
+
+function dataUrlDecodedByteLength(value: string): number | undefined {
+  const match = BASE64_DATA_URL_PATTERN.exec(value);
+  if (!match) {
+    return;
+  }
+
+  const base64 = match[1].replace(BASE64_LINE_BREAK_PATTERN, "");
+  let padding = 0;
+  if (base64.endsWith("==")) {
+    padding = 2;
+  } else if (base64.endsWith("=")) {
+    padding = 1;
+  }
+  return Math.max(0, (base64.length / 4) * 3 - padding);
+}
+
+function truncateText(text: string, maxOutputChars: number): string {
+  return `${text.slice(0, Math.max(0, maxOutputChars))}${TRUNCATED_SUFFIX}`;
+}
+
+function createLookAtTool({
+  handles,
+  maxOutputChars,
+  signal,
+  visionModel,
+}: {
+  handles: ReadonlyMap<string, ImageHandle>;
+  maxOutputChars: number;
+  signal: AbortSignal;
+  visionModel: LanguageModel;
+}) {
+  return tool({
+    description: "Inspect a previously attached image by handle.",
+    execute: async (input: unknown, options): Promise<LookAtResult> => {
+      const parsed = parseLookAtInput(input);
+      if (!parsed.ok) {
+        return safeError(
+          "invalid_input",
+          "look_at requires imageId and question strings"
+        );
+      }
+
+      const handle = handles.get(parsed.imageId);
+      if (!handle) {
+        return safeError(
+          "unknown_image",
+          "Unknown image handle",
+          parsed.imageId
+        );
+      }
+
+      try {
+        const result = await generateText({
+          abortSignal: options.abortSignal ?? signal,
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: parsed.question },
+                { ...handle.part } as never,
+              ],
+            },
+          ],
+          model: visionModel,
+        });
+        const text = sanitizeText(
+          typeof result.text === "string" ? result.text : ""
+        );
+        const truncated = text.length > maxOutputChars;
+
+        return {
+          imageId: parsed.imageId,
+          ok: true,
+          text: truncated ? truncateText(text, maxOutputChars) : text,
+          truncated,
+        };
+      } catch {
+        return safeError(
+          "vision_model_error",
+          "Vision model failed",
+          parsed.imageId
+        );
+      }
+    },
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: {
+        imageId: { type: "string" },
+        question: { type: "string" },
+      },
+      required: ["imageId", "question"],
+      additionalProperties: false,
+    }),
+    outputSchema: jsonSchema({
+      type: "object",
+      additionalProperties: true,
+    }),
+  });
+}
+
+function parseLookAtInput(
+  input: unknown
+): { imageId: string; ok: true; question: string } | { ok: false } {
+  if (
+    !isRecord(input) ||
+    typeof input.imageId !== "string" ||
+    typeof input.question !== "string"
+  ) {
+    return { ok: false };
+  }
+
+  return { imageId: input.imageId, ok: true, question: input.question };
+}
+
+function safeError(
+  code: string,
+  message: string,
+  imageId?: string
+): LookAtResult {
+  return {
+    ...(imageId === undefined ? {} : { imageId }),
+    error: { code, message },
+    ok: false,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}


### PR DESCRIPTION
## Summary
- Add runtime createLookAtLlm support for sanitizing image history, exposing a look_at tool, and delegating image inspection to a vision model.
- Wire coding-agent PSS_LOOK_AT_* env/model configuration and use it in the TUI when enabled.
- Add Ctrl+V clipboard image attachment support for the TUI, with clipboard platform readers and bounded/no-raw-data output.
- Add runtime, env/model, clipboard, TUI, and integration tests plus docs and a changeset.

## Validation
- pnpm boundaries: passed
- pnpm lint: passed
- pnpm typecheck: passed
- pnpm test: passed
- pnpm build: passed
- pnpm verify:release: passed
- no-base64 leak allowlist scan: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multimodal image inspection to the CLI by wrapping the main model with a `look_at` tool and delegating actual image analysis to a vision model. Also adds TUI clipboard image attachments (Ctrl+V) with safe, non-leaky output.

- New Features
  - Runtime (`@minpeter/pss-runtime`): `createLookAtLlm` injects a `look_at` tool, sanitizes image history into handles, runs vision calls on the original media, and bounds output; exports defaults and docs.
  - Coding agent (`@minpeter/pss-coding-agent`): `PSS_LOOK_AT_*` env enables vision delegation in the TUI; adds Ctrl+V clipboard image attachment (PNG/JPEG) with platform readers (`pngpaste`, `wl-paste`, `xclip`) and no raw data printing.
  - Tests/Docs: end-to-end, runtime, env, TUI, and clipboard tests; README updates; changeset.

- Migration
  - To enable vision delegation: set `PSS_LOOK_AT_MODEL` (optional: `PSS_LOOK_AT_BASE_URL`, `PSS_LOOK_AT_API_KEY`, `PSS_LOOK_AT_MAX_OUTPUT_CHARS`, `PSS_LOOK_AT_MAX_IMAGE_BYTES`). Otherwise `look_at` stays disabled.
  - For clipboard paste: ensure a supported OS command is installed (`pngpaste` on macOS, `wl-paste` for Wayland, or `xclip` for X11), then press Ctrl+V in the TUI to attach an image.

<sup>Written for commit 3699adce2d6d452c14af322e33e8af5509bc6ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/54?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

