### PR TITLE
Load dotenv in basic example

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,8 +1,10 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { Agent } from "@minpeter/pss-runtime";
 import { createEnv } from "@t3-oss/env-core";
+import { config as loadEnv } from "dotenv";
 import { z } from "zod";
 
+loadEnv({ path: ".env", quiet: true, override: true });
 const env = createEnv({
   runtimeEnv: process.env,
   server: {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@minpeter/pss-runtime": "workspace:*",
     "@t3-oss/env-core": "^0.13.11",
     "@types/node": "^25.9.1",
+    "dotenv": "^17.4.2",
     "tsx": "^4.22.3",
     "turbo": "^2.9.15",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       tsx:
         specifier: ^4.22.3
         version: 4.22.3


### PR DESCRIPTION
## Summary
- load .env before validating the basic example environment
- add dotenv as a workspace dependency

## Testing
- Not run (PR requested quickly from existing changes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load `.env` in the basic example before validating with `@t3-oss/env-core` so environment variables are available. Adds `dotenv` to the workspace.

- **Dependencies**
  - Added `dotenv` ^17.4.2

<sup>Written for commit 5608fdab04f1297888ed7173c112a08d8c6fd2dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

