### PR TITLE
[codex] Fix runtime kill active runs

### DIFF
--- a/.changeset/quiet-runs-close.md
+++ b/.changeset/quiet-runs-close.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Close active run streams immediately when sessions are killed.

--- a/packages/runtime/src/session/run.test.ts
+++ b/packages/runtime/src/session/run.test.ts
@@ -148,6 +148,16 @@ describe("AgentRun", () => {
     });
   });
 
+  it("close() settles queued boundary acknowledgements", async () => {
+    const run = new BufferedAgentRun();
+    const boundary = run.emitBoundary({ type: "step-start" });
+    await expectPending(boundary);
+
+    run.close(undefined, "Session killed");
+
+    await expect(boundary).resolves.toBeUndefined();
+  });
+
   it("closes and discards queued events when the events iterator returns early", async () => {
     const run = new BufferedAgentRun();
     const iterator = run.events()[Symbol.asyncIterator]();

--- a/packages/runtime/src/session/run.ts
+++ b/packages/runtime/src/session/run.ts
@@ -49,6 +49,7 @@ export class BufferedAgentRun implements AgentRun {
     this.#closed = true;
     this.#error = error;
     this.#settlePendingAck();
+    this.#settleQueuedAcks();
 
     if (!this.#waiter) {
       return;

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -31,6 +31,18 @@ const collect = async (run: Awaited<ReturnType<Agent["send"]>>) => {
   return events;
 };
 
+const timeoutMarker = Symbol("timeout");
+
+const withShortTimeout = async <T>(
+  promise: Promise<T>
+): Promise<T | typeof timeoutMarker> =>
+  Promise.race([
+    promise,
+    new Promise<typeof timeoutMarker>((resolve) => {
+      setTimeout(() => resolve(timeoutMarker), 25);
+    }),
+  ]);
+
 class SpyStore implements SessionStore {
   readonly commits: Array<{
     key: string;
@@ -156,6 +168,32 @@ describe("Agent session API", () => {
     expect(hookCalls).toEqual([
       "user-text:before:0",
       "user-text:after:completed:2",
+    ]);
+  });
+
+  it("closes the active run when a killed session has a pending model call", async () => {
+    const llmStarted = createDeferred();
+    const agent = await Agent.create({
+      llm: () => {
+        llmStarted.resolve();
+        return new Promise<never>(() => undefined);
+      },
+    });
+    const session = agent.session("kill-pending-model");
+    const collecting = collect(await session.send("hello"));
+    await llmStarted.promise;
+
+    session.kill();
+
+    const events = await withShortTimeout(collecting);
+    if (events === timeoutMarker) {
+      throw new Error("session.kill() did not close the active run");
+    }
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "turn-error",
     ]);
   });
 
@@ -1079,7 +1117,7 @@ describe("Agent session API", () => {
     session.kill();
     llmGate.resolve();
 
-    expect(eventTypes(await firstEvents)).toContain("turn-abort");
+    expect(eventTypes(await firstEvents)).toContain("turn-error");
     expect(eventTypes(await secondEvents)).toEqual(["user-text", "turn-error"]);
     await expect(session.steer("late")).rejects.toThrow("Session killed");
   });

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -39,7 +39,7 @@ const withShortTimeout = async <T>(
   Promise.race([
     promise,
     new Promise<typeof timeoutMarker>((resolve) => {
-      setTimeout(() => resolve(timeoutMarker), 25);
+      setTimeout(() => resolve(timeoutMarker), 100);
     }),
   ]);
 

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -197,6 +197,37 @@ describe("Agent session API", () => {
     ]);
   });
 
+  it("closes the active run when a killed session has a pending afterTurn hook", async () => {
+    const afterTurnStarted = createDeferred();
+    const agent = await Agent.create({
+      hooks: {
+        afterTurn: () => {
+          afterTurnStarted.resolve();
+          return new Promise<never>(() => undefined);
+        },
+      },
+      llm: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+    const session = agent.session("kill-pending-after-turn");
+    const collecting = collect(await session.send("hello"));
+    await afterTurnStarted.promise;
+
+    session.kill();
+
+    const events = await withShortTimeout(collecting);
+    if (events === timeoutMarker) {
+      throw new Error("session.kill() did not close the afterTurn run");
+    }
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-error",
+    ]);
+  });
+
   it("commits successful output before afterTurn failures", async () => {
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -56,6 +56,7 @@ export class AgentSession {
   #loadPromise?: Promise<void>;
   #loaded = false;
   #running = false;
+  #runToCloseOnKill?: BufferedAgentRun;
   #storeVersion: string | undefined;
 
   constructor(
@@ -123,25 +124,24 @@ export class AgentSession {
     }
 
     this.#killed = true;
+    const killedError = sessionKilledError();
     this.#activeAbort?.abort();
-    this.#closeRuntimeInput(
-      this.#activeRuntimeInput,
-      sessionKilledError().message
-    );
-    this.#activeRun?.emit({
+    this.#closeRuntimeInput(this.#activeRuntimeInput, killedError.message);
+    const runToClose = this.#runToCloseOnKill ?? this.#activeRun;
+    runToClose?.emit({
       type: "turn-error",
-      message: sessionKilledError().message,
+      message: killedError.message,
     });
-    this.#activeRun?.close(undefined, sessionKilledError().message);
+    runToClose?.close(undefined, killedError.message);
 
     while (this.#inputQueue.length > 0) {
       const item = this.#inputQueue.shift();
-      this.#closeRuntimeInput(item?.runtimeInput, sessionKilledError().message);
+      this.#closeRuntimeInput(item?.runtimeInput, killedError.message);
       item?.run.emit({
         type: "turn-error",
-        message: sessionKilledError().message,
+        message: killedError.message,
       });
-      item?.run.close(undefined, sessionKilledError().message);
+      item?.run.close(undefined, killedError.message);
     }
   }
 
@@ -203,6 +203,7 @@ export class AgentSession {
     this.#activeAbort = activeAbort;
     this.#activeRun = run;
     this.#activeRuntimeInput = runtimeInput;
+    this.#runToCloseOnKill = run;
     const historySnapshot = this.#history.modelSnapshot();
 
     try {
@@ -299,6 +300,7 @@ export class AgentSession {
       this.#activeAbort = undefined;
       this.#activeRun = undefined;
       this.#activeRuntimeInput = undefined;
+      this.#runToCloseOnKill = undefined;
       run.close(undefined, runtimeInput.closedReason);
     }
   }

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -128,6 +128,11 @@ export class AgentSession {
       this.#activeRuntimeInput,
       sessionKilledError().message
     );
+    this.#activeRun?.emit({
+      type: "turn-error",
+      message: sessionKilledError().message,
+    });
+    this.#activeRun?.close(undefined, sessionKilledError().message);
 
     while (this.#inputQueue.length > 0) {
       const item = this.#inputQueue.shift();


### PR DESCRIPTION
## What changed

- Close the active `AgentRun` immediately when `session.kill()` is called.
- Settle queued boundary acknowledgements when a buffered run closes.
- Add regression coverage for pending model calls and queued boundary ACKs.
- Add a patch changeset for `@minpeter/pss-runtime`.

## Why

A killed session previously only aborted the active controller. If the active model call or boundary path ignored the abort, callers consuming `run.events()` could remain pending indefinitely. This caused downstream agent surfaces to need timeout-based recovery instead of relying on the runtime cancellation contract.

## Validation

- `pnpm --dir packages/runtime test`
- `pnpm --dir packages/runtime typecheck`
- `pnpm --dir packages/runtime build`
- `pnpm --dir packages/runtime lint`
- Manual QA: imported the built runtime, started a pending model call, called `session.kill()`, and verified the stream ended with `["user-text","turn-start","step-start","turn-error"]`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Killing a session now reliably cancels and closes the active run, even during pending model calls or `afterTurn` hooks, so event consumers don’t hang. Includes a patch release for `@minpeter/pss-runtime`.

- **Bug Fixes**
  - Close the active `AgentRun` and emit `turn-error` on `session.kill()`, including during pending LLM calls and `afterTurn`.
  - Settle queued boundary acknowledgements when a buffered run closes to prevent stuck ACKs.
  - Add regression tests for pending model calls, `afterTurn` hooks, and queued boundary ACKs, with a short timeout guard to avoid flakes.

<sup>Written for commit 906195de9c70d50dfcfda5d6179acbac6e7429ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

