### PR TITLE
[codex] fix next prerelease publish command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish",
-    "release:next": "pnpm build && changeset publish --tag next",
+    "release:next": "pnpm build && changeset publish",
     "verify:release": "node scripts/verify-release-artifacts.mjs",
     "boundaries": "turbo boundaries",
     "repo:packages": "turbo query ls --output json",

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -7,8 +7,9 @@ describe("release workflow", () => {
     const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 
     expect(packageJson.scripts["release:next"]).toBe(
-      "pnpm build && changeset publish --tag next"
+      "pnpm build && changeset publish"
     );
+    expect(packageJson.scripts["release:next"]).not.toContain("--tag next");
     expect(workflow).toContain("      - main\n      - v0.1");
     expect(workflow).toContain("if: github.ref_name == 'main'");
     expect(workflow).toContain("publish: pnpm release\n");


### PR DESCRIPTION
## Summary

- Fix the `release:next` script to let Changesets pre-mode choose the npm dist-tag from `.changeset/pre.json`.
- Update the release workflow regression test to forbid `--tag next`, which Changesets rejects while in pre-mode.

## Validation

- `pnpm exec vitest run scripts/release-workflow.test.mjs` RED before the script fix, then GREEN after
- `pnpm test`
- `pnpm lint`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `release:next` script to let Changesets pre‑mode choose the npm dist‑tag from `.changeset/pre.json` by removing the hardcoded `--tag next`. Updated the release workflow test to require `pnpm build && changeset publish` and forbid `--tag next`.

<sup>Written for commit 9a90e37402944c3b4fcd6f4498b26a23128d7deb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

