### PR TITLE
[codex] add v0.1 next release lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v0.1
   workflow_dispatch:
 
 permissions:
@@ -70,6 +71,7 @@ jobs:
         run: pnpm verify:release
 
       - name: Create release pull request or publish
+        if: github.ref_name == 'main'
         uses: changesets/action@v1
         with:
           publish: pnpm release
@@ -77,4 +79,12 @@ jobs:
           # npm publish is authenticated by npm Trusted Publishing/OIDC.
           # Configure each package on npm with repository minpeter/pss-next
           # and workflow filename release.yml; do not add NPM_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create next release pull request or publish
+        if: github.ref_name == 'v0.1'
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release:next
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish",
+    "release:next": "pnpm build && changeset publish --tag next",
     "verify:release": "node scripts/verify-release-artifacts.mjs",
     "boundaries": "turbo boundaries",
     "repo:packages": "turbo query ls --output json",

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("release workflow", () => {
+  it("publishes the v0.1 release lane with the next dist tag", () => {
+    const workflow = readFileSync(".github/workflows/release.yml", "utf8");
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+
+    expect(packageJson.scripts["release:next"]).toBe(
+      "pnpm build && changeset publish --tag next"
+    );
+    expect(workflow).toContain("      - main\n      - v0.1");
+    expect(workflow).toContain("if: github.ref_name == 'main'");
+    expect(workflow).toContain("publish: pnpm release\n");
+    expect(workflow).toContain("if: github.ref_name == 'v0.1'");
+    expect(workflow).toContain("publish: pnpm release:next\n");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a `release:next` script that publishes Changesets releases with npm dist-tag `next`.
- Extend the release workflow to run on `v0.1` as well as `main`.
- Keep `main` publishing through `pnpm release`, and route `v0.1` through `pnpm release:next`.
- Add a release workflow regression test that guards the branch trigger and publish commands.

## Validation

- `pnpm exec vitest run scripts/release-workflow.test.mjs` RED before the workflow/script change, then GREEN after
- `pnpm exec vitest run scripts/*.test.mjs`
- `pnpm test`
- `pnpm lint`
- `git diff --check`
- tmux config smoke: `WORKFLOW_NEXT_OK`, `EXIT:0`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated v0.1 “next” release lane that publishes with the npm `next` dist-tag, while keeping `main` on the stable lane. Also adds a regression test to lock down the workflow triggers and publish commands.

- **New Features**
  - Added `release:next` script in `package.json` to run `changeset publish --tag next`.
  - Updated `.github/workflows/release.yml` to trigger on `v0.1` and run `pnpm release:next`; `main` continues to run `pnpm release`.
  - Added `scripts/release-workflow.test.mjs` to verify branch triggers and publish commands.

<sup>Written for commit 6a5bec575eb714a7c5af308725d9e814dc3cd83e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

