### PR TITLE
[codex] add durable background host resume

### DIFF
--- a/.changeset/background-notify-runs.md
+++ b/.changeset/background-notify-runs.md
@@ -1,0 +1,28 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add the `host` execution contract for resumable runs, durable notification resume,
+and background subagent capability detection. Advanced execution host, store,
+and scheduler contracts live under `@minpeter/pss-runtime/execution`.
+Background delegation now exposes background tools only when the host advertises
+support, persists child run links for cleanup/cancellation, and resumes parents
+through an idempotent notification claim. Scheduler resume calls now carry the
+notification idempotency metadata adapters need to resume the parent without
+reconstructing internal keys.
+
+Agent construction now routes session persistence through
+`host: { sessionStore }` plus top-level `namespace`. App-facing `SessionHandle`
+objects expose `send`, `steer`, `delete`, `interrupt`, and `kill`;
+runtime-originated input resumes through `Agent.resume(runId)`. The public
+`Agent` constructor uses `model` for both AI SDK models and custom `RuntimeLlm`
+functions. High-level managed model turns on an execution host now record
+`user-turn` runs and before/after tool checkpoints. `AgentToolChoice` now
+preserves the AI SDK tool-choice shape, including named tool selection for
+providers that support it.
+
+Durable adapters own actual scheduling/leases/resume workers; the Cloudflare
+example shows a Worker/Durable Object shaped host adapter with local `ctx.storage`
+simulation, alarm-driven resume, and Wrangler entrypoints. This prerelease branch
+uses a patch changeset by default per repository release policy; no semver-major
+release level was requested for this work.

--- a/.changeset/background-notify-runs.md
+++ b/.changeset/background-notify-runs.md
@@ -21,8 +21,16 @@ functions. High-level managed model turns on an execution host now record
 preserves the AI SDK tool-choice shape, including named tool selection for
 providers that support it.
 
+Durable checkpoints store tool execution metadata only; raw tool input/output
+stays in the live execution callback path and is not persisted for resume.
+`delete()` and `kill()` now hard-stop the active session before durable child
+cleanup or store deletion is awaited, so killed work cannot keep running while
+cleanup is blocked. Grouped background notifications filter stale cancelled
+siblings without dropping completed sibling notifications.
+
 Durable adapters own actual scheduling/leases/resume workers; the Cloudflare
 example shows a Worker/Durable Object shaped host adapter with local `ctx.storage`
-simulation, alarm-driven resume, and Wrangler entrypoints. This prerelease branch
-uses a patch changeset by default per repository release policy; no semver-major
-release level was requested for this work.
+simulation, alarm-driven resume, request-derived Durable Object/session/storage
+identity, and Wrangler entrypoints. This prerelease branch uses a patch changeset
+by default per repository release policy; no semver-major release level was
+requested for this work.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@minpeter/pss-example-basic",
+    "@minpeter/pss-example-cloudflare-edge-subagent",
     "@minpeter/pss-example-plugin",
     "@minpeter/pss-example-subagent"
   ]

--- a/.changeset/runtime-plugin-constructor.md
+++ b/.changeset/runtime-plugin-constructor.md
@@ -2,4 +2,4 @@
 "@minpeter/pss-runtime": patch
 ---
 
-Implement constructor-level `plugins: [...]` event observers and lifecycle middleware, and reject legacy `hooks` constructor options.
+Implement constructor-level `plugins: [...]` event observers and lifecycle middleware.

--- a/.changeset/runtime-plugin-sessions.md
+++ b/.changeset/runtime-plugin-sessions.md
@@ -5,8 +5,8 @@
 Add plugin-first session persistence, memory, and compaction APIs, plus event-first runtime control.
 
 - Keep `run.events()` as the app-owned runtime control loop for synchronized rendering, tracing, and continuation policy.
-- Add constructor-level `plugins: [...]` lifecycle middleware support and reject legacy `hooks` constructor options.
+- Add constructor-level `plugins: [...]` lifecycle middleware support.
 - Expand plugin lifecycle middleware with `turn.before`, `step.before`, `step.after`, and `turn.after` handlers that can call scoped `steer(...)`.
-- Add `Agent.create({ onPluginError })` for routing plugin lifecycle handler failures to caller-owned observability instead of the default console reporter.
+- Route plugin lifecycle handler failures through the returned run so callers own observability.
 - Add runtime-owned tool policy middleware with `tool.call` and `tool.result` for allow, modify, reject-and-continue, synthesize, error, and result replacement flows.
-- Remove legacy top-level `Agent.create({ sessions: { store } })` and `Agent.create({ hooks })` options. Use `plugins: [sessions.custom(store)]` for persistence, `run.events()` plus `session.steer()` for app control, or plugin lifecycle handlers for reusable middleware.
+- Use `host: { sessionStore }` for persistence, `run.events()` plus `session.steer()` for app control, or plugin lifecycle handlers for reusable middleware.

--- a/examples/cloudflare-edge-subagent/README.md
+++ b/examples/cloudflare-edge-subagent/README.md
@@ -1,0 +1,80 @@
+# Cloudflare Edge Support Subagent Example
+
+This example shows a support-agent style Cloudflare Worker/Durable Object
+background subagent loop. The foreground agent receives a support-ticket turn,
+launches compact background research, returns control to the request boundary,
+then resumes from a Durable Object alarm when the child result is ready:
+
+- `createCloudflareDurableObjectHost(...)` stores sessions, runs,
+  checkpoints, events, notifications, and scheduled session prompts on a storage port
+  compatible with `ctx.storage`.
+- `enqueueRun(...)` and `resumeSession(...)` do not run child work inline. They
+  persist scheduled work and set a Durable Object alarm.
+- `AgentDurableObject.alarm()` reconstructs the agent in a later invocation,
+  calls `Agent.resume(...)` for queued background runs, then resumes the parent
+  notification run.
+- Scheduled runs and session prompts are acked only after successful processing.
+  If a resume throws, the item remains stored and the alarm is rescheduled.
+- The parent and child agents use stable top-level `namespace` values so
+  reconstructed agents map back to the same parent and subagent transcripts.
+- Long-running Node.js remains first class in the runtime. It uses the same
+  background APIs, but it can keep one process and one host instance alive.
+
+## Run
+
+Run the deterministic Worker/Durable Object simulation without provider
+credentials:
+
+```sh
+pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent start
+```
+
+Create `.env` in `examples/cloudflare-edge-subagent/` only for the
+provider-backed CLI reconstruction scenario:
+
+```sh
+AI_API_KEY=...
+AI_BASE_URL=https://apis.opengateway.ai/v1
+AI_MODEL=minimax/MiniMax-M2.7
+```
+
+Run that edge reconstruction CLI scenario:
+
+```sh
+pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent start:cli
+```
+
+Run the actual Worker/Durable Object entrypoint through Wrangler:
+
+```sh
+pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent dev:worker
+```
+
+Typecheck the Worker surface with Cloudflare Worker globals:
+
+```sh
+pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent typecheck:worker
+```
+
+## Durable Object Shape
+
+The adapter consumes the same operations exposed by Cloudflare Durable Object
+storage:
+
+```ts
+import { createCloudflareDurableObjectHost } from "./cloudflare-host";
+
+const host = createCloudflareDurableObjectHost({
+  storage: ctx.storage,
+});
+```
+
+`wrangler.jsonc` binds `AgentDurableObject` as `AGENT_DURABLE_OBJECT`. The
+default Worker `fetch` forwards requests to that Durable Object, and the DO
+class owns the alarm that drains scheduled runs and session prompts.
+
+Deploy the Worker after configuring the target account:
+
+```sh
+pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent deploy:worker
+```

--- a/examples/cloudflare-edge-subagent/package.json
+++ b/examples/cloudflare-edge-subagent/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@minpeter/pss-example-cloudflare-edge-subagent",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy:worker": "wrangler deploy",
+    "dev:worker": "wrangler dev",
+    "start": "tsx --conditions=@minpeter/pss-source src/worker-simulation.ts",
+    "start:cli": "tsx --conditions=@minpeter/pss-source src/index.ts",
+    "start:edge-cases": "tsx --conditions=@minpeter/pss-source src/worker-edge-cases.ts",
+    "start:worker-sim": "tsx --conditions=@minpeter/pss-source src/worker-simulation.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:worker": "tsc -p tsconfig.worker.json --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/openai-compatible": "3.0.0-canary.48",
+    "@minpeter/pss-runtime": "workspace:*",
+    "@t3-oss/env-core": "^0.13.11",
+    "ai": "7.0.0-canary.142",
+    "dotenv": "^17.4.2",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260608.1",
+    "tsx": "^4.22.3",
+    "typescript": "^6.0.3",
+    "wrangler": "^4.98.0"
+  }
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-alarm-drainer.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-alarm-drainer.ts
@@ -1,0 +1,240 @@
+import type { AgentEvent, AgentRun } from "@minpeter/pss-runtime";
+import type { RunStatus } from "@minpeter/pss-runtime/execution";
+import {
+  ackScheduledCloudflareRun,
+  ackScheduledCloudflareSessionPrompt,
+  type CloudflareDurableObjectStorage,
+  type CloudflareScheduledSessionPrompt,
+  createCloudflareDurableObjectHost,
+  listScheduledCloudflareRuns,
+  listScheduledCloudflareSessionPrompts,
+  rescheduleCloudflareAlarm,
+} from "./cloudflare-host";
+
+export interface CloudflareAlarmDrainSummary {
+  readonly consumedSessionPrompts: readonly string[];
+  readonly events: readonly AgentEvent[];
+  readonly failedRuns: readonly FailedScheduledWork[];
+  readonly failedSessionPrompts: readonly FailedScheduledWork[];
+  readonly markers: readonly string[];
+  readonly resumedRuns: readonly string[];
+}
+
+export interface CloudflareAlarmAgent {
+  resume(runId: string): Promise<AgentRun | null>;
+}
+
+interface FailedScheduledWork {
+  readonly error: string;
+  readonly id: string;
+}
+
+export async function drainCloudflareAlarm({
+  agent,
+  prefix,
+  storage,
+}: {
+  readonly agent: CloudflareAlarmAgent;
+  readonly prefix: string;
+  readonly storage: CloudflareDurableObjectStorage;
+}): Promise<CloudflareAlarmDrainSummary> {
+  const events: AgentEvent[] = [];
+  const failedRuns: FailedScheduledWork[] = [];
+  const failedSessionPrompts: FailedScheduledWork[] = [];
+  const resumedRuns: string[] = [];
+  const consumedSessionPrompts: string[] = [];
+
+  for (const runId of await listScheduledCloudflareRuns(storage, { prefix })) {
+    await resumeScheduledRun({
+      agent,
+      events,
+      failedRuns,
+      prefix,
+      resumedRuns,
+      runId,
+      storage,
+    });
+  }
+
+  for (const prompt of await listScheduledCloudflareSessionPrompts(storage, {
+    prefix,
+  })) {
+    await resumeScheduledSessionPrompt({
+      agent,
+      consumedSessionPrompts,
+      events,
+      failedSessionPrompts,
+      prefix,
+      prompt,
+      storage,
+    });
+  }
+
+  if (failedRuns.length > 0 || failedSessionPrompts.length > 0) {
+    await rescheduleCloudflareAlarm(storage, { runAfterMs: 1000 });
+  }
+
+  return {
+    consumedSessionPrompts,
+    events,
+    failedRuns,
+    failedSessionPrompts,
+    markers: ["alarm:resume", "resume:session-prompt"],
+    resumedRuns,
+  };
+}
+
+export async function drainAgentRun(run: AgentRun): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of run.events()) {
+    events.push(event);
+  }
+  return events;
+}
+
+async function resumeScheduledRun({
+  agent,
+  events,
+  failedRuns,
+  prefix,
+  resumedRuns,
+  runId,
+  storage,
+}: {
+  readonly agent: CloudflareAlarmAgent;
+  readonly events: AgentEvent[];
+  readonly failedRuns: FailedScheduledWork[];
+  readonly prefix: string;
+  readonly resumedRuns: string[];
+  readonly runId: string;
+  readonly storage: CloudflareDurableObjectStorage;
+}): Promise<void> {
+  try {
+    const run = await agent.resume(runId);
+    if (!run) {
+      if (await shouldRetryScheduledRun(storage, prefix, runId)) {
+        failedRuns.push({
+          error: "Run was not claimable during this alarm.",
+          id: runId,
+        });
+        return;
+      }
+      await ackScheduledCloudflareRun(storage, runId, { prefix });
+      return;
+    }
+    resumedRuns.push(runId);
+    events.push(...(await drainAgentRun(run)));
+    await ackScheduledCloudflareRun(storage, runId, { prefix });
+  } catch (error) {
+    failedRuns.push({ error: describeError(error), id: runId });
+  }
+}
+
+async function resumeScheduledSessionPrompt({
+  agent,
+  consumedSessionPrompts,
+  events,
+  failedSessionPrompts,
+  prefix,
+  prompt,
+  storage,
+}: {
+  readonly agent: CloudflareAlarmAgent;
+  readonly consumedSessionPrompts: string[];
+  readonly events: AgentEvent[];
+  readonly failedSessionPrompts: FailedScheduledWork[];
+  readonly prefix: string;
+  readonly prompt: CloudflareScheduledSessionPrompt;
+  readonly storage: CloudflareDurableObjectStorage;
+}): Promise<void> {
+  try {
+    const runId = await scheduledSessionPromptRunId(storage, prefix, prompt);
+    if (!runId) {
+      failedSessionPrompts.push({
+        error: "Session prompt did not include or resolve to a run id.",
+        id: sessionPromptId(prompt),
+      });
+      return;
+    }
+
+    const run = await agent.resume(runId);
+    if (!run) {
+      if (await shouldRetryScheduledSessionPrompt(storage, prefix, prompt)) {
+        failedSessionPrompts.push({
+          error: "Session prompt was not claimable during this alarm.",
+          id: sessionPromptId(prompt),
+        });
+        return;
+      }
+      await ackScheduledCloudflareSessionPrompt(storage, prompt, { prefix });
+      return;
+    }
+    consumedSessionPrompts.push(sessionPromptId(prompt));
+    events.push(...(await drainAgentRun(run)));
+    await ackScheduledCloudflareSessionPrompt(storage, prompt, { prefix });
+  } catch (error) {
+    failedSessionPrompts.push({
+      error: describeError(error),
+      id: sessionPromptId(prompt),
+    });
+  }
+}
+
+async function shouldRetryScheduledRun(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  runId: string
+): Promise<boolean> {
+  const run = await createCloudflareDurableObjectHost({
+    prefix,
+    storage,
+  }).store.runs.get(runId);
+  return run ? isRetryableRunStatus(run.status) : true;
+}
+
+async function shouldRetryScheduledSessionPrompt(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  prompt: CloudflareScheduledSessionPrompt
+): Promise<boolean> {
+  const runId = await scheduledSessionPromptRunId(storage, prefix, prompt);
+  return runId
+    ? await shouldRetryScheduledRun(storage, prefix, runId)
+    : prompt.idempotencyKey !== undefined;
+}
+
+async function scheduledSessionPromptRunId(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  prompt: CloudflareScheduledSessionPrompt
+): Promise<string | undefined> {
+  if (prompt.runId) {
+    return prompt.runId;
+  }
+  if (!prompt.idempotencyKey) {
+    return;
+  }
+
+  const notification = await createCloudflareDurableObjectHost({
+    prefix,
+    storage,
+  }).store.notifications.getByIdempotencyKey(prompt.idempotencyKey);
+  return notification?.runId;
+}
+
+function sessionPromptId(prompt: CloudflareScheduledSessionPrompt): string {
+  return prompt.idempotencyKey ?? prompt.runId ?? "<missing-run-id>";
+}
+
+function isRetryableRunStatus(status: RunStatus | undefined): boolean {
+  return (
+    status === "leased" ||
+    status === "queued" ||
+    status === "running" ||
+    status === "suspended"
+  );
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-checkpoint-store.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-checkpoint-store.ts
@@ -1,0 +1,65 @@
+import type {
+  CheckpointStore,
+  CheckpointWriteResult,
+  RunCheckpoint,
+} from "@minpeter/pss-runtime/execution";
+import {
+  getRun,
+  putRun,
+  readList,
+  storeKey,
+  withTransaction,
+} from "./cloudflare-store-utils";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+
+export class DurableObjectCheckpointStore implements CheckpointStore {
+  readonly #prefix: string;
+  readonly #storage: CloudflareDurableObjectStorage;
+
+  constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
+    this.#prefix = prefix;
+    this.#storage = storage;
+  }
+
+  async append(
+    checkpoint: RunCheckpoint,
+    options: { readonly expectedVersion: number }
+  ): Promise<CheckpointWriteResult> {
+    return await withTransaction(this.#storage, async (storage) => {
+      const run = await getRun(storage, this.#prefix, checkpoint.runId);
+      const currentVersion = run?.checkpointVersion ?? 0;
+      if (currentVersion !== options.expectedVersion) {
+        return {
+          currentVersion,
+          ok: false,
+          reason: "stale-version",
+        };
+      }
+
+      const checkpoints = await readList<RunCheckpoint>(
+        storage,
+        storeKey(this.#prefix, "checkpoints", checkpoint.runId)
+      );
+      checkpoints.push(structuredClone(checkpoint));
+      await storage.put(
+        storeKey(this.#prefix, "checkpoints", checkpoint.runId),
+        checkpoints
+      );
+      if (run) {
+        await putRun(storage, this.#prefix, {
+          ...run,
+          checkpointVersion: checkpoint.version,
+        });
+      }
+      return { ok: true, version: checkpoint.version };
+    });
+  }
+
+  async latest(runId: string): Promise<RunCheckpoint | null> {
+    const checkpoints = await readList<RunCheckpoint>(
+      this.#storage,
+      storeKey(this.#prefix, "checkpoints", runId)
+    );
+    return checkpoints.at(-1) ?? null;
+  }
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-event-store.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-event-store.ts
@@ -1,0 +1,46 @@
+import type { AgentEvent } from "@minpeter/pss-runtime";
+import type {
+  EventCursor,
+  EventStore,
+  StoredAgentEvent,
+} from "@minpeter/pss-runtime/execution";
+import { readList, storeKey, withTransaction } from "./cloudflare-store-utils";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+
+export class DurableObjectEventStore implements EventStore {
+  readonly #prefix: string;
+  readonly #storage: CloudflareDurableObjectStorage;
+
+  constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
+    this.#prefix = prefix;
+    this.#storage = storage;
+  }
+
+  async append(runId: string, event: AgentEvent): Promise<EventCursor> {
+    return await withTransaction(this.#storage, async (storage) => {
+      const events = await readList<StoredAgentEvent>(
+        storage,
+        storeKey(this.#prefix, "events", runId)
+      );
+      const cursor = { offset: events.length + 1 };
+      events.push({ cursor, event: structuredClone(event), runId });
+      await storage.put(storeKey(this.#prefix, "events", runId), events);
+      return cursor;
+    });
+  }
+
+  async *read(
+    runId: string,
+    cursor?: EventCursor
+  ): AsyncIterable<StoredAgentEvent> {
+    await Promise.resolve();
+    const events = await readList<StoredAgentEvent>(
+      this.#storage,
+      storeKey(this.#prefix, "events", runId)
+    );
+    const start = cursor?.offset ?? 0;
+    for (const event of events.slice(start)) {
+      yield event;
+    }
+  }
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-execution-session-store.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-execution-session-store.ts
@@ -1,0 +1,64 @@
+import type {
+  CommitResult,
+  ExpectedSessionVersion,
+  SessionStore,
+  SessionStoreCommit,
+  StoredSession,
+} from "@minpeter/pss-runtime";
+import {
+  getSession,
+  putSession,
+  storeKey,
+  withTransaction,
+} from "./cloudflare-store-utils";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+
+export class DurableObjectExecutionSessionStore implements SessionStore {
+  readonly #prefix: string;
+  readonly #storage: CloudflareDurableObjectStorage;
+
+  constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
+    this.#prefix = prefix;
+    this.#storage = storage;
+  }
+
+  async commit(
+    sessionKey: string,
+    next: SessionStoreCommit,
+    options: { readonly expectedVersion: ExpectedSessionVersion }
+  ): Promise<CommitResult> {
+    return await withTransaction(this.#storage, async (storage) => {
+      const stored = await getSession(storage, this.#prefix, sessionKey);
+      const currentVersion = stored?.version ?? null;
+      if (options.expectedVersion !== currentVersion) {
+        return { ok: false, reason: "conflict" };
+      }
+
+      const version = String(
+        ((await storage.get<number>(
+          storeKey(this.#prefix, "session-version", sessionKey)
+        )) ?? 0) + 1
+      );
+      await storage.put(
+        storeKey(this.#prefix, "session-version", sessionKey),
+        Number(version)
+      );
+      await putSession(storage, this.#prefix, sessionKey, {
+        state: next.state,
+        version,
+      });
+      return { ok: true, version };
+    });
+  }
+
+  async delete(sessionKey: string): Promise<void> {
+    await this.#storage.delete(storeKey(this.#prefix, "session", sessionKey));
+    await this.#storage.delete(
+      storeKey(this.#prefix, "session-version", sessionKey)
+    );
+  }
+
+  async load(sessionKey: string): Promise<StoredSession | null> {
+    return await getSession(this.#storage, this.#prefix, sessionKey);
+  }
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-execution-store.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-execution-store.ts
@@ -1,0 +1,53 @@
+import type { SessionStore } from "@minpeter/pss-runtime";
+import type {
+  CheckpointStore,
+  EventStore,
+  ExecutionStore,
+  ExecutionStoreTransaction,
+  NotificationInbox,
+  RunStore,
+} from "@minpeter/pss-runtime/execution";
+import { DurableObjectCheckpointStore } from "./cloudflare-checkpoint-store";
+import { DurableObjectEventStore } from "./cloudflare-event-store";
+import { DurableObjectExecutionSessionStore } from "./cloudflare-execution-session-store";
+import { DurableObjectNotificationInbox } from "./cloudflare-notification-store";
+import { DurableObjectRunStore } from "./cloudflare-run-store";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+
+export class DurableObjectExecutionStore implements ExecutionStore {
+  readonly checkpoints: CheckpointStore;
+  readonly events: EventStore;
+  readonly notifications: NotificationInbox;
+  readonly runs: RunStore;
+  readonly sessions: SessionStore;
+  readonly #prefix: string;
+  readonly #storage: CloudflareDurableObjectStorage;
+
+  constructor({
+    prefix = "pss-runtime",
+    storage,
+  }: {
+    readonly prefix?: string;
+    readonly storage: CloudflareDurableObjectStorage;
+  }) {
+    this.#prefix = prefix;
+    this.#storage = storage;
+    this.checkpoints = new DurableObjectCheckpointStore(storage, prefix);
+    this.events = new DurableObjectEventStore(storage, prefix);
+    this.notifications = new DurableObjectNotificationInbox(storage, prefix);
+    this.runs = new DurableObjectRunStore(storage, prefix);
+    this.sessions = new DurableObjectExecutionSessionStore(storage, prefix);
+  }
+
+  async transaction<T>(
+    fn: (tx: ExecutionStoreTransaction) => Promise<T>
+  ): Promise<T> {
+    if (this.#storage.transaction) {
+      return await this.#storage.transaction((storage) =>
+        fn(new DurableObjectExecutionStore({ prefix: this.#prefix, storage }))
+      );
+    }
+
+    return await fn(this);
+  }
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-host.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-host.ts
@@ -1,0 +1,236 @@
+import type { SessionStore } from "@minpeter/pss-runtime";
+import type {
+  ExecutionHost,
+  ExecutionScheduler,
+} from "@minpeter/pss-runtime/execution";
+import { DurableObjectExecutionStore } from "./cloudflare-execution-store";
+import {
+  InMemoryCloudflareDurableObjectStorage as BaseInMemoryCloudflareDurableObjectStorage,
+  type CloudflareDurableObjectStorage as DurableObjectStoragePort,
+} from "./durable-object-storage";
+
+const defaultPrefix = "pss-runtime";
+
+export interface CloudflareScheduledSessionPrompt {
+  readonly idempotencyKey?: string;
+  readonly notificationId?: string;
+  readonly runId?: string;
+  readonly sessionKey: string;
+}
+
+export type CloudflareDurableObjectStorage = DurableObjectStoragePort;
+
+export class InMemoryCloudflareDurableObjectStorage extends BaseInMemoryCloudflareDurableObjectStorage {}
+
+export function createCloudflareDurableObjectHost({
+  prefix = defaultPrefix,
+  sessionStore,
+  storage,
+  scheduler = createCloudflareAlarmScheduler({ prefix, storage }),
+}: {
+  readonly prefix?: string;
+  readonly scheduler?: ExecutionScheduler;
+  readonly sessionStore?: SessionStore;
+  readonly storage: CloudflareDurableObjectStorage;
+}): ExecutionHost {
+  const store = new DurableObjectExecutionStore({ prefix, storage });
+  return {
+    capabilities: {
+      backgroundSubagents: "durable",
+    },
+    scheduler,
+    store: sessionStore
+      ? executionStoreWithSessions(store, sessionStore)
+      : store,
+  };
+}
+
+export function createCloudflareAlarmScheduler({
+  prefix = defaultPrefix,
+  storage,
+}: {
+  readonly prefix?: string;
+  readonly storage: CloudflareDurableObjectStorage;
+}): ExecutionScheduler {
+  return {
+    enqueueRun: async (runId, options) => {
+      await appendUnique(storage, scheduledRunsKey(prefix), runId);
+      await setAlarm(storage, options?.runAfterMs ?? 0);
+    },
+    resumeSession: async (sessionKey, options) => {
+      await appendSessionPrompt(storage, scheduledSessionPromptsKey(prefix), {
+        idempotencyKey: options?.idempotencyKey,
+        notificationId: options?.notificationId,
+        runId: options?.runId,
+        sessionKey,
+      });
+      await setAlarm(storage, 0);
+    },
+  };
+}
+
+export async function listScheduledCloudflareRuns(
+  storage: CloudflareDurableObjectStorage,
+  options: { readonly prefix?: string } = {}
+): Promise<readonly string[]> {
+  return await readList<string>(
+    storage,
+    scheduledRunsKey(options.prefix ?? defaultPrefix)
+  );
+}
+
+export async function ackScheduledCloudflareRun(
+  storage: CloudflareDurableObjectStorage,
+  runId: string,
+  options: { readonly prefix?: string } = {}
+): Promise<void> {
+  await removeFromList<string>(
+    storage,
+    scheduledRunsKey(options.prefix ?? defaultPrefix),
+    (scheduledRunId) => scheduledRunId === runId
+  );
+}
+
+export async function listScheduledCloudflareSessionPrompts(
+  storage: CloudflareDurableObjectStorage,
+  options: { readonly prefix?: string } = {}
+): Promise<readonly CloudflareScheduledSessionPrompt[]> {
+  return await readList<CloudflareScheduledSessionPrompt>(
+    storage,
+    scheduledSessionPromptsKey(options.prefix ?? defaultPrefix)
+  );
+}
+
+export async function ackScheduledCloudflareSessionPrompt(
+  storage: CloudflareDurableObjectStorage,
+  prompt: CloudflareScheduledSessionPrompt,
+  options: { readonly prefix?: string } = {}
+): Promise<void> {
+  await removeFromList<CloudflareScheduledSessionPrompt>(
+    storage,
+    scheduledSessionPromptsKey(options.prefix ?? defaultPrefix),
+    (scheduledPrompt) => sessionPromptsMatch(scheduledPrompt, prompt)
+  );
+}
+
+export async function rescheduleCloudflareAlarm(
+  storage: CloudflareDurableObjectStorage,
+  options: { readonly runAfterMs?: number } = {}
+): Promise<void> {
+  await setAlarm(storage, options.runAfterMs ?? 0);
+}
+
+async function appendUnique(
+  storage: CloudflareDurableObjectStorage,
+  key: string,
+  value: string
+): Promise<void> {
+  await withTransaction(storage, async (tx) => {
+    const values = await readList<string>(tx, key);
+    if (!values.includes(value)) {
+      values.push(value);
+      await tx.put(key, values);
+    }
+  });
+}
+
+async function appendSessionPrompt(
+  storage: CloudflareDurableObjectStorage,
+  key: string,
+  prompt: CloudflareScheduledSessionPrompt
+): Promise<void> {
+  await withTransaction(storage, async (tx) => {
+    const values = await readList<CloudflareScheduledSessionPrompt>(tx, key);
+    const isDuplicate = values.some(
+      (existing) =>
+        existing.sessionKey === prompt.sessionKey &&
+        existing.idempotencyKey === prompt.idempotencyKey &&
+        existing.runId === prompt.runId
+    );
+    if (!isDuplicate) {
+      values.push(prompt);
+      await tx.put(key, values);
+    }
+  });
+}
+
+async function removeFromList<T>(
+  storage: CloudflareDurableObjectStorage,
+  key: string,
+  shouldRemove: (value: T) => boolean
+): Promise<void> {
+  await withTransaction(storage, async (tx) => {
+    const remaining = (await readList<T>(tx, key)).filter(
+      (value) => !shouldRemove(value)
+    );
+    await tx.put(key, remaining);
+  });
+}
+
+async function readList<T>(
+  storage: CloudflareDurableObjectStorage,
+  key: string
+): Promise<T[]> {
+  return ((await storage.get<readonly T[]>(key)) ?? []).map((item) =>
+    structuredClone(item)
+  );
+}
+
+async function setAlarm(
+  storage: CloudflareDurableObjectStorage,
+  runAfterMs: number
+): Promise<void> {
+  await storage.setAlarm?.(Date.now() + Math.max(0, runAfterMs));
+}
+
+async function withTransaction<T>(
+  storage: CloudflareDurableObjectStorage,
+  fn: (storage: CloudflareDurableObjectStorage) => Promise<T>
+): Promise<T> {
+  return storage.transaction
+    ? await storage.transaction(fn)
+    : await fn(storage);
+}
+
+function scheduledRunsKey(prefix: string): string {
+  return `${prefix}:scheduled-runs`;
+}
+
+function scheduledSessionPromptsKey(prefix: string): string {
+  return `${prefix}:scheduled-session-prompts`;
+}
+
+function sessionPromptsMatch(
+  left: CloudflareScheduledSessionPrompt,
+  right: CloudflareScheduledSessionPrompt
+): boolean {
+  return (
+    left.idempotencyKey === right.idempotencyKey &&
+    left.notificationId === right.notificationId &&
+    left.runId === right.runId &&
+    left.sessionKey === right.sessionKey
+  );
+}
+
+function executionStoreWithSessions(
+  store: ExecutionHost["store"],
+  sessions: SessionStore
+): ExecutionHost["store"] {
+  return {
+    checkpoints: store.checkpoints,
+    events: store.events,
+    notifications: store.notifications,
+    runs: store.runs,
+    sessions,
+    transaction: (fn) =>
+      store.transaction((tx) =>
+        fn({
+          checkpoints: tx.checkpoints,
+          events: tx.events,
+          notifications: tx.notifications,
+          runs: tx.runs,
+          sessions,
+        })
+      ),
+  };
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-notification-store.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-notification-store.ts
@@ -1,0 +1,78 @@
+import type {
+  NotificationClaimResult,
+  NotificationInbox,
+  NotificationRecord,
+  NotificationWriteResult,
+} from "@minpeter/pss-runtime/execution";
+import {
+  getNotification,
+  putNotification,
+  withTransaction,
+} from "./cloudflare-store-utils";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+
+export class DurableObjectNotificationInbox implements NotificationInbox {
+  readonly #prefix: string;
+  readonly #storage: CloudflareDurableObjectStorage;
+
+  constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
+    this.#prefix = prefix;
+    this.#storage = storage;
+  }
+
+  async claimByIdempotencyKey(
+    idempotencyKey: string
+  ): Promise<NotificationClaimResult> {
+    return await withTransaction(this.#storage, async (storage) => {
+      const record = await getNotification(
+        storage,
+        this.#prefix,
+        idempotencyKey
+      );
+      if (!record) {
+        return { ok: false, reason: "not-found" };
+      }
+      if (record.status !== "pending") {
+        return { ok: false, reason: "already-claimed", record };
+      }
+      const claimed: NotificationRecord = { ...record, status: "acked" };
+      await putNotification(storage, this.#prefix, claimed);
+      return { ok: true, record: claimed };
+    });
+  }
+
+  async enqueue(record: NotificationRecord): Promise<NotificationWriteResult> {
+    return await withTransaction(this.#storage, async (storage) => {
+      const current = await getNotification(
+        storage,
+        this.#prefix,
+        record.idempotencyKey
+      );
+      if (current) {
+        return {
+          existingNotificationId: current.notificationId,
+          ok: false,
+          reason: "duplicate",
+        };
+      }
+      await putNotification(storage, this.#prefix, record);
+      return { ok: true };
+    });
+  }
+
+  async getByIdempotencyKey(
+    idempotencyKey: string
+  ): Promise<NotificationRecord | null> {
+    return await getNotification(this.#storage, this.#prefix, idempotencyKey);
+  }
+
+  async releaseByIdempotencyKey(idempotencyKey: string): Promise<void> {
+    const record = await this.getByIdempotencyKey(idempotencyKey);
+    if (record?.status === "acked") {
+      await putNotification(this.#storage, this.#prefix, {
+        ...record,
+        status: "pending",
+      });
+    }
+  }
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-run-store.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-run-store.ts
@@ -1,0 +1,100 @@
+import type {
+  ClaimRunOptions,
+  ClaimRunResult,
+  RunRecord,
+  RunStatus,
+  RunStore,
+} from "@minpeter/pss-runtime/execution";
+import {
+  getRun,
+  indexRun,
+  putRun,
+  readList,
+  storeKey,
+  withTransaction,
+} from "./cloudflare-store-utils";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+
+const claimableStatuses = new Set<RunStatus>([
+  "leased",
+  "queued",
+  "running",
+  "suspended",
+]);
+
+export class DurableObjectRunStore implements RunStore {
+  readonly #prefix: string;
+  readonly #storage: CloudflareDurableObjectStorage;
+
+  constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
+    this.#prefix = prefix;
+    this.#storage = storage;
+  }
+
+  async claim(
+    runId: string,
+    options: ClaimRunOptions
+  ): Promise<ClaimRunResult> {
+    return await withTransaction(this.#storage, async (storage) => {
+      const run = await getRun(storage, this.#prefix, runId);
+      if (!run) {
+        return { ok: false, reason: "not-found" };
+      }
+      if (!claimableStatuses.has(run.status)) {
+        return { ok: false, reason: "not-claimable" };
+      }
+      if (run.lease && run.lease.leaseUntilMs > options.nowMs) {
+        return { ok: false, reason: "leased" };
+      }
+
+      const lease = {
+        attempt: options.attempt,
+        leaseId: options.leaseId,
+        leaseUntilMs: options.nowMs + options.leaseMs,
+      };
+      const claimed: RunRecord = { ...run, lease, status: "leased" };
+      await putRun(storage, this.#prefix, claimed);
+      return { lease, ok: true, record: structuredClone(claimed) };
+    });
+  }
+
+  async create(record: RunRecord): Promise<RunRecord> {
+    return await withTransaction(this.#storage, async (storage) => {
+      await putRun(storage, this.#prefix, record);
+      await indexRun(storage, this.#prefix, record);
+      return structuredClone(record);
+    });
+  }
+
+  async get(runId: string): Promise<RunRecord | null> {
+    return await getRun(this.#storage, this.#prefix, runId);
+  }
+
+  async getByDedupeKey(dedupeKey: string): Promise<RunRecord | null> {
+    const runId = await this.#storage.get<string>(
+      storeKey(this.#prefix, "run-dedupe", dedupeKey)
+    );
+    return runId ? await this.get(runId) : null;
+  }
+
+  async listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]> {
+    const runIds = await readList<string>(
+      this.#storage,
+      storeKey(this.#prefix, "run-parent", parentRunId)
+    );
+    const runs = await Promise.all(runIds.map((runId) => this.get(runId)));
+    return runs.filter(isRunRecord);
+  }
+
+  async update(record: RunRecord): Promise<RunRecord> {
+    return await withTransaction(this.#storage, async (storage) => {
+      await putRun(storage, this.#prefix, record);
+      await indexRun(storage, this.#prefix, record);
+      return structuredClone(record);
+    });
+  }
+}
+
+function isRunRecord(record: RunRecord | null): record is RunRecord {
+  return record !== null;
+}

--- a/examples/cloudflare-edge-subagent/src/cloudflare-store-utils.ts
+++ b/examples/cloudflare-edge-subagent/src/cloudflare-store-utils.ts
@@ -1,0 +1,109 @@
+import type { StoredSession } from "@minpeter/pss-runtime";
+import type {
+  NotificationRecord,
+  RunRecord,
+} from "@minpeter/pss-runtime/execution";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+
+export async function withTransaction<T>(
+  storage: CloudflareDurableObjectStorage,
+  fn: (storage: CloudflareDurableObjectStorage) => Promise<T>
+): Promise<T> {
+  return storage.transaction
+    ? await storage.transaction(fn)
+    : await fn(storage);
+}
+
+export async function getRun(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  runId: string
+): Promise<RunRecord | null> {
+  return (await storage.get<RunRecord>(storeKey(prefix, "run", runId))) ?? null;
+}
+
+export async function putRun(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  record: RunRecord
+): Promise<void> {
+  await storage.put(storeKey(prefix, "run", record.runId), record);
+}
+
+export async function indexRun(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  record: RunRecord
+): Promise<void> {
+  if (record.dedupeKey) {
+    await storage.put(
+      storeKey(prefix, "run-dedupe", record.dedupeKey),
+      record.runId
+    );
+  }
+  if (record.parentRunId) {
+    const parentKey = storeKey(prefix, "run-parent", record.parentRunId);
+    const runIds = await readList<string>(storage, parentKey);
+    if (!runIds.includes(record.runId)) {
+      runIds.push(record.runId);
+      await storage.put(parentKey, runIds);
+    }
+  }
+}
+
+export async function getNotification(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  idempotencyKey: string
+): Promise<NotificationRecord | null> {
+  return (
+    (await storage.get<NotificationRecord>(
+      storeKey(prefix, "notification", idempotencyKey)
+    )) ?? null
+  );
+}
+
+export async function putNotification(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  record: NotificationRecord
+): Promise<void> {
+  await storage.put(
+    storeKey(prefix, "notification", record.idempotencyKey),
+    record
+  );
+}
+
+export async function getSession(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  sessionKey: string
+): Promise<StoredSession | null> {
+  return (
+    (await storage.get<StoredSession>(
+      storeKey(prefix, "session", sessionKey)
+    )) ?? null
+  );
+}
+
+export async function putSession(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  sessionKey: string,
+  session: StoredSession
+): Promise<void> {
+  await storage.put(storeKey(prefix, "session", sessionKey), session);
+}
+
+export async function readList<T>(
+  storage: CloudflareDurableObjectStorage,
+  storageKey: string
+): Promise<T[]> {
+  return ((await storage.get<readonly T[]>(storageKey)) ?? []).map((item) =>
+    structuredClone(item)
+  );
+}
+
+export function storeKey(prefix: string, scope: string, id: string): string {
+  return `${prefix}:${scope}:${encodeURIComponent(id)}`;
+}

--- a/examples/cloudflare-edge-subagent/src/durable-object-session-store.ts
+++ b/examples/cloudflare-edge-subagent/src/durable-object-session-store.ts
@@ -5,6 +5,7 @@ import type {
   SessionStoreCommit,
   StoredSession,
 } from "@minpeter/pss-runtime";
+import { storeKey } from "./cloudflare-store-utils";
 import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
 
 export class DurableObjectSessionStore implements SessionStore {
@@ -49,6 +50,6 @@ export class DurableObjectSessionStore implements SessionStore {
   }
 
   #storageKey(key: string): string {
-    return `${this.#prefix}:${encodeURIComponent(key)}`;
+    return storeKey(this.#prefix, "session", key);
   }
 }

--- a/examples/cloudflare-edge-subagent/src/durable-object-session-store.ts
+++ b/examples/cloudflare-edge-subagent/src/durable-object-session-store.ts
@@ -5,7 +5,12 @@ import type {
   SessionStoreCommit,
   StoredSession,
 } from "@minpeter/pss-runtime";
-import { storeKey } from "./cloudflare-store-utils";
+import {
+  getSession,
+  putSession,
+  storeKey,
+  withTransaction,
+} from "./cloudflare-store-utils";
 import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
 
 export class DurableObjectSessionStore implements SessionStore {
@@ -25,18 +30,21 @@ export class DurableObjectSessionStore implements SessionStore {
     next: SessionStoreCommit,
     options: { readonly expectedVersion: ExpectedSessionVersion }
   ): Promise<CommitResult> {
-    const storageKey = this.#storageKey(key);
-    const current =
-      (await this.#storage.get<StoredSession>(storageKey)) ?? null;
-    const currentVersion = current?.version ?? null;
+    return await withTransaction(this.#storage, async (storage) => {
+      const current = await getSession(storage, this.#prefix, key);
+      const currentVersion = current?.version ?? null;
 
-    if (options.expectedVersion !== currentVersion) {
-      return { ok: false, reason: "conflict" };
-    }
+      if (options.expectedVersion !== currentVersion) {
+        return { ok: false, reason: "conflict" };
+      }
 
-    const version = crypto.randomUUID();
-    await this.#storage.put(storageKey, { state: next.state, version });
-    return { ok: true, version };
+      const version = crypto.randomUUID();
+      await putSession(storage, this.#prefix, key, {
+        state: next.state,
+        version,
+      });
+      return { ok: true, version };
+    });
   }
 
   async delete(key: string): Promise<void> {

--- a/examples/cloudflare-edge-subagent/src/durable-object-session-store.ts
+++ b/examples/cloudflare-edge-subagent/src/durable-object-session-store.ts
@@ -1,0 +1,54 @@
+import type {
+  CommitResult,
+  ExpectedSessionVersion,
+  SessionStore,
+  SessionStoreCommit,
+  StoredSession,
+} from "@minpeter/pss-runtime";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+
+export class DurableObjectSessionStore implements SessionStore {
+  readonly #prefix: string;
+  readonly #storage: CloudflareDurableObjectStorage;
+
+  constructor(
+    storage: CloudflareDurableObjectStorage,
+    options: { readonly prefix?: string } = {}
+  ) {
+    this.#prefix = options.prefix ?? "pss-runtime";
+    this.#storage = storage;
+  }
+
+  async commit(
+    key: string,
+    next: SessionStoreCommit,
+    options: { readonly expectedVersion: ExpectedSessionVersion }
+  ): Promise<CommitResult> {
+    const storageKey = this.#storageKey(key);
+    const current =
+      (await this.#storage.get<StoredSession>(storageKey)) ?? null;
+    const currentVersion = current?.version ?? null;
+
+    if (options.expectedVersion !== currentVersion) {
+      return { ok: false, reason: "conflict" };
+    }
+
+    const version = crypto.randomUUID();
+    await this.#storage.put(storageKey, { state: next.state, version });
+    return { ok: true, version };
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.#storage.delete(this.#storageKey(key));
+  }
+
+  async load(key: string): Promise<StoredSession | null> {
+    return (
+      (await this.#storage.get<StoredSession>(this.#storageKey(key))) ?? null
+    );
+  }
+
+  #storageKey(key: string): string {
+    return `${this.#prefix}:${encodeURIComponent(key)}`;
+  }
+}

--- a/examples/cloudflare-edge-subagent/src/durable-object-storage.ts
+++ b/examples/cloudflare-edge-subagent/src/durable-object-storage.ts
@@ -1,0 +1,115 @@
+export interface CloudflareDurableObjectStorage {
+  delete(key: string): Promise<unknown>;
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  setAlarm?(scheduledTime: Date | number): Promise<void>;
+  transaction?<T>(
+    fn: (storage: CloudflareDurableObjectStorage) => Promise<T>
+  ): Promise<T>;
+}
+
+export class InMemoryCloudflareDurableObjectStorage
+  implements CloudflareDurableObjectStorage
+{
+  #alarmTime: Date | number | undefined;
+  #transactionChain: Promise<void> = Promise.resolve();
+  #values = new Map<string, unknown>();
+
+  alarmTime(): Date | number | undefined {
+    return this.#alarmTime;
+  }
+
+  delete(key: string): Promise<boolean> {
+    return Promise.resolve(this.#values.delete(key));
+  }
+
+  get<T>(key: string): Promise<T | undefined> {
+    const value = this.#values.get(key);
+    return Promise.resolve(
+      value === undefined ? undefined : (structuredClone(value) as T)
+    );
+  }
+
+  put<T>(key: string, value: T): Promise<void> {
+    this.#values.set(key, structuredClone(value));
+    return Promise.resolve();
+  }
+
+  setAlarm(scheduledTime: Date | number): Promise<void> {
+    this.#alarmTime = scheduledTime;
+    return Promise.resolve();
+  }
+
+  async transaction<T>(
+    fn: (storage: CloudflareDurableObjectStorage) => Promise<T>
+  ): Promise<T> {
+    const previousTransaction = this.#transactionChain;
+    let releaseTransaction: () => void = () => undefined;
+    this.#transactionChain = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+    await previousTransaction;
+
+    const transactionValues = cloneMap(this.#values);
+    const transactionStorage = new TransactionalCloudflareStorage(
+      transactionValues,
+      (scheduledTime) => {
+        this.#alarmTime = scheduledTime;
+      }
+    );
+
+    try {
+      const result = await fn(transactionStorage);
+      this.#values = transactionValues;
+      return result;
+    } finally {
+      releaseTransaction();
+    }
+  }
+}
+
+class TransactionalCloudflareStorage implements CloudflareDurableObjectStorage {
+  readonly #setAlarm: (scheduledTime: Date | number) => void;
+  readonly #values: Map<string, unknown>;
+
+  constructor(
+    values: Map<string, unknown>,
+    setAlarm: (scheduledTime: Date | number) => void
+  ) {
+    this.#setAlarm = setAlarm;
+    this.#values = values;
+  }
+
+  delete(key: string): Promise<boolean> {
+    return Promise.resolve(this.#values.delete(key));
+  }
+
+  get<T>(key: string): Promise<T | undefined> {
+    const value = this.#values.get(key);
+    return Promise.resolve(
+      value === undefined ? undefined : (structuredClone(value) as T)
+    );
+  }
+
+  put<T>(key: string, value: T): Promise<void> {
+    this.#values.set(key, structuredClone(value));
+    return Promise.resolve();
+  }
+
+  setAlarm(scheduledTime: Date | number): Promise<void> {
+    this.#setAlarm(scheduledTime);
+    return Promise.resolve();
+  }
+
+  async transaction<T>(
+    fn: (storage: CloudflareDurableObjectStorage) => Promise<T>
+  ): Promise<T> {
+    return await fn(this);
+  }
+}
+
+function cloneMap(values: Map<string, unknown>): Map<string, unknown> {
+  return new Map(
+    [...values.entries()].map(([key, value]) => [key, structuredClone(value)])
+  );
+}

--- a/examples/cloudflare-edge-subagent/src/failing-run-lookup-storage.ts
+++ b/examples/cloudflare-edge-subagent/src/failing-run-lookup-storage.ts
@@ -1,0 +1,42 @@
+import type { CloudflareDurableObjectStorage } from "./cloudflare-host";
+
+export class FailingRunLookupStorage implements CloudflareDurableObjectStorage {
+  readonly #runId: string;
+  readonly #storage: CloudflareDurableObjectStorage;
+
+  constructor(storage: CloudflareDurableObjectStorage, runId: string) {
+    this.#runId = runId;
+    this.#storage = storage;
+  }
+
+  async delete(key: string): Promise<unknown> {
+    return await this.#storage.delete(key);
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    if (key.includes(encodeURIComponent(this.#runId))) {
+      throw new Error("forced run lookup failure");
+    }
+    return await this.#storage.get<T>(key);
+  }
+
+  async put<T>(key: string, value: T): Promise<void> {
+    await this.#storage.put(key, value);
+  }
+
+  async setAlarm(scheduledTime: Date | number): Promise<void> {
+    await this.#storage.setAlarm?.(scheduledTime);
+  }
+
+  async transaction<T>(
+    fn: (storage: CloudflareDurableObjectStorage) => Promise<T>
+  ): Promise<T> {
+    if (!this.#storage.transaction) {
+      return await fn(this);
+    }
+    return await this.#storage.transaction(
+      async (storage) =>
+        await fn(new FailingRunLookupStorage(storage, this.#runId))
+    );
+  }
+}

--- a/examples/cloudflare-edge-subagent/src/index.ts
+++ b/examples/cloudflare-edge-subagent/src/index.ts
@@ -18,6 +18,7 @@ import {
   listScheduledCloudflareRuns,
   listScheduledCloudflareSessionPrompts,
 } from "./cloudflare-host";
+import { workerStorePrefix } from "./worker-constants";
 
 loadEnv({ path: ".env", quiet: true, override: true });
 
@@ -38,7 +39,6 @@ const provider = createOpenAICompatible({
 const model = provider(env.AI_MODEL);
 
 const sessionKey = "room:demo:user:edge";
-const cloudflareStorePrefix = "cloudflare-edge-subagent-demo";
 const turns = [
   "Start background research on why stable task ids matter in edge-hosted agent turns. Return after the background task is launched.",
 ] as const;
@@ -75,7 +75,7 @@ async function runEdgeScenario(inputs: readonly string[]): Promise<void> {
 
   for (const [index, input] of inputs.entries()) {
     const host = createCloudflareDurableObjectHost({
-      prefix: cloudflareStorePrefix,
+      prefix: workerStorePrefix,
       storage,
     });
     const coordinator = createCoordinator({ host });
@@ -90,7 +90,7 @@ async function runEdgeScenario(inputs: readonly string[]): Promise<void> {
     const notificationKey = backgroundNotificationKey(taskId);
 
     const resumedHost = createCloudflareDurableObjectHost({
-      prefix: cloudflareStorePrefix,
+      prefix: workerStorePrefix,
       storage,
     });
     const resumedCoordinator = createCoordinator({
@@ -132,7 +132,7 @@ async function drainCloudflareScheduledWork(
   storage: InMemoryCloudflareDurableObjectStorage
 ): Promise<void> {
   const runIds = await listScheduledCloudflareRuns(storage, {
-    prefix: cloudflareStorePrefix,
+    prefix: workerStorePrefix,
   });
   for (const runId of runIds) {
     const run = await agent.resume(runId);
@@ -140,12 +140,12 @@ async function drainCloudflareScheduledWork(
       await drainRun(run);
     }
     await ackScheduledCloudflareRun(storage, runId, {
-      prefix: cloudflareStorePrefix,
+      prefix: workerStorePrefix,
     });
   }
 
   const prompts = await listScheduledCloudflareSessionPrompts(storage, {
-    prefix: cloudflareStorePrefix,
+    prefix: workerStorePrefix,
   });
   for (const prompt of prompts) {
     const runId =
@@ -153,7 +153,7 @@ async function drainCloudflareScheduledWork(
       (prompt.idempotencyKey
         ? await notificationRunId(
             createCloudflareDurableObjectHost({
-              prefix: cloudflareStorePrefix,
+              prefix: workerStorePrefix,
               storage,
             }),
             prompt.idempotencyKey
@@ -168,7 +168,7 @@ async function drainCloudflareScheduledWork(
       await drainRun(run);
     }
     await ackScheduledCloudflareSessionPrompt(storage, prompt, {
-      prefix: cloudflareStorePrefix,
+      prefix: workerStorePrefix,
     });
   }
 }

--- a/examples/cloudflare-edge-subagent/src/index.ts
+++ b/examples/cloudflare-edge-subagent/src/index.ts
@@ -1,0 +1,217 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { AgentHost } from "@minpeter/pss-runtime";
+import {
+  Agent,
+  type AgentEvent,
+  type AgentRun,
+  type SessionHandle,
+} from "@minpeter/pss-runtime";
+import type { ExecutionHost } from "@minpeter/pss-runtime/execution";
+import { createEnv } from "@t3-oss/env-core";
+import { config as loadEnv } from "dotenv";
+import { z } from "zod";
+import {
+  ackScheduledCloudflareRun,
+  ackScheduledCloudflareSessionPrompt,
+  createCloudflareDurableObjectHost,
+  InMemoryCloudflareDurableObjectStorage,
+  listScheduledCloudflareRuns,
+  listScheduledCloudflareSessionPrompts,
+} from "./cloudflare-host";
+
+loadEnv({ path: ".env", quiet: true, override: true });
+
+const env = createEnv({
+  runtimeEnv: process.env,
+  server: {
+    AI_API_KEY: z.string().trim().min(1),
+    AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
+    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
+  },
+});
+
+const provider = createOpenAICompatible({
+  name: "custom",
+  apiKey: env.AI_API_KEY,
+  baseURL: env.AI_BASE_URL,
+});
+const model = provider(env.AI_MODEL);
+
+const sessionKey = "room:demo:user:edge";
+const cloudflareStorePrefix = "cloudflare-edge-subagent-demo";
+const turns = [
+  "Start background research on why stable task ids matter in edge-hosted agent turns. Return after the background task is launched.",
+] as const;
+
+await runEdgeScenario(turns);
+
+function createCoordinator({ host }: { readonly host: AgentHost }): Agent {
+  const researcher = new Agent({
+    name: "researcher",
+    description: "Produces compact research notes for the coordinator.",
+    host,
+    model,
+    namespace: "edge-demo-researcher",
+    instructions:
+      "Answer delegated prompts in one sentence. Return only the compact result the coordinator needs.",
+  });
+
+  return new Agent({
+    host,
+    model,
+    namespace: "edge-demo-coordinator",
+    subagents: [researcher],
+    instructions: [
+      "Coordinate a turn-based support agent.",
+      "When the user asks for background research, call delegate_to_researcher once with run_in_background: true.",
+      "Do not call background_output until a <system-reminder> says the background task completed.",
+      "After the reminder, call background_output with block: true and return a concise final answer.",
+    ].join(" "),
+  });
+}
+
+async function runEdgeScenario(inputs: readonly string[]): Promise<void> {
+  const storage = new InMemoryCloudflareDurableObjectStorage();
+
+  for (const [index, input] of inputs.entries()) {
+    const host = createCloudflareDurableObjectHost({
+      prefix: cloudflareStorePrefix,
+      storage,
+    });
+    const coordinator = createCoordinator({ host });
+    const session = coordinator.session(sessionKey);
+
+    const launchEvents = await runTurn({
+      input,
+      label: `edge turn ${index + 1}`,
+      session,
+    });
+    const taskId = backgroundTaskIdFromEvents(launchEvents);
+    const notificationKey = backgroundNotificationKey(taskId);
+
+    const resumedHost = createCloudflareDurableObjectHost({
+      prefix: cloudflareStorePrefix,
+      storage,
+    });
+    const resumedCoordinator = createCoordinator({
+      host: resumedHost,
+    });
+    await drainCloudflareScheduledWork(resumedCoordinator, storage);
+    const duplicate = await resumedCoordinator.resume(
+      await notificationRunId(resumedHost, notificationKey)
+    );
+    console.log({ duplicateSessionPromptIgnored: duplicate === null });
+  }
+}
+
+async function runTurn({
+  input,
+  label,
+  session,
+}: {
+  readonly input: string;
+  readonly label: string;
+  readonly session: SessionHandle;
+}): Promise<AgentEvent[]> {
+  console.log(`\n=== ${label} ===`);
+  console.log(`user: ${input}`);
+  return await drainRun(await session.send(input));
+}
+
+async function drainRun(run: AgentRun): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of run.events()) {
+    events.push(event);
+    console.log(event);
+  }
+  return events;
+}
+
+async function drainCloudflareScheduledWork(
+  agent: Agent,
+  storage: InMemoryCloudflareDurableObjectStorage
+): Promise<void> {
+  const runIds = await listScheduledCloudflareRuns(storage, {
+    prefix: cloudflareStorePrefix,
+  });
+  for (const runId of runIds) {
+    const run = await agent.resume(runId);
+    if (run) {
+      await drainRun(run);
+    }
+    await ackScheduledCloudflareRun(storage, runId, {
+      prefix: cloudflareStorePrefix,
+    });
+  }
+
+  const prompts = await listScheduledCloudflareSessionPrompts(storage, {
+    prefix: cloudflareStorePrefix,
+  });
+  for (const prompt of prompts) {
+    const runId =
+      prompt.runId ??
+      (prompt.idempotencyKey
+        ? await notificationRunId(
+            createCloudflareDurableObjectHost({
+              prefix: cloudflareStorePrefix,
+              storage,
+            }),
+            prompt.idempotencyKey
+          )
+        : undefined);
+    if (!runId) {
+      throw new Error("Scheduled session prompt did not resolve to a run id.");
+    }
+
+    const run = await agent.resume(runId);
+    if (run) {
+      await drainRun(run);
+    }
+    await ackScheduledCloudflareSessionPrompt(storage, prompt, {
+      prefix: cloudflareStorePrefix,
+    });
+  }
+}
+
+function backgroundTaskIdFromEvents(events: readonly AgentEvent[]): string {
+  for (const event of events) {
+    if (event.type !== "tool-result") {
+      continue;
+    }
+    const output = event.output;
+    if (
+      isRecord(output) &&
+      output.type === "json" &&
+      isRecord(output.value) &&
+      typeof output.value.task_id === "string"
+    ) {
+      return output.value.task_id;
+    }
+
+    if (isRecord(output) && typeof output.task_id === "string") {
+      return output.task_id;
+    }
+  }
+
+  throw new Error("Background task id was not emitted.");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function backgroundNotificationKey(taskId: string): string {
+  return `background-complete:${sessionKey}:${taskId}`;
+}
+
+async function notificationRunId(
+  host: ExecutionHost,
+  notificationKey: string
+): Promise<string> {
+  const notification =
+    await host.store.notifications.getByIdempotencyKey(notificationKey);
+  if (!notification) {
+    throw new Error(`Notification ${notificationKey} was not enqueued.`);
+  }
+  return notification.runId;
+}

--- a/examples/cloudflare-edge-subagent/src/worker-constants.ts
+++ b/examples/cloudflare-edge-subagent/src/worker-constants.ts
@@ -1,0 +1,1 @@
+export const workerStorePrefix = "cloudflare-edge-subagent-demo";

--- a/examples/cloudflare-edge-subagent/src/worker-edge-cases.ts
+++ b/examples/cloudflare-edge-subagent/src/worker-edge-cases.ts
@@ -1,0 +1,277 @@
+import type { AgentEvent } from "@minpeter/pss-runtime";
+import { drainCloudflareAlarm } from "./cloudflare-alarm-drainer";
+import {
+  ackScheduledCloudflareRun,
+  createCloudflareDurableObjectHost,
+  InMemoryCloudflareDurableObjectStorage,
+  listScheduledCloudflareRuns,
+  listScheduledCloudflareSessionPrompts,
+} from "./cloudflare-host";
+import { FailingRunLookupStorage } from "./failing-run-lookup-storage";
+import {
+  AgentDurableObject,
+  createWorkerCoordinator,
+  workerStorePrefix,
+} from "./worker";
+
+const sessionKey = "room:demo:user:edge";
+const noRun = () => Promise.resolve(null);
+const unclaimableAgent = { resume: noRun };
+
+async function checkDuplicateAlarmDelivery(): Promise<boolean> {
+  const storage = new InMemoryCloudflareDurableObjectStorage();
+  const host = createCloudflareDurableObjectHost({
+    prefix: workerStorePrefix,
+    storage,
+  });
+  await host.scheduler.enqueueRun("background:bg_duplicate");
+  await host.scheduler.enqueueRun("background:bg_duplicate");
+
+  const first = await listScheduledCloudflareRuns(storage, {
+    prefix: workerStorePrefix,
+  });
+  await ackScheduledCloudflareRun(storage, "background:bg_duplicate", {
+    prefix: workerStorePrefix,
+  });
+  const second = await listScheduledCloudflareRuns(storage, {
+    prefix: workerStorePrefix,
+  });
+  return (
+    first.length === 1 &&
+    first[0] === "background:bg_duplicate" &&
+    second.length === 0
+  );
+}
+
+async function checkCancelledRunNotification(): Promise<boolean> {
+  const storage = new InMemoryCloudflareDurableObjectStorage();
+  const agent = createWorkerCoordinator(storage);
+  const launchEvents = await collectEvents(
+    await agent.session(sessionKey).send("Start background research.")
+  );
+  const taskId = backgroundTaskIdFromEvents(launchEvents);
+  const runId = (
+    await listScheduledCloudflareRuns(storage, {
+      prefix: workerStorePrefix,
+    })
+  )[0];
+  if (!runId) {
+    throw new Error("Background run was not scheduled.");
+  }
+
+  const host = createCloudflareDurableObjectHost({
+    prefix: workerStorePrefix,
+    storage,
+  });
+  const run = await host.store.runs.get(runId);
+  if (!run) {
+    throw new Error("Background run record was not stored.");
+  }
+  await host.store.runs.update({ ...run, status: "cancelled" });
+
+  const resumed = await agent.resume(runId);
+  const notification = await host.store.notifications.getByIdempotencyKey(
+    backgroundNotificationKey(taskId)
+  );
+  return resumed === null && notification === null;
+}
+
+async function checkStaleCheckpoint(): Promise<boolean> {
+  const storage = new InMemoryCloudflareDurableObjectStorage();
+  const host = createCloudflareDurableObjectHost({
+    prefix: workerStorePrefix,
+    storage,
+  });
+  await host.store.runs.create({
+    checkpointVersion: 0,
+    kind: "background-subagent",
+    rootRunId: "background:bg_stale",
+    runId: "background:bg_stale",
+    sessionKey: "child:bg_stale",
+    status: "queued",
+  });
+
+  const first = await host.store.checkpoints.append(
+    {
+      checkpointId: "checkpoint-1",
+      phase: "before-model",
+      runId: "background:bg_stale",
+      runtimeState: {},
+      sessionSnapshot: {},
+      version: 1,
+    },
+    { expectedVersion: 0 }
+  );
+  const stale = await host.store.checkpoints.append(
+    {
+      checkpointId: "checkpoint-2",
+      phase: "after-model",
+      runId: "background:bg_stale",
+      runtimeState: {},
+      sessionSnapshot: {},
+      version: 2,
+    },
+    { expectedVersion: 0 }
+  );
+
+  return first.ok && !stale.ok && stale.reason === "stale-version";
+}
+
+async function checkMalformedSessionPrompt(): Promise<boolean> {
+  const storage = new InMemoryCloudflareDurableObjectStorage();
+  const agent = createWorkerCoordinator(storage);
+  return (await agent.resume("notification:not-a-real-notification")) === null;
+}
+
+async function checkFailedAlarmKeepsRunScheduled(): Promise<boolean> {
+  const storage = new InMemoryCloudflareDurableObjectStorage();
+  const host = createCloudflareDurableObjectHost({
+    prefix: workerStorePrefix,
+    storage,
+  });
+  const runId = "background:bg_retry";
+  await host.scheduler.enqueueRun(runId);
+
+  const failingStorage = new FailingRunLookupStorage(storage, runId);
+  const summary = await new AgentDurableObject(
+    {
+      storage: failingStorage,
+      waitUntil: () => undefined,
+    },
+    {}
+  ).alarm();
+  const pendingRuns = await listScheduledCloudflareRuns(storage, {
+    prefix: workerStorePrefix,
+  });
+
+  return (
+    summary.failedRuns.length === 1 &&
+    summary.failedRuns[0]?.id === runId &&
+    pendingRuns.length === 1 &&
+    pendingRuns[0] === runId &&
+    storage.alarmTime() !== undefined
+  );
+}
+
+async function checkUnclaimableRunKeepsRunScheduled(): Promise<boolean> {
+  const storage = new InMemoryCloudflareDurableObjectStorage();
+  const host = createCloudflareDurableObjectHost({
+    prefix: workerStorePrefix,
+    storage,
+  });
+  const runId = "background:bg_leased";
+  await host.scheduler.enqueueRun(runId);
+
+  const summary = await drainCloudflareAlarm({
+    agent: unclaimableAgent,
+    prefix: workerStorePrefix,
+    storage,
+  });
+  const pendingRuns = await listScheduledCloudflareRuns(storage, {
+    prefix: workerStorePrefix,
+  });
+
+  return (
+    summary.failedRuns.length === 1 &&
+    summary.failedRuns[0]?.id === runId &&
+    pendingRuns.length === 1 &&
+    pendingRuns[0] === runId &&
+    storage.alarmTime() !== undefined
+  );
+}
+
+async function checkUnclaimableSessionPromptKeepsPromptScheduled(): Promise<boolean> {
+  const storage = new InMemoryCloudflareDurableObjectStorage();
+  const host = createCloudflareDurableObjectHost({
+    prefix: workerStorePrefix,
+    storage,
+  });
+  const idempotencyKey = "background-complete:demo:bg_unclaimable";
+  const runId = "notification:bg_unclaimable";
+  await host.scheduler.resumeSession(sessionKey, { idempotencyKey, runId });
+
+  const summary = await drainCloudflareAlarm({
+    agent: unclaimableAgent,
+    prefix: workerStorePrefix,
+    storage,
+  });
+  const pendingPrompts = await listScheduledCloudflareSessionPrompts(storage, {
+    prefix: workerStorePrefix,
+  });
+
+  return (
+    summary.failedSessionPrompts.length === 1 &&
+    summary.failedSessionPrompts[0]?.id === idempotencyKey &&
+    pendingPrompts.length === 1 &&
+    pendingPrompts[0]?.idempotencyKey === idempotencyKey &&
+    pendingPrompts[0]?.runId === runId &&
+    storage.alarmTime() !== undefined
+  );
+}
+
+async function collectEvents(run: {
+  events(): AsyncIterable<AgentEvent>;
+}): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of run.events()) {
+    events.push(event);
+  }
+  return events;
+}
+
+function backgroundTaskIdFromEvents(events: readonly AgentEvent[]): string {
+  for (const event of events) {
+    if (event.type !== "tool-result") {
+      continue;
+    }
+    const output = event.output;
+    if (
+      isRecord(output) &&
+      output.type === "json" &&
+      isRecord(output.value) &&
+      typeof output.value.task_id === "string"
+    ) {
+      return output.value.task_id;
+    }
+  }
+
+  throw new Error("Background task id was not emitted.");
+}
+
+const backgroundNotificationKey = (taskId: string) =>
+  `background-complete:${sessionKey}:${taskId}`;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const duplicateAlarmIdempotent = await checkDuplicateAlarmDelivery();
+const cancelledRunSkippedNotification = await checkCancelledRunNotification();
+const staleCheckpointRejected = await checkStaleCheckpoint();
+const malformedSessionPromptRejected = await checkMalformedSessionPrompt();
+const failedAlarmKeepsRunScheduled = await checkFailedAlarmKeepsRunScheduled();
+const unclaimableRunKeepsRunScheduled =
+  await checkUnclaimableRunKeepsRunScheduled();
+const unclaimableSessionPromptKeepsPromptScheduled =
+  await checkUnclaimableSessionPromptKeepsPromptScheduled();
+
+console.log({ duplicateAlarmIdempotent });
+console.log({ cancelledRunSkippedNotification });
+console.log({ staleCheckpointRejected });
+console.log({ malformedSessionPromptRejected });
+console.log({ failedAlarmKeepsRunScheduled });
+console.log({ unclaimableRunKeepsRunScheduled });
+console.log({ unclaimableSessionPromptKeepsPromptScheduled });
+
+if (
+  !(
+    duplicateAlarmIdempotent &&
+    cancelledRunSkippedNotification &&
+    staleCheckpointRejected &&
+    malformedSessionPromptRejected &&
+    failedAlarmKeepsRunScheduled &&
+    unclaimableRunKeepsRunScheduled &&
+    unclaimableSessionPromptKeepsPromptScheduled
+  )
+) {
+  throw new Error("Cloudflare edge-case checks failed.");
+}

--- a/examples/cloudflare-edge-subagent/src/worker-edge-cases.ts
+++ b/examples/cloudflare-edge-subagent/src/worker-edge-cases.ts
@@ -8,11 +8,8 @@ import {
   listScheduledCloudflareSessionPrompts,
 } from "./cloudflare-host";
 import { FailingRunLookupStorage } from "./failing-run-lookup-storage";
-import {
-  AgentDurableObject,
-  createWorkerCoordinator,
-  workerStorePrefix,
-} from "./worker";
+import { AgentDurableObject, createWorkerCoordinator } from "./worker";
+import { workerStorePrefix } from "./worker-constants";
 
 const sessionKey = "room:demo:user:edge";
 const noRun = () => Promise.resolve(null);

--- a/examples/cloudflare-edge-subagent/src/worker-model.ts
+++ b/examples/cloudflare-edge-subagent/src/worker-model.ts
@@ -1,0 +1,120 @@
+import type { RuntimeLlm } from "@minpeter/pss-runtime";
+import type { AssistantModelMessage, LanguageModel } from "ai";
+
+const delegateToolCallId = "call_cloudflare_delegate";
+const outputToolCallId = "call_cloudflare_background_output";
+const taskIdPattern = /bg_[a-z0-9]+/i;
+
+export function createWorkerCoordinatorModel(): LanguageModel {
+  return {
+    specificationVersion: "v4",
+    provider: "pss-example",
+    modelId: "cloudflare-worker-coordinator",
+    supportedUrls: {},
+    doGenerate: ({ prompt }) => {
+      const serializedPrompt = JSON.stringify(prompt);
+      if (serializedPrompt.includes(outputToolCallId)) {
+        return Promise.resolve(
+          textResult(
+            "Background result retrieved after the Durable Object alarm resumed the child run."
+          )
+        );
+      }
+
+      if (serializedPrompt.includes("[BACKGROUND TASK COMPLETED]")) {
+        return Promise.resolve(
+          toolCallResult(outputToolCallId, "background_output", {
+            block: true,
+            task_id: extractTaskId(serializedPrompt),
+          })
+        );
+      }
+
+      if (serializedPrompt.includes(delegateToolCallId)) {
+        return Promise.resolve(
+          textResult("Background task launched; awaiting durable resume.")
+        );
+      }
+
+      return Promise.resolve(
+        toolCallResult(delegateToolCallId, "delegate_to_researcher", {
+          prompt:
+            "Give one sentence on why task IDs matter for background subagents.",
+          run_in_background: true,
+        })
+      );
+    },
+    doStream: () => {
+      throw new Error(
+        "The Cloudflare worker example uses non-streaming calls."
+      );
+    },
+  } satisfies LanguageModel;
+}
+
+export const workerResearcherModel: RuntimeLlm = async () => [
+  assistantMessage(
+    "Task IDs let the parent resume, retrieve, and cancel exact background subagent jobs across request boundaries."
+  ),
+];
+
+function assistantMessage(
+  content: AssistantModelMessage["content"]
+): AssistantModelMessage {
+  return { content, role: "assistant" };
+}
+
+function textResult(text: string) {
+  return {
+    content: [{ text, type: "text" as const }],
+    finishReason: { raw: "stop", unified: "stop" as const },
+    usage: emptyUsage(),
+    warnings: [],
+  };
+}
+
+function toolCallResult(
+  toolCallId: string,
+  toolName: string,
+  input: Record<string, unknown>
+) {
+  return {
+    content: [
+      {
+        input: JSON.stringify(input),
+        toolCallId,
+        toolName,
+        type: "tool-call" as const,
+      },
+    ],
+    finishReason: { raw: "tool-calls", unified: "tool-calls" as const },
+    usage: emptyUsage(),
+    warnings: [],
+  };
+}
+
+function emptyUsage() {
+  return {
+    inputTokens: {
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      noCache: undefined,
+      total: undefined,
+    },
+    outputTokens: {
+      reasoning: undefined,
+      text: undefined,
+      total: undefined,
+    },
+  };
+}
+
+function extractTaskId(value: string): string {
+  const match = taskIdPattern.exec(value);
+  if (!match) {
+    throw new Error(
+      "Background completion reminder did not include a task id."
+    );
+  }
+  return match[0];
+}

--- a/examples/cloudflare-edge-subagent/src/worker-route.ts
+++ b/examples/cloudflare-edge-subagent/src/worker-route.ts
@@ -1,0 +1,126 @@
+import type { CloudflareDurableObjectStorage } from "./cloudflare-host";
+import { workerStorePrefix } from "./worker-constants";
+
+const workerRouteStorageKey = "__pss_worker_route";
+
+export interface WorkerRoute {
+  readonly conversationId: string;
+  readonly objectName: string;
+  readonly sessionKey: string;
+  readonly storePrefix: string;
+  readonly tenantId: string;
+  readonly userId: string;
+}
+
+export function routeWorkerRequest(
+  requestUrl: string,
+  body: unknown
+): WorkerRoute | undefined {
+  const url = new URL(requestUrl);
+  const tenantId = readRouteValue(body, url, "tenantId", "tenant");
+  const userId = readRouteValue(body, url, "userId", "user");
+  const conversationId = readRouteValue(
+    body,
+    url,
+    "conversationId",
+    "conversation"
+  );
+  if (!(tenantId && userId && conversationId)) {
+    return;
+  }
+
+  return {
+    conversationId,
+    objectName: objectNameFromRoute({ conversationId, tenantId, userId }),
+    sessionKey: sessionKeyFromRoute({ conversationId, tenantId, userId }),
+    storePrefix: storePrefixFromRoute({ conversationId, tenantId, userId }),
+    tenantId,
+    userId,
+  };
+}
+
+export function sessionKeyFromRoute(route: {
+  readonly conversationId: string;
+  readonly tenantId: string;
+  readonly userId: string;
+}): string {
+  return [
+    "tenant",
+    routeToken(route.tenantId),
+    "conversation",
+    routeToken(route.conversationId),
+    "user",
+    routeToken(route.userId),
+  ].join(":");
+}
+
+export async function writeWorkerRoute(
+  storage: CloudflareDurableObjectStorage,
+  route: WorkerRoute
+): Promise<void> {
+  await storage.put(workerRouteStorageKey, route);
+}
+
+export async function readWorkerRoute(
+  storage: CloudflareDurableObjectStorage
+): Promise<WorkerRoute | undefined> {
+  return await storage.get<WorkerRoute>(workerRouteStorageKey);
+}
+
+function objectNameFromRoute(route: {
+  readonly conversationId: string;
+  readonly tenantId: string;
+  readonly userId: string;
+}): string {
+  return [
+    "support-agent",
+    routeToken(route.tenantId),
+    routeToken(route.conversationId),
+    routeToken(route.userId),
+  ].join(":");
+}
+
+function storePrefixFromRoute(route: {
+  readonly conversationId: string;
+  readonly tenantId: string;
+  readonly userId: string;
+}): string {
+  return [
+    workerStorePrefix,
+    "tenant",
+    routeToken(route.tenantId),
+    "conversation",
+    routeToken(route.conversationId),
+    "user",
+    routeToken(route.userId),
+  ].join(":");
+}
+
+function readRouteValue(
+  body: unknown,
+  url: URL,
+  bodyKey: string,
+  queryKey: string
+): string | undefined {
+  const bodyValue = readBodyStringField(body, bodyKey);
+  const value = bodyValue ?? url.searchParams.get(queryKey) ?? undefined;
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readBodyStringField(body: unknown, key: string): string | undefined {
+  if (!isRecord(body)) {
+    return;
+  }
+
+  const value = body[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function routeToken(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/examples/cloudflare-edge-subagent/src/worker-simulation.ts
+++ b/examples/cloudflare-edge-subagent/src/worker-simulation.ts
@@ -7,10 +7,20 @@ import {
   AgentDurableObject,
   type CloudflareDurableObjectState,
   createWorkerCoordinator,
-  workerStorePrefix,
 } from "./worker";
+import { routeWorkerRequest, sessionKeyFromRoute } from "./worker-route";
 
-const sessionKey = "room:demo:user:edge";
+const route = {
+  conversationId: "edge-task-ids",
+  tenantId: "demo",
+  userId: "edge",
+};
+const sessionKey = sessionKeyFromRoute(route);
+const workerRoute = routeWorkerRequest("https://worker.example/turn", route);
+if (!workerRoute) {
+  throw new Error("Worker simulation route was not valid.");
+}
+const workerRouteStorePrefix = workerRoute.storePrefix;
 
 const storage = new InMemoryCloudflareDurableObjectStorage();
 const state: CloudflareDurableObjectState = {
@@ -26,8 +36,11 @@ const launchObject = new AgentDurableObject(state, {});
 const launchResponse = await launchObject.fetch(
   new Request("https://worker.example/turn", {
     body: JSON.stringify({
+      conversationId: route.conversationId,
       input:
         "Start background research on why stable task ids matter in edge-hosted agent turns.",
+      tenantId: route.tenantId,
+      userId: route.userId,
     }),
     method: "POST",
   })
@@ -46,9 +59,13 @@ console.log("alarm:resume", alarmSummary.resumedRuns);
 console.log("resume:session-prompt", alarmSummary.consumedSessionPrompts);
 console.log("finalAnswer", extractFinalAnswer(alarmSummary.events));
 
-const duplicate = await createWorkerCoordinator(storage).resume(
-  await notificationRunId(backgroundNotificationKey(taskId))
-);
+const duplicate = await createWorkerCoordinator(
+  storage,
+  {},
+  {
+    prefix: workerRouteStorePrefix,
+  }
+).resume(await notificationRunId(backgroundNotificationKey(taskId)));
 console.log({ duplicateSessionPromptIgnored: duplicate === null });
 
 function backgroundTaskIdFromEvents(events: readonly AgentEvent[]): string {
@@ -87,7 +104,7 @@ function backgroundNotificationKey(taskId: string): string {
 
 async function notificationRunId(notificationKey: string): Promise<string> {
   const host = createCloudflareDurableObjectHost({
-    prefix: workerStorePrefix,
+    prefix: workerRouteStorePrefix,
     storage,
   });
   const notification =

--- a/examples/cloudflare-edge-subagent/src/worker-simulation.ts
+++ b/examples/cloudflare-edge-subagent/src/worker-simulation.ts
@@ -1,0 +1,118 @@
+import type { AgentEvent } from "@minpeter/pss-runtime";
+import {
+  createCloudflareDurableObjectHost,
+  InMemoryCloudflareDurableObjectStorage,
+} from "./cloudflare-host";
+import {
+  AgentDurableObject,
+  type CloudflareDurableObjectState,
+  createWorkerCoordinator,
+  workerStorePrefix,
+} from "./worker";
+
+const sessionKey = "room:demo:user:edge";
+
+const storage = new InMemoryCloudflareDurableObjectStorage();
+const state: CloudflareDurableObjectState = {
+  storage,
+  waitUntil: (promise) => {
+    promise.catch((error: unknown) => {
+      console.error(error);
+    });
+  },
+};
+
+const launchObject = new AgentDurableObject(state, {});
+const launchResponse = await launchObject.fetch(
+  new Request("https://worker.example/turn", {
+    body: JSON.stringify({
+      input:
+        "Start background research on why stable task ids matter in edge-hosted agent turns.",
+    }),
+    method: "POST",
+  })
+);
+const launchBody = await readResponseJson(launchResponse);
+const launchEvents = readEvents(launchBody);
+const taskId = backgroundTaskIdFromEvents(launchEvents);
+
+console.log("request-boundary:launch", taskId);
+console.log("alarmScheduled", storage.alarmTime() !== undefined);
+
+const alarmObject = new AgentDurableObject(state, {});
+const alarmSummary = await alarmObject.alarm();
+
+console.log("alarm:resume", alarmSummary.resumedRuns);
+console.log("resume:session-prompt", alarmSummary.consumedSessionPrompts);
+console.log("finalAnswer", extractFinalAnswer(alarmSummary.events));
+
+const duplicate = await createWorkerCoordinator(storage).resume(
+  await notificationRunId(backgroundNotificationKey(taskId))
+);
+console.log({ duplicateSessionPromptIgnored: duplicate === null });
+
+function backgroundTaskIdFromEvents(events: readonly AgentEvent[]): string {
+  for (const event of events) {
+    if (event.type !== "tool-result") {
+      continue;
+    }
+    const output = event.output;
+    if (
+      isRecord(output) &&
+      output.type === "json" &&
+      isRecord(output.value) &&
+      typeof output.value.task_id === "string"
+    ) {
+      return output.value.task_id;
+    }
+  }
+
+  throw new Error("Background task id was not emitted.");
+}
+
+function extractFinalAnswer(events: readonly AgentEvent[]): string {
+  const assistantText = events.find(
+    (event): event is Extract<AgentEvent, { type: "assistant-text" }> =>
+      event.type === "assistant-text"
+  );
+  if (!assistantText) {
+    throw new Error("Final assistant answer was not emitted.");
+  }
+  return assistantText.text;
+}
+
+function backgroundNotificationKey(taskId: string): string {
+  return `background-complete:${sessionKey}:${taskId}`;
+}
+
+async function notificationRunId(notificationKey: string): Promise<string> {
+  const host = createCloudflareDurableObjectHost({
+    prefix: workerStorePrefix,
+    storage,
+  });
+  const notification =
+    await host.store.notifications.getByIdempotencyKey(notificationKey);
+  if (!notification) {
+    throw new Error(`Notification ${notificationKey} was not enqueued.`);
+  }
+  return notification.runId;
+}
+
+async function readResponseJson(response: Response): Promise<unknown> {
+  if (!response.ok) {
+    throw new Error(`Worker response failed with ${response.status}.`);
+  }
+  return await response.json();
+}
+
+function readEvents(value: unknown): readonly AgentEvent[] {
+  if (isRecord(value) && Array.isArray(value.events)) {
+    return value.events as AgentEvent[];
+  }
+
+  throw new Error("Worker response did not include events.");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/examples/cloudflare-edge-subagent/src/worker.ts
+++ b/examples/cloudflare-edge-subagent/src/worker.ts
@@ -8,13 +8,16 @@ import {
   type CloudflareDurableObjectStorage,
   createCloudflareDurableObjectHost,
 } from "./cloudflare-host";
+import { workerStorePrefix } from "./worker-constants";
 import {
   createWorkerCoordinatorModel,
   workerResearcherModel,
 } from "./worker-model";
-
-const defaultSessionKey = "room:demo:user:edge";
-export const workerStorePrefix = "cloudflare-edge-subagent-demo";
+import {
+  readWorkerRoute,
+  routeWorkerRequest,
+  writeWorkerRoute,
+} from "./worker-route";
 
 export interface Env {
   readonly AGENT_DURABLE_OBJECT?: AgentDurableObjectNamespace;
@@ -28,7 +31,7 @@ interface AgentDurableObjectNamespace {
 type AgentDurableObjectId = unknown;
 
 interface AgentDurableObjectStub {
-  fetch(request: Request): Promise<Response>;
+  fetch(request: unknown): Promise<Response>;
 }
 
 export interface CloudflareDurableObjectState {
@@ -49,9 +52,23 @@ export class AgentDurableObject {
     const url = new URL(request.url);
     if (request.method === "POST" && url.pathname === "/turn") {
       const body = await readJsonBody(request);
+      const route = routeWorkerRequest(request.url, body);
+      if (!route) {
+        return jsonResponse(
+          {
+            error:
+              "tenantId, userId, and conversationId are required for /turn.",
+          },
+          400
+        );
+      }
+
+      await writeWorkerRoute(this.#state.storage, route);
       const input = readTextInput(body);
       const events = await drainAgentRun(
-        await this.#agent().session(defaultSessionKey).send(input)
+        await this.#agent(route.storePrefix)
+          .session(route.sessionKey)
+          .send(input)
       );
       return jsonResponse({
         events,
@@ -59,30 +76,37 @@ export class AgentDurableObject {
       });
     }
 
-    if (request.method === "POST" && url.pathname === "/alarm") {
-      const summary = await this.alarm();
-      return jsonResponse(summary);
-    }
-
     return jsonResponse({ error: "not found" }, 404);
   }
 
   async alarm(): Promise<AlarmDrainSummary> {
+    const route = await readWorkerRoute(this.#state.storage);
     return await drainCloudflareAlarm({
-      agent: this.#agent(),
-      prefix: workerStorePrefix,
+      agent: this.#agent(route?.storePrefix ?? workerStorePrefix),
+      prefix: route?.storePrefix ?? workerStorePrefix,
       storage: this.#state.storage,
     });
   }
 
-  #agent(): Agent {
-    return createWorkerCoordinator(this.#state.storage, this.#env);
+  #agent(prefix = workerStorePrefix): Agent {
+    return createWorkerCoordinator(this.#state.storage, this.#env, { prefix });
   }
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const id = env.AGENT_DURABLE_OBJECT?.idFromName("default");
+    const route = routeWorkerRequest(
+      request.url,
+      await readJsonBody(request.clone())
+    );
+    if (!route) {
+      return jsonResponse(
+        { error: "tenantId, userId, and conversationId are required." },
+        400
+      );
+    }
+
+    const id = env.AGENT_DURABLE_OBJECT?.idFromName(route.objectName);
     const stub = id ? env.AGENT_DURABLE_OBJECT?.get(id) : undefined;
     if (stub) {
       return await stub.fetch(request);
@@ -100,10 +124,11 @@ export default {
 
 export function createWorkerCoordinator(
   storage: CloudflareDurableObjectStorage,
-  _env: Env = {}
+  _env: Env = {},
+  options: { readonly prefix?: string } = {}
 ): Agent {
   const host = createCloudflareDurableObjectHost({
-    prefix: workerStorePrefix,
+    prefix: options.prefix ?? workerStorePrefix,
     storage,
   });
   const researcher = new Agent({
@@ -130,7 +155,9 @@ export function createWorkerCoordinator(
 
 type AlarmDrainSummary = CloudflareAlarmDrainSummary;
 
-async function readJsonBody(request: Request): Promise<unknown> {
+async function readJsonBody(request: {
+  json(): Promise<unknown>;
+}): Promise<unknown> {
   try {
     return await request.json();
   } catch {

--- a/examples/cloudflare-edge-subagent/src/worker.ts
+++ b/examples/cloudflare-edge-subagent/src/worker.ts
@@ -1,0 +1,156 @@
+import { Agent } from "@minpeter/pss-runtime";
+import {
+  type CloudflareAlarmDrainSummary,
+  drainAgentRun,
+  drainCloudflareAlarm,
+} from "./cloudflare-alarm-drainer";
+import {
+  type CloudflareDurableObjectStorage,
+  createCloudflareDurableObjectHost,
+} from "./cloudflare-host";
+import {
+  createWorkerCoordinatorModel,
+  workerResearcherModel,
+} from "./worker-model";
+
+const defaultSessionKey = "room:demo:user:edge";
+export const workerStorePrefix = "cloudflare-edge-subagent-demo";
+
+export interface Env {
+  readonly AGENT_DURABLE_OBJECT?: AgentDurableObjectNamespace;
+}
+
+interface AgentDurableObjectNamespace {
+  get(id: AgentDurableObjectId): AgentDurableObjectStub;
+  idFromName(name: string): AgentDurableObjectId;
+}
+
+type AgentDurableObjectId = unknown;
+
+interface AgentDurableObjectStub {
+  fetch(request: Request): Promise<Response>;
+}
+
+export interface CloudflareDurableObjectState {
+  readonly storage: CloudflareDurableObjectStorage;
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+export class AgentDurableObject {
+  readonly #env: Env;
+  readonly #state: CloudflareDurableObjectState;
+
+  constructor(state: CloudflareDurableObjectState, env: Env) {
+    this.#env = env;
+    this.#state = state;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/turn") {
+      const body = await readJsonBody(request);
+      const input = readTextInput(body);
+      const events = await drainAgentRun(
+        await this.#agent().session(defaultSessionKey).send(input)
+      );
+      return jsonResponse({
+        events,
+        markers: ["request-boundary:launch"],
+      });
+    }
+
+    if (request.method === "POST" && url.pathname === "/alarm") {
+      const summary = await this.alarm();
+      return jsonResponse(summary);
+    }
+
+    return jsonResponse({ error: "not found" }, 404);
+  }
+
+  async alarm(): Promise<AlarmDrainSummary> {
+    return await drainCloudflareAlarm({
+      agent: this.#agent(),
+      prefix: workerStorePrefix,
+      storage: this.#state.storage,
+    });
+  }
+
+  #agent(): Agent {
+    return createWorkerCoordinator(this.#state.storage, this.#env);
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.AGENT_DURABLE_OBJECT?.idFromName("default");
+    const stub = id ? env.AGENT_DURABLE_OBJECT?.get(id) : undefined;
+    if (stub) {
+      return await stub.fetch(request);
+    }
+
+    return jsonResponse(
+      {
+        error:
+          "AGENT_DURABLE_OBJECT binding is required outside the local simulation.",
+      },
+      500
+    );
+  },
+};
+
+export function createWorkerCoordinator(
+  storage: CloudflareDurableObjectStorage,
+  _env: Env = {}
+): Agent {
+  const host = createCloudflareDurableObjectHost({
+    prefix: workerStorePrefix,
+    storage,
+  });
+  const researcher = new Agent({
+    description: "Produces compact research notes for the coordinator.",
+    host,
+    model: workerResearcherModel,
+    name: "researcher",
+    namespace: "cloudflare-worker-researcher",
+  });
+
+  return new Agent({
+    host,
+    instructions: [
+      "Coordinate background research in a Worker Durable Object.",
+      "When asked for background research, call delegate_to_researcher once with run_in_background: true.",
+      "Do not call background_output until a <system-reminder> says the background task completed.",
+      "After the reminder, call background_output with block: true and return a concise final answer.",
+    ].join(" "),
+    model: createWorkerCoordinatorModel(),
+    namespace: "cloudflare-worker-coordinator",
+    subagents: [researcher],
+  });
+}
+
+type AlarmDrainSummary = CloudflareAlarmDrainSummary;
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return {};
+  }
+}
+
+function readTextInput(body: unknown): string {
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    "input" in body &&
+    typeof body.input === "string"
+  ) {
+    return body.input;
+  }
+
+  return "Start background research on edge-hosted task ids.";
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return Response.json(body, { status });
+}

--- a/examples/cloudflare-edge-subagent/tsconfig.json
+++ b/examples/cloudflare-edge-subagent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "customConditions": ["@minpeter/pss-source"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/cloudflare-edge-subagent/tsconfig.worker.json
+++ b/examples/cloudflare-edge-subagent/tsconfig.worker.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/cloudflare-edge-subagent/wrangler.jsonc
+++ b/examples/cloudflare-edge-subagent/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "pss-cloudflare-edge-subagent",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-08",
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "AgentDurableObject",
+        "name": "AGENT_DURABLE_OBJECT"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "new_sqlite_classes": ["AgentDurableObject"],
+      "tag": "v1"
+    }
+  ]
+}

--- a/examples/subagent/package.json
+++ b/examples/subagent/package.json
@@ -5,12 +5,14 @@
   "scripts": {
     "start": "tsx --conditions=@minpeter/pss-source src/index.ts",
     "start:background": "tsx --conditions=@minpeter/pss-source src/background.ts",
+    "start:background:wait": "tsx --conditions=@minpeter/pss-source src/background-wait.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "3.0.0-canary.48",
     "@minpeter/pss-runtime": "workspace:*",
     "@t3-oss/env-core": "^0.13.11",
+    "ai": "7.0.0-canary.142",
     "dotenv": "^17.4.2",
     "zod": "^4.4.3"
   },

--- a/examples/subagent/src/background-wait.ts
+++ b/examples/subagent/src/background-wait.ts
@@ -1,0 +1,48 @@
+import { Agent, type AgentEvent, type AgentRun } from "@minpeter/pss-runtime";
+import {
+  createLocalCoordinatorModel,
+  localResearcherModel,
+} from "./local-background-model";
+import { localHost } from "./local-host";
+
+const sessionKey = "local:background:wait";
+const host = localHost({ agent: createCoordinator });
+
+const researcher = new Agent({
+  name: "researcher",
+  description: "Runs longer research tasks for the coordinator.",
+  host,
+  model: localResearcherModel,
+  namespace: "local-wait-researcher",
+});
+
+const launchCoordinator = createCoordinator();
+const session = launchCoordinator.session(sessionKey);
+await drainRun(
+  await session.send(
+    "Start the one-sentence background researcher task and return after the launch is recorded."
+  )
+);
+
+console.log("\n=== waiting for background completion ===");
+await drainRun(await host.resumeSession());
+
+function createCoordinator(): Agent {
+  return new Agent({
+    host,
+    model: createLocalCoordinatorModel(),
+    namespace: "local-wait-coordinator",
+    instructions:
+      "Coordinate the task. Start researcher work with delegate_to_researcher({ prompt: 'Give one sentence on why task IDs matter for background subagents.', run_in_background: true }) and save the returned task_id. Do not call background_output until a <system-reminder> says the task completed. After the reminder, call background_output({ task_id, block: true }) and summarize the result.",
+    subagents: [researcher],
+  });
+}
+
+async function drainRun(run: AgentRun): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of run.events()) {
+    events.push(event);
+    console.log(event);
+  }
+  return events;
+}

--- a/examples/subagent/src/background.ts
+++ b/examples/subagent/src/background.ts
@@ -32,12 +32,14 @@ const researcher = new Agent({
 const coordinator = new Agent({
   model,
   instructions:
-    "Coordinate the task. Start researcher work with delegate_to_researcher({ prompt: 'Give one sentence on why task IDs matter for background subagents.', run_in_background: true }), save the returned task_id, then call background_output({ task_id, block: true }) before answering. Use background_cancel({ task_id }) only when the background task is no longer needed.",
+    "Coordinate the task. Start researcher work with delegate_to_researcher({ prompt: 'Give one sentence on why task IDs matter for background subagents.', run_in_background: true }) and save the returned task_id. Do not call background_output until a <system-reminder> says the task completed. If no reminder is present, finish after confirming the background task started. Use background_cancel({ task_id }) only when the background task is no longer needed.",
   subagents: [researcher],
 });
 
-const run = await coordinator.send(
-  "Start the one-sentence background researcher task, retrieve it with background_output, then summarize the result."
+const session = coordinator.session("default");
+
+const run = await session.send(
+  "Start the one-sentence background researcher task and return after the launch is recorded."
 );
 
 for await (const event of run.events()) {

--- a/examples/subagent/src/local-background-model.ts
+++ b/examples/subagent/src/local-background-model.ts
@@ -1,0 +1,143 @@
+import type { RuntimeLlm } from "@minpeter/pss-runtime";
+import type { AssistantModelMessage, LanguageModel } from "ai";
+
+const delegateToolCallId = "call_local_delegate";
+const outputToolCallId = "call_local_background_output";
+const backgroundPrompt =
+  "Give one sentence on why task IDs matter for background subagents.";
+const taskIdPattern = /bg_[a-z0-9]+/i;
+
+class LocalBackgroundModelError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocalBackgroundModelError";
+  }
+}
+
+export function createLocalCoordinatorModel(): LanguageModel {
+  return {
+    specificationVersion: "v4",
+    provider: "pss-example",
+    modelId: "local-background-coordinator",
+    supportedUrls: {},
+    doGenerate: ({ prompt }) => {
+      const serializedPrompt = JSON.stringify(prompt);
+      if (serializedPrompt.includes(outputToolCallId)) {
+        return Promise.resolve(
+          textResult(
+            "Task completed. Task IDs let the parent track, retrieve, and cancel asynchronous subagent work without blocking the main turn."
+          )
+        );
+      }
+
+      if (serializedPrompt.includes("[BACKGROUND TASK COMPLETED]")) {
+        return Promise.resolve(
+          toolCallResult(
+            outputToolCallId,
+            "background_output",
+            {
+              block: true,
+              task_id: extractTaskId(serializedPrompt),
+            },
+            "tool-calls"
+          )
+        );
+      }
+
+      if (serializedPrompt.includes(delegateToolCallId)) {
+        return Promise.resolve(
+          textResult("Launch recorded. Waiting for the background resume.")
+        );
+      }
+
+      return Promise.resolve(
+        toolCallResult(
+          delegateToolCallId,
+          "delegate_to_researcher",
+          {
+            prompt: backgroundPrompt,
+            run_in_background: true,
+          },
+          "tool-calls"
+        )
+      );
+    },
+    doStream: () => {
+      throw new LocalBackgroundModelError(
+        "The local background example only uses non-streaming generation."
+      );
+    },
+  } satisfies LanguageModel;
+}
+
+export const localResearcherModel: RuntimeLlm = async () => [
+  assistantMessage(
+    "Task IDs matter for background subagents because they let the parent track, retrieve, and cancel specific asynchronous jobs."
+  ),
+];
+
+function assistantMessage(
+  content: AssistantModelMessage["content"]
+): AssistantModelMessage {
+  return {
+    content,
+    role: "assistant",
+  };
+}
+
+function textResult(text: string) {
+  return {
+    content: [{ text, type: "text" as const }],
+    finishReason: { raw: "stop", unified: "stop" as const },
+    usage: emptyUsage(),
+    warnings: [],
+  };
+}
+
+function toolCallResult(
+  toolCallId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+  finishReason: "tool-calls"
+) {
+  return {
+    content: [
+      {
+        input: JSON.stringify(input),
+        toolCallId,
+        toolName,
+        type: "tool-call" as const,
+      },
+    ],
+    finishReason: { raw: finishReason, unified: finishReason },
+    usage: emptyUsage(),
+    warnings: [],
+  };
+}
+
+function emptyUsage() {
+  return {
+    inputTokens: {
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      noCache: undefined,
+      total: undefined,
+    },
+    outputTokens: {
+      reasoning: undefined,
+      text: undefined,
+      total: undefined,
+    },
+  };
+}
+
+function extractTaskId(value: string): string {
+  const match = taskIdPattern.exec(value);
+  if (!match) {
+    throw new LocalBackgroundModelError(
+      "The background completion reminder did not include a task id."
+    );
+  }
+
+  return match[0];
+}

--- a/examples/subagent/src/local-host.ts
+++ b/examples/subagent/src/local-host.ts
@@ -1,0 +1,196 @@
+import type { Agent, AgentRun } from "@minpeter/pss-runtime";
+import {
+  createInMemoryExecutionHost,
+  type ExecutionHost,
+  type ResumeSessionOptions,
+} from "@minpeter/pss-runtime/execution";
+
+const defaultResumeTimeoutMs = 60_000;
+
+interface LocalSessionPrompt {
+  readonly options: ResumeSessionOptions;
+  readonly sessionKey: string;
+}
+
+interface LocalSessionPromptState {
+  readonly pendingErrors: Error[];
+  readonly pendingPrompts: LocalSessionPrompt[];
+  readonly waiters: SessionPromptWaiter[];
+}
+
+interface SessionPromptWaiter {
+  reject(error: Error): void;
+  resolve(prompt: LocalSessionPrompt): void;
+}
+
+export interface LocalHost extends ExecutionHost {
+  resumeSession(options?: { readonly timeoutMs?: number }): Promise<AgentRun>;
+}
+
+class LocalHostError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocalHostError";
+  }
+}
+
+export function localHost({
+  agent,
+}: {
+  readonly agent: () => Agent;
+}): LocalHost {
+  const baseHost = createInMemoryExecutionHost();
+  const promptState: LocalSessionPromptState = {
+    pendingErrors: [],
+    pendingPrompts: [],
+    waiters: [],
+  };
+  const host: ExecutionHost = {
+    ...baseHost,
+    capabilities: {
+      ...baseHost.capabilities,
+      backgroundSubagents: "durable",
+    },
+    scheduler: {
+      enqueueRun: async (runId, options) => {
+        await baseHost.scheduler.enqueueRun(runId, options);
+        resumeQueuedRun(agent, runId, promptState);
+      },
+      resumeSession: async (sessionKey, options) => {
+        await baseHost.scheduler.resumeSession(sessionKey, options);
+        publishPrompt(promptState, { options, sessionKey });
+      },
+    },
+  };
+
+  return {
+    ...host,
+    resumeSession: async (options) => {
+      const prompt = await waitForPrompt(
+        promptState,
+        options?.timeoutMs ?? defaultResumeTimeoutMs
+      );
+      if (!prompt.options.runId) {
+        throw new LocalHostError(
+          `Session ${prompt.sessionKey} resumed without a run id.`
+        );
+      }
+
+      const run = await agent().resume(prompt.options.runId);
+      if (!run) {
+        throw new LocalHostError(
+          `Run ${prompt.options.runId} was already consumed.`
+        );
+      }
+      return run;
+    },
+  };
+}
+
+function publishPrompt(
+  state: LocalSessionPromptState,
+  prompt: LocalSessionPrompt
+): void {
+  const waiter = state.waiters.shift();
+  if (waiter) {
+    waiter.resolve(prompt);
+    return;
+  }
+
+  state.pendingPrompts.push(prompt);
+}
+
+function publishError(state: LocalSessionPromptState, error: Error): void {
+  const waiter = state.waiters.shift();
+  if (waiter) {
+    waiter.reject(error);
+    return;
+  }
+
+  state.pendingErrors.push(error);
+}
+
+function resumeQueuedRun(
+  agent: () => Agent,
+  runId: string,
+  state: LocalSessionPromptState
+): void {
+  queueMicrotask(() => {
+    agent()
+      .resume(runId)
+      .then((run) => {
+        if (!run) {
+          publishError(
+            state,
+            new LocalHostError(`Run ${runId} was not resumable.`)
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        publishError(state, errorMessage(error));
+      });
+  });
+}
+
+function waitForPrompt(
+  state: LocalSessionPromptState,
+  timeoutMs: number
+): Promise<LocalSessionPrompt> {
+  const pendingError = state.pendingErrors.shift();
+  if (pendingError) {
+    return Promise.reject(pendingError);
+  }
+
+  const pendingPrompt = state.pendingPrompts.shift();
+  if (pendingPrompt) {
+    return Promise.resolve(pendingPrompt);
+  }
+
+  let waiter: SessionPromptWaiter | undefined;
+  let settled = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const cleanup = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    const index = waiter ? state.waiters.indexOf(waiter) : -1;
+    if (index >= 0) {
+      state.waiters.splice(index, 1);
+    }
+  };
+  const complete = (action: () => void) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    action();
+  };
+
+  return new Promise<LocalSessionPrompt>((resolve, reject) => {
+    waiter = {
+      reject: (error) => complete(() => reject(error)),
+      resolve: (prompt) => complete(() => resolve(prompt)),
+    };
+    timeoutId = setTimeout(
+      () =>
+        complete(() =>
+          reject(
+            new LocalHostError(
+              `No session prompt resume arrived within ${timeoutMs}ms.`
+            )
+          )
+        ),
+      timeoutMs
+    );
+    state.waiters.push(waiter);
+  });
+}
+
+function errorMessage(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new LocalHostError(String(error));
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Patch Changes
 
-- 20103d2: Make the coding-agent TUI subpath import-safe, correct multimodal docs, and remove redundant runtime type aliases.
+- 20103d2: Make the coding-agent TUI subpath import-safe, correct multimodal docs, and remove redundant runtime type exports.
 - Updated dependencies [20103d2]
   - @minpeter/pss-runtime@0.0.9
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -58,7 +58,7 @@ pnpm add -g @minpeter/pss-coding-agent
 pss
 ```
 
-Bin aliases: `pss`, `pss-coding-agent`.
+CLI commands: `pss`, `pss-coding-agent`.
 
 When the TUI is idle, submitting text starts a normal `session.send()` turn. When
 a run is active, submitting text calls `session.steer(trimmed)` so the text lands

--- a/packages/coding-agent/src/tui.ts
+++ b/packages/coding-agent/src/tui.ts
@@ -19,12 +19,12 @@ import { safeInlineText } from "./tui-tool-printer";
 export async function startTui(): Promise<void> {
   const sessionConfig = resolveCodingAgentSessionConfig();
   const agent = new Agent({
+    host: {
+      sessionStore: new FileSessionStore(sessionConfig.directory),
+    },
     instructions:
       "Answer in 2 short sentences and 280 characters or fewer unless the user explicitly asks for detail. Avoid headings.",
     model: createCodingLanguageModel(),
-    sessions: {
-      store: new FileSessionStore(sessionConfig.directory),
-    },
     tools,
   });
   const session = agent.session(sessionConfig.key);

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -14,9 +14,9 @@
 
   - Keep `run.events()` as the app-owned runtime control loop for synchronized rendering, tracing, and continuation policy.
   - Expand plugin lifecycle middleware with `turn.before`, `step.before`, `step.after`, and `turn.after` handlers that can call scoped `steer(...)`.
-  - Add `Agent.create({ onPluginError })` for routing plugin lifecycle handler failures to caller-owned observability instead of the default console reporter.
+  - Route plugin lifecycle handler failures through the returned run so callers own observability.
   - Add runtime-owned tool policy middleware with `tool.call` and `tool.result` for allow, modify, reject-and-continue, synthesize, error, and result replacement flows.
-  - Remove legacy top-level `Agent.create({ sessions: { store } })` and `Agent.create({ hooks })` options. Use `plugins: [sessions.custom(store)]` for persistence, `run.events()` plus `session.steer()` for app control, or plugin lifecycle handlers for reusable middleware.
+  - Use `host: { sessionStore }` for persistence, `run.events()` plus `session.steer()` for app control, or plugin lifecycle handlers for reusable middleware.
 
 ### Patch Changes
 
@@ -34,7 +34,7 @@
 
 ### Patch Changes
 
-- 20103d2: Make the coding-agent TUI subpath import-safe, correct multimodal docs, and remove redundant runtime type aliases.
+- 20103d2: Make the coding-agent TUI subpath import-safe, correct multimodal docs, and trim redundant runtime type exports.
 
 ## 0.0.8
 
@@ -48,7 +48,7 @@
 
 ### Patch Changes
 
-- c71ea7d: Add runtime `toolChoice` configuration and lifecycle hooks for turns and steps.
+- c71ea7d: Add runtime `toolChoice` configuration and lifecycle events for turns and steps.
 
 ## 0.0.6
 
@@ -82,9 +82,9 @@
 
 - f503ccd: Enhance `AgentSession` with state hydration, mutation tracking, and broader TypeScript type exports:
 
-  - Add `history` hydration via `SessionOptions` in `Agent.createSession()` and `AgentSession` constructor.
+  - Add `history` hydration through `AgentSession` constructor options.
   - Introduce `getHistory()` to retrieve the current snapshot of the agent's message history.
-  - Add `onHistoryChange` lifecycle callback hook to `AgentSession` (and underlying model history) to observe and persist serialized mutation-time history snapshots.
+  - Add lifecycle callbacks to `AgentSession` and model history for serialized mutation-time history snapshots.
   - Keep `kill()` from hanging active turns that are waiting on stalled history persistence.
   - Export `AgentMessage` globally from `@minpeter/pss-runtime` for clean external representation of internal AI SDK message structures.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -49,6 +49,23 @@ consume the events for the run to progress. This is what lets code react to
 `turn-start`, `step-start`, and `step-end` before the next model snapshot is
 created.
 
+`model` is the single public constructor key for model execution. Pass an AI SDK
+`LanguageModel` for the managed runtime path with `instructions`, `tools`, and
+`subagents`, or pass a custom `RuntimeLlm` function when you want to own the model
+adapter yourself:
+
+```ts
+import { Agent, type RuntimeLlm } from "@minpeter/pss-runtime";
+
+const runtimeModel: RuntimeLlm = async ({ history }) => [
+  { role: "assistant", content: `Seen ${history.length} messages.` },
+];
+
+const agent = new Agent({
+  model: runtimeModel,
+});
+```
+
 Per-key conversations use `session(key)`:
 
 ```ts
@@ -136,9 +153,11 @@ delegate_to_researcher({
 ```
 
 When the model sets `run_in_background: true`, the parent run can finish while
-the child keeps working. The launch result includes a `bg_...` `task_id`. A
-compact runtime reminder is queued for the parent when the child finishes, and
-the model can retrieve the result with `background_output`.
+the child keeps working. The launch result includes a `bg_...` `task_id` and
+tells the model to wait for a `<system-reminder>` before retrieving output.
+When background work finishes, the session is notified with compact runtime
+input. Hosts that support durable background work should resume the parent session
+through the notification inbox and drain the returned `AgentRun`.
 
 ```ts
 delegate_to_researcher({
@@ -146,6 +165,7 @@ delegate_to_researcher({
   run_in_background: true,
 });
 
+// After the completion reminder arrives:
 background_output({ task_id: "bg_...", block: true });
 background_cancel({ task_id: "bg_..." });
 ```
@@ -153,20 +173,38 @@ background_cancel({ task_id: "bg_..." });
 The parent model context stays compact by default: completion reminders include
 the task id, subagent name, description, and retrieval instruction. Full child
 traces are not injected into the parent transcript by default. Background jobs
-run in task-scoped child sessions, and retrieved completed jobs are forgotten
-after `background_output` returns.
+run in task-scoped child sessions. In-memory job handles are cleaned up after
+completed output retrieval, while durable hosts keep compact completed output
+available through the execution store for reconstructed agents. Background jobs
+launched during the same parent turn share an internal completion barrier:
+successful jobs notify once when the group settles, while failed jobs notify
+immediately.
 
-## Send and Steer
+## Send, Host Resume, and Steer
 
 Use `session.send(input)` for a new user turn. If a run is already active, the
-turn is queued until the active run finishes. Use `session.steer(input)` when the
-input should steer the active run; if no run is active, it starts a normal run.
+turn is queued until the active run finishes. Use `session.steer(input)` when
+the input should steer the active run; if no run is active, it starts a normal
+run.
 
-Both APIs accept the same input shapes: strings, arrays of strings,
+Durable hosts resume completed background work by writing a notification record
+and calling `agent.resume(notificationRunId)`. The resume call claims the
+notification idempotently through its durable run id and returns one `AgentRun`,
+or `null` when a duplicate queue/alarm delivery already claimed it.
+
+Runtime-originated input is delivered through the host notification inbox and
+internal plugin paths. App code should use `session.send()`, `session.steer()`,
+or `agent.resume(runId)` for host-scheduled durable work.
+
+Each accepted call returns one `AgentRun`. Drain that run's `events()` stream to
+observe the turn; each `AgentRun.events()` stream is single-consumer.
+
+Input APIs accept the same input shapes: strings, arrays of strings,
 `{ type: "user-text", text }`, and multipart `{ type: "user-message", content }`
-values. Active steering emits `runtime-input` events. A `runtime-input` is
-runtime/API-originated input mapped internally to the model's user role. It is
-distinct from human-origin `user-text` and `user-message` events.
+values. Active steering and host resume input emit `runtime-input` events. A
+`runtime-input` is runtime/API-originated input mapped internally to the model's
+user role. It is distinct from human-origin `user-text` and `user-message`
+events.
 
 Runtime input windows are tied to synchronized events:
 
@@ -207,6 +245,10 @@ Stored session state is an opaque, versioned runtime snapshot for continuation.
 Do not inspect it as a replay log; exact replay should be modeled separately as
 an `AgentEvent` log if that capability is added later.
 
+`SessionStore` is snapshot-only. It does not own background task ids, run
+leases, checkpoints, notification inbox state, or scheduling. Those live on the
+optional `host` execution contract.
+
 Custom stores own version generation. `load(key)` returns the opaque `state` with
 the store-minted `version`; `commit(key, { state }, { expectedVersion })` receives
 state only and should reject stale versions by returning `{ ok: false, reason:
@@ -215,15 +257,14 @@ new version to the runtime. `delete(key)` removes the persisted session for that
 key.
 
 ```ts
-import type { SessionStore } from "@minpeter/pss-runtime";
 import { MemorySessionStore } from "@minpeter/pss-runtime/session-store/memory";
 
 const agent = new Agent({
-  model,
-  sessions: {
-    namespace: "support-agent",
-    store: new MemorySessionStore(), // default when omitted
+  host: {
+    sessionStore: new MemorySessionStore(), // default when omitted
   },
+  model,
+  namespace: "support-agent",
 });
 ```
 
@@ -235,17 +276,65 @@ session and child `sessionKey` suffixes back to the same child transcripts:
 import { FileSessionStore } from "@minpeter/pss-runtime/session-store/file";
 
 const agent = new Agent({
-  model,
-  sessions: {
-    namespace: "support-agent",
-    store: new FileSessionStore(".pss/sessions"),
+  host: {
+    sessionStore: new FileSessionStore(".pss/sessions"),
   },
+  model,
+  namespace: "support-agent",
 });
 ```
 
-## Future adapter boundary: Cloudflare multi-user DX
+Hosts that need durable runs pass `host:` into `Agent`. A durable host owns
+execution state, scheduling, and its session snapshot store through
+`store.sessions`; `ExecutionHost` does not accept a separate `sessionStore`
+override.
 
-Cloudflare Durable Objects are a future adapter target, not a runtime dependency.
+```ts
+import { Agent } from "@minpeter/pss-runtime";
+import {
+  createInMemoryExecutionHost,
+  type ExecutionHost,
+} from "@minpeter/pss-runtime/execution";
+
+const host = createInMemoryExecutionHost();
+
+const agent = new Agent({
+  host,
+  model,
+  namespace: "support-agent",
+});
+
+const durableHost: ExecutionHost = {
+  capabilities: { backgroundSubagents: "durable" },
+  scheduler,
+  store,
+};
+```
+
+## Supported Deployment Shapes
+
+The runtime supports both long-running Node.js processes and edge hosts that
+reconstruct runtime objects between turns. The same public DX stays centered on
+`new Agent({ subagents: [...] })`; host-specific durability and scheduling live
+behind the `host` boundary.
+
+Long-running Node.js can keep an `Agent` and `SessionHandle` alive across turns.
+The default in-memory host advertises in-process background subagent capability,
+so `run_in_background`, `background_output`, and `background_cancel` remain
+available while that process owns the work. `FileSessionStore` persists session
+snapshots only; it does not make background work durable by itself.
+
+Cloudflare Durable Objects and similar edge hosts should reconstruct `Agent`
+objects per turn and persist opaque session state through `store.sessions`.
+When a host does not advertise background subagent capability, the runtime hides
+background tools from the parent model and exposes blocking delegation only.
+This avoids pretending that in-memory background work survived a hibernation,
+isolate restart, or request deadline.
+
+See `examples/cloudflare-edge-subagent` for an edge-hosted turn loop with a
+Worker/Durable Object-shaped host, and `examples/subagent` for a long-running
+local background subagent flow.
+
 The same core API supports room/user/session routing through stable session keys.
 
 Recommended key patterns:
@@ -254,6 +343,39 @@ Recommended key patterns:
 - Per-user memory inside room: `room:<roomId>:user:<userId>`
 - Ticketed workspace flows: `tenant:<tenantId>:ticket:<ticketId>`
 
-In a Durable Object, map the `SessionStore` contract to `ctx.storage` so DO storage is
-durable across hibernation/restores, while in-memory state remains request-local.
-Do not store canonical agent session state in memory attachments.
+In a Durable Object, map the execution store contract to `ctx.storage` so DO
+storage is durable across hibernation/restores, while in-memory state remains
+request-local. Do not store canonical agent session or run state in memory
+attachments.
+
+Durable background subagents require a host capability that owns task ids,
+attempts, leases, checkpoints, cancellation, scheduling, and completion
+notifications. The Cloudflare edge example includes a Worker/Durable
+Object-shaped host that persists scheduled runs and session prompts, sets alarms, and
+resumes work through `Agent.resume(...)`.
+
+## Checkpoints and Cancellation
+
+Resume is safe only at committed boundaries. Durable hosts can checkpoint before
+and after model steps, around notifications, before child run creation, when a
+child link is committed, and when a run suspends. If a process is killed inside a
+provider call or unsafe tool execution, resume rolls back to the last committed
+checkpoint and may re-enter the operation.
+
+When `Agent` receives an `ExecutionHost`, high-level model turns create a
+`user-turn` run record and thread tool execution context into managed model
+calls. Tools are checkpointed before and after execution and receive stable
+`attempt`, `idempotencyKey`, `retryPolicy`, `signal`, and public `toolCallId`
+values. The `@minpeter/pss-runtime/execution` entrypoint also exposes the same
+low-level tool execution checkpoint types for custom resume runners built
+directly on `createLlm`.
+
+These checkpoints are rollback boundaries, not a complete host adapter by
+themselves. Edge hosts still need durable scheduling, leases, resume workers,
+and notification resume handling; externally visible side-effect tools still need
+idempotent execution or a manual recovery flow.
+
+Cancellation is persisted before aborting active work. Parent `delete()` and
+`kill()` mark linked child runs as `cancelled` through the execution store before
+falling back to process-local cleanup, so stale child completions cannot enqueue
+new parent notifications.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -20,6 +20,16 @@
       "@minpeter/pss-source": "./src/session/store/file.ts",
       "types": "./dist/session/store/file.d.ts",
       "import": "./dist/session/store/file.js"
+    },
+    "./execution": {
+      "@minpeter/pss-source": "./src/execution/index.ts",
+      "types": "./dist/execution/index.d.ts",
+      "import": "./dist/execution/index.js"
+    },
+    "./execution/memory": {
+      "@minpeter/pss-source": "./src/execution/memory.ts",
+      "types": "./dist/execution/memory.d.ts",
+      "import": "./dist/execution/memory.js"
     }
   },
   "files": [

--- a/packages/runtime/src/agent-child-runs.ts
+++ b/packages/runtime/src/agent-child-runs.ts
@@ -1,0 +1,23 @@
+import { executionHost } from "./execution/host";
+import type { AgentHost } from "./execution/types";
+import { cancelBackgroundChildRun } from "./subagent-background-child-run";
+
+export async function cancelDurableChildRuns(
+  host: AgentHost,
+  parentRunId: string
+): Promise<void> {
+  const durableHost = executionHost(host);
+  if (!durableHost) {
+    return;
+  }
+
+  const childRuns = await durableHost.store.runs.listByParentRunId(parentRunId);
+  await Promise.all(
+    childRuns.map((run) =>
+      cancelBackgroundChildRun({
+        executionHost: durableHost,
+        runId: run.runId,
+      })
+    )
+  );
+}

--- a/packages/runtime/src/agent-host-api.test.ts
+++ b/packages/runtime/src/agent-host-api.test.ts
@@ -1,0 +1,140 @@
+import type { LanguageModel } from "ai";
+import { describe, expect, it } from "vitest";
+import { Agent, type AgentHost, type AgentOptions } from "./agent";
+import type { ExecutionHost } from "./execution/types";
+import type { RuntimeLlm } from "./llm";
+import { collect, SpyStore } from "./session/session.test-support";
+import { assistantMessage, eventTypes } from "./test-fixtures";
+
+const fakeModel = {} as LanguageModel;
+
+const inProcessHost = {} satisfies AgentHost;
+
+const acceptsHostOptions: AgentOptions = {
+  host: inProcessHost,
+  model: fakeModel,
+};
+const runtimeModel: RuntimeLlm = () =>
+  Promise.resolve([assistantMessage("RUNTIME MODEL")]);
+const acceptsRuntimeModelOptions: AgentOptions = {
+  model: runtimeModel,
+};
+
+type IsAssignable<Source, Target> = Source extends Target ? true : false;
+type AssertFalse<T extends false> = T;
+type AcceptsHostOption = IsAssignable<typeof acceptsHostOptions, AgentOptions>;
+type AcceptsRuntimeModelOption = IsAssignable<
+  typeof acceptsRuntimeModelOptions,
+  AgentOptions
+>;
+type RejectsLlmOptionKey = AssertFalse<
+  "llm" extends keyof AgentOptions ? true : false
+>;
+type RejectsRuntimeOptionKey = AssertFalse<
+  "runtime" extends keyof AgentOptions ? true : false
+>;
+type RejectsSessionsOptionKey = AssertFalse<
+  "sessions" extends keyof AgentOptions ? true : false
+>;
+type AcceptsHostSessionStoreKey = IsAssignable<
+  { readonly sessionStore: SpyStore },
+  AgentHost
+>;
+type RejectsExecutionHostSessionStoreKey = AssertFalse<
+  IsAssignable<{ readonly sessionStore: SpyStore }, ExecutionHost>
+>;
+type RejectsHostKindKey = AssertFalse<
+  "kind" extends keyof AgentHost ? true : false
+>;
+
+const typeFixtures = [acceptsHostOptions];
+const acceptsHostOptionAssertion: AcceptsHostOption = true;
+const acceptsRuntimeModelOptionAssertion: AcceptsRuntimeModelOption = true;
+const llmOptionAssertion: RejectsLlmOptionKey = false;
+const runtimeOptionAssertion: RejectsRuntimeOptionKey = false;
+const sessionsOptionAssertion: RejectsSessionsOptionKey = false;
+const hostSessionStoreAssertion: AcceptsHostSessionStoreKey = true;
+const executionSessionStoreAssertion: RejectsExecutionHostSessionStoreKey = false;
+const hostKindAssertion: RejectsHostKindKey = false;
+
+describe("Agent host public API", () => {
+  it("accepts host option and keeps unsupported option keys out of AgentOptions", () => {
+    expect(typeFixtures).toHaveLength(1);
+    expect(acceptsHostOptionAssertion).toBe(true);
+    expect(acceptsRuntimeModelOptionAssertion).toBe(true);
+    expect(llmOptionAssertion).toBe(false);
+    expect(runtimeOptionAssertion).toBe(false);
+    expect(sessionsOptionAssertion).toBe(false);
+    expect(hostSessionStoreAssertion).toBe(true);
+    expect(executionSessionStoreAssertion).toBe(false);
+    expect(hostKindAssertion).toBe(false);
+    expect(new Agent({ host: inProcessHost, model: fakeModel })).toBeInstanceOf(
+      Agent
+    );
+  });
+
+  it("accepts custom runtime model functions through model", async () => {
+    const seenHistories: unknown[] = [];
+    const agent = new Agent({
+      model: ({ history }) => {
+        seenHistories.push(history);
+        return Promise.resolve([assistantMessage("CUSTOM MODEL DONE")]);
+      },
+    });
+
+    const events = await collect(
+      await agent.session("runtime-model").send("hello")
+    );
+
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(events).toContainEqual({
+      text: "CUSTOM MODEL DONE",
+      type: "assistant-text",
+    });
+    expect(JSON.stringify(seenHistories)).toContain("hello");
+  });
+
+  it("rejects unsupported llm sessions and runtime options at runtime", () => {
+    expect(
+      () =>
+        new Agent({
+          llm: () => Promise.resolve([assistantMessage("DONE")]),
+        } as unknown as AgentOptions)
+    ).toThrow("Agent: unsupported options.llm");
+
+    expect(
+      () =>
+        new Agent({
+          model: () => Promise.resolve([assistantMessage("DONE")]),
+          sessions: { store: new SpyStore() },
+        } as unknown as AgentOptions)
+    ).toThrow("Agent: unsupported options.sessions");
+
+    expect(
+      () =>
+        new Agent({
+          model: () => Promise.resolve([assistantMessage("DONE")]),
+          runtime: {},
+        } as unknown as AgentOptions)
+    ).toThrow("Agent: unsupported options.runtime");
+  });
+
+  it("uses host session store for session snapshots", async () => {
+    const sessionStore = new SpyStore();
+    const agent = new Agent({
+      host: { sessionStore },
+      model: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+
+    await collect(await agent.session("host-owned").send("hello"));
+
+    expect(sessionStore.commits.at(-1)?.key).toBe("host-owned");
+  });
+});

--- a/packages/runtime/src/agent-host-capabilities.ts
+++ b/packages/runtime/src/agent-host-capabilities.ts
@@ -1,0 +1,12 @@
+import type { AgentHost, ExecutionHost } from "./execution/types";
+
+export function supportsBackgroundSubagents(
+  host: AgentHost,
+  executionHost: ExecutionHost | undefined
+): boolean {
+  const capability = host.capabilities?.backgroundSubagents;
+  return (
+    capability === "in-process" ||
+    (capability === "durable" && executionHost !== undefined)
+  );
+}

--- a/packages/runtime/src/agent-host-session-store.ts
+++ b/packages/runtime/src/agent-host-session-store.ts
@@ -1,0 +1,15 @@
+import { executionHost } from "./execution/host";
+import type { AgentHost } from "./execution/types";
+import { MemorySessionStore } from "./session/store/memory";
+import type { SessionStore } from "./session/store/types";
+
+export function sessionStoreForHost(host: AgentHost): SessionStore {
+  if ("sessionStore" in host && host.sessionStore) {
+    return host.sessionStore;
+  }
+
+  const hostExecution = executionHost(host);
+  return hostExecution
+    ? hostExecution.store.sessions
+    : new MemorySessionStore();
+}

--- a/packages/runtime/src/agent-loop-background.test.ts
+++ b/packages/runtime/src/agent-loop-background.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { runAgentLoop } from "./agent-loop";
+import type { RuntimeLlm } from "./llm";
+import type { AgentEvent } from "./session/events";
+import { ModelMessageHistory } from "./session/history";
+import { assistantMessage, eventTypes, toolCallPart } from "./test-fixtures";
+
+describe("runAgentLoop background delegation", () => {
+  it("continues the model loop after a background launch tool result", async () => {
+    const events: AgentEvent[] = [];
+    const history = new ModelMessageHistory();
+    const toolCall = toolCallPart("call-bg-1", "delegate_to_researcher", {
+      prompt: "research this",
+      run_in_background: true,
+    });
+    let llmCalls = 0;
+    const llm: RuntimeLlm = () => {
+      llmCalls += 1;
+      if (llmCalls === 1) {
+        return Promise.resolve([
+          assistantMessage([toolCall]),
+          {
+            content: [
+              {
+                output: {
+                  type: "json",
+                  value: {
+                    message: "Background job started.",
+                    run_in_background: true,
+                    status: "running",
+                    subagent: "researcher",
+                    task_id: "bg_123",
+                  },
+                },
+                toolCallId: toolCall.toolCallId,
+                toolName: toolCall.toolName,
+                type: "tool-result",
+              },
+            ],
+            role: "tool",
+          },
+        ]);
+      }
+
+      return Promise.resolve([
+        assistantMessage("Background task started; waiting for notification."),
+      ]);
+    };
+
+    await expect(
+      runAgentLoop({
+        emit: (event) => {
+          events.push(event);
+        },
+        history,
+        llm,
+      })
+    ).resolves.toBe("completed");
+
+    expect(llmCalls).toBe(2);
+    expect(eventTypes(events)).toEqual([
+      "step-start",
+      "tool-call",
+      "tool-result",
+      "step-end",
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+    expect(history.modelSnapshot()).toEqual([
+      assistantMessage([toolCall]),
+      {
+        content: [
+          {
+            output: {
+              type: "json",
+              value: {
+                message: "Background job started.",
+                run_in_background: true,
+                status: "running",
+                subagent: "researcher",
+                task_id: "bg_123",
+              },
+            },
+            toolCallId: toolCall.toolCallId,
+            toolName: toolCall.toolName,
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+      assistantMessage("Background task started; waiting for notification."),
+    ]);
+  });
+});

--- a/packages/runtime/src/agent-loop-resume-checkpoint.test.ts
+++ b/packages/runtime/src/agent-loop-resume-checkpoint.test.ts
@@ -63,10 +63,12 @@ describe("resumeRun checkpoint recovery", () => {
       policy: "idempotent",
       toolName: "checkpointed_tool",
     });
+    expect(checkpoints[1]?.pendingToolCall).not.toHaveProperty("input");
     expect(checkpoints[2]?.pendingToolCall).toMatchObject({
-      output: { ok: true },
       toolCallId: "call-tool-1",
     });
+    expect(checkpoints[2]?.pendingToolCall).not.toHaveProperty("input");
+    expect(checkpoints[2]?.pendingToolCall).not.toHaveProperty("output");
   });
 
   it("stops for manual recovery when resuming from a pending tool checkpoint", async () => {

--- a/packages/runtime/src/agent-loop-resume-checkpoint.test.ts
+++ b/packages/runtime/src/agent-loop-resume-checkpoint.test.ts
@@ -1,0 +1,113 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import { resumeRun } from "./execution/resume";
+import {
+  createCheckpointSpyHost,
+  createQueuedUserTurnRun,
+} from "./execution-checkpoint-test-support";
+import type { RuntimeLlm, RuntimeToolExecutionCheckpoint } from "./llm";
+import { ToolExecutionNeedsRecoveryError } from "./llm-tool-execution";
+import { assistantMessage } from "./test-fixtures";
+
+describe("resumeRun checkpoint recovery", () => {
+  it("passes tool execution checkpoints to resumed model calls", async () => {
+    const { checkpoints, host } = createCheckpointSpyHost();
+    const history: ModelMessage[] = [];
+    await host.store.runs.create(createQueuedUserTurnRun());
+
+    const llm: RuntimeLlm = async ({ toolExecution }) => {
+      if (!toolExecution) {
+        return [assistantMessage("NO TOOL EXECUTION")];
+      }
+
+      const checkpoint: RuntimeToolExecutionCheckpoint = {
+        attempt: toolExecution.attempt,
+        idempotencyKey: `${toolExecution.runId}:call-tool-1`,
+        input: {},
+        policy: "idempotent",
+        toolCallId: "call-tool-1",
+        toolName: "checkpointed_tool",
+      };
+      await toolExecution.beforeTool?.(checkpoint);
+      await toolExecution.afterTool?.({
+        ...checkpoint,
+        output: { ok: true },
+      });
+      return [assistantMessage("DONE")];
+    };
+
+    await expect(
+      resumeRun({
+        budget: { maxSteps: 1 },
+        host,
+        llm,
+        loadState: () => Promise.resolve({ history }),
+        runId: "run-1",
+        saveState: (state) => {
+          history.length = 0;
+          history.push(...state.history);
+          return Promise.resolve();
+        },
+      })
+    ).resolves.toEqual({ status: "completed", steps: 1 });
+
+    expect(checkpoints.map((checkpoint) => checkpoint.phase)).toEqual([
+      "before-model",
+      "before-tool",
+      "after-tool",
+      "after-model",
+    ]);
+    expect(checkpoints[1]?.pendingToolCall).toMatchObject({
+      idempotencyKey: "run-1:call-tool-1",
+      policy: "idempotent",
+      toolName: "checkpointed_tool",
+    });
+    expect(checkpoints[2]?.pendingToolCall).toMatchObject({
+      output: { ok: true },
+      toolCallId: "call-tool-1",
+    });
+  });
+
+  it("stops for manual recovery when resuming from a pending tool checkpoint", async () => {
+    const host = createInMemoryExecutionHost();
+    let llmCalls = 0;
+    const pendingToolCall: RuntimeToolExecutionCheckpoint = {
+      attempt: 1,
+      idempotencyKey: "run-1:call-tool-1",
+      input: {},
+      policy: "manual-recovery",
+      toolCallId: "call-tool-1",
+      toolName: "dangerous_tool",
+    };
+    const llm: RuntimeLlm = () => {
+      llmCalls += 1;
+      return Promise.resolve([assistantMessage("SHOULD NOT RUN")]);
+    };
+    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.checkpoints.append(
+      {
+        checkpointId: "pending-tool",
+        pendingToolCall,
+        phase: "before-tool",
+        runId: "run-1",
+        runtimeState: { step: 1 },
+        sessionSnapshot: { history: [] },
+        version: 1,
+      },
+      { expectedVersion: 0 }
+    );
+
+    await expect(
+      resumeRun({
+        budget: { maxSteps: 1 },
+        host,
+        llm,
+        loadState: () => Promise.resolve({ history: [] }),
+        runId: "run-1",
+        saveState: () => Promise.resolve(),
+      })
+    ).rejects.toBeInstanceOf(ToolExecutionNeedsRecoveryError);
+    expect(llmCalls).toBe(0);
+  });
+});

--- a/packages/runtime/src/agent-loop-resume.test.ts
+++ b/packages/runtime/src/agent-loop-resume.test.ts
@@ -1,0 +1,206 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import { resumeRun } from "./execution/resume";
+import type { ExecutionHost } from "./execution/types";
+import { createQueuedUserTurnRun } from "./execution-checkpoint-test-support";
+import type { RuntimeLlm } from "./llm";
+import type { AgentEvent } from "./session/events";
+import {
+  assistantMessage,
+  eventTypes,
+  toolCallPart,
+  toolResultFor,
+} from "./test-fixtures";
+
+const collectEvents = async (
+  host: ExecutionHost,
+  runId = "run-1"
+): Promise<AgentEvent[]> => {
+  const events: AgentEvent[] = [];
+  for await (const event of host.store.events.read(runId)) {
+    events.push(event.event);
+  }
+  return events;
+};
+
+describe("resumeRun", () => {
+  it("suspends without calling the model when maxSteps is zero", async () => {
+    const host = createInMemoryExecutionHost();
+    let llmCalls = 0;
+    const llm: RuntimeLlm = () => {
+      llmCalls += 1;
+      return Promise.resolve([assistantMessage("DONE")]);
+    };
+    await host.store.runs.create(createQueuedUserTurnRun());
+
+    await expect(
+      resumeRun({
+        budget: { maxSteps: 0 },
+        host,
+        llm,
+        loadState: () => Promise.resolve({ history: [] }),
+        runId: "run-1",
+        saveState: () => Promise.resolve(),
+      })
+    ).resolves.toEqual({ status: "suspended", steps: 0 });
+
+    expect(llmCalls).toBe(0);
+    await expect(host.store.checkpoints.latest("run-1")).resolves.toBeNull();
+  });
+
+  it("aborts before writing a step when signal is already aborted", async () => {
+    const host = createInMemoryExecutionHost();
+    const controller = new AbortController();
+    controller.abort();
+    let llmCalls = 0;
+    const llm: RuntimeLlm = () => {
+      llmCalls += 1;
+      return Promise.resolve([assistantMessage("DONE")]);
+    };
+    await host.store.runs.create(createQueuedUserTurnRun());
+
+    await expect(
+      resumeRun({
+        budget: { maxSteps: 1 },
+        host,
+        llm,
+        loadState: () => Promise.resolve({ history: [] }),
+        runId: "run-1",
+        saveState: () => Promise.resolve(),
+        signal: controller.signal,
+      })
+    ).resolves.toEqual({ status: "aborted", steps: 0 });
+
+    expect(llmCalls).toBe(0);
+    expect(await collectEvents(host)).toEqual([]);
+  });
+
+  it("suspends after maxSteps and resumes to completion", async () => {
+    const host = createInMemoryExecutionHost();
+    const toolCall = toolCallPart("call-tool-1");
+    const history: ModelMessage[] = [];
+    let llmCalls = 0;
+    const llm: RuntimeLlm = () => {
+      llmCalls += 1;
+      if (llmCalls === 1) {
+        return Promise.resolve([
+          assistantMessage([
+            { text: "I need the tool.", type: "text" },
+            toolCall,
+          ]),
+          toolResultFor(toolCall),
+        ]);
+      }
+      return Promise.resolve([assistantMessage("DONE")]);
+    };
+    await host.store.runs.create(createQueuedUserTurnRun());
+
+    const first = await resumeRun({
+      budget: { maxSteps: 1 },
+      host,
+      llm,
+      loadState: () => Promise.resolve({ history }),
+      runId: "run-1",
+      saveState: (state) => {
+        history.length = 0;
+        history.push(...state.history);
+        return Promise.resolve();
+      },
+    });
+
+    expect(first).toEqual({ status: "suspended", steps: 1 });
+    await expect(host.store.checkpoints.latest("run-1")).resolves.toMatchObject(
+      {
+        phase: "suspended",
+      }
+    );
+
+    const second = await resumeRun({
+      budget: { maxSteps: 2 },
+      host,
+      llm,
+      loadState: () => Promise.resolve({ history }),
+      runId: "run-1",
+      saveState: (state) => {
+        history.length = 0;
+        history.push(...state.history);
+        return Promise.resolve();
+      },
+    });
+
+    expect(second).toEqual({ status: "completed", steps: 1 });
+    expect(llmCalls).toBe(2);
+    expect(eventTypes(await collectEvents(host))).toEqual([
+      "step-start",
+      "assistant-text",
+      "tool-call",
+      "tool-result",
+      "step-end",
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+  });
+
+  it("rolls back to before model when model output was not committed", async () => {
+    const host = createInMemoryExecutionHost();
+    const history: ModelMessage[] = [];
+    let llmCalls = 0;
+    let failCommit = true;
+    const llm: RuntimeLlm = () => {
+      llmCalls += 1;
+      return Promise.resolve([assistantMessage(`attempt ${llmCalls}`)]);
+    };
+    await host.store.runs.create(createQueuedUserTurnRun());
+
+    await expect(
+      resumeRun({
+        budget: { maxSteps: 1 },
+        host,
+        llm,
+        loadState: () => Promise.resolve({ history }),
+        runId: "run-1",
+        saveState: (state) => {
+          if (failCommit) {
+            failCommit = false;
+            return Promise.reject(new Error("state commit failed"));
+          }
+          history.length = 0;
+          history.push(...state.history);
+          return Promise.resolve();
+        },
+      })
+    ).rejects.toThrow("state commit failed");
+
+    await expect(host.store.checkpoints.latest("run-1")).resolves.toMatchObject(
+      {
+        phase: "before-model",
+      }
+    );
+    expect(history).toEqual([]);
+
+    await expect(
+      resumeRun({
+        budget: { maxSteps: 1 },
+        host,
+        llm,
+        loadState: () => Promise.resolve({ history }),
+        runId: "run-1",
+        saveState: (state) => {
+          history.length = 0;
+          history.push(...state.history);
+          return Promise.resolve();
+        },
+      })
+    ).resolves.toEqual({ status: "completed", steps: 1 });
+
+    expect(llmCalls).toBe(2);
+    expect(eventTypes(await collectEvents(host))).toEqual([
+      "step-start",
+      "assistant-text",
+      "step-end",
+    ]);
+    expect(history).toEqual([assistantMessage("attempt 2")]);
+  });
+});

--- a/packages/runtime/src/agent-loop.ts
+++ b/packages/runtime/src/agent-loop.ts
@@ -1,5 +1,6 @@
 import type { ModelMessage } from "ai";
 import type { RuntimeLlm, RuntimeLlmOutput } from "./llm";
+import type { RuntimeToolExecutionContext } from "./llm-tool-execution";
 import type { AgentEvent } from "./session/events";
 import { modelMessageToAgentEvents } from "./session/mapping";
 
@@ -14,6 +15,7 @@ interface RunAgentLoopOptions {
   history: ModelHistory;
   llm: RuntimeLlm;
   signal?: AbortSignal;
+  toolExecution?: RuntimeToolExecutionContext;
 }
 
 type AgentLoopResult = "completed" | "aborted";
@@ -46,6 +48,7 @@ export async function runAgentLoop({
   history,
   llm,
   signal = new AbortController().signal,
+  toolExecution,
 }: RunAgentLoopOptions): Promise<AgentLoopResult> {
   while (true) {
     if (signal.aborted) {
@@ -63,7 +66,7 @@ export async function runAgentLoop({
     }
 
     const capturedOutput = await captureObserverEvents(() =>
-      readLlmOutput({ history, llm, signal })
+      readLlmOutput({ history, llm, signal, toolExecution })
     );
     const output = capturedOutput.value;
 
@@ -163,11 +166,17 @@ async function readLlmOutput({
   history,
   llm,
   signal,
+  toolExecution,
 }: Pick<RunAgentLoopOptions, "history" | "llm"> & {
   signal: AbortSignal;
+  toolExecution?: RuntimeToolExecutionContext;
 }): Promise<RuntimeLlmOutput | "aborted"> {
   try {
-    return await llm({ history: history.modelSnapshot(), signal });
+    return await llm({
+      history: history.modelSnapshot(),
+      signal,
+      toolExecution,
+    });
   } catch (error) {
     if (signal.aborted) {
       return "aborted";

--- a/packages/runtime/src/agent-namespace.ts
+++ b/packages/runtime/src/agent-namespace.ts
@@ -23,3 +23,26 @@ export function parentSessionNamespace({
     sessionKey
   )}:generation:${generation}`;
 }
+
+export function ownsAgentNamespace(
+  ownerNamespace: string | undefined,
+  sessionNamespace: string
+): boolean {
+  return (
+    ownerNamespace === sessionNamespace ||
+    ownerNamespace?.startsWith(`${sessionNamespace}:session:`) === true
+  );
+}
+
+export function stableAgentNamespace({
+  name,
+  namespace,
+}: {
+  readonly name?: string;
+  readonly namespace?: string;
+}): string {
+  const stableNamespace = namespace ?? name;
+  return stableNamespace
+    ? agentNamespace(stableNamespace)
+    : randomAgentNamespace();
+}

--- a/packages/runtime/src/agent-options.ts
+++ b/packages/runtime/src/agent-options.ts
@@ -1,0 +1,80 @@
+import type { LanguageModel, ToolSet } from "ai";
+import type { Agent } from "./agent";
+import type { AgentHost } from "./execution/types";
+import type { AgentToolChoice, RuntimeLlm } from "./llm";
+import type { AgentPlugin } from "./plugins";
+
+interface AgentLanguageModelOptions {
+  readonly description?: string;
+  readonly host?: AgentHost;
+  readonly instructions?: string;
+  readonly model: LanguageModel;
+  readonly name?: string;
+  readonly namespace?: string;
+  readonly plugins?: readonly AgentPlugin[];
+  readonly subagents?: readonly Agent[];
+  readonly toolChoice?: AgentToolChoice;
+  readonly tools?: ToolSet;
+}
+
+interface AgentRuntimeModelOptions {
+  readonly description?: string;
+  readonly host?: AgentHost;
+  readonly instructions?: never;
+  readonly model: RuntimeLlm;
+  readonly name?: string;
+  readonly namespace?: string;
+  readonly plugins?: readonly AgentPlugin[];
+  readonly subagents?: never;
+  readonly toolChoice?: never;
+  readonly tools?: never;
+}
+
+export type AgentModelOptions = Pick<
+  AgentLanguageModelOptions,
+  "instructions" | "model" | "toolChoice"
+>;
+export type AgentOptions = AgentLanguageModelOptions | AgentRuntimeModelOptions;
+
+export function assertAgentOptions(
+  options: unknown
+): asserts options is AgentOptions {
+  if (options === null || typeof options !== "object") {
+    throw new TypeError("Agent options are required. Provide { model }.");
+  }
+
+  if ("sessions" in options) {
+    throw new TypeError(
+      "Agent: unsupported options.sessions. Use host: { sessionStore } and namespace instead."
+    );
+  }
+
+  if ("runtime" in options) {
+    throw new TypeError("Agent: unsupported options.runtime. Use host.");
+  }
+
+  if ("llm" in options) {
+    throw new TypeError(
+      "Agent: unsupported options.llm. Use model for both AI SDK models and custom RuntimeLlm functions."
+    );
+  }
+
+  const hasModel = "model" in options && options.model != null;
+
+  if (!hasModel) {
+    throw new TypeError("Agent: missing options.model.");
+  }
+
+  if (
+    typeof options.model !== "function" &&
+    (typeof options.model !== "object" || options.model === null)
+  ) {
+    throw new TypeError("Agent: invalid options.model.");
+  }
+}
+
+export function hasRuntimeModel(
+  options: AgentOptions
+): options is AgentRuntimeModelOptions {
+  return typeof options.model === "function";
+}

--- a/packages/runtime/src/agent-resume-security.test.ts
+++ b/packages/runtime/src/agent-resume-security.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "./agent";
+import { agentNamespace } from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+
+describe("Agent durable resume ownership", () => {
+  it("does not let another agent claim a foreign background run", async () => {
+    const host = createInMemoryExecutionHost();
+    await host.store.runs.create({
+      checkpointVersion: 0,
+      kind: "background-subagent",
+      ownerNamespace: agentNamespace("owner"),
+      publicTaskId: "bg_foreign",
+      rootRunId: "owner",
+      runId: "background:bg_foreign",
+      sessionKey:
+        "parent:agent:owner:session:default:generation:0:default:subagent:researcher:task:bg_foreign",
+      status: "queued",
+    });
+    const attacker = new Agent({
+      host,
+      model: () => Promise.resolve([]),
+      namespace: "attacker",
+    });
+
+    await expect(attacker.resume("background:bg_foreign")).resolves.toBeNull();
+    await expect(host.store.runs.get("background:bg_foreign")).resolves.toEqual(
+      expect.objectContaining({ status: "queued" })
+    );
+  });
+
+  it("treats explicit owner namespace as authoritative", async () => {
+    const host = createInMemoryExecutionHost();
+    await host.store.runs.create({
+      checkpointVersion: 0,
+      kind: "background-subagent",
+      ownerNamespace: agentNamespace("owner"),
+      publicTaskId: "bg_poisoned",
+      rootRunId: "owner",
+      runId: "background:bg_poisoned",
+      sessionKey:
+        "parent:agent:attacker:session:default:generation:0:default:subagent:researcher:task:bg_poisoned",
+      status: "queued",
+    });
+    const attacker = new Agent({
+      host,
+      model: () => Promise.resolve([]),
+      namespace: "attacker",
+    });
+
+    await expect(attacker.resume("background:bg_poisoned")).resolves.toBeNull();
+    await expect(
+      host.store.runs.get("background:bg_poisoned")
+    ).resolves.toEqual(expect.objectContaining({ status: "queued" }));
+  });
+});

--- a/packages/runtime/src/agent-resume.ts
+++ b/packages/runtime/src/agent-resume.ts
@@ -1,0 +1,242 @@
+import { ownsAgentNamespace } from "./agent-namespace";
+import { StoredAgentRun } from "./execution/run";
+import type {
+  ExecutionHost,
+  NotificationRecord,
+  RunRecord,
+} from "./execution/types";
+import { type AgentRun, BufferedAgentRun } from "./session/run";
+import { readDurableBackgroundChildRunState } from "./subagent-background-child-run-state";
+import { buildDurableResumeGroups } from "./subagent-background-resume-group";
+import { runBackgroundJob } from "./subagent-background-runner";
+import type { RuntimeInputSink, Subagent, SubagentJob } from "./subagent-types";
+
+const defaultResumeLeaseMs = 300_000;
+
+interface ResumeAgentRunInput {
+  readonly host: ExecutionHost;
+  readonly ownerNamespace: string;
+  resumeNotification(notification: NotificationRecord): Promise<AgentRun>;
+  readonly runId: string;
+  readonly subagents: readonly Subagent[];
+}
+
+export async function resumeAgentRun({
+  host,
+  ownerNamespace,
+  resumeNotification,
+  runId,
+  subagents,
+}: ResumeAgentRunInput): Promise<AgentRun | null> {
+  const run = await host.store.runs.get(runId);
+  if (!run) {
+    return null;
+  }
+  if (!canAccessRun(run, ownerNamespace)) {
+    return null;
+  }
+
+  if (run.kind === "background-subagent") {
+    return await resumeBackgroundSubagentRun({ host, run, subagents });
+  }
+
+  if (run.kind === "notification" && run.dedupeKey) {
+    const idempotencyKey = run.dedupeKey;
+    const claimed = await claimRun(host, run);
+    if (!claimed) {
+      return null;
+    }
+
+    const notification = await claimNotificationForRun({
+      host,
+      idempotencyKey,
+      ownerNamespace,
+    });
+    if (!notification) {
+      return null;
+    }
+
+    try {
+      const notificationRun = await resumeNotification(notification);
+      await completeNotificationRun(host, claimed.runId);
+      return notificationRun;
+    } catch (error) {
+      await host.store.notifications.releaseByIdempotencyKey(idempotencyKey);
+      throw error;
+    }
+  }
+
+  return null;
+}
+
+async function claimNotificationForRun({
+  host,
+  idempotencyKey,
+  ownerNamespace,
+}: {
+  readonly host: ExecutionHost;
+  readonly idempotencyKey: string;
+  readonly ownerNamespace: string;
+}): Promise<NotificationRecord | null> {
+  const current =
+    await host.store.notifications.getByIdempotencyKey(idempotencyKey);
+  if (!ownsAgentNamespace(current?.ownerNamespace, ownerNamespace)) {
+    return null;
+  }
+
+  const claim =
+    await host.store.notifications.claimByIdempotencyKey(idempotencyKey);
+  if (claim.ok) {
+    if (ownsAgentNamespace(claim.record.ownerNamespace, ownerNamespace)) {
+      return claim.record;
+    }
+    await host.store.notifications.releaseByIdempotencyKey(idempotencyKey);
+    return null;
+  }
+
+  if (
+    claim.reason === "already-claimed" &&
+    ownsAgentNamespace(claim.record?.ownerNamespace, ownerNamespace)
+  ) {
+    return claim.record ?? null;
+  }
+
+  return null;
+}
+
+function canAccessRun(run: RunRecord, ownerNamespace: string): boolean {
+  if (run.ownerNamespace) {
+    return ownsAgentNamespace(run.ownerNamespace, ownerNamespace);
+  }
+
+  return (
+    run.sessionKey.startsWith(`parent:${ownerNamespace}:`) ||
+    run.parentRunId?.startsWith(`${ownerNamespace}:session:`) === true
+  );
+}
+
+export async function completeNotificationRun(
+  host: ExecutionHost,
+  runId: string
+): Promise<void> {
+  const run = await host.store.runs.get(runId);
+  if (run?.kind !== "notification" || run.status === "completed") {
+    return;
+  }
+
+  await host.store.runs.update({ ...run, status: "completed" });
+}
+
+async function resumeBackgroundSubagentRun({
+  host,
+  run,
+  subagents,
+}: {
+  readonly host: ExecutionHost;
+  readonly run: RunRecord;
+  readonly subagents: readonly Subagent[];
+}): Promise<AgentRun | null> {
+  const claimed = await claimRun(host, run);
+  if (!claimed) {
+    return null;
+  }
+
+  const checkpoint = await host.store.checkpoints.latest(run.runId);
+  const state = readDurableBackgroundChildRunState(checkpoint);
+  if (!state) {
+    throw new AgentResumeError(run.runId, "missing background run state");
+  }
+
+  const subagent = subagents.find(
+    (candidate) => candidate.name === state.subagent
+  );
+  if (!subagent) {
+    throw new AgentResumeError(
+      run.runId,
+      `missing subagent ${JSON.stringify(state.subagent)}`
+    );
+  }
+
+  const childSession = subagent.session(claimed.sessionKey);
+  const job: SubagentJob = {
+    abort: () => childSession.interrupt(),
+    childRunId: claimed.runId,
+    childRunLeaseId: claimed.lease?.leaseId,
+    cleanup: () => Promise.resolve(),
+    dedupeKey: claimed.dedupeKey,
+    delegateToolCallId: state.delegateToolCallId,
+    description: state.description,
+    executionHost: host,
+    groupId: state.groupId,
+    id: claimed.publicTaskId ?? claimed.runId,
+    ownerNamespace: claimed.ownerNamespace,
+    parentRunId: claimed.parentRunId,
+    parentSessionKey: state.parentSessionKey,
+    promise: Promise.resolve(),
+    sessionKey: claimed.sessionKey,
+    settled: false,
+    status: "running",
+    subagent: state.subagent,
+  };
+  const jobs = new Map([[job.id, job]]);
+  const groups = await buildDurableResumeGroups({
+    currentJob: job,
+    host,
+    run: claimed,
+    state,
+    jobs,
+  });
+  const parentSession = durableParentSession(host, run.runId);
+
+  job.promise = runBackgroundJob({
+    childSession,
+    groups,
+    jobs,
+    job,
+    parentSession,
+    prompt: state.prompt,
+  });
+  await job.promise;
+
+  return new StoredAgentRun({
+    eventStore: host.store.events,
+    runId: run.runId,
+  });
+}
+
+async function claimRun(
+  host: ExecutionHost,
+  run: RunRecord
+): Promise<RunRecord | null> {
+  const claim = await host.store.runs.claim(run.runId, {
+    attempt: (run.lease?.attempt ?? 0) + 1,
+    leaseId: crypto.randomUUID(),
+    leaseMs: defaultResumeLeaseMs,
+    nowMs: Date.now(),
+  });
+  return claim.ok ? claim.record : null;
+}
+
+function durableParentSession(
+  host: ExecutionHost,
+  runId: string
+): RuntimeInputSink {
+  return {
+    emitObserverEvent: (event) => host.store.events.append(runId, event).then(),
+    enqueueRuntimeInput: () => undefined,
+    notify: () => Promise.resolve(emptyRun()),
+  };
+}
+
+function emptyRun(): AgentRun {
+  const run = new BufferedAgentRun();
+  run.close();
+  return run;
+}
+
+class AgentResumeError extends Error {
+  constructor(runId: string, reason: string) {
+    super(`Cannot resume agent run ${runId}: ${reason}`);
+    this.name = "AgentResumeError";
+  }
+}

--- a/packages/runtime/src/agent-resume.ts
+++ b/packages/runtime/src/agent-resume.ts
@@ -195,6 +195,8 @@ async function resumeBackgroundSubagentRun({
     job,
     parentSession,
     prompt: state.prompt,
+  }).finally(() => {
+    job.settled = true;
   });
   await job.promise;
 

--- a/packages/runtime/src/agent-session-entry.ts
+++ b/packages/runtime/src/agent-session-entry.ts
@@ -1,0 +1,15 @@
+import type { AgentRun } from "./session/run";
+import type { AgentInput, NotifyOptions } from "./session/session";
+
+export interface SessionHandle {
+  delete(): Promise<void>;
+  interrupt(): void;
+  kill(): Promise<void>;
+  send(input: AgentInput): Promise<AgentRun>;
+  steer(input: AgentInput): Promise<AgentRun>;
+}
+
+export interface AgentSessionEntry {
+  notify(input: AgentInput, options?: NotifyOptions): Promise<AgentRun>;
+  readonly publicHandle: SessionHandle;
+}

--- a/packages/runtime/src/agent-validation.ts
+++ b/packages/runtime/src/agent-validation.ts
@@ -1,19 +1,20 @@
 import type { ToolSet } from "ai";
-import type { Agent, AgentOptions } from "./agent";
+import type { Agent } from "./agent";
+import type { AgentOptions } from "./agent-options";
 
 const subagentNamePattern = /^[a-z][a-z0-9_-]{0,51}$/;
 
 export function assertSubagents(
   options: AgentOptions,
   agentClass: new (options: AgentOptions) => Agent,
-  hasCustomLlm: boolean
+  hasRuntimeModel: boolean
 ): void {
   if (!("subagents" in options) || options.subagents === undefined) {
     return;
   }
 
-  if (hasCustomLlm) {
-    throw new TypeError("Agent: subagents require options.model.");
+  if (hasRuntimeModel) {
+    throw new TypeError("Agent: subagents require an AI SDK model.");
   }
 
   if (!Array.isArray(options.subagents)) {

--- a/packages/runtime/src/agent.test.ts
+++ b/packages/runtime/src/agent.test.ts
@@ -4,20 +4,18 @@ import { Agent, type AgentOptions } from "./agent";
 import type { RuntimeLlm } from "./llm";
 
 const fakeModel = {} as LanguageModel;
-const fakeLlm: RuntimeLlm = () => Promise.resolve([]);
-const ambiguousOptionsPattern = /either options\.llm or options\.model/;
-const invalidLlmPattern = /invalid options\.llm/;
+const fakeRuntimeModel: RuntimeLlm = () => Promise.resolve([]);
+const invalidModelPattern = /invalid options\.model/;
 const missingModelPattern = /missing options\.model/;
 const missingOptionsPattern = /Agent options are required/;
+const unsupportedLlmPattern = /unsupported options\.llm/;
 const duplicateSubagentToolNamePattern = /duplicate subagent tool name/;
 const existingToolCollisionPattern = /collides with an existing tool/;
 const objectMapSubagentsPattern = /subagents must be an array/;
 const reservedToolCollisionPattern = /collides with a reserved subagent tool/;
 const subagentMetadataPattern = /subagents\[0\].name/;
 const subagentNameLengthPattern = /too long/;
-const subagentsOnCustomLlmPattern = /subagents require options.model/;
-const legacyLifecyclePattern = /unsupported legacy lifecycle option/;
-const legacyLifecycleKey = ["h", "o", "o", "k", "s"].join("");
+const subagentsOnRuntimeModelPattern = /subagents require an AI SDK model/;
 
 const acceptsModelOptions: AgentOptions = {
   instructions: "Use the injected model.",
@@ -26,48 +24,32 @@ const acceptsModelOptions: AgentOptions = {
   toolChoice: "auto",
   tools: {},
 };
-const acceptsCustomLlmOptions: AgentOptions = { llm: fakeLlm, plugins: [] };
+const acceptsRuntimeModelOptions: AgentOptions = {
+  model: fakeRuntimeModel,
+  plugins: [],
+};
 const acceptsModelSubagentsOptions: AgentOptions = {
   model: fakeModel,
   subagents: [
     new Agent({
       description: "Researches facts.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: "researcher",
     }),
   ],
 };
 
-type IsAssignable<Source, Target> = Source extends Target ? true : false;
 type AssertFalse<T extends false> = T;
-type RejectsAmbiguousModelPrecedence = AssertFalse<
-  IsAssignable<
-    { readonly llm: RuntimeLlm; readonly model: LanguageModel },
-    AgentOptions
-  >
+type RejectsLlmOptionKey = AssertFalse<
+  "llm" extends keyof AgentOptions ? true : false
 >;
-type RejectsIgnoredCreateLlmOptions = AssertFalse<
-  IsAssignable<
-    { readonly llm: RuntimeLlm; readonly tools: Record<PropertyKey, never> },
-    AgentOptions
-  >
->;
-type LegacyLifecycleKey = `${"h"}${"o"}${"o"}${"k"}${"s"}`;
-type RejectsLegacyLifecycleOptionKey = AssertFalse<
-  LegacyLifecycleKey extends keyof AgentOptions ? true : false
->;
-
 const typeFixtures = [
   acceptsModelOptions,
-  acceptsCustomLlmOptions,
+  acceptsRuntimeModelOptions,
   acceptsModelSubagentsOptions,
 ];
-type TypeFixtureAssertions = [
-  RejectsAmbiguousModelPrecedence,
-  RejectsIgnoredCreateLlmOptions,
-  RejectsLegacyLifecycleOptionKey,
-];
-const typeFixtureAssertions: TypeFixtureAssertions = [false, false, false];
+type TypeFixtureAssertions = [RejectsLlmOptionKey];
+const typeFixtureAssertions: TypeFixtureAssertions = [false];
 
 const collectRun = async (run: Awaited<ReturnType<Agent["send"]>>) => {
   for await (const _event of run.events()) {
@@ -78,37 +60,37 @@ const collectRun = async (run: Awaited<ReturnType<Agent["send"]>>) => {
 describe("Agent", () => {
   it("keeps AgentOptions type fixtures reachable", () => {
     expect(typeFixtures).toHaveLength(3);
-    expect(typeFixtureAssertions).toHaveLength(3);
+    expect(typeFixtureAssertions).toHaveLength(1);
   });
 
   it("constructs agents with new Agent", () => {
     expect(new Agent({ model: fakeModel })).toBeInstanceOf(Agent);
   });
 
-  it("does not expose Agent.create", () => {
+  it("does not expose a static factory", () => {
     expect(Object.hasOwn(Agent, "create")).toBe(false);
   });
 
-  it("creates agents from a caller-owned LLM", () => {
-    expect(new Agent({ llm: fakeLlm })).toBeInstanceOf(Agent);
+  it("creates agents from a caller-owned runtime model", () => {
+    expect(new Agent({ model: fakeRuntimeModel })).toBeInstanceOf(Agent);
   });
 
   it("uses the default session for agent.send", async () => {
-    const agent = new Agent({ llm: fakeLlm });
+    const agent = new Agent({ model: fakeRuntimeModel });
     await expect(agent.send("hello")).resolves.toBeDefined();
   });
 
   it("reuses handles for named sessions", () => {
-    const agent = new Agent({ llm: fakeLlm });
+    const agent = new Agent({ model: fakeRuntimeModel });
     expect(agent.session("a")).toBe(agent.session("a"));
     expect(agent.session("a")).not.toBe(agent.session("b"));
   });
 
   it("drops killed session handles so keys can be reused", async () => {
-    const agent = new Agent({ llm: fakeLlm });
+    const agent = new Agent({ model: fakeRuntimeModel });
     const first = agent.session("reuse");
 
-    first.kill();
+    await first.kill();
     const second = agent.session("reuse");
     await collectRun(await second.send("hello"));
 
@@ -125,36 +107,26 @@ describe("Agent", () => {
     expect(() => new Agent({} as AgentOptions)).toThrow(missingModelPattern);
   });
 
-  it("rejects invalid custom LLM configuration with an actionable error", () => {
+  it("rejects invalid model configuration with an actionable error", () => {
     expect(
-      () => new Agent({ llm: "not-an-llm" } as unknown as AgentOptions)
-    ).toThrow(invalidLlmPattern);
+      () => new Agent({ model: "not-a-model" } as unknown as AgentOptions)
+    ).toThrow(invalidModelPattern);
   });
 
-  it("rejects legacy lifecycle constructor options", () => {
+  it("rejects unsupported llm configuration with an actionable error", () => {
     expect(
       () =>
         new Agent({
-          [legacyLifecycleKey]: {},
-          llm: fakeLlm,
-        } as unknown as AgentOptions)
-    ).toThrow(legacyLifecyclePattern);
-  });
-
-  it("rejects ambiguous model and custom LLM configuration", () => {
-    expect(
-      () =>
-        new Agent({
-          llm: fakeLlm,
+          llm: fakeRuntimeModel,
           model: fakeModel,
         } as unknown as AgentOptions)
-    ).toThrow(ambiguousOptionsPattern);
+    ).toThrow(unsupportedLlmPattern);
   });
 
   it("accepts array subagents with child metadata while main metadata is omitted", () => {
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: "researcher",
     });
 
@@ -169,7 +141,7 @@ describe("Agent", () => {
   it("rejects object-map subagents", () => {
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: "researcher",
     });
 
@@ -183,7 +155,7 @@ describe("Agent", () => {
   });
 
   it("requires child subagent metadata", () => {
-    const unnamed = new Agent({ llm: fakeLlm });
+    const unnamed = new Agent({ model: fakeRuntimeModel });
 
     expect(
       () =>
@@ -198,7 +170,7 @@ describe("Agent", () => {
     const longName = `a${"b".repeat(52)}`;
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: longName,
     });
 
@@ -211,31 +183,31 @@ describe("Agent", () => {
     ).toThrow(subagentNameLengthPattern);
   });
 
-  it("rejects subagents on custom llm parents", () => {
+  it("rejects subagents on runtime model parents", () => {
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: "researcher",
     });
 
     expect(
       () =>
         new Agent({
-          llm: fakeLlm,
+          model: fakeRuntimeModel,
           subagents: [researcher],
         } as unknown as AgentOptions)
-    ).toThrow(subagentsOnCustomLlmPattern);
+    ).toThrow(subagentsOnRuntimeModelPattern);
   });
 
   it("rejects duplicate normalized subagent names", () => {
     const one = new Agent({
       description: "Researches facts.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: "research-agent",
     });
     const two = new Agent({
       description: "Researches facts again.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: "research_agent",
     });
 
@@ -251,7 +223,7 @@ describe("Agent", () => {
   it("rejects generated tool collisions", () => {
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: "researcher",
     });
 
@@ -268,7 +240,7 @@ describe("Agent", () => {
   it("rejects reserved background tool collisions", () => {
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: fakeLlm,
+      model: fakeRuntimeModel,
       name: "researcher",
     });
 

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -1,64 +1,39 @@
-import type { LanguageModel, ToolSet } from "ai";
+import type { ToolSet } from "ai";
+import { cancelDurableChildRuns } from "./agent-child-runs";
+import { supportsBackgroundSubagents } from "./agent-host-capabilities";
+import { sessionStoreForHost } from "./agent-host-session-store";
 import {
-  agentNamespace,
   parentSessionNamespace,
-  randomAgentNamespace,
+  stableAgentNamespace,
 } from "./agent-namespace";
+import {
+  type AgentModelOptions,
+  type AgentOptions,
+  assertAgentOptions,
+  hasRuntimeModel,
+} from "./agent-options";
+import { resumeAgentRun } from "./agent-resume";
+import type { AgentSessionEntry, SessionHandle } from "./agent-session-entry";
 import { assertSubagents } from "./agent-validation";
 import { ChildSessionCleanups } from "./child-session-cleanups";
-import { type AgentToolChoice, createLlm, type RuntimeLlm } from "./llm";
+import { executionHost } from "./execution/host";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { AgentHost, NotificationRecord } from "./execution/types";
+import { createLlm, type RuntimeLlm } from "./llm";
 import type { AgentPlugin } from "./plugins";
 import type { UserInput } from "./session/events";
 import type { AgentRun } from "./session/run";
-import { type AgentInput, AgentSession } from "./session/session";
-import { MemorySessionStore } from "./session/store/memory";
+import {
+  type AgentInput,
+  AgentSession,
+  type NotifyOptions,
+} from "./session/session";
 import type { SessionStore } from "./session/store/types";
 import { createSubagentTools } from "./subagents";
 
-interface AgentLanguageModelOptions {
-  description?: string;
-  instructions?: string;
-  llm?: never;
-  model: LanguageModel;
-  name?: string;
-  plugins?: readonly AgentPlugin[];
-  sessions?: AgentSessionOptions;
-  subagents?: readonly Agent[];
-  toolChoice?: AgentToolChoice;
-  tools?: ToolSet;
-}
-
-interface AgentLlmOptions {
-  description?: string;
-  instructions?: never;
-  llm: RuntimeLlm;
-  model?: never;
-  name?: string;
-  plugins?: readonly AgentPlugin[];
-  sessions?: AgentSessionOptions;
-  subagents?: never;
-  toolChoice?: never;
-  tools?: never;
-}
-
-export interface AgentSessionOptions {
-  namespace?: string;
-  store?: SessionStore;
-}
-
-export interface SessionHandle {
-  delete(): Promise<void>;
-  interrupt(): void;
-  kill(): void;
-  send(input: AgentInput): Promise<AgentRun>;
-  steer(input: AgentInput): Promise<AgentRun>;
-}
-
-export type AgentOptions = AgentLanguageModelOptions | AgentLlmOptions;
-type AgentModelOptions = Pick<
-  AgentLanguageModelOptions,
-  "instructions" | "model" | "toolChoice"
->;
+export type { AgentOptions } from "./agent-options";
+export type { SessionHandle } from "./agent-session-entry";
+export type { AgentHost } from "./execution/types";
 
 export class Agent {
   readonly #baseTools?: ToolSet;
@@ -66,9 +41,10 @@ export class Agent {
   readonly #modelOptions?: AgentModelOptions;
   readonly #childSessionCleanups = new ChildSessionCleanups();
   readonly #sessionGenerations = new Map<string, number>();
-  readonly #sessions = new Map<string, SessionHandle>();
+  readonly #sessions = new Map<string, AgentSessionEntry>();
   readonly #sessionNamespace: string;
   readonly #store: SessionStore;
+  readonly #host: AgentHost;
   readonly #plugins: readonly AgentPlugin[];
   readonly #subagents: readonly Agent[];
   readonly description?: string;
@@ -79,13 +55,17 @@ export class Agent {
 
     this.description = options.description;
     this.name = options.name;
-    this.#sessionNamespace = stableAgentNamespace(options);
-    this.#store = options.sessions?.store ?? new MemorySessionStore();
+    this.#sessionNamespace = stableAgentNamespace({
+      name: options.name,
+      namespace: options.namespace,
+    });
+    this.#host = options.host ?? createInMemoryExecutionHost();
+    this.#store = sessionStoreForHost(this.#host);
     this.#plugins = options.plugins ?? [];
-    assertSubagents(options, Agent, hasCustomLlm(options));
-    this.#subagents = hasCustomLlm(options) ? [] : (options.subagents ?? []);
-    if (hasCustomLlm(options)) {
-      this.#llm = options.llm;
+    assertSubagents(options, Agent, hasRuntimeModel(options));
+    this.#subagents = hasRuntimeModel(options) ? [] : (options.subagents ?? []);
+    if (hasRuntimeModel(options)) {
+      this.#llm = options.model;
     } else {
       this.#baseTools = options.tools;
       this.#modelOptions = {
@@ -100,7 +80,27 @@ export class Agent {
     return this.session("default").send(input);
   }
 
+  async resume(runId: string): Promise<AgentRun | null> {
+    const host = executionHost(this.#host);
+    if (!host) {
+      throw new Error("Agent host does not support durable run resume.");
+    }
+
+    return await resumeAgentRun({
+      host,
+      ownerNamespace: this.#sessionNamespace,
+      resumeNotification: (notification) =>
+        this.#resumeNotification(notification),
+      runId,
+      subagents: this.#subagents,
+    });
+  }
+
   session(key: string): SessionHandle {
+    return this.#sessionEntry(key).publicHandle;
+  }
+
+  #sessionEntry(key: string): AgentSessionEntry {
     const existing = this.#sessions.get(key);
     if (existing) {
       return existing;
@@ -126,55 +126,94 @@ export class Agent {
           parentAgentNamespace,
           (input: UserInput, placement?: "turn-start") =>
             getSession().enqueueRuntimeInput(input, placement),
-          (event) => getSession().emitObserverEvent(event)
+          (event) => getSession().emitObserverEvent(event),
+          (input: UserInput, options?: NotifyOptions) =>
+            getSession().notify(input, options),
+          () => getSession().currentTurnId(),
+          () => parentAgentNamespace
         )
       );
-    session = new AgentSession(llm, { key, store: this.#store }, this.#plugins);
-    const handle: SessionHandle = {
+    session = new AgentSession(
+      llm,
+      { key, store: this.#store },
+      this.#plugins,
+      {
+        executionHost: executionHost(this.#host),
+      }
+    );
+    const publicHandle: SessionHandle = {
       delete: async () => {
+        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
         await session.delete();
         this.#sessions.delete(key);
         this.#sessionGenerations.set(
           key,
           (this.#sessionGenerations.get(key) ?? 0) + 1
         );
-        await this.#deleteChildSessions(key);
+        await this.#childSessionCleanups.delete(key);
       },
       interrupt: () => session.interrupt(),
-      kill: () => {
+      kill: async () => {
+        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
         session.kill();
         this.#sessionGenerations.set(
           key,
           (this.#sessionGenerations.get(key) ?? 0) + 1
         );
-        this.#deleteChildSessions(key).catch(() => undefined);
         this.#sessions.delete(key);
+        await this.#childSessionCleanups.delete(key);
       },
       send: (input) => session.send(input),
       steer: (input) => session.steer(input),
     };
-    this.#sessions.set(key, handle);
-    return handle;
+    const entry: AgentSessionEntry = {
+      notify: (input, options) => session.notify(input, options),
+      publicHandle,
+    };
+    this.#sessions.set(key, entry);
+    return entry;
+  }
+
+  #resumeNotification(notification: NotificationRecord): Promise<AgentRun> {
+    return this.#sessionEntry(notification.sessionKey).notify(
+      notification.input,
+      { observerEvents: notification.observerEvents }
+    );
   }
 
   #createLlmOptionsForSession(
     key: string,
     parentAgentNamespace: string,
     enqueueRuntimeInput: AgentSession["enqueueRuntimeInput"],
-    emitObserverEvent: AgentSession["emitObserverEvent"]
+    emitObserverEvent: AgentSession["emitObserverEvent"],
+    notify: (input: UserInput, options?: NotifyOptions) => Promise<AgentRun>,
+    currentBackgroundGroupId: () => string | undefined,
+    currentRunId: () => string | undefined
   ): Parameters<typeof createLlm>[0] {
     const modelOptions = this.#modelOptions;
     if (!modelOptions) {
       throw new Error("Agent: missing model options.");
     }
+    const hostExecution = executionHost(this.#host);
     const tools =
       this.#subagents.length === 0
         ? this.#baseTools
         : {
             ...this.#baseTools,
             ...createSubagentTools({
+              backgroundSubagents: supportsBackgroundSubagents(
+                this.#host,
+                hostExecution
+              ),
+              executionHost: hostExecution,
               parentAgentNamespace,
-              parentSession: { emitObserverEvent, enqueueRuntimeInput },
+              parentSession: {
+                currentBackgroundGroupId,
+                currentRunId,
+                emitObserverEvent,
+                enqueueRuntimeInput,
+                notify,
+              },
               parentSessionKey: key,
               registerChildSession: (sessionKey, cleanup) =>
                 this.#childSessionCleanups.register(sessionKey, cleanup),
@@ -189,45 +228,4 @@ export class Agent {
       tools,
     };
   }
-
-  async #deleteChildSessions(parentSessionKey: string): Promise<void> {
-    await this.#childSessionCleanups.delete(parentSessionKey);
-  }
-}
-
-function stableAgentNamespace(options: AgentOptions): string {
-  const namespace = options.sessions?.namespace ?? options.name;
-  return namespace ? agentNamespace(namespace) : randomAgentNamespace();
-}
-
-function assertAgentOptions(options: unknown): asserts options is AgentOptions {
-  if (options === null || typeof options !== "object") {
-    throw new TypeError(
-      "Agent options are required. Provide either { model } or { llm }."
-    );
-  }
-
-  const hasLlm = hasCustomLlm(options);
-  const hasModel = "model" in options && options.model != null;
-
-  const legacyLifecycleOption = ["h", "o", "o", "k", "s"].join("");
-  if (legacyLifecycleOption in options) {
-    throw new TypeError("Agent: unsupported legacy lifecycle option.");
-  }
-
-  if (hasLlm && hasModel) {
-    throw new TypeError("Agent: provide either options.llm or options.model.");
-  }
-
-  if ("llm" in options && options.llm !== undefined && !hasLlm) {
-    throw new TypeError("Agent: invalid options.llm.");
-  }
-
-  if (!(hasLlm || hasModel)) {
-    throw new TypeError("Agent: missing options.model.");
-  }
-}
-
-function hasCustomLlm(options: object): options is AgentLlmOptions {
-  return "llm" in options && typeof options.llm === "function";
 }

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -143,24 +143,25 @@ export class Agent {
     );
     const publicHandle: SessionHandle = {
       delete: async () => {
-        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
-        await session.delete();
+        session.kill();
         this.#sessions.delete(key);
         this.#sessionGenerations.set(
           key,
           (this.#sessionGenerations.get(key) ?? 0) + 1
         );
+        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
+        await session.delete();
         await this.#childSessionCleanups.delete(key);
       },
       interrupt: () => session.interrupt(),
       kill: async () => {
-        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
         session.kill();
         this.#sessionGenerations.set(
           key,
           (this.#sessionGenerations.get(key) ?? 0) + 1
         );
         this.#sessions.delete(key);
+        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
         await this.#childSessionCleanups.delete(key);
       },
       send: (input) => session.send(input),

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -144,24 +144,22 @@ export class Agent {
     const publicHandle: SessionHandle = {
       delete: async () => {
         session.kill();
-        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
-        this.#sessions.delete(key);
-        this.#sessionGenerations.set(
+        await this.#cancelDurableChildRunsBeforeLocalCleanup(
           key,
-          (this.#sessionGenerations.get(key) ?? 0) + 1
+          parentAgentNamespace
         );
+        this.#evictSessionHandle(key);
         await session.delete();
         await this.#childSessionCleanups.delete(key);
       },
       interrupt: () => session.interrupt(),
       kill: async () => {
         session.kill();
-        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
-        this.#sessionGenerations.set(
+        await this.#cancelDurableChildRunsBeforeLocalCleanup(
           key,
-          (this.#sessionGenerations.get(key) ?? 0) + 1
+          parentAgentNamespace
         );
-        this.#sessions.delete(key);
+        this.#evictSessionHandle(key);
         await this.#childSessionCleanups.delete(key);
       },
       send: (input) => session.send(input),
@@ -173,6 +171,26 @@ export class Agent {
     };
     this.#sessions.set(key, entry);
     return entry;
+  }
+
+  async #cancelDurableChildRunsBeforeLocalCleanup(
+    key: string,
+    parentAgentNamespace: string
+  ): Promise<void> {
+    try {
+      await cancelDurableChildRuns(this.#host, parentAgentNamespace);
+    } catch (error) {
+      this.#evictSessionHandle(key);
+      throw error;
+    }
+  }
+
+  #evictSessionHandle(key: string): void {
+    this.#sessions.delete(key);
+    this.#sessionGenerations.set(
+      key,
+      (this.#sessionGenerations.get(key) ?? 0) + 1
+    );
   }
 
   #resumeNotification(notification: NotificationRecord): Promise<AgentRun> {

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -144,24 +144,24 @@ export class Agent {
     const publicHandle: SessionHandle = {
       delete: async () => {
         session.kill();
+        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
         this.#sessions.delete(key);
         this.#sessionGenerations.set(
           key,
           (this.#sessionGenerations.get(key) ?? 0) + 1
         );
-        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
         await session.delete();
         await this.#childSessionCleanups.delete(key);
       },
       interrupt: () => session.interrupt(),
       kill: async () => {
         session.kill();
+        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
         this.#sessionGenerations.set(
           key,
           (this.#sessionGenerations.get(key) ?? 0) + 1
         );
         this.#sessions.delete(key);
-        await cancelDurableChildRuns(this.#host, parentAgentNamespace);
         await this.#childSessionCleanups.delete(key);
       },
       send: (input) => session.send(input),

--- a/packages/runtime/src/edge-reconstruction-host.test.ts
+++ b/packages/runtime/src/edge-reconstruction-host.test.ts
@@ -1,0 +1,241 @@
+import type { ToolSet } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  parentSessionNamespace,
+  stableAgentNamespace,
+} from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost } from "./execution/types";
+import {
+  collectRun,
+  fakeModel,
+  getGenerateTextMock,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import { resumeBackgroundTask } from "./subagent-background-test-support";
+import {
+  assistantMessage,
+  eventTypes,
+  toolCallPart,
+  userText,
+} from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+const sessionKey = "room:edge:user:1";
+
+describe("edge reconstruction host", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reconstructs agent and resumes suspended run", async () => {
+    const Agent = await loadAgent();
+    const host = createDurableHost();
+    let taskId = "";
+    let parentCalls = 0;
+
+    generateTextMock.mockImplementation(
+      async ({ messages, tools }: { messages: unknown; tools?: ToolSet }) => {
+        parentCalls += 1;
+        if (parentCalls === 1) {
+          const toolCall = toolCallPart("call-bg", "delegate_to_researcher", {
+            prompt: "research edge resume",
+            run_in_background: true,
+          });
+          const launch = (await tools?.delegate_to_researcher?.execute?.(
+            {
+              prompt: "research edge resume",
+              run_in_background: true,
+            },
+            toolExecutionOptions()
+          )) as { readonly task_id: string };
+          taskId = launch.task_id;
+          return {
+            responseMessages: [
+              assistantMessage([toolCall]),
+              {
+                content: [
+                  {
+                    output: { type: "json", value: launch },
+                    toolCallId: toolCall.toolCallId,
+                    toolName: toolCall.toolName,
+                    type: "tool-result",
+                  },
+                ],
+                role: "tool",
+              },
+              assistantMessage("WAITING FOR HOST WAKE"),
+            ],
+          };
+        }
+
+        expect(JSON.stringify(messages)).toContain(
+          "[BACKGROUND TASK COMPLETED]"
+        );
+        expect(JSON.stringify(messages)).toContain(taskId);
+        await expect(
+          tools?.background_output?.execute?.(
+            { task_id: taskId },
+            toolExecutionOptions()
+          )
+        ).resolves.toMatchObject({
+          result: {
+            result: "completed",
+            subagent: "researcher",
+            text: "CHILD DONE",
+          },
+          status: "completed",
+          task_id: taskId,
+        });
+        return {
+          responseMessages: [assistantMessage("RESUMED AFTER NOTIFICATION")],
+        };
+      }
+    );
+
+    const firstAgent = createCoordinator(Agent, host);
+    const firstEvents = await collectRun(
+      await firstAgent.session(sessionKey).send(userText("start background"))
+    );
+    const callsAfterLaunch = parentCalls;
+    expect(eventTypes(firstEvents)).not.toContain("runtime-input");
+
+    const notificationKey = backgroundNotificationKey(taskId);
+    const resumeAgent = createCoordinator(Agent, host);
+    await collectRun(await resumeBackgroundTask(resumeAgent, taskId));
+    const notificationRunId = await waitForNotification(host, notificationKey);
+    const reconstructedAgent = createCoordinator(Agent, host);
+    const notificationRun = await reconstructedAgent.resume(notificationRunId);
+    expect(notificationRun).not.toBeNull();
+    if (!notificationRun) {
+      throw new Error("Expected notification resume run.");
+    }
+
+    const notificationEvents = await collectRun(notificationRun);
+    expect(eventTypes(notificationEvents)).toEqual([
+      "subagent-job-end",
+      "turn-start",
+      "runtime-input",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(parentCalls).toBe(callsAfterLaunch + 1);
+  });
+
+  it("dedupes duplicate notification delivery", async () => {
+    const Agent = await loadAgent();
+    const host = createDurableHost();
+    const notificationKey = "background-complete:room:edge:user:1:bg_dup";
+    await host.store.notifications.enqueue({
+      idempotencyKey: notificationKey,
+      input: {
+        text: "<system-reminder>Task bg_dup is ready</system-reminder>",
+        type: "user-text",
+      },
+      notificationId: "notification-dup",
+      observerEvents: [
+        {
+          eventCount: 1,
+          status: "completed",
+          subagent: "researcher",
+          task_id: "bg_dup",
+          type: "subagent-job-end",
+        },
+      ],
+      ownerNamespace: edgeCoordinatorSessionNamespace(),
+      runId: "notification-run-dup",
+      sessionKey,
+      status: "pending",
+    });
+    await host.store.runs.create({
+      checkpointVersion: 0,
+      dedupeKey: notificationKey,
+      kind: "notification",
+      ownerNamespace: edgeCoordinatorSessionNamespace(),
+      rootRunId: "notification-run-dup",
+      runId: "notification-run-dup",
+      sessionKey,
+      status: "queued",
+    });
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("NOTIFIED ONCE")],
+    });
+    const agent = createCoordinator(Agent, host);
+
+    const first = await agent.resume("notification-run-dup");
+    const second = await agent.resume("notification-run-dup");
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    if (first) {
+      expect(eventTypes(await collectRun(first))).toContain("runtime-input");
+    }
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createDurableHost(): ExecutionHost {
+  const host = createInMemoryExecutionHost();
+  return {
+    ...host,
+    capabilities: {
+      ...host.capabilities,
+      backgroundSubagents: "durable",
+    },
+  };
+}
+
+function createCoordinator(
+  Agent: typeof import("./agent").Agent,
+  host: ExecutionHost
+): import("./agent").Agent {
+  const researcher = new Agent({
+    description: "Researches one sentence.",
+    model: async () => [assistantMessage("CHILD DONE")],
+    name: "researcher",
+    namespace: "edge-researcher",
+  });
+
+  return new Agent({
+    host,
+    model: fakeModel,
+    namespace: "edge-coordinator",
+    subagents: [researcher],
+  });
+}
+
+function backgroundNotificationKey(taskId: string): string {
+  return `background-complete:${sessionKey}:${taskId}`;
+}
+
+function edgeCoordinatorSessionNamespace(): string {
+  return parentSessionNamespace({
+    generation: 0,
+    sessionKey,
+    sessionNamespace: stableAgentNamespace({ namespace: "edge-coordinator" }),
+  });
+}
+
+async function waitForNotification(
+  host: ExecutionHost,
+  idempotencyKey: string
+): Promise<string> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const notification =
+      await host.store.notifications.getByIdempotencyKey(idempotencyKey);
+    if (notification) {
+      return notification.runId;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  throw new Error(`Expected notification ${idempotencyKey}.`);
+}

--- a/packages/runtime/src/execution-checkpoint-test-support.ts
+++ b/packages/runtime/src/execution-checkpoint-test-support.ts
@@ -1,0 +1,76 @@
+import type { Tool, ToolSet } from "ai";
+import { jsonSchema, tool } from "ai";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type {
+  ExecutionHost,
+  RunCheckpoint,
+  RunRecord,
+} from "./execution/types";
+
+export interface GenerateTextToolOptions {
+  readonly tools?: ToolSet;
+}
+
+export const createQueuedUserTurnRun = (runId = "run-1"): RunRecord => ({
+  checkpointVersion: 0,
+  kind: "user-turn",
+  rootRunId: runId,
+  runId,
+  sessionKey: "session-1",
+  status: "queued",
+});
+
+export function checkpointedTool(
+  retryPolicy: "idempotent" | "manual-recovery" | "pure",
+  execute: (input: unknown, options: unknown) => unknown
+): Tool & { readonly retryPolicy: "idempotent" | "manual-recovery" | "pure" } {
+  return {
+    ...tool({
+      execute,
+      inputSchema: jsonSchema({
+        additionalProperties: false,
+        properties: {},
+        type: "object",
+      }),
+    }),
+    retryPolicy,
+  };
+}
+
+export function toolOptions(toolCallId: string, signal: AbortSignal) {
+  return {
+    abortSignal: signal,
+    context: undefined,
+    messages: [],
+    toolCallId,
+  };
+}
+
+export function createCheckpointSpyHost(): {
+  readonly checkpoints: RunCheckpoint[];
+  readonly host: ExecutionHost;
+} {
+  const baseHost = createInMemoryExecutionHost();
+  const checkpoints: RunCheckpoint[] = [];
+  return {
+    checkpoints,
+    host: {
+      capabilities: baseHost.capabilities,
+      scheduler: baseHost.scheduler,
+      store: {
+        checkpoints: {
+          append: async (checkpoint, options) => {
+            checkpoints.push(checkpoint);
+            return await baseHost.store.checkpoints.append(checkpoint, options);
+          },
+          latest: (runId) => baseHost.store.checkpoints.latest(runId),
+        },
+        events: baseHost.store.events,
+        notifications: baseHost.store.notifications,
+        runs: baseHost.store.runs,
+        sessions: baseHost.store.sessions,
+        transaction: (fn) => baseHost.store.transaction(fn),
+      },
+    },
+  };
+}

--- a/packages/runtime/src/execution-run-events.test.ts
+++ b/packages/runtime/src/execution-run-events.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import { StoredAgentRun } from "./execution/run";
+import type { AgentEvent } from "./session/events";
+
+async function collectRunEvents(run: StoredAgentRun): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of run.events()) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("stored AgentRun events", () => {
+  it("replays stored events from cursor without session runs", async () => {
+    const host = createInMemoryExecutionHost();
+    await host.store.runs.create({
+      checkpointVersion: 0,
+      kind: "user-turn",
+      rootRunId: "run-1",
+      runId: "run-1",
+      sessionKey: "session-1",
+      status: "queued",
+    });
+    const cursor = await host.store.events.append("run-1", {
+      type: "turn-start",
+    });
+    await host.store.events.append("run-1", { type: "turn-end" });
+
+    const run = new StoredAgentRun({
+      cursor,
+      eventStore: host.store.events,
+      runId: "run-1",
+    });
+
+    await expect(collectRunEvents(run)).resolves.toEqual([
+      { type: "turn-end" },
+    ]);
+  });
+
+  it("rejects concurrent event iteration for one run", () => {
+    const host = createInMemoryExecutionHost();
+    const run = new StoredAgentRun({
+      eventStore: host.store.events,
+      runId: "run-1",
+    });
+
+    run.events();
+
+    expect(() => run.events()).toThrow(
+      "AgentRun.events() can only be consumed once"
+    );
+  });
+});

--- a/packages/runtime/src/execution-store-contract.test.ts
+++ b/packages/runtime/src/execution-store-contract.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type {
+  CheckpointWriteResult,
+  ExecutionStore,
+  RunRecord,
+  StoredAgentEvent,
+} from "./execution/types";
+
+const createQueuedRun = (runId = "run-1"): RunRecord => ({
+  checkpointVersion: 0,
+  kind: "user-turn",
+  rootRunId: runId,
+  runId,
+  sessionKey: "session-1",
+  status: "queued",
+});
+
+const collectEvents = async (
+  events: AsyncIterable<StoredAgentEvent>
+): Promise<StoredAgentEvent[]> => {
+  const collected: StoredAgentEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+};
+
+describe("ExecutionStore contract", () => {
+  it("transactions commit run checkpoint event and notification atomically", async () => {
+    const host = createInMemoryExecutionHost();
+
+    await host.store.transaction(async (tx) => {
+      await tx.runs.create(createQueuedRun());
+      const checkpointResult = await tx.checkpoints.append(
+        {
+          checkpointId: "checkpoint-1",
+          phase: "before-model",
+          runId: "run-1",
+          runtimeState: { step: 1 },
+          sessionSnapshot: { messages: [] },
+          version: 1,
+        },
+        { expectedVersion: 0 }
+      );
+      await tx.events.append("run-1", { type: "turn-start" });
+      await tx.notifications.enqueue({
+        idempotencyKey: "notify-1",
+        input: { text: "ready", type: "user-text" },
+        notificationId: "notification-1",
+        runId: "run-1",
+        sessionKey: "session-1",
+        status: "pending",
+      });
+      await tx.sessions.commit(
+        "session-1",
+        { state: { messages: ["committed transaction"] } },
+        { expectedVersion: null }
+      );
+
+      expect(checkpointResult).toEqual({ ok: true, version: 1 });
+    });
+
+    await expect(host.store.runs.get("run-1")).resolves.toMatchObject({
+      runId: "run-1",
+      status: "queued",
+    });
+    await expect(host.store.checkpoints.latest("run-1")).resolves.toMatchObject(
+      {
+        checkpointId: "checkpoint-1",
+        version: 1,
+      }
+    );
+    expect(await collectEvents(host.store.events.read("run-1"))).toHaveLength(
+      1
+    );
+    await expect(
+      host.store.notifications.getByIdempotencyKey("notify-1")
+    ).resolves.toMatchObject({
+      notificationId: "notification-1",
+    });
+    await expect(host.store.sessions.load("session-1")).resolves.toMatchObject({
+      state: { messages: ["committed transaction"] },
+      version: "1",
+    });
+  });
+
+  it("rolls back transaction writes when the transaction fails", async () => {
+    const host = createInMemoryExecutionHost();
+
+    await expect(
+      host.store.transaction(async (tx) => {
+        await tx.runs.create(createQueuedRun());
+        throw new Error("transaction failed");
+      })
+    ).rejects.toThrow("transaction failed");
+
+    await expect(host.store.runs.get("run-1")).resolves.toBeNull();
+  });
+
+  it("rolls back transaction session writes when the transaction fails", async () => {
+    const host = createInMemoryExecutionHost();
+
+    await expect(
+      host.store.transaction(async (tx) => {
+        await tx.sessions.commit(
+          "session-1",
+          { state: { messages: ["inside transaction"] } },
+          { expectedVersion: null }
+        );
+        throw new Error("transaction failed");
+      })
+    ).rejects.toThrow("transaction failed");
+
+    await expect(host.store.sessions.load("session-1")).resolves.toBeNull();
+  });
+
+  it("serializes concurrent transactions", async () => {
+    const host = createInMemoryExecutionHost();
+    const firstStarted = createDeferred();
+    const firstCanFinish = createDeferred();
+    let secondSettled = false;
+
+    const first = host.store.transaction(async (tx) => {
+      await tx.runs.create(createQueuedRun("run-serial"));
+      firstStarted.resolve();
+      await firstCanFinish.promise;
+    });
+    await firstStarted.promise;
+    const second = host.store
+      .transaction(async (tx) => {
+        const run = await tx.runs.get("run-serial");
+        if (!run) {
+          throw new Error("Expected first transaction to commit first.");
+        }
+        await tx.runs.update({ ...run, status: "cancelled" });
+      })
+      .then(() => {
+        secondSettled = true;
+      });
+
+    await Promise.resolve();
+    expect(secondSettled).toBe(false);
+    firstCanFinish.resolve();
+    await Promise.all([first, second]);
+
+    await expect(host.store.runs.get("run-serial")).resolves.toMatchObject({
+      status: "cancelled",
+    });
+  });
+
+  it("rejects duplicate active run claims", async () => {
+    const host = createInMemoryExecutionHost();
+    await host.store.runs.create(createQueuedRun());
+
+    await expect(
+      host.store.runs.claim("run-1", {
+        attempt: 1,
+        leaseId: "lease-1",
+        leaseMs: 100,
+        nowMs: 0,
+      })
+    ).resolves.toMatchObject({ ok: true });
+    await expect(
+      host.store.runs.claim("run-1", {
+        attempt: 2,
+        leaseId: "lease-2",
+        leaseMs: 100,
+        nowMs: 50,
+      })
+    ).resolves.toEqual({ ok: false, reason: "leased" });
+  });
+
+  it("rejects stale checkpoint writes", async () => {
+    const host = createInMemoryExecutionHost();
+    await host.store.runs.create(createQueuedRun());
+
+    const first = await appendCheckpoint(host.store, 0);
+    const stale = await appendCheckpoint(host.store, 0);
+
+    expect(first).toEqual({ ok: true, version: 1 });
+    expect(stale).toEqual({
+      currentVersion: 1,
+      ok: false,
+      reason: "stale-version",
+    });
+  });
+
+  it("replays events from a cursor without duplicates", async () => {
+    const host = createInMemoryExecutionHost();
+    await host.store.runs.create(createQueuedRun());
+
+    const firstCursor = await host.store.events.append("run-1", {
+      type: "turn-start",
+    });
+    await host.store.events.append("run-1", { type: "turn-end" });
+
+    const replayed = await collectEvents(
+      host.store.events.read("run-1", firstCursor)
+    );
+
+    expect(replayed).toEqual([
+      {
+        cursor: { offset: 2 },
+        event: { type: "turn-end" },
+        runId: "run-1",
+      },
+    ]);
+  });
+
+  it("dedupes notifications by idempotency key", async () => {
+    const host = createInMemoryExecutionHost();
+    const input = { text: "ready", type: "user-text" } as const;
+
+    await expect(
+      host.store.notifications.enqueue({
+        idempotencyKey: "notify-1",
+        input,
+        notificationId: "notification-1",
+        runId: "run-1",
+        sessionKey: "session-1",
+        status: "pending",
+      })
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      host.store.notifications.enqueue({
+        idempotencyKey: "notify-1",
+        input,
+        notificationId: "notification-2",
+        runId: "run-1",
+        sessionKey: "session-1",
+        status: "pending",
+      })
+    ).resolves.toEqual({
+      existingNotificationId: "notification-1",
+      ok: false,
+      reason: "duplicate",
+    });
+  });
+});
+
+function createDeferred(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function appendCheckpoint(
+  store: ExecutionStore,
+  expectedVersion: number
+): Promise<CheckpointWriteResult> {
+  return await store.checkpoints.append(
+    {
+      checkpointId: `checkpoint-${expectedVersion + 1}`,
+      phase: "before-model",
+      runId: "run-1",
+      runtimeState: {},
+      sessionSnapshot: {},
+      version: expectedVersion + 1,
+    },
+    { expectedVersion }
+  );
+}

--- a/packages/runtime/src/execution/host.ts
+++ b/packages/runtime/src/execution/host.ts
@@ -1,0 +1,25 @@
+import type { AgentHost, ExecutionHost } from "./types";
+
+export function executionHost(host: AgentHost): ExecutionHost | undefined {
+  if (isExecutionHost(host)) {
+    return host;
+  }
+
+  return;
+}
+
+function isExecutionHost(host: AgentHost): host is ExecutionHost {
+  return "scheduler" in host && "store" in host && isExecutionStore(host.store);
+}
+
+function isExecutionStore(store: unknown): store is ExecutionHost["store"] {
+  return (
+    typeof store === "object" &&
+    store !== null &&
+    "checkpoints" in store &&
+    "events" in store &&
+    "notifications" in store &&
+    "runs" in store &&
+    "sessions" in store
+  );
+}

--- a/packages/runtime/src/execution/index.ts
+++ b/packages/runtime/src/execution/index.ts
@@ -1,0 +1,36 @@
+// biome-ignore-all lint/performance/noBarrelFile: Public package subpath entrypoint required by package exports.
+export type {
+  RuntimeToolExecutionCheckpoint,
+  RuntimeToolExecutionContext,
+  RuntimeToolExecutionDecision,
+  RuntimeToolRetryPolicy,
+} from "../llm-tool-execution";
+export { ToolExecutionNeedsRecoveryError } from "../llm-tool-execution";
+export { createInMemoryExecutionHost } from "./memory";
+export type {
+  AgentHostCapabilities,
+  CheckpointPhase,
+  CheckpointStore,
+  CheckpointWriteResult,
+  ClaimRunOptions,
+  ClaimRunResult,
+  EventCursor,
+  EventStore,
+  ExecutionHost,
+  ExecutionScheduler,
+  ExecutionStore,
+  ExecutionStoreTransaction,
+  NotificationClaimResult,
+  NotificationInbox,
+  NotificationRecord,
+  NotificationStatus,
+  NotificationWriteResult,
+  ResumeSessionOptions,
+  RunCheckpoint,
+  RunKind,
+  RunLease,
+  RunRecord,
+  RunStatus,
+  RunStore,
+  StoredAgentEvent,
+} from "./types";

--- a/packages/runtime/src/execution/memory-notifications.ts
+++ b/packages/runtime/src/execution/memory-notifications.ts
@@ -1,0 +1,80 @@
+import type { ExecutionState } from "./memory-state";
+import type {
+  NotificationClaimResult,
+  NotificationInbox,
+  NotificationRecord,
+  NotificationWriteResult,
+} from "./types";
+
+export class InMemoryNotificationInbox implements NotificationInbox {
+  readonly #state: () => ExecutionState;
+
+  constructor(state: () => ExecutionState) {
+    this.#state = state;
+  }
+
+  claimByIdempotencyKey(
+    idempotencyKey: string
+  ): Promise<NotificationClaimResult> {
+    const record = this.#state().notificationsByKey.get(idempotencyKey);
+    if (!record) {
+      return Promise.resolve({ ok: false, reason: "not-found" });
+    }
+
+    if (record.status !== "pending") {
+      return Promise.resolve({
+        ok: false,
+        reason: "already-claimed",
+        record: structuredClone(record),
+      });
+    }
+
+    this.#state().notificationsByKey.set(idempotencyKey, {
+      ...record,
+      status: "acked",
+    });
+    return Promise.resolve({
+      ok: true,
+      record: structuredClone(record),
+    });
+  }
+
+  enqueue(record: NotificationRecord): Promise<NotificationWriteResult> {
+    const existing = this.#state().notificationsByKey.get(
+      record.idempotencyKey
+    );
+    if (existing) {
+      return Promise.resolve({
+        existingNotificationId: existing.notificationId,
+        ok: false,
+        reason: "duplicate",
+      });
+    }
+
+    this.#state().notificationsByKey.set(
+      record.idempotencyKey,
+      structuredClone(record)
+    );
+    return Promise.resolve({ ok: true });
+  }
+
+  getByIdempotencyKey(
+    idempotencyKey: string
+  ): Promise<NotificationRecord | null> {
+    const record = this.#state().notificationsByKey.get(idempotencyKey);
+    return Promise.resolve(record ? structuredClone(record) : null);
+  }
+
+  releaseByIdempotencyKey(idempotencyKey: string): Promise<void> {
+    const record = this.#state().notificationsByKey.get(idempotencyKey);
+    if (record?.status !== "acked") {
+      return Promise.resolve();
+    }
+
+    this.#state().notificationsByKey.set(idempotencyKey, {
+      ...record,
+      status: "pending",
+    });
+    return Promise.resolve();
+  }
+}

--- a/packages/runtime/src/execution/memory-state.ts
+++ b/packages/runtime/src/execution/memory-state.ts
@@ -1,0 +1,66 @@
+import type { StoredSession } from "../session/store/types";
+import type {
+  NotificationRecord,
+  RunCheckpoint,
+  RunRecord,
+  StoredAgentEvent,
+} from "./types";
+
+export interface ExecutionState {
+  readonly checkpoints: Map<string, RunCheckpoint[]>;
+  readonly events: Map<string, StoredAgentEvent[]>;
+  readonly notificationsByKey: Map<string, NotificationRecord>;
+  readonly runs: Map<string, RunRecord>;
+  readonly sessions: Map<string, StoredSession>;
+  readonly sessionVersions: Map<string, number>;
+}
+
+export function createEmptyState(): ExecutionState {
+  return {
+    checkpoints: new Map(),
+    events: new Map(),
+    notificationsByKey: new Map(),
+    runs: new Map(),
+    sessionVersions: new Map(),
+    sessions: new Map(),
+  };
+}
+
+export function cloneState(state: ExecutionState): ExecutionState {
+  return {
+    checkpoints: cloneCheckpointMap(state.checkpoints),
+    events: cloneEventMap(state.events),
+    notificationsByKey: cloneRecordMap(state.notificationsByKey),
+    runs: cloneRecordMap(state.runs),
+    sessionVersions: cloneRecordMap(state.sessionVersions),
+    sessions: cloneRecordMap(state.sessions),
+  };
+}
+
+function cloneCheckpointMap(
+  map: ReadonlyMap<string, readonly RunCheckpoint[]>
+): Map<string, RunCheckpoint[]> {
+  return new Map(
+    [...map.entries()].map(([key, value]) => [
+      key,
+      value.map((checkpoint) => structuredClone(checkpoint)),
+    ])
+  );
+}
+
+function cloneEventMap(
+  map: ReadonlyMap<string, readonly StoredAgentEvent[]>
+): Map<string, StoredAgentEvent[]> {
+  return new Map(
+    [...map.entries()].map(([key, value]) => [
+      key,
+      value.map((event) => structuredClone(event)),
+    ])
+  );
+}
+
+function cloneRecordMap<T>(map: ReadonlyMap<string, T>): Map<string, T> {
+  return new Map(
+    [...map.entries()].map(([key, value]) => [key, structuredClone(value)])
+  );
+}

--- a/packages/runtime/src/execution/memory-store.ts
+++ b/packages/runtime/src/execution/memory-store.ts
@@ -1,0 +1,273 @@
+import type { AgentEvent } from "../session/events";
+import type {
+  CommitResult,
+  ExpectedSessionVersion,
+  SessionStore,
+  SessionStoreCommit,
+  StoredSession,
+} from "../session/store/types";
+import { InMemoryNotificationInbox } from "./memory-notifications";
+import type { ExecutionState } from "./memory-state";
+import { cloneState, createEmptyState } from "./memory-state";
+import type {
+  CheckpointStore,
+  CheckpointWriteResult,
+  ClaimRunOptions,
+  ClaimRunResult,
+  EventCursor,
+  EventStore,
+  ExecutionStore,
+  ExecutionStoreTransaction,
+  NotificationInbox,
+  RunCheckpoint,
+  RunRecord,
+  RunStatus,
+  RunStore,
+  StoredAgentEvent,
+} from "./types";
+
+const claimableStatuses = new Set<RunStatus>([
+  "leased",
+  "queued",
+  "running",
+  "suspended",
+]);
+
+export class InMemoryExecutionStore implements ExecutionStore {
+  #state = createEmptyState();
+  #transactionChain: Promise<void> = Promise.resolve();
+  readonly checkpoints: CheckpointStore = new InMemoryCheckpointStore(
+    () => this.#state
+  );
+  readonly events: EventStore = new InMemoryEventStore(() => this.#state);
+  readonly notifications: NotificationInbox = new InMemoryNotificationInbox(
+    () => this.#state
+  );
+  readonly runs: RunStore = new InMemoryRunStore(() => this.#state);
+  readonly sessions: SessionStore = new InMemoryExecutionSessionStore(
+    () => this.#state
+  );
+
+  async transaction<T>(
+    fn: (tx: ExecutionStoreTransaction) => Promise<T>
+  ): Promise<T> {
+    const previousTransaction = this.#transactionChain;
+    let releaseTransaction: () => void = () => undefined;
+    this.#transactionChain = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+    await previousTransaction;
+    const transactionState = cloneState(this.#state);
+    const transactionStore = new InMemoryTransactionStore(transactionState);
+    try {
+      const result = await fn(transactionStore);
+      this.#state = transactionState;
+      return result;
+    } finally {
+      releaseTransaction();
+    }
+  }
+}
+
+class InMemoryTransactionStore implements ExecutionStoreTransaction {
+  readonly checkpoints: CheckpointStore;
+  readonly events: EventStore;
+  readonly notifications: NotificationInbox;
+  readonly runs: RunStore;
+  readonly sessions: SessionStore;
+  readonly #state: ExecutionState;
+
+  constructor(state: ExecutionState) {
+    this.#state = state;
+    this.checkpoints = new InMemoryCheckpointStore(() => this.#state);
+    this.events = new InMemoryEventStore(() => this.#state);
+    this.notifications = new InMemoryNotificationInbox(() => this.#state);
+    this.runs = new InMemoryRunStore(() => this.#state);
+    this.sessions = new InMemoryExecutionSessionStore(() => this.#state);
+  }
+}
+
+class InMemoryExecutionSessionStore implements SessionStore {
+  readonly #state: () => ExecutionState;
+
+  constructor(state: () => ExecutionState) {
+    this.#state = state;
+  }
+
+  commit(
+    key: string,
+    next: SessionStoreCommit,
+    options: { readonly expectedVersion: ExpectedSessionVersion }
+  ): Promise<CommitResult> {
+    const state = this.#state();
+    const current = state.sessions.get(key);
+    const currentVersion = current?.version ?? null;
+
+    if (options.expectedVersion !== currentVersion) {
+      return Promise.resolve({ ok: false, reason: "conflict" });
+    }
+
+    const versionNumber = (state.sessionVersions.get(key) ?? 0) + 1;
+    const version = String(versionNumber);
+    state.sessionVersions.set(key, versionNumber);
+    state.sessions.set(key, structuredClone({ state: next.state, version }));
+    return Promise.resolve({ ok: true, version });
+  }
+
+  delete(key: string): Promise<void> {
+    const state = this.#state();
+    state.sessions.delete(key);
+    state.sessionVersions.delete(key);
+    return Promise.resolve();
+  }
+
+  load(key: string): Promise<StoredSession | null> {
+    const stored = this.#state().sessions.get(key);
+    return Promise.resolve(stored ? structuredClone(stored) : null);
+  }
+}
+
+class InMemoryRunStore implements RunStore {
+  readonly #state: () => ExecutionState;
+
+  constructor(state: () => ExecutionState) {
+    this.#state = state;
+  }
+
+  create(record: RunRecord): Promise<RunRecord> {
+    const stored = structuredClone(record);
+    this.#state().runs.set(record.runId, stored);
+    return Promise.resolve(structuredClone(stored));
+  }
+
+  get(runId: string): Promise<RunRecord | null> {
+    const record = this.#state().runs.get(runId);
+    return Promise.resolve(record ? structuredClone(record) : null);
+  }
+
+  getByDedupeKey(dedupeKey: string): Promise<RunRecord | null> {
+    const record = [...this.#state().runs.values()].find(
+      (candidate) => candidate.dedupeKey === dedupeKey
+    );
+    return Promise.resolve(record ? structuredClone(record) : null);
+  }
+
+  listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]> {
+    const records = [...this.#state().runs.values()].filter(
+      (candidate) => candidate.parentRunId === parentRunId
+    );
+    return Promise.resolve(records.map((record) => structuredClone(record)));
+  }
+
+  update(record: RunRecord): Promise<RunRecord> {
+    const stored = structuredClone(record);
+    this.#state().runs.set(record.runId, stored);
+    return Promise.resolve(structuredClone(stored));
+  }
+
+  claim(runId: string, options: ClaimRunOptions): Promise<ClaimRunResult> {
+    const record = this.#state().runs.get(runId);
+    if (!record) {
+      return Promise.resolve({ ok: false, reason: "not-found" });
+    }
+
+    if (!claimableStatuses.has(record.status)) {
+      return Promise.resolve({ ok: false, reason: "not-claimable" });
+    }
+
+    if (record.lease && record.lease.leaseUntilMs > options.nowMs) {
+      return Promise.resolve({ ok: false, reason: "leased" });
+    }
+
+    const lease = {
+      attempt: options.attempt,
+      leaseId: options.leaseId,
+      leaseUntilMs: options.nowMs + options.leaseMs,
+    };
+    const claimed: RunRecord = {
+      ...record,
+      lease,
+      status: "leased",
+    };
+    this.#state().runs.set(runId, claimed);
+    return Promise.resolve({
+      lease,
+      ok: true,
+      record: structuredClone(claimed),
+    });
+  }
+}
+
+class InMemoryCheckpointStore implements CheckpointStore {
+  readonly #state: () => ExecutionState;
+
+  constructor(state: () => ExecutionState) {
+    this.#state = state;
+  }
+
+  append(
+    checkpoint: RunCheckpoint,
+    options: { readonly expectedVersion: number }
+  ): Promise<CheckpointWriteResult> {
+    const run = this.#state().runs.get(checkpoint.runId);
+    const currentVersion = run?.checkpointVersion ?? 0;
+    if (currentVersion !== options.expectedVersion) {
+      return Promise.resolve({
+        currentVersion,
+        ok: false,
+        reason: "stale-version",
+      });
+    }
+
+    const stored = structuredClone(checkpoint);
+    const checkpoints = this.#state().checkpoints.get(checkpoint.runId) ?? [];
+    checkpoints.push(stored);
+    this.#state().checkpoints.set(checkpoint.runId, checkpoints);
+    if (run) {
+      this.#state().runs.set(checkpoint.runId, {
+        ...run,
+        checkpointVersion: checkpoint.version,
+      });
+    }
+
+    return Promise.resolve({ ok: true, version: checkpoint.version });
+  }
+
+  latest(runId: string): Promise<RunCheckpoint | null> {
+    const checkpoints = this.#state().checkpoints.get(runId) ?? [];
+    const checkpoint = checkpoints.at(-1);
+    return Promise.resolve(checkpoint ? structuredClone(checkpoint) : null);
+  }
+}
+
+class InMemoryEventStore implements EventStore {
+  readonly #state: () => ExecutionState;
+
+  constructor(state: () => ExecutionState) {
+    this.#state = state;
+  }
+
+  append(runId: string, event: AgentEvent): Promise<EventCursor> {
+    const events = this.#state().events.get(runId) ?? [];
+    const cursor = { offset: events.length + 1 };
+    events.push({
+      cursor,
+      event: structuredClone(event),
+      runId,
+    });
+    this.#state().events.set(runId, events);
+    return Promise.resolve(cursor);
+  }
+
+  async *read(
+    runId: string,
+    cursor?: EventCursor
+  ): AsyncIterable<StoredAgentEvent> {
+    await Promise.resolve();
+    const events = this.#state().events.get(runId) ?? [];
+    const start = cursor?.offset ?? 0;
+    for (const event of events.slice(start)) {
+      yield structuredClone(event);
+    }
+  }
+}

--- a/packages/runtime/src/execution/memory.ts
+++ b/packages/runtime/src/execution/memory.ts
@@ -1,0 +1,37 @@
+import { InMemoryExecutionStore } from "./memory-store";
+import type {
+  ExecutionHost,
+  ExecutionScheduler,
+  ResumeSessionOptions,
+} from "./types";
+
+export function createInMemoryExecutionHost(): ExecutionHost {
+  return {
+    capabilities: {
+      backgroundSubagents: "in-process",
+    },
+    store: new InMemoryExecutionStore(),
+    scheduler: new InMemoryExecutionScheduler(),
+  };
+}
+
+class InMemoryExecutionScheduler implements ExecutionScheduler {
+  readonly #queuedRunIds: string[] = [];
+  readonly #resumedSessions: {
+    readonly options: ResumeSessionOptions;
+    readonly sessionKey: string;
+  }[] = [];
+
+  enqueueRun(runId: string): Promise<void> {
+    this.#queuedRunIds.push(runId);
+    return Promise.resolve();
+  }
+
+  resumeSession(
+    sessionKey: string,
+    options: ResumeSessionOptions
+  ): Promise<void> {
+    this.#resumedSessions.push({ options, sessionKey });
+    return Promise.resolve();
+  }
+}

--- a/packages/runtime/src/execution/resume-checkpoints.ts
+++ b/packages/runtime/src/execution/resume-checkpoints.ts
@@ -1,4 +1,4 @@
-import type { RuntimeToolExecutionCheckpoint } from "../llm";
+import type { RuntimeToolExecutionCheckpointMetadata } from "../llm";
 import { ToolExecutionNeedsRecoveryError } from "../llm-tool-execution";
 import type { ResumeRunState } from "./resume-types";
 import type { CheckpointPhase, ExecutionHost, RunCheckpoint } from "./types";
@@ -133,7 +133,7 @@ export async function appendCheckpoint({
 
 function runtimeToolCheckpoint(
   value: unknown
-): RuntimeToolExecutionCheckpoint | undefined {
+): RuntimeToolExecutionCheckpointMetadata | undefined {
   if (typeof value !== "object" || value === null) {
     return;
   }
@@ -170,7 +170,6 @@ function runtimeToolCheckpoint(
   return {
     attempt: value.attempt,
     idempotencyKey: value.idempotencyKey,
-    input: "input" in value ? value.input : undefined,
     policy: value.policy,
     toolCallId: value.toolCallId,
     toolName: value.toolName,

--- a/packages/runtime/src/execution/resume-checkpoints.ts
+++ b/packages/runtime/src/execution/resume-checkpoints.ts
@@ -1,0 +1,192 @@
+import type { RuntimeToolExecutionCheckpoint } from "../llm";
+import { ToolExecutionNeedsRecoveryError } from "../llm-tool-execution";
+import type { ResumeRunState } from "./resume-types";
+import type { CheckpointPhase, ExecutionHost, RunCheckpoint } from "./types";
+
+const maxCheckpointWriteAttempts = 5;
+
+type ResumeStepStart = "new-step" | "resume-before-model";
+
+interface ResumeStep {
+  readonly phase: ResumeStepStart;
+  readonly stepNumber: number;
+}
+
+class ResumeRunCheckpointError extends Error {
+  readonly currentVersion: number;
+  readonly expectedVersion: number;
+  readonly runId: string;
+
+  constructor(runId: string, expectedVersion: number, currentVersion: number) {
+    super(
+      `Cannot write checkpoint for run ${runId}: expected version ${expectedVersion}, got ${currentVersion}`
+    );
+    this.currentVersion = currentVersion;
+    this.expectedVersion = expectedVersion;
+    this.name = "ResumeRunCheckpointError";
+    this.runId = runId;
+  }
+}
+
+class ResumeRunMissingRunError extends Error {
+  readonly runId: string;
+
+  constructor(runId: string) {
+    super(`Cannot resume missing run ${runId}`);
+    this.name = "ResumeRunMissingRunError";
+    this.runId = runId;
+  }
+}
+
+export function resumeStepFromCheckpoint(
+  checkpoint: RunCheckpoint | null
+): ResumeStep {
+  if (
+    checkpoint?.phase === "before-model" ||
+    checkpoint?.phase === "before-tool" ||
+    checkpoint?.phase === "after-tool"
+  ) {
+    return {
+      phase: "resume-before-model",
+      stepNumber: checkpointStep(checkpoint),
+    };
+  }
+
+  return {
+    phase: "new-step",
+    stepNumber: checkpoint ? checkpointStep(checkpoint) + 1 : 1,
+  };
+}
+
+export function throwIfManualToolRecoveryRequired(
+  checkpoint: RunCheckpoint | null
+): void {
+  if (
+    checkpoint?.phase !== "before-tool" &&
+    checkpoint?.phase !== "after-tool"
+  ) {
+    return;
+  }
+
+  const pendingToolCall = runtimeToolCheckpoint(checkpoint.pendingToolCall);
+  if (pendingToolCall?.policy !== "manual-recovery") {
+    return;
+  }
+
+  throw new ToolExecutionNeedsRecoveryError(pendingToolCall);
+}
+
+export async function appendCheckpoint({
+  host,
+  phase,
+  pendingToolCall,
+  runId,
+  runtimeState,
+  sessionSnapshot,
+}: {
+  readonly host: ExecutionHost;
+  readonly pendingToolCall?: unknown;
+  readonly phase: CheckpointPhase;
+  readonly runId: string;
+  readonly runtimeState: unknown;
+  readonly sessionSnapshot: ResumeRunState;
+}): Promise<void> {
+  let lastConflict:
+    | { readonly current: number; readonly expected: number }
+    | undefined;
+  for (let attempt = 0; attempt < maxCheckpointWriteAttempts; attempt += 1) {
+    const run = await host.store.runs.get(runId);
+    if (!run) {
+      throw new ResumeRunMissingRunError(runId);
+    }
+
+    const version = run.checkpointVersion + 1;
+    const result = await host.store.checkpoints.append(
+      {
+        checkpointId: crypto.randomUUID(),
+        ...(pendingToolCall === undefined ? {} : { pendingToolCall }),
+        phase,
+        runId,
+        runtimeState,
+        sessionSnapshot,
+        version,
+      },
+      { expectedVersion: run.checkpointVersion }
+    );
+
+    if (result.ok) {
+      return;
+    }
+
+    lastConflict = {
+      current: result.currentVersion,
+      expected: run.checkpointVersion,
+    };
+  }
+
+  throw new ResumeRunCheckpointError(
+    runId,
+    lastConflict?.expected ?? 0,
+    lastConflict?.current ?? 0
+  );
+}
+
+function runtimeToolCheckpoint(
+  value: unknown
+): RuntimeToolExecutionCheckpoint | undefined {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+
+  if (
+    !(
+      "attempt" in value &&
+      "idempotencyKey" in value &&
+      "policy" in value &&
+      "toolCallId" in value &&
+      "toolName" in value
+    )
+  ) {
+    return;
+  }
+
+  if (
+    typeof value.attempt !== "number" ||
+    typeof value.idempotencyKey !== "string" ||
+    typeof value.toolCallId !== "string" ||
+    typeof value.toolName !== "string"
+  ) {
+    return;
+  }
+
+  if (
+    value.policy !== "idempotent" &&
+    value.policy !== "manual-recovery" &&
+    value.policy !== "pure"
+  ) {
+    return;
+  }
+
+  return {
+    attempt: value.attempt,
+    idempotencyKey: value.idempotencyKey,
+    input: "input" in value ? value.input : undefined,
+    policy: value.policy,
+    toolCallId: value.toolCallId,
+    toolName: value.toolName,
+  };
+}
+
+function checkpointStep(checkpoint: RunCheckpoint): number {
+  const state = checkpoint.runtimeState;
+  if (
+    typeof state === "object" &&
+    state !== null &&
+    "step" in state &&
+    typeof state.step === "number"
+  ) {
+    return state.step;
+  }
+
+  return checkpoint.version;
+}

--- a/packages/runtime/src/execution/resume-llm.ts
+++ b/packages/runtime/src/execution/resume-llm.ts
@@ -1,0 +1,112 @@
+import type { ModelMessage } from "ai";
+import type {
+  RuntimeLlm,
+  RuntimeLlmOutput,
+  RuntimeToolExecutionContext,
+} from "../llm";
+import { modelMessageToAgentEvents } from "../session/mapping";
+import { appendCheckpoint } from "./resume-checkpoints";
+import type { ResumeRunState } from "./resume-types";
+import type { ExecutionHost } from "./types";
+
+export async function readLlmOutput({
+  history,
+  llm,
+  signal,
+  toolExecution,
+}: {
+  readonly history: readonly ModelMessage[];
+  readonly llm: RuntimeLlm;
+  readonly signal: AbortSignal;
+  readonly toolExecution: RuntimeToolExecutionContext;
+}): Promise<RuntimeLlmOutput | "aborted"> {
+  try {
+    return await llm({ history, signal, toolExecution });
+  } catch (error) {
+    if (signal.aborted) {
+      return "aborted";
+    }
+
+    throw error;
+  }
+}
+
+export async function createResumeToolExecution({
+  host,
+  runId,
+  sessionSnapshot,
+  stepNumber,
+}: {
+  readonly host: ExecutionHost;
+  readonly runId: string;
+  readonly sessionSnapshot: ResumeRunState;
+  readonly stepNumber: number;
+}): Promise<RuntimeToolExecutionContext> {
+  const run = await host.store.runs.get(runId);
+  return {
+    attempt: run?.lease?.attempt ?? 1,
+    afterTool: (checkpoint) =>
+      appendCheckpoint({
+        host,
+        pendingToolCall: checkpoint,
+        phase: "after-tool",
+        runId,
+        runtimeState: {
+          step: stepNumber,
+          toolCallId: checkpoint.toolCallId,
+          toolName: checkpoint.toolName,
+        },
+        sessionSnapshot,
+      }),
+    beforeTool: async (checkpoint) => {
+      await appendCheckpoint({
+        host,
+        pendingToolCall: checkpoint,
+        phase: "before-tool",
+        runId,
+        runtimeState: {
+          step: stepNumber,
+          toolCallId: checkpoint.toolCallId,
+          toolName: checkpoint.toolName,
+        },
+        sessionSnapshot,
+      });
+    },
+    runId,
+  };
+}
+
+export function appendModelOutput(
+  state: ResumeRunState,
+  output: RuntimeLlmOutput
+): ResumeRunState {
+  return {
+    history: [
+      ...state.history,
+      ...output.map((message) => structuredClone(message)),
+    ],
+  };
+}
+
+export async function emitModelOutputEvents({
+  host,
+  output,
+  runId,
+}: {
+  readonly host: ExecutionHost;
+  readonly output: RuntimeLlmOutput;
+  readonly runId: string;
+}): Promise<boolean> {
+  let shouldContinue = false;
+
+  for (const message of output) {
+    for (const event of modelMessageToAgentEvents(message)) {
+      await host.store.events.append(runId, event);
+      if (event.type === "tool-call") {
+        shouldContinue = true;
+      }
+    }
+  }
+
+  return shouldContinue;
+}

--- a/packages/runtime/src/execution/resume-llm.ts
+++ b/packages/runtime/src/execution/resume-llm.ts
@@ -4,6 +4,7 @@ import type {
   RuntimeLlmOutput,
   RuntimeToolExecutionContext,
 } from "../llm";
+import { persistedToolExecutionCheckpoint } from "../llm-tool-execution";
 import { modelMessageToAgentEvents } from "../session/mapping";
 import { appendCheckpoint } from "./resume-checkpoints";
 import type { ResumeRunState } from "./resume-types";
@@ -48,7 +49,7 @@ export async function createResumeToolExecution({
     afterTool: (checkpoint) =>
       appendCheckpoint({
         host,
-        pendingToolCall: checkpoint,
+        pendingToolCall: persistedToolExecutionCheckpoint(checkpoint),
         phase: "after-tool",
         runId,
         runtimeState: {
@@ -61,7 +62,7 @@ export async function createResumeToolExecution({
     beforeTool: async (checkpoint) => {
       await appendCheckpoint({
         host,
-        pendingToolCall: checkpoint,
+        pendingToolCall: persistedToolExecutionCheckpoint(checkpoint),
         phase: "before-tool",
         runId,
         runtimeState: {

--- a/packages/runtime/src/execution/resume-types.ts
+++ b/packages/runtime/src/execution/resume-types.ts
@@ -1,0 +1,28 @@
+import type { ModelMessage } from "ai";
+import type { RuntimeLlm } from "../llm";
+import type { ExecutionHost } from "./types";
+
+export interface ResumeRunState {
+  readonly history: readonly ModelMessage[];
+}
+
+export interface ResumeRunBudget {
+  readonly maxSteps: number;
+}
+
+export type ResumeRunStatus = "aborted" | "completed" | "suspended";
+
+export interface ResumeRunResult {
+  readonly status: ResumeRunStatus;
+  readonly steps: number;
+}
+
+export interface ResumeRunOptions {
+  readonly budget: ResumeRunBudget;
+  readonly host: ExecutionHost;
+  readonly llm: RuntimeLlm;
+  readonly loadState: () => Promise<ResumeRunState>;
+  readonly runId: string;
+  readonly saveState: (state: ResumeRunState) => Promise<void>;
+  readonly signal?: AbortSignal;
+}

--- a/packages/runtime/src/execution/resume.ts
+++ b/packages/runtime/src/execution/resume.ts
@@ -1,0 +1,115 @@
+import {
+  appendCheckpoint,
+  resumeStepFromCheckpoint,
+  throwIfManualToolRecoveryRequired,
+} from "./resume-checkpoints";
+import {
+  appendModelOutput,
+  createResumeToolExecution,
+  emitModelOutputEvents,
+  readLlmOutput,
+} from "./resume-llm";
+import type { ResumeRunOptions, ResumeRunResult } from "./resume-types";
+
+export type {
+  ResumeRunBudget,
+  ResumeRunOptions,
+  ResumeRunResult,
+  ResumeRunState,
+  ResumeRunStatus,
+} from "./resume-types";
+
+export async function resumeRun(
+  options: ResumeRunOptions
+): Promise<ResumeRunResult> {
+  const signal = options.signal ?? new AbortController().signal;
+  if (options.budget.maxSteps <= 0) {
+    return { status: "suspended", steps: 0 };
+  }
+
+  const initialCheckpoint = await options.host.store.checkpoints.latest(
+    options.runId
+  );
+  throwIfManualToolRecoveryRequired(initialCheckpoint);
+  let nextStep = resumeStepFromCheckpoint(initialCheckpoint);
+  let steps = 0;
+
+  while (steps < options.budget.maxSteps) {
+    if (signal.aborted) {
+      return { status: "aborted", steps };
+    }
+
+    if (nextStep.phase === "new-step") {
+      await options.host.store.events.append(options.runId, {
+        type: "step-start",
+      });
+      const state = await options.loadState();
+      await appendCheckpoint({
+        host: options.host,
+        phase: "before-model",
+        runId: options.runId,
+        runtimeState: { step: nextStep.stepNumber },
+        sessionSnapshot: state,
+      });
+    }
+
+    const stateBeforeModel = await options.loadState();
+    const toolExecution = await createResumeToolExecution({
+      host: options.host,
+      runId: options.runId,
+      sessionSnapshot: stateBeforeModel,
+      stepNumber: nextStep.stepNumber,
+    });
+    const output = await readLlmOutput({
+      history: stateBeforeModel.history,
+      llm: options.llm,
+      signal,
+      toolExecution,
+    });
+    if (output === "aborted") {
+      return { status: "aborted", steps };
+    }
+
+    const stateAfterModel = appendModelOutput(stateBeforeModel, output);
+    await options.saveState(stateAfterModel);
+    await appendCheckpoint({
+      host: options.host,
+      phase: "after-model",
+      runId: options.runId,
+      runtimeState: { step: nextStep.stepNumber },
+      sessionSnapshot: stateAfterModel,
+    });
+
+    const shouldContinue = await emitModelOutputEvents({
+      host: options.host,
+      output,
+      runId: options.runId,
+    });
+    await options.host.store.events.append(options.runId, {
+      type: "step-end",
+    });
+    steps += 1;
+
+    if (!shouldContinue) {
+      return { status: "completed", steps };
+    }
+
+    if (steps >= options.budget.maxSteps) {
+      await appendCheckpoint({
+        host: options.host,
+        phase: "suspended",
+        runId: options.runId,
+        runtimeState: { step: nextStep.stepNumber },
+        sessionSnapshot: stateAfterModel,
+      });
+      return { status: "suspended", steps };
+    }
+
+    nextStep = {
+      phase: "new-step",
+      stepNumber: nextStep.stepNumber + 1,
+    };
+  }
+
+  return { status: "suspended", steps };
+}

--- a/packages/runtime/src/execution/run.ts
+++ b/packages/runtime/src/execution/run.ts
@@ -1,0 +1,73 @@
+import type { AgentEvent } from "../session/events";
+import type { AgentRun } from "../session/run";
+import type { EventCursor, EventStore, StoredAgentEvent } from "./types";
+
+export class StoredAgentRun implements AgentRun {
+  readonly #cursor: EventCursor | undefined;
+  readonly #eventStore: EventStore;
+  readonly #runId: string;
+  #eventsStarted = false;
+
+  constructor({
+    cursor,
+    eventStore,
+    runId,
+  }: {
+    readonly cursor?: EventCursor;
+    readonly eventStore: EventStore;
+    readonly runId: string;
+  }) {
+    this.#cursor = cursor;
+    this.#eventStore = eventStore;
+    this.#runId = runId;
+  }
+
+  events(): AsyncIterable<AgentEvent> {
+    if (this.#eventsStarted) {
+      throw new Error("AgentRun.events() can only be consumed once");
+    }
+    this.#eventsStarted = true;
+
+    return new StoredAgentEventIterator(
+      this.#eventStore.read(this.#runId, this.#cursor)
+    );
+  }
+}
+
+class StoredAgentEventIterator implements AsyncIterableIterator<AgentEvent> {
+  readonly #source: AsyncIterator<StoredAgentEvent>;
+  #nextPending = false;
+
+  constructor(events: AsyncIterable<StoredAgentEvent>) {
+    this.#source = events[Symbol.asyncIterator]();
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<AgentEvent> {
+    return this;
+  }
+
+  async next(): Promise<IteratorResult<AgentEvent>> {
+    if (this.#nextPending) {
+      throw new Error(
+        "AgentRun.events() does not allow concurrent next() calls"
+      );
+    }
+
+    this.#nextPending = true;
+    try {
+      const next = await this.#source.next();
+      if (next.done) {
+        return { done: true, value: undefined };
+      }
+
+      return { done: false, value: next.value.event };
+    } finally {
+      this.#nextPending = false;
+    }
+  }
+
+  async return(): Promise<IteratorResult<AgentEvent>> {
+    await this.#source.return?.();
+    return { done: true, value: undefined };
+  }
+}

--- a/packages/runtime/src/execution/types.ts
+++ b/packages/runtime/src/execution/types.ts
@@ -1,0 +1,204 @@
+import type { AgentEvent, UserInput } from "../session/events";
+import type { SessionStore } from "../session/store/types";
+
+export type AgentHost = SessionHost | ExecutionHost;
+
+interface SessionHost {
+  readonly capabilities?: AgentHostCapabilities;
+  readonly sessionStore?: SessionStore;
+}
+
+export interface ExecutionHost {
+  readonly capabilities: AgentHostCapabilities;
+  readonly scheduler: ExecutionScheduler;
+  readonly store: ExecutionStore;
+}
+
+export interface AgentHostCapabilities {
+  readonly backgroundSubagents?: "durable" | "in-process";
+}
+
+export interface ExecutionScheduler {
+  enqueueRun(
+    runId: string,
+    options?: { readonly runAfterMs?: number }
+  ): Promise<void>;
+  resumeSession(
+    sessionKey: string,
+    options: ResumeSessionOptions
+  ): Promise<void>;
+}
+
+export interface ResumeSessionOptions {
+  readonly idempotencyKey?: string;
+  readonly notificationId?: string;
+  readonly runId: string;
+}
+
+export type RunKind =
+  | "background-subagent"
+  | "notification"
+  | "subagent"
+  | "tool-recovery"
+  | "user-turn";
+
+export type RunStatus =
+  | "cancelled"
+  | "completed"
+  | "error"
+  | "leased"
+  | "needs-recovery"
+  | "queued"
+  | "running"
+  | "suspended";
+
+export interface RunLease {
+  readonly attempt: number;
+  readonly leaseId: string;
+  readonly leaseUntilMs: number;
+}
+
+export interface RunRecord {
+  readonly checkpointVersion: number;
+  readonly dedupeKey?: string;
+  readonly kind: RunKind;
+  readonly lease?: RunLease;
+  readonly output?: unknown;
+  readonly ownerNamespace?: string;
+  readonly parentRunId?: string;
+  readonly publicTaskId?: string;
+  readonly rootRunId: string;
+  readonly runId: string;
+  readonly sessionKey: string;
+  readonly status: RunStatus;
+}
+
+export type ClaimRunResult =
+  | { readonly lease: RunLease; readonly ok: true; readonly record: RunRecord }
+  | {
+      readonly ok: false;
+      readonly reason: "leased" | "not-claimable" | "not-found";
+    };
+
+export interface ClaimRunOptions {
+  readonly attempt: number;
+  readonly leaseId: string;
+  readonly leaseMs: number;
+  readonly nowMs: number;
+}
+
+export type CheckpointPhase =
+  | "after-model"
+  | "after-notification"
+  | "after-tool"
+  | "before-child-run"
+  | "before-model"
+  | "before-notification"
+  | "before-tool"
+  | "child-linked"
+  | "suspended";
+
+export interface RunCheckpoint {
+  readonly checkpointId: string;
+  readonly childRunId?: string;
+  readonly pendingToolCall?: unknown;
+  readonly phase: CheckpointPhase;
+  readonly runId: string;
+  readonly runtimeState: unknown;
+  readonly sessionSnapshot: unknown;
+  readonly version: number;
+}
+
+export type CheckpointWriteResult =
+  | { readonly ok: true; readonly version: number }
+  | {
+      readonly currentVersion: number;
+      readonly ok: false;
+      readonly reason: "stale-version";
+    };
+
+export interface EventCursor {
+  readonly offset: number;
+}
+
+export interface StoredAgentEvent {
+  readonly cursor: EventCursor;
+  readonly event: AgentEvent;
+  readonly runId: string;
+}
+
+export type NotificationStatus = "acked" | "cancelled" | "pending";
+
+export interface NotificationRecord {
+  readonly idempotencyKey: string;
+  readonly input: UserInput;
+  readonly notificationId: string;
+  readonly observerEvents?: readonly AgentEvent[];
+  readonly ownerNamespace?: string;
+  readonly runId: string;
+  readonly sessionKey: string;
+  readonly status: NotificationStatus;
+}
+
+export type NotificationWriteResult =
+  | { readonly ok: true }
+  | {
+      readonly existingNotificationId: string;
+      readonly ok: false;
+      readonly reason: "duplicate";
+    };
+
+export type NotificationClaimResult =
+  | { readonly ok: true; readonly record: NotificationRecord }
+  | {
+      readonly ok: false;
+      readonly reason: "already-claimed" | "not-found";
+      readonly record?: NotificationRecord;
+    };
+
+export interface RunStore {
+  claim(runId: string, options: ClaimRunOptions): Promise<ClaimRunResult>;
+  create(record: RunRecord): Promise<RunRecord>;
+  get(runId: string): Promise<RunRecord | null>;
+  getByDedupeKey(dedupeKey: string): Promise<RunRecord | null>;
+  listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]>;
+  update(record: RunRecord): Promise<RunRecord>;
+}
+
+export interface CheckpointStore {
+  append(
+    checkpoint: RunCheckpoint,
+    options: { readonly expectedVersion: number }
+  ): Promise<CheckpointWriteResult>;
+  latest(runId: string): Promise<RunCheckpoint | null>;
+}
+
+export interface EventStore {
+  append(runId: string, event: AgentEvent): Promise<EventCursor>;
+  read(runId: string, cursor?: EventCursor): AsyncIterable<StoredAgentEvent>;
+}
+
+export interface NotificationInbox {
+  claimByIdempotencyKey(
+    idempotencyKey: string
+  ): Promise<NotificationClaimResult>;
+  enqueue(record: NotificationRecord): Promise<NotificationWriteResult>;
+  getByIdempotencyKey(
+    idempotencyKey: string
+  ): Promise<NotificationRecord | null>;
+  releaseByIdempotencyKey(idempotencyKey: string): Promise<void>;
+}
+
+export interface ExecutionStorePorts {
+  readonly checkpoints: CheckpointStore;
+  readonly events: EventStore;
+  readonly notifications: NotificationInbox;
+  readonly runs: RunStore;
+  readonly sessions: SessionStore;
+}
+
+export interface ExecutionStoreTransaction extends ExecutionStorePorts {}
+
+export interface ExecutionStore extends ExecutionStorePorts {
+  transaction<T>(fn: (tx: ExecutionStoreTransaction) => Promise<T>): Promise<T>;
+}

--- a/packages/runtime/src/host-notify-durable.test.ts
+++ b/packages/runtime/src/host-notify-durable.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { agentNamespace } from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, ResumeSessionOptions } from "./execution/types";
+import type { UserInput } from "./session/input";
+import type { AgentRun } from "./session/run";
+import { notifyBackgroundCompletion } from "./subagent-background-notify";
+import type { RuntimeInputSink, SubagentJob } from "./subagent-types";
+
+describe("durable background notification resume", () => {
+  it("enqueues durable notification and schedules the parent session resume", async () => {
+    const host = createDurableHost();
+    const inlineNotifications: UserInput[] = [];
+    const job = createCompletedBackgroundJob(host);
+    const jobs = new Map([[job.id, job]]);
+
+    await notifyBackgroundCompletion({
+      endEvent: {
+        eventCount: 1,
+        status: "completed",
+        subagent: "researcher",
+        task_id: job.id,
+        type: "subagent-job-end",
+      },
+      groups: new Map(),
+      job,
+      jobs,
+      parentSession: createParentSession(inlineNotifications),
+    });
+
+    await expect(
+      host.store.notifications.getByIdempotencyKey(
+        "background-complete:default:bg_1"
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          text: expect.stringContaining("bg_1"),
+        }),
+        observerEvents: [
+          expect.objectContaining({
+            task_id: "bg_1",
+            type: "subagent-job-end",
+          }),
+        ],
+        sessionKey: "default",
+        status: "pending",
+      })
+    );
+    expect(host.resumedSessionKeys).toEqual(["default"]);
+    expect(host.resumedSessions).toEqual([
+      {
+        options: expect.objectContaining({
+          idempotencyKey: "background-complete:default:bg_1",
+        }),
+        sessionKey: "default",
+      },
+    ]);
+    expect(inlineNotifications).toEqual([]);
+
+    await notifyBackgroundCompletion({
+      endEvent: {
+        eventCount: 1,
+        status: "completed",
+        subagent: "researcher",
+        task_id: job.id,
+        type: "subagent-job-end",
+      },
+      groups: new Map(),
+      job,
+      jobs,
+      parentSession: createParentSession(inlineNotifications),
+    });
+
+    expect(host.resumedSessionKeys).toEqual(["default", "default"]);
+  });
+});
+
+interface DurableTestHost extends ExecutionHost {
+  readonly resumedSessionKeys: readonly string[];
+  readonly resumedSessions: readonly {
+    readonly options?: ResumeSessionOptions;
+    readonly sessionKey: string;
+  }[];
+}
+
+function createDurableHost(): DurableTestHost {
+  const base = createInMemoryExecutionHost();
+  const resumedSessionKeys: string[] = [];
+  const resumedSessions: {
+    readonly options?: ResumeSessionOptions;
+    readonly sessionKey: string;
+  }[] = [];
+  return {
+    ...base,
+    capabilities: {
+      backgroundSubagents: "durable",
+    },
+    scheduler: {
+      enqueueRun: () => Promise.resolve(),
+      resumeSession: (sessionKey, options) => {
+        resumedSessionKeys.push(sessionKey);
+        resumedSessions.push({ options, sessionKey });
+        return Promise.resolve();
+      },
+    },
+    resumedSessionKeys,
+    resumedSessions,
+  };
+}
+
+function createCompletedBackgroundJob(host: ExecutionHost): SubagentJob {
+  return {
+    abort: () => undefined,
+    childRunId: "background:bg_1",
+    cleanup: () => Promise.resolve(),
+    executionHost: host,
+    id: "bg_1",
+    ownerNamespace: agentNamespace("notify-owner"),
+    parentSessionKey: "default",
+    promise: Promise.resolve(),
+    sessionKey: "child:bg_1",
+    settled: true,
+    status: "completed",
+    subagent: "researcher",
+  };
+}
+
+function createParentSession(notifications: UserInput[]): RuntimeInputSink {
+  return {
+    emitObserverEvent: () => Promise.resolve(),
+    enqueueRuntimeInput: () => undefined,
+    notify: (input) => {
+      notifications.push(input);
+      return Promise.resolve(createEmptyRun());
+    },
+  };
+}
+
+function createEmptyRun(): AgentRun {
+  return {
+    events: () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          next: () =>
+            Promise.resolve({
+              done: true,
+              value: undefined,
+            }),
+        };
+      },
+    }),
+  };
+}

--- a/packages/runtime/src/host-notify-resume.test.ts
+++ b/packages/runtime/src/host-notify-resume.test.ts
@@ -1,0 +1,261 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { Agent } from "./agent";
+import { agentNamespace } from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, RunRecord } from "./execution/types";
+import type { AgentRun } from "./session/run";
+import { collectAgentRun } from "./subagent-background-test-support";
+import { assistantMessage, eventTypes, userText } from "./test-fixtures";
+
+describe("host notification resume", () => {
+  it("host resumes parent notification run once without direct prompt resume surface", async () => {
+    const host = createInMemoryExecutionHost();
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = new Agent({
+      host,
+      model: ({ history }) => {
+        calls += 1;
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("NOTIFIED")]);
+      },
+      namespace: "notify-owner",
+    });
+    const notification = {
+      idempotencyKey: "background-complete:bg_1",
+      input: userText("background task bg_1 is ready"),
+      notificationId: "notification-1",
+      observerEvents: [
+        {
+          eventCount: 1,
+          status: "completed",
+          subagent: "researcher",
+          task_id: "bg_1",
+          type: "subagent-job-end",
+        },
+      ],
+      ownerNamespace: agentNamespace("notify-owner"),
+      runId: "notification-run-1",
+      sessionKey: "default",
+      status: "pending",
+    } as const;
+    await host.store.notifications.enqueue(notification);
+    await host.store.runs.create(
+      notificationRunRecord({
+        idempotencyKey: notification.idempotencyKey,
+        runId: notification.runId,
+      })
+    );
+    expectResumeSurface(agent);
+
+    const run = await agent.resume(notification.runId);
+    expect(run).not.toBeNull();
+    if (!run) {
+      throw new Error("Expected notification resume to return a run.");
+    }
+
+    const events = await collectAgentRun(run);
+    expect(eventTypes(events)).toEqual([
+      "subagent-job-end",
+      "turn-start",
+      "runtime-input",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(seenHistory).toHaveLength(1);
+    expect(JSON.stringify(seenHistory[0])).toContain("bg_1");
+
+    const duplicateRun = await agent.resume(notification.runId);
+    expect(duplicateRun).toBeNull();
+    expect(calls).toBe(1);
+  });
+
+  it("does not let another agent claim a foreign notification", async () => {
+    const host = createInMemoryExecutionHost();
+    const owner = new Agent({
+      host,
+      model: () => Promise.resolve([assistantMessage("OWNER NOTIFIED")]),
+      namespace: "owner",
+    });
+    const attacker = new Agent({
+      host,
+      model: () => Promise.resolve([assistantMessage("ATTACKER NOTIFIED")]),
+      namespace: "attacker",
+    });
+    const notification = {
+      idempotencyKey: "background-complete:default:bg_foreign",
+      input: userText("background task bg_foreign is ready"),
+      notificationId: "notification-foreign",
+      ownerNamespace: agentNamespace("owner"),
+      runId: "notification-run-foreign",
+      sessionKey: "default",
+      status: "pending",
+    } as const;
+    await host.store.notifications.enqueue(notification);
+    await host.store.runs.create(
+      notificationRunRecord({
+        idempotencyKey: notification.idempotencyKey,
+        ownerNamespace: agentNamespace("owner"),
+        runId: notification.runId,
+      })
+    );
+
+    await expect(attacker.resume(notification.runId)).resolves.toBeNull();
+    await expect(
+      host.store.notifications.getByIdempotencyKey(notification.idempotencyKey)
+    ).resolves.toEqual(expect.objectContaining({ status: "pending" }));
+
+    await expect(owner.resume(notification.runId)).resolves.not.toBeNull();
+  });
+
+  it("keeps notification pending when session resume is not accepted", async () => {
+    const host = createSessionLoadFailingHost();
+    const agent = new Agent({
+      host,
+      model: () => Promise.resolve([assistantMessage("NOTIFIED")]),
+      namespace: "notify-owner",
+    });
+    const notification = {
+      idempotencyKey: "background-complete:bg_retry",
+      input: userText("background task bg_retry is ready"),
+      notificationId: "notification-retry",
+      ownerNamespace: agentNamespace("notify-owner"),
+      runId: "notification-run-retry",
+      sessionKey: "default",
+      status: "pending",
+    } as const;
+    await host.store.notifications.enqueue(notification);
+    await host.store.runs.create(
+      notificationRunRecord({
+        idempotencyKey: notification.idempotencyKey,
+        runId: notification.runId,
+      })
+    );
+
+    await expect(agent.resume(notification.runId)).rejects.toThrow(
+      "session load failed"
+    );
+    await expect(
+      host.store.notifications.getByIdempotencyKey(notification.idempotencyKey)
+    ).resolves.toEqual(expect.objectContaining({ status: "pending" }));
+  });
+
+  it("resumes an acked notification when durable run retry owns the lease", async () => {
+    const host = createInMemoryExecutionHost();
+    let calls = 0;
+    const agent = new Agent({
+      host,
+      model: () => {
+        calls += 1;
+        return Promise.resolve([assistantMessage("RECOVERED")]);
+      },
+      namespace: "notify-owner",
+    });
+    const idempotencyKey = "background-complete:bg_recover";
+    const runId = "notification-run-recover";
+    await host.store.notifications.enqueue({
+      idempotencyKey,
+      input: userText("background task bg_recover is ready"),
+      notificationId: "notification-recover",
+      ownerNamespace: agentNamespace("notify-owner"),
+      runId,
+      sessionKey: "default",
+      status: "acked",
+    });
+    await host.store.runs.create(
+      notificationRunRecord({ idempotencyKey, runId })
+    );
+
+    const run = await agent.resume(runId);
+    expect(run).not.toBeNull();
+    if (!run) {
+      throw new Error("Expected notification resume retry to return a run.");
+    }
+
+    expect(eventTypes(await collectAgentRun(run))).toContain("assistant-text");
+    await expect(
+      host.store.notifications.getByIdempotencyKey(idempotencyKey)
+    ).resolves.toEqual(expect.objectContaining({ status: "acked" }));
+    await expect(host.store.runs.get(runId)).resolves.toEqual(
+      expect.objectContaining({ status: "completed" })
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("does not complete durable notification run when payload is unavailable", async () => {
+    const host = createInMemoryExecutionHost();
+    const agent = new Agent({
+      host,
+      model: () => Promise.resolve([assistantMessage("UNREACHABLE")]),
+      namespace: "notify-owner",
+    });
+    const idempotencyKey = "background-complete:bg_missing";
+    const runId = "notification-run-missing";
+    await host.store.runs.create(
+      notificationRunRecord({ idempotencyKey, runId })
+    );
+
+    await expect(agent.resume(runId)).resolves.toBeNull();
+    await expect(host.store.runs.get(runId)).resolves.toEqual(
+      expect.objectContaining({ status: "leased" })
+    );
+  });
+});
+
+interface ResumableAgent {
+  resume(runId: string): Promise<AgentRun | null>;
+}
+
+function expectResumeSurface(agent: unknown): asserts agent is ResumableAgent {
+  expect(
+    getProperty(agent, "resume"),
+    "agent resume path is not available"
+  ).toBeTypeOf("function");
+}
+
+function getProperty(value: unknown, property: "resume"): unknown {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+
+  return property in value ? value[property] : undefined;
+}
+
+function createSessionLoadFailingHost(): ExecutionHost {
+  const base = createInMemoryExecutionHost();
+  return {
+    ...base,
+    store: {
+      ...base.store,
+      sessions: {
+        commit: base.store.sessions.commit.bind(base.store.sessions),
+        delete: base.store.sessions.delete.bind(base.store.sessions),
+        load: () => Promise.reject(new Error("session load failed")),
+      },
+    },
+  };
+}
+
+function notificationRunRecord({
+  idempotencyKey,
+  ownerNamespace = agentNamespace("notify-owner"),
+  runId,
+}: {
+  readonly idempotencyKey: string;
+  readonly ownerNamespace?: string;
+  readonly runId: string;
+}): RunRecord {
+  return {
+    checkpointVersion: 0,
+    dedupeKey: idempotencyKey,
+    kind: "notification",
+    ownerNamespace,
+    rootRunId: runId,
+    runId,
+    sessionKey: "default",
+    status: "queued",
+  };
+}

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1,9 +1,67 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+  AgentHostCapabilities,
+  CheckpointStore,
+  EventStore,
+  ExecutionHost,
+  ExecutionScheduler,
+  ExecutionStore,
+  ExecutionStoreTransaction,
+  NotificationInbox,
+  NotificationRecord,
+  RunRecord,
+  RunStore,
+} from "./execution";
+import type { AgentHost } from "./index";
+import { Agent } from "./index";
+
+type EmptyHostIsAccepted =
+  Record<string, never> extends AgentHost ? true : false;
+const emptyHostIsAccepted: EmptyHostIsAccepted = true;
 
 describe("runtime public exports", () => {
   it("does not expose internal agent loop runner from package root", async () => {
     const runtime = await import("./index");
 
     expect(runtime).not.toHaveProperty("runAgentLoop");
+  });
+
+  it("keeps package root app-facing and omits run stream helpers", async () => {
+    const runtime = await import("./index");
+    const runStreamExport = ["Agent", "Run", "Stream"].join("");
+
+    expect(runtime).toHaveProperty("Agent", Agent);
+    expect(runtime).not.toHaveProperty("createInMemoryExecutionHost");
+    expect(runtime).not.toHaveProperty("ToolExecutionNeedsRecoveryError");
+    expect(runtime).not.toHaveProperty(runStreamExport);
+    expect(emptyHostIsAccepted).toBe(true);
+  });
+
+  it("types advanced host contracts", () => {
+    expectTypeOf<
+      ExecutionHost["scheduler"]
+    >().toEqualTypeOf<ExecutionScheduler>();
+    expectTypeOf<ExecutionHost["store"]>().toEqualTypeOf<ExecutionStore>();
+    expectTypeOf<
+      ExecutionStore["notifications"]
+    >().toEqualTypeOf<NotificationInbox>();
+    expectTypeOf<
+      ExecutionHost["capabilities"]
+    >().toEqualTypeOf<AgentHostCapabilities>();
+    expectTypeOf<ExecutionStore["runs"]>().toEqualTypeOf<RunStore>();
+    expectTypeOf<
+      ExecutionStore["checkpoints"]
+    >().toEqualTypeOf<CheckpointStore>();
+    expectTypeOf<ExecutionStore["events"]>().toEqualTypeOf<EventStore>();
+    expectTypeOf<
+      Parameters<NotificationInbox["enqueue"]>[0]
+    >().toEqualTypeOf<NotificationRecord>();
+    expectTypeOf<
+      Awaited<ReturnType<RunStore["get"]>>
+    >().toEqualTypeOf<RunRecord | null>();
+    expectTypeOf<ExecutionStoreTransaction["runs"]>().toEqualTypeOf<RunStore>();
+    expectTypeOf<
+      ExecutionStoreTransaction["notifications"]
+    >().toEqualTypeOf<NotificationInbox>();
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,9 +1,9 @@
 export {
   Agent,
   type AgentOptions,
-  type AgentSessionOptions,
   type SessionHandle,
 } from "./agent";
+export type { AgentHost } from "./execution/types";
 export type {
   AgentToolChoice,
   RuntimeCreateLlmOptions,

--- a/packages/runtime/src/llm-tool-execution.ts
+++ b/packages/runtime/src/llm-tool-execution.ts
@@ -8,14 +8,21 @@ type RuntimeLlmMessage = RuntimeLlmOutput[number];
 
 export type RuntimeToolRetryPolicy = "idempotent" | "manual-recovery" | "pure";
 
-export interface RuntimeToolExecutionCheckpoint {
+export interface RuntimeToolExecutionCheckpointMetadata {
   readonly attempt: number;
   readonly idempotencyKey: string;
-  readonly input: unknown;
   readonly policy: RuntimeToolRetryPolicy;
   readonly toolCallId: string;
   readonly toolName: string;
 }
+
+export interface RuntimeToolExecutionCheckpoint
+  extends RuntimeToolExecutionCheckpointMetadata {
+  readonly input: unknown;
+}
+
+export type RuntimePersistedToolExecutionCheckpoint =
+  RuntimeToolExecutionCheckpointMetadata;
 
 export type RuntimeToolExecutionDecision =
   | { readonly status: "needs-recovery" }
@@ -38,7 +45,7 @@ export class ToolExecutionNeedsRecoveryError extends Error {
   readonly toolCallId: string;
   readonly toolName: string;
 
-  constructor(checkpoint: RuntimeToolExecutionCheckpoint) {
+  constructor(checkpoint: RuntimeToolExecutionCheckpointMetadata) {
     super(
       `Tool ${checkpoint.toolName} requires manual recovery for ${checkpoint.idempotencyKey}`
     );
@@ -47,6 +54,18 @@ export class ToolExecutionNeedsRecoveryError extends Error {
     this.toolCallId = checkpoint.toolCallId;
     this.toolName = checkpoint.toolName;
   }
+}
+
+export function persistedToolExecutionCheckpoint(
+  checkpoint: RuntimeToolExecutionCheckpointMetadata
+): RuntimePersistedToolExecutionCheckpoint {
+  return {
+    attempt: checkpoint.attempt,
+    idempotencyKey: checkpoint.idempotencyKey,
+    policy: checkpoint.policy,
+    toolCallId: checkpoint.toolCallId,
+    toolName: checkpoint.toolName,
+  };
 }
 
 export function normalizeToolCallIds(

--- a/packages/runtime/src/llm-tool-execution.ts
+++ b/packages/runtime/src/llm-tool-execution.ts
@@ -1,0 +1,264 @@
+import type { AssistantModelMessage, ToolModelMessage, ToolSet } from "ai";
+import type { RuntimeLlmOutput } from "./llm";
+
+const toolCallIdPrefix = "call_";
+const publicToolCallIdPattern = /^call[-_]/;
+
+type RuntimeLlmMessage = RuntimeLlmOutput[number];
+
+export type RuntimeToolRetryPolicy = "idempotent" | "manual-recovery" | "pure";
+
+export interface RuntimeToolExecutionCheckpoint {
+  readonly attempt: number;
+  readonly idempotencyKey: string;
+  readonly input: unknown;
+  readonly policy: RuntimeToolRetryPolicy;
+  readonly toolCallId: string;
+  readonly toolName: string;
+}
+
+export type RuntimeToolExecutionDecision =
+  | { readonly status: "needs-recovery" }
+  | undefined;
+
+export interface RuntimeToolExecutionContext {
+  readonly afterTool?: (
+    checkpoint: RuntimeToolExecutionCheckpoint & { readonly output: unknown }
+  ) => Promise<void> | void;
+  readonly attempt: number;
+  readonly beforeTool?: (
+    checkpoint: RuntimeToolExecutionCheckpoint
+  ) => Promise<RuntimeToolExecutionDecision> | RuntimeToolExecutionDecision;
+  readonly runId: string;
+}
+
+export class ToolExecutionNeedsRecoveryError extends Error {
+  readonly idempotencyKey: string;
+  readonly status = "needs-recovery";
+  readonly toolCallId: string;
+  readonly toolName: string;
+
+  constructor(checkpoint: RuntimeToolExecutionCheckpoint) {
+    super(
+      `Tool ${checkpoint.toolName} requires manual recovery for ${checkpoint.idempotencyKey}`
+    );
+    this.idempotencyKey = checkpoint.idempotencyKey;
+    this.name = "ToolExecutionNeedsRecoveryError";
+    this.toolCallId = checkpoint.toolCallId;
+    this.toolName = checkpoint.toolName;
+  }
+}
+
+export function normalizeToolCallIds(
+  tools: ToolSet | undefined,
+  toolCallIds: Map<string, string>,
+  toolExecution: RuntimeToolExecutionContext | undefined
+): ToolSet | undefined {
+  if (!tools) {
+    return;
+  }
+
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, candidate]) => [
+      name,
+      wrapToolExecute(name, candidate, toolCallIds, toolExecution),
+    ])
+  ) as ToolSet;
+}
+
+export function rewriteMessageToolCallIds(
+  message: RuntimeLlmMessage,
+  toolCallIds: Map<string, string>
+): RuntimeLlmMessage {
+  if (message.role === "assistant") {
+    return rewriteAssistantToolCallIds(message, toolCallIds);
+  }
+
+  if (message.role === "tool") {
+    return rewriteToolResultCallIds(message, toolCallIds);
+  }
+
+  return message;
+}
+
+function wrapToolExecute(
+  toolName: string,
+  toolDefinition: unknown,
+  toolCallIds: Map<string, string>,
+  toolExecution: RuntimeToolExecutionContext | undefined
+): unknown {
+  if (!isExecutableToolDefinition(toolDefinition)) {
+    return toolDefinition;
+  }
+
+  const { execute } = toolDefinition;
+  if (!toolExecution) {
+    return {
+      ...toolDefinition,
+      execute: (input: unknown, options: ToolExecutionOptionsLike) =>
+        execute(input, {
+          ...options,
+          toolCallId: publicToolCallId(options.toolCallId, toolCallIds),
+        }),
+    };
+  }
+
+  return {
+    ...toolDefinition,
+    execute: async (input: unknown, options: ToolExecutionOptionsLike) => {
+      const toolCallId = publicToolCallId(options.toolCallId, toolCallIds);
+      const checkpoint = toolCheckpoint({
+        input,
+        policy: toolRetryPolicy(toolDefinition),
+        toolCallId,
+        toolExecution,
+        toolName,
+      });
+      const decision = await toolExecution.beforeTool?.(checkpoint);
+      if (decision?.status === "needs-recovery") {
+        throw new ToolExecutionNeedsRecoveryError(checkpoint);
+      }
+
+      const output = await execute(input, {
+        ...options,
+        attempt: checkpoint.attempt,
+        idempotencyKey: checkpoint.idempotencyKey,
+        retryPolicy: checkpoint.policy,
+        ...(options.abortSignal === undefined
+          ? {}
+          : { signal: options.abortSignal }),
+        toolCallId,
+      });
+      await toolExecution.afterTool?.({ ...checkpoint, output });
+      return output;
+    },
+  };
+}
+
+function isExecutableToolDefinition(value: unknown): value is {
+  readonly execute: (
+    input: unknown,
+    options: RuntimeToolExecutionOptionsLike | ToolExecutionOptionsLike
+  ) => unknown;
+} {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "execute" in value &&
+    typeof value.execute === "function"
+  );
+}
+
+interface ToolExecutionOptionsLike {
+  readonly abortSignal?: AbortSignal;
+  readonly toolCallId: string;
+}
+
+interface RuntimeToolExecutionOptionsLike extends ToolExecutionOptionsLike {
+  readonly attempt: number;
+  readonly idempotencyKey: string;
+  readonly retryPolicy: RuntimeToolRetryPolicy;
+  readonly signal?: AbortSignal;
+}
+
+function toolCheckpoint({
+  input,
+  policy,
+  toolCallId,
+  toolExecution,
+  toolName,
+}: {
+  readonly input: unknown;
+  readonly policy: RuntimeToolRetryPolicy;
+  readonly toolCallId: string;
+  readonly toolExecution: RuntimeToolExecutionContext;
+  readonly toolName: string;
+}): RuntimeToolExecutionCheckpoint {
+  return {
+    attempt: toolExecution.attempt,
+    idempotencyKey: `${toolExecution.runId}:${toolCallId}`,
+    input,
+    policy,
+    toolCallId,
+    toolName,
+  };
+}
+
+function toolRetryPolicy(toolDefinition: unknown): RuntimeToolRetryPolicy {
+  if (
+    typeof toolDefinition === "object" &&
+    toolDefinition !== null &&
+    "retryPolicy" in toolDefinition &&
+    isToolRetryPolicy(toolDefinition.retryPolicy)
+  ) {
+    return toolDefinition.retryPolicy;
+  }
+
+  return "manual-recovery";
+}
+
+function isToolRetryPolicy(value: unknown): value is RuntimeToolRetryPolicy {
+  return (
+    value === "idempotent" || value === "manual-recovery" || value === "pure"
+  );
+}
+
+function rewriteAssistantToolCallIds(
+  message: AssistantModelMessage,
+  toolCallIds: Map<string, string>
+): AssistantModelMessage {
+  if (typeof message.content === "string") {
+    return message;
+  }
+
+  return {
+    ...message,
+    content: message.content.map((part) =>
+      "toolCallId" in part
+        ? {
+            ...part,
+            toolCallId: publicToolCallId(part.toolCallId, toolCallIds),
+          }
+        : part
+    ),
+  };
+}
+
+function rewriteToolResultCallIds(
+  message: ToolModelMessage,
+  toolCallIds: Map<string, string>
+): ToolModelMessage {
+  return {
+    ...message,
+    content: message.content.map((part) =>
+      "toolCallId" in part
+        ? {
+            ...part,
+            toolCallId: publicToolCallId(part.toolCallId, toolCallIds),
+          }
+        : part
+    ),
+  };
+}
+
+function publicToolCallId(
+  toolCallId: string,
+  toolCallIds: Map<string, string>
+): string {
+  if (publicToolCallIdPattern.test(toolCallId)) {
+    return toolCallId;
+  }
+
+  const existing = toolCallIds.get(toolCallId);
+  if (existing) {
+    return existing;
+  }
+
+  const generated = createToolCallId();
+  toolCallIds.set(toolCallId, generated);
+  return generated;
+}
+
+function createToolCallId(): string {
+  return `${toolCallIdPrefix}${crypto.randomUUID().replaceAll("-", "")}`;
+}

--- a/packages/runtime/src/llm.test.ts
+++ b/packages/runtime/src/llm.test.ts
@@ -72,6 +72,29 @@ describe("createLlm", () => {
       })
     );
   });
+
+  it("passes a configured named toolChoice to generateText", async () => {
+    const createLlm = await loadCreateLlm();
+    const signal = new AbortController().signal;
+    const history = [{ role: "user" as const, content: "hello" }];
+    const tools = { injected: createNoopTool() } satisfies ToolSet;
+    const toolChoice = { type: "tool", toolName: "injected" } as const;
+    const llm = createLlm({
+      model: fakeModel,
+      toolChoice,
+      tools,
+    });
+
+    await expect(llm({ history, signal })).resolves.toEqual([
+      assistantMessage("DONE"),
+    ]);
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolChoice,
+      })
+    );
+  });
 });
 
 describe("Agent tool wiring", () => {

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -1,25 +1,28 @@
-import type {
-  AssistantModelMessage,
-  LanguageModel,
-  ModelMessage,
-  ToolModelMessage,
-  ToolSet,
-} from "ai";
+import type { LanguageModel, ModelMessage, ToolChoice, ToolSet } from "ai";
 import { generateText } from "ai";
+import type { RuntimeToolExecutionContext } from "./llm-tool-execution";
+import {
+  normalizeToolCallIds,
+  rewriteMessageToolCallIds,
+} from "./llm-tool-execution";
 
-const toolCallIdPrefix = "call_";
-const publicToolCallIdPattern = /^call[-_]/;
+export type {
+  RuntimeToolExecutionCheckpoint,
+  RuntimeToolExecutionContext,
+  RuntimeToolExecutionDecision,
+  RuntimeToolRetryPolicy,
+} from "./llm-tool-execution";
 
-export type AgentToolChoice = "auto" | "required";
+export type AgentToolChoice = ToolChoice<ToolSet>;
 export type RuntimeLlmOutput = Awaited<
   ReturnType<typeof generateText>
 >["responseMessages"];
 export type RuntimeLlmOutputPart = RuntimeLlmOutput[number];
-type RuntimeLlmMessage = RuntimeLlmOutput[number];
 
 export interface RuntimeLlmContext {
   history: readonly ModelMessage[];
   signal: AbortSignal;
+  toolExecution?: RuntimeToolExecutionContext;
 }
 
 export type RuntimeLlm = (
@@ -39,7 +42,7 @@ export function createLlm({
   toolChoice,
   tools,
 }: RuntimeCreateLlmOptions): RuntimeLlm {
-  return async ({ history, signal }) => {
+  return async ({ history, signal, toolExecution }) => {
     const toolCallIds = new Map<string, string>();
     const { responseMessages } = await generateText({
       abortSignal: signal,
@@ -47,139 +50,11 @@ export function createLlm({
       messages: [...history],
       model,
       toolChoice,
-      tools: normalizeToolCallIds(tools, toolCallIds),
+      tools: normalizeToolCallIds(tools, toolCallIds, toolExecution),
     });
 
     return responseMessages.map((message) =>
       rewriteMessageToolCallIds(message, toolCallIds)
     );
   };
-}
-
-function createToolCallId(): string {
-  return `${toolCallIdPrefix}${crypto.randomUUID().replaceAll("-", "")}`;
-}
-
-function normalizeToolCallIds(
-  tools: ToolSet | undefined,
-  toolCallIds: Map<string, string>
-): ToolSet | undefined {
-  if (!tools) {
-    return;
-  }
-
-  return Object.fromEntries(
-    Object.entries(tools).map(([name, candidate]) => [
-      name,
-      wrapToolExecute(candidate, toolCallIds),
-    ])
-  ) as ToolSet;
-}
-
-function wrapToolExecute(
-  toolDefinition: unknown,
-  toolCallIds: Map<string, string>
-): unknown {
-  if (!isExecutableToolDefinition(toolDefinition)) {
-    return toolDefinition;
-  }
-
-  const { execute } = toolDefinition;
-  return {
-    ...toolDefinition,
-    execute: (input: unknown, options: ToolExecutionOptionsLike) =>
-      execute(input, {
-        ...options,
-        toolCallId: publicToolCallId(options.toolCallId, toolCallIds),
-      }),
-  };
-}
-
-function isExecutableToolDefinition(value: unknown): value is {
-  readonly execute: (
-    input: unknown,
-    options: ToolExecutionOptionsLike
-  ) => unknown;
-} {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "execute" in value &&
-    typeof value.execute === "function"
-  );
-}
-
-interface ToolExecutionOptionsLike {
-  readonly toolCallId: string;
-}
-
-function rewriteMessageToolCallIds(
-  message: RuntimeLlmMessage,
-  toolCallIds: Map<string, string>
-): RuntimeLlmMessage {
-  if (message.role === "assistant") {
-    return rewriteAssistantToolCallIds(message, toolCallIds);
-  }
-
-  if (message.role === "tool") {
-    return rewriteToolResultCallIds(message, toolCallIds);
-  }
-
-  return message;
-}
-
-function rewriteAssistantToolCallIds(
-  message: AssistantModelMessage,
-  toolCallIds: Map<string, string>
-): AssistantModelMessage {
-  if (typeof message.content === "string") {
-    return message;
-  }
-
-  return {
-    ...message,
-    content: message.content.map((part) =>
-      "toolCallId" in part
-        ? {
-            ...part,
-            toolCallId: publicToolCallId(part.toolCallId, toolCallIds),
-          }
-        : part
-    ),
-  };
-}
-
-function rewriteToolResultCallIds(
-  message: ToolModelMessage,
-  toolCallIds: Map<string, string>
-): ToolModelMessage {
-  return {
-    ...message,
-    content: message.content.map((part) =>
-      "toolCallId" in part
-        ? {
-            ...part,
-            toolCallId: publicToolCallId(part.toolCallId, toolCallIds),
-          }
-        : part
-    ),
-  };
-}
-
-function publicToolCallId(
-  toolCallId: string,
-  toolCallIds: Map<string, string>
-): string {
-  if (publicToolCallIdPattern.test(toolCallId)) {
-    return toolCallId;
-  }
-
-  const existing = toolCallIds.get(toolCallId);
-  if (existing) {
-    return existing;
-  }
-
-  const generated = createToolCallId();
-  toolCallIds.set(toolCallId, generated);
-  return generated;
 }

--- a/packages/runtime/src/llm.ts
+++ b/packages/runtime/src/llm.ts
@@ -7,7 +7,9 @@ import {
 } from "./llm-tool-execution";
 
 export type {
+  RuntimePersistedToolExecutionCheckpoint,
   RuntimeToolExecutionCheckpoint,
+  RuntimeToolExecutionCheckpointMetadata,
   RuntimeToolExecutionContext,
   RuntimeToolExecutionDecision,
   RuntimeToolRetryPolicy,

--- a/packages/runtime/src/notification-inbox-transaction.test.ts
+++ b/packages/runtime/src/notification-inbox-transaction.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { agentNamespace } from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, RunRecord } from "./execution/types";
+import { enqueueDurableBackgroundNotification } from "./subagent-background-notification-inbox";
+import type { SubagentJob } from "./subagent-types";
+import { userText } from "./test-fixtures";
+
+describe("NotificationInbox transaction behavior", () => {
+  it("does not create a notification run when transaction enqueue loses a duplicate race", async () => {
+    const host = createDuplicateOnEnqueueHost();
+    const job = createBackgroundJob(host);
+    const input = userText("background task bg_1 is ready");
+
+    await expect(
+      enqueueDurableBackgroundNotification({
+        input,
+        jobs: [job],
+        observerEvents: [],
+      })
+    ).resolves.toBe("queued-only");
+
+    expect(host.createdRuns).toEqual([]);
+    expect(host.resumedSessionKeys).toEqual([]);
+  });
+});
+
+function createDuplicateOnEnqueueHost(): ExecutionHost & {
+  readonly createdRuns: readonly RunRecord[];
+  readonly resumedSessionKeys: readonly string[];
+} {
+  const base = createInMemoryExecutionHost();
+  const createdRuns: RunRecord[] = [];
+  const resumedSessionKeys: string[] = [];
+  const duplicateNotifications = {
+    claimByIdempotencyKey: base.store.notifications.claimByIdempotencyKey.bind(
+      base.store.notifications
+    ),
+    enqueue: () =>
+      Promise.resolve({
+        existingNotificationId: "existing-notification",
+        ok: false as const,
+        reason: "duplicate" as const,
+      }),
+    getByIdempotencyKey: () => Promise.resolve(null),
+    releaseByIdempotencyKey:
+      base.store.notifications.releaseByIdempotencyKey.bind(
+        base.store.notifications
+      ),
+  };
+  const runStore = {
+    claim: base.store.runs.claim.bind(base.store.runs),
+    create: (record: RunRecord) => {
+      createdRuns.push(record);
+      return base.store.runs.create(record);
+    },
+    get: base.store.runs.get.bind(base.store.runs),
+    getByDedupeKey: base.store.runs.getByDedupeKey.bind(base.store.runs),
+    listByParentRunId: base.store.runs.listByParentRunId.bind(base.store.runs),
+    update: base.store.runs.update.bind(base.store.runs),
+  };
+  const store = {
+    checkpoints: base.store.checkpoints,
+    events: base.store.events,
+    notifications: duplicateNotifications,
+    runs: runStore,
+    sessions: base.store.sessions,
+    transaction: async <T>(
+      fn: Parameters<ExecutionHost["store"]["transaction"]>[0]
+    ): Promise<T> =>
+      (await fn({
+        checkpoints: base.store.checkpoints,
+        events: base.store.events,
+        notifications: duplicateNotifications,
+        runs: runStore,
+        sessions: base.store.sessions,
+      })) as T,
+  } satisfies ExecutionHost["store"];
+  return {
+    ...base,
+    capabilities: {
+      ...base.capabilities,
+      backgroundSubagents: "durable",
+    },
+    scheduler: {
+      enqueueRun: () => Promise.resolve(),
+      resumeSession: (sessionKey) => {
+        resumedSessionKeys.push(sessionKey);
+        return Promise.resolve();
+      },
+    },
+    store,
+    createdRuns,
+    resumedSessionKeys,
+  };
+}
+
+function createBackgroundJob(executionHost: ExecutionHost): SubagentJob {
+  return {
+    abort: () => undefined,
+    childRunId: "background:bg_1",
+    cleanup: () => Promise.resolve(),
+    executionHost,
+    id: "bg_1",
+    ownerNamespace: agentNamespace("notify-owner"),
+    parentSessionKey: "default",
+    promise: Promise.resolve(),
+    sessionKey: "default:task:bg_1",
+    settled: true,
+    status: "completed",
+    subagent: "researcher",
+  };
+}

--- a/packages/runtime/src/notification-inbox.test.ts
+++ b/packages/runtime/src/notification-inbox.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { agentNamespace } from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, NotificationRecord } from "./execution/types";
+import { enqueueDurableBackgroundNotification } from "./subagent-background-notification-inbox";
+import type { SubagentJob } from "./subagent-types";
+import { userText } from "./test-fixtures";
+
+describe("NotificationInbox", () => {
+  it("dedupes duplicate completion notification by key", async () => {
+    const host = createInMemoryExecutionHost();
+    const record = createNotificationRecord();
+
+    await expect(host.store.notifications.enqueue(record)).resolves.toEqual({
+      ok: true,
+    });
+
+    const firstClaim = await host.store.notifications.claimByIdempotencyKey(
+      record.idempotencyKey
+    );
+    expect(firstClaim).toEqual({
+      ok: true,
+      record: expect.objectContaining({
+        idempotencyKey: record.idempotencyKey,
+        status: "pending",
+      }),
+    });
+    await expect(
+      host.store.notifications.getByIdempotencyKey(record.idempotencyKey)
+    ).resolves.toEqual(expect.objectContaining({ status: "acked" }));
+
+    const duplicateClaim = await host.store.notifications.claimByIdempotencyKey(
+      record.idempotencyKey
+    );
+    expect(duplicateClaim).toEqual({
+      ok: false,
+      reason: "already-claimed",
+      record: expect.objectContaining({ status: "acked" }),
+    });
+  });
+
+  it("does not enqueue in-process background completion notifications", async () => {
+    const host = createResumeTrackingHost();
+    const job = createBackgroundJob(host);
+    const input = userText("background task bg_1 is ready");
+    const observerEvents = [
+      {
+        eventCount: 1,
+        status: "completed",
+        subagent: "researcher",
+        task_id: job.id,
+        type: "subagent-job-end",
+      },
+    ] as const;
+
+    await expect(
+      enqueueDurableBackgroundNotification({
+        input,
+        jobs: [job],
+        observerEvents,
+      })
+    ).resolves.toBe("inline");
+    await expect(
+      host.store.notifications.getByIdempotencyKey(
+        "background-complete:default:bg_1"
+      )
+    ).resolves.toBeNull();
+    await expect(
+      enqueueDurableBackgroundNotification({
+        input,
+        jobs: [job],
+        observerEvents,
+      })
+    ).resolves.toBe("inline");
+    expect(host.resumedSessionKeys).toEqual([]);
+  });
+
+  it("retries durable session resume for an existing pending notification", async () => {
+    const host = createFlakyDurableResumeHost();
+    const job = createBackgroundJob(host);
+    const input = userText("background task bg_1 is ready");
+    const observerEvents = [
+      {
+        eventCount: 1,
+        status: "completed",
+        subagent: "researcher",
+        task_id: job.id,
+        type: "subagent-job-end",
+      },
+    ] as const;
+
+    await expect(
+      enqueueDurableBackgroundNotification({
+        input,
+        jobs: [job],
+        observerEvents,
+      })
+    ).rejects.toThrow("resume failed");
+    await expect(
+      host.store.notifications.getByIdempotencyKey(
+        "background-complete:default:bg_1"
+      )
+    ).resolves.toEqual(expect.objectContaining({ status: "pending" }));
+
+    await expect(
+      enqueueDurableBackgroundNotification({
+        input,
+        jobs: [job],
+        observerEvents,
+      })
+    ).resolves.toBe("queued-only");
+    expect(host.resumedSessionKeys).toEqual(["default", "default"]);
+  });
+});
+
+function createNotificationRecord(): NotificationRecord {
+  return {
+    idempotencyKey: "background-complete:bg_1",
+    input: userText("background task bg_1 is ready"),
+    notificationId: "notification-1",
+    ownerNamespace: agentNamespace("notify-owner"),
+    runId: "notification-run-1",
+    sessionKey: "default",
+    status: "pending",
+  };
+}
+
+function createResumeTrackingHost(): ExecutionHost & {
+  readonly resumedSessionKeys: readonly string[];
+} {
+  const base = createInMemoryExecutionHost();
+  const resumedSessionKeys: string[] = [];
+  return {
+    ...base,
+    scheduler: {
+      enqueueRun: () => Promise.resolve(),
+      resumeSession: (sessionKey) => {
+        resumedSessionKeys.push(sessionKey);
+        return Promise.resolve();
+      },
+    },
+    resumedSessionKeys,
+  };
+}
+
+function createFlakyDurableResumeHost(): ExecutionHost & {
+  readonly resumedSessionKeys: readonly string[];
+} {
+  const base = createInMemoryExecutionHost();
+  const resumedSessionKeys: string[] = [];
+  return {
+    ...base,
+    capabilities: {
+      ...base.capabilities,
+      backgroundSubagents: "durable",
+    },
+    scheduler: {
+      enqueueRun: () => Promise.resolve(),
+      resumeSession: (sessionKey) => {
+        resumedSessionKeys.push(sessionKey);
+        return resumedSessionKeys.length === 1
+          ? Promise.reject(new Error("resume failed"))
+          : Promise.resolve();
+      },
+    },
+    resumedSessionKeys,
+  };
+}
+
+function createBackgroundJob(executionHost: ExecutionHost): SubagentJob {
+  return {
+    abort: () => undefined,
+    childRunId: "background:bg_1",
+    cleanup: () => Promise.resolve(),
+    executionHost,
+    id: "bg_1",
+    ownerNamespace: agentNamespace("notify-owner"),
+    parentSessionKey: "default",
+    promise: Promise.resolve(),
+    sessionKey: "default:task:bg_1",
+    settled: true,
+    status: "completed",
+    subagent: "researcher",
+  };
+}

--- a/packages/runtime/src/session/runtime-input.ts
+++ b/packages/runtime/src/session/runtime-input.ts
@@ -1,4 +1,4 @@
-import type { RuntimeInput } from "./events";
+import type { AgentEvent, RuntimeInput } from "./events";
 import type { AgentInput, UserInput } from "./input";
 import { normalizeAgentInput } from "./input-normalization";
 import type { BufferedAgentRun } from "./run";
@@ -19,7 +19,9 @@ export interface RuntimeInputState {
 }
 
 export interface QueuedInput {
-  readonly input: UserInput;
+  readonly initialEvents: AgentEvent[];
+  readonly input?: UserInput;
+  readonly preUserRuntimeInputs: QueuedRuntimeInput[];
   readonly run: BufferedAgentRun;
   readonly runtimeInput: RuntimeInputState;
 }
@@ -42,7 +44,7 @@ export function addSteeringInput(
       throw runtimeInputClosedError(runtimeInput.closedReason);
     }
 
-    runtimeInput.queue.push({
+    queueRuntimeInput(runtimeInput, {
       input: normalizeAgentInput(input),
       placement:
         runtimeInput.steerPlacement ?? runtimeInput.placement ?? "step-end",
@@ -104,6 +106,13 @@ export function shiftRuntimeInput(
   }
 
   return runtimeInput.queue.splice(index, 1)[0];
+}
+
+export function queueRuntimeInput(
+  runtimeInput: RuntimeInputState,
+  input: QueuedRuntimeInput
+): void {
+  runtimeInput.queue.push(input);
 }
 
 function runtimeInputClosedError(reason: string): Error {

--- a/packages/runtime/src/session/session-delete-failure.test.ts
+++ b/packages/runtime/src/session/session-delete-failure.test.ts
@@ -13,8 +13,8 @@ describe("Agent session delete failure", () => {
   it("keeps the session handle usable when persistence deletion fails", async () => {
     const store = new RejectingDeleteStore();
     const agent = new Agent({
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
-      sessions: { store },
+      host: { sessionStore: store },
+      model: () => Promise.resolve([assistantMessage("DONE")]),
     });
     const session = agent.session("delete-failure");
 

--- a/packages/runtime/src/session/session-delete-failure.test.ts
+++ b/packages/runtime/src/session/session-delete-failure.test.ts
@@ -10,7 +10,7 @@ class RejectingDeleteStore extends SpyStore {
 }
 
 describe("Agent session delete failure", () => {
-  it("keeps the session handle usable when persistence deletion fails", async () => {
+  it("hard-stops the session handle when persistence deletion fails", async () => {
     const store = new RejectingDeleteStore();
     const agent = new Agent({
       host: { sessionStore: store },
@@ -22,8 +22,8 @@ describe("Agent session delete failure", () => {
 
     await expect(session.delete()).rejects.toThrow("delete failed");
 
-    await collect(await session.send("after"));
-    expect(JSON.stringify(store.sessions.get("delete-failure"))).toContain(
+    await expect(session.send("after")).rejects.toThrow("Session killed");
+    expect(JSON.stringify(store.sessions.get("delete-failure"))).not.toContain(
       "after"
     );
   });

--- a/packages/runtime/src/session/session-events.ts
+++ b/packages/runtime/src/session/session-events.ts
@@ -1,0 +1,92 @@
+import type { RuntimeLlmContext } from "../llm";
+import { type AgentPlugin, runEventPlugins } from "../plugins";
+import type { AgentEvent } from "./events";
+import type { BufferedAgentRun } from "./run";
+
+interface SessionEventDispatcherOptions {
+  readonly history: () => RuntimeLlmContext["history"];
+  readonly plugins: readonly AgentPlugin[];
+  readonly signal: () => AbortSignal | undefined;
+}
+
+export class SessionEventDispatcher {
+  readonly #history: () => RuntimeLlmContext["history"];
+  #observerEventBuffer?: AgentEvent[];
+  readonly #plugins: readonly AgentPlugin[];
+  readonly #signal: () => AbortSignal | undefined;
+
+  constructor(options: SessionEventDispatcherOptions) {
+    this.#history = options.history;
+    this.#plugins = options.plugins;
+    this.#signal = options.signal;
+  }
+
+  async captureObserverEvents<T>(
+    run: BufferedAgentRun,
+    callback: () => Promise<T>
+  ): Promise<{
+    readonly events: AgentEvent[];
+    readonly release: () => void;
+    readonly value: T;
+  }> {
+    const previousBuffer = this.#observerEventBuffer;
+    const buffer: AgentEvent[] = [];
+    this.#observerEventBuffer = buffer;
+    try {
+      const value = await callback();
+      return {
+        events: buffer,
+        release: () => {
+          if (this.#observerEventBuffer === buffer) {
+            this.#observerEventBuffer = previousBuffer;
+          }
+        },
+        value,
+      };
+    } catch (error) {
+      for (const event of buffer.splice(0)) {
+        await this.emitRunEvent(run, event);
+      }
+      this.#observerEventBuffer = previousBuffer;
+      throw error;
+    }
+  }
+
+  emitObserverEvent(
+    activeRun: BufferedAgentRun | undefined,
+    event: AgentEvent
+  ): Promise<void> {
+    const observerEventBuffer = this.#observerEventBuffer;
+    if (observerEventBuffer) {
+      observerEventBuffer.push(structuredClone(event));
+      return Promise.resolve();
+    }
+
+    if (!activeRun) {
+      return Promise.resolve();
+    }
+
+    return this.emitRunEvent(activeRun, event);
+  }
+
+  async emitRunBoundaryEvent(
+    run: BufferedAgentRun,
+    event: AgentEvent
+  ): Promise<void> {
+    await this.#runPlugins(event);
+    await run.emitBoundary(event);
+  }
+
+  async emitRunEvent(run: BufferedAgentRun, event: AgentEvent): Promise<void> {
+    await this.#runPlugins(event);
+    run.emit(event);
+  }
+
+  #runPlugins(event: AgentEvent): Promise<void> {
+    return runEventPlugins(this.#plugins, {
+      event,
+      history: this.#history(),
+      signal: this.#signal(),
+    });
+  }
+}

--- a/packages/runtime/src/session/session-execution.ts
+++ b/packages/runtime/src/session/session-execution.ts
@@ -1,0 +1,167 @@
+import type {
+  CheckpointPhase,
+  ExecutionHost,
+  RunRecord,
+  RunStatus,
+} from "../execution/types";
+import type {
+  RuntimeToolExecutionCheckpoint,
+  RuntimeToolExecutionContext,
+} from "../llm";
+import type { SessionState } from "./session-state";
+
+const maxCheckpointWriteAttempts = 5;
+
+export interface SessionExecutionOptions {
+  readonly executionHost?: ExecutionHost;
+}
+
+export interface SessionExecutionRun {
+  complete(status: SessionExecutionTerminalStatus): Promise<void>;
+  readonly runId: string;
+  readonly toolExecution: RuntimeToolExecutionContext;
+}
+
+export type SessionExecutionTerminalStatus = Extract<
+  RunStatus,
+  "cancelled" | "completed" | "error" | "needs-recovery"
+>;
+
+export class SessionExecutionCheckpointError extends Error {
+  constructor(runId: string, expectedVersion: number, currentVersion: number) {
+    super(
+      `Session execution run ${runId} checkpoint conflict: expected ${expectedVersion}, got ${currentVersion}`
+    );
+    this.name = "SessionExecutionCheckpointError";
+  }
+}
+
+export async function startSessionExecutionRun({
+  executionHost,
+  sessionKey,
+  state,
+  turnId,
+}: {
+  readonly executionHost?: ExecutionHost;
+  readonly sessionKey: string;
+  readonly state: SessionState;
+  readonly turnId: string;
+}): Promise<SessionExecutionRun | undefined> {
+  if (!executionHost) {
+    return;
+  }
+
+  const runId = `turn:${sessionKey}:${turnId}`;
+  const run: RunRecord = {
+    checkpointVersion: 0,
+    dedupeKey: runId,
+    kind: "user-turn",
+    rootRunId: runId,
+    runId,
+    sessionKey,
+    status: "running",
+  };
+  await executionHost.store.runs.create(run);
+
+  return {
+    complete: (status) =>
+      completeSessionExecutionRun({ executionHost, runId, status }),
+    runId,
+    toolExecution: {
+      attempt: 1,
+      afterTool: (checkpoint) =>
+        appendToolExecutionCheckpoint({
+          executionHost,
+          phase: "after-tool",
+          runId,
+          state,
+          toolCall: checkpoint,
+        }),
+      beforeTool: async (checkpoint) => {
+        await appendToolExecutionCheckpoint({
+          executionHost,
+          phase: "before-tool",
+          runId,
+          state,
+          toolCall: checkpoint,
+        });
+        return;
+      },
+      runId,
+    },
+  };
+}
+
+async function appendToolExecutionCheckpoint({
+  executionHost,
+  phase,
+  runId,
+  state,
+  toolCall,
+}: {
+  readonly executionHost: ExecutionHost;
+  readonly phase: Extract<CheckpointPhase, "after-tool" | "before-tool">;
+  readonly runId: string;
+  readonly state: SessionState;
+  readonly toolCall: RuntimeToolExecutionCheckpoint & {
+    readonly output?: unknown;
+  };
+}): Promise<void> {
+  let lastConflict:
+    | { readonly current: number; readonly expected: number }
+    | undefined;
+  for (let attempt = 0; attempt < maxCheckpointWriteAttempts; attempt += 1) {
+    const run = await executionHost.store.runs.get(runId);
+    if (!run) {
+      throw new Error(`Session execution run ${runId} is missing.`);
+    }
+
+    const result = await executionHost.store.checkpoints.append(
+      {
+        checkpointId: crypto.randomUUID(),
+        pendingToolCall: toolCall,
+        phase,
+        runId,
+        runtimeState: {
+          toolCallId: toolCall.toolCallId,
+          toolName: toolCall.toolName,
+        },
+        sessionSnapshot: { history: state.modelSnapshot() },
+        version: run.checkpointVersion + 1,
+      },
+      { expectedVersion: run.checkpointVersion }
+    );
+
+    if (result.ok) {
+      return;
+    }
+
+    lastConflict = {
+      current: result.currentVersion,
+      expected: run.checkpointVersion,
+    };
+  }
+
+  throw new SessionExecutionCheckpointError(
+    runId,
+    lastConflict?.expected ?? 0,
+    lastConflict?.current ?? 0
+  );
+}
+
+async function completeSessionExecutionRun({
+  executionHost,
+  runId,
+  status,
+}: {
+  readonly executionHost: ExecutionHost;
+  readonly runId: string;
+  readonly status: SessionExecutionTerminalStatus;
+}): Promise<void> {
+  const run = await executionHost.store.runs.get(runId);
+  if (!run) {
+    return;
+  }
+
+  await executionHost.store.runs.update({ ...run, status });
+}

--- a/packages/runtime/src/session/session-execution.ts
+++ b/packages/runtime/src/session/session-execution.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeToolExecutionCheckpoint,
   RuntimeToolExecutionContext,
 } from "../llm";
+import { persistedToolExecutionCheckpoint } from "../llm-tool-execution";
 import type { SessionState } from "./session-state";
 
 const maxCheckpointWriteAttempts = 5;
@@ -119,7 +120,7 @@ async function appendToolExecutionCheckpoint({
     const result = await executionHost.store.checkpoints.append(
       {
         checkpointId: crypto.randomUUID(),
-        pendingToolCall: toolCall,
+        pendingToolCall: persistedToolExecutionCheckpoint(toolCall),
         phase,
         runId,
         runtimeState: {

--- a/packages/runtime/src/session/session-lifecycle.test.ts
+++ b/packages/runtime/src/session/session-lifecycle.test.ts
@@ -8,15 +8,13 @@ import {
   userText,
 } from "../test-fixtures";
 import { userTextToModelMessage } from "./mapping";
-import { collect, SpyStore } from "./session.test-support";
-
-const timeoutMarker = Symbol("timeout");
+import { collect } from "./session.test-support";
 
 describe("Agent session lifecycle", () => {
   it("idle session.steer starts a new run after turn-end", async () => {
     let calls = 0;
     const agent = new Agent({
-      llm: () => {
+      model: () => {
         calls += 1;
         return Promise.resolve([assistantMessage("DONE")]);
       },
@@ -33,7 +31,7 @@ describe("Agent session lifecycle", () => {
   it("idle session.steer starts a new run after model turn-error", async () => {
     let calls = 0;
     const agent = new Agent({
-      llm: () => {
+      model: () => {
         calls += 1;
         return Promise.reject(new Error("model unavailable"));
       },
@@ -53,7 +51,7 @@ describe("Agent session lifecycle", () => {
     const llmStarted = createDeferred();
     const llmGate = createDeferred();
     const session = new Agent({
-      llm: async () => {
+      model: async () => {
         llmStarted.resolve();
         await llmGate.promise;
         return [assistantMessage("DONE")];
@@ -72,146 +70,9 @@ describe("Agent session lifecycle", () => {
     );
   });
 
-  it("rejects runtime input after kill and settles queued runs", async () => {
-    const llmStarted = createDeferred();
-    const llmGate = createDeferred();
-    const session = new Agent({
-      llm: async () => {
-        llmStarted.resolve();
-        await llmGate.promise;
-        return [assistantMessage("DONE")];
-      },
-    }).session("kill-terminal");
-    const firstRun = await session.send("first");
-    const secondRun = await session.send("second");
-    const firstEvents = collect(firstRun);
-    const secondEvents = collect(secondRun);
-
-    await llmStarted.promise;
-    session.kill();
-    llmGate.resolve();
-
-    expect(eventTypes(await firstEvents)).toContain("turn-error");
-    expect(eventTypes(await secondEvents)).toEqual(["user-text", "turn-error"]);
-    await expect(session.steer("late")).rejects.toThrow("Session killed");
-  });
-
-  it("closes the active run when a killed session has a pending model call", async () => {
-    const llmStarted = createDeferred();
-    const agent = new Agent({
-      llm: () => {
-        llmStarted.resolve();
-        return new Promise<never>(() => undefined);
-      },
-    });
-    const session = agent.session("kill-pending-model");
-    const collecting = collect(await session.send("hello"));
-    await llmStarted.promise;
-
-    session.kill();
-
-    const events = await withShortTimeout(collecting);
-    if (events === timeoutMarker) {
-      throw new Error("session.kill() did not close the active run");
-    }
-    expect(eventTypes(events)).toEqual([
-      "user-text",
-      "turn-start",
-      "step-start",
-      "turn-error",
-    ]);
-  });
-
-  it("closes the active run when a killed session has a pending terminal event plugin", async () => {
-    const terminalPluginStarted = createDeferred();
-    const agent = new Agent({
-      plugins: [
-        {
-          events: {
-            on: ({ event }) => {
-              if (event.type === "turn-end") {
-                terminalPluginStarted.resolve();
-                return new Promise<never>(() => undefined);
-              }
-            },
-          },
-        },
-      ],
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
-    });
-    const session = agent.session("kill-pending-terminal-event");
-    const collecting = collect(await session.send("hello"));
-    await terminalPluginStarted.promise;
-
-    session.kill();
-
-    const events = await withShortTimeout(collecting);
-    if (events === timeoutMarker) {
-      throw new Error("session.kill() did not close the terminal event run");
-    }
-    expect(eventTypes(events)).toEqual([
-      "user-text",
-      "turn-start",
-      "step-start",
-      "assistant-text",
-      "step-end",
-      "turn-error",
-    ]);
-  });
-
-  it("does not persist an active turn after session delete", async () => {
-    const llmStarted = createDeferred();
-    const llmGate = createDeferred();
-    const seenHistory: ModelMessage[][] = [];
-    const agent = new Agent({
-      llm: async ({ history }) => {
-        seenHistory.push([...history]);
-        if (seenHistory.length === 1) {
-          llmStarted.resolve();
-          await llmGate.promise;
-        }
-        return [assistantMessage("DONE")];
-      },
-    });
-    const session = agent.session("delete-active");
-    const deletedRun = collect(await session.send("first"));
-
-    await llmStarted.promise;
-    await session.delete();
-    llmGate.resolve();
-    await deletedRun;
-    await collect(await agent.session("delete-active").send("fresh"));
-
-    expect(seenHistory.at(-1)).toEqual([
-      userTextToModelMessage(userText("fresh")),
-    ]);
-  });
-
-  it("rejects new input while session delete is pending", async () => {
-    const store = new BlockingDeleteStore();
-    const session = new Agent({
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
-      sessions: { store },
-    }).session("delete-pending");
-
-    await collect(await session.send("before"));
-    const deletion = session.delete();
-    await store.deleteStarted.promise;
-    await expect(session.send("during")).rejects.toThrow(
-      "Session delete in progress"
-    );
-    await expect(session.steer("during")).rejects.toThrow(
-      "Session delete in progress"
-    );
-    store.allowDelete.resolve();
-    await deletion;
-
-    await expect(session.send("after")).rejects.toThrow("Session killed");
-  });
-
   it("rejects runtime input after events return", async () => {
     const agent = new Agent({
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
+      model: () => Promise.resolve([assistantMessage("DONE")]),
     });
     const run = await agent.send("initial");
     const iterator = run.events()[Symbol.asyncIterator]();
@@ -232,7 +93,7 @@ describe("Agent session lifecycle", () => {
 
   it("emits turn-error in the run when the LLM fails", async () => {
     const agent = new Agent({
-      llm: () => Promise.reject(new Error("model unavailable")),
+      model: () => Promise.reject(new Error("model unavailable")),
     });
 
     const events = await collect(await agent.send("fail"));
@@ -251,7 +112,7 @@ describe("Agent session lifecycle", () => {
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
     const session = new Agent({
-      llm: async ({ history }) => {
+      model: async ({ history }) => {
         calls += 1;
         seenHistory.push([...history]);
         if (calls === 1) {
@@ -280,25 +141,3 @@ describe("Agent session lifecycle", () => {
     ]);
   });
 });
-
-function withShortTimeout<T>(
-  promise: Promise<T>
-): Promise<T | typeof timeoutMarker> {
-  return Promise.race([
-    promise,
-    new Promise<typeof timeoutMarker>((resolve) => {
-      setTimeout(() => resolve(timeoutMarker), 100);
-    }),
-  ]);
-}
-
-class BlockingDeleteStore extends SpyStore {
-  readonly allowDelete = createDeferred();
-  readonly deleteStarted = createDeferred();
-
-  override async delete(key: string): Promise<void> {
-    this.deleteStarted.resolve();
-    await this.allowDelete.promise;
-    await super.delete(key);
-  }
-}

--- a/packages/runtime/src/session/session-notification.ts
+++ b/packages/runtime/src/session/session-notification.ts
@@ -1,0 +1,84 @@
+import type { AgentEvent } from "./events";
+import type { AgentInput } from "./input";
+import { normalizeAgentInput } from "./input-normalization";
+import { type AgentRun, BufferedAgentRun } from "./run";
+import {
+  createRuntimeInputState,
+  type QueuedInput,
+  type QueuedRuntimeInput,
+  queueRuntimeInput,
+  type RuntimeInputState,
+} from "./runtime-input";
+import { errorMessage } from "./session-errors";
+
+export interface NotifyOptions {
+  readonly deferWhenUnobserved?: boolean;
+  readonly observerEvents?: readonly AgentEvent[];
+}
+
+interface QueueSessionNotificationOptions {
+  readonly activeRun: BufferedAgentRun | undefined;
+  readonly activeRuntimeInput: RuntimeInputState | undefined;
+  readonly drain: () => Promise<void>;
+  readonly inputQueue: QueuedInput[];
+  readonly pendingRuntimeInputs: QueuedRuntimeInput[];
+}
+
+export function queueSessionNotification(
+  input: AgentInput,
+  options: NotifyOptions,
+  state: QueueSessionNotificationOptions
+): AgentRun {
+  const queuedRuntimeInput: QueuedRuntimeInput = {
+    input: normalizeAgentInput(input),
+    placement: "turn-start",
+  };
+  const observerEvents = cloneObserverEvents(options.observerEvents ?? []);
+  const queuedTurn = state.inputQueue[0];
+  if (queuedTurn) {
+    queuedTurn.initialEvents.push(...observerEvents);
+    queuedTurn.preUserRuntimeInputs.push(queuedRuntimeInput);
+    return queuedTurn.run;
+  }
+
+  const activeRun = state.activeRun;
+  const runtimeInput = state.activeRuntimeInput;
+  if (runtimeInput && activeRun && !runtimeInput.closedReason) {
+    queueRuntimeInput(runtimeInput, {
+      input: structuredClone(queuedRuntimeInput.input),
+      placement: "step-end",
+    });
+    return activeRun;
+  }
+
+  if (options.deferWhenUnobserved === true) {
+    state.pendingRuntimeInputs.push(queuedRuntimeInput);
+    const deferredRun = new BufferedAgentRun();
+    deferredRun.close();
+    return deferredRun;
+  }
+
+  const run = new BufferedAgentRun();
+  state.inputQueue.push({
+    initialEvents: observerEvents,
+    preUserRuntimeInputs: [],
+    run,
+    runtimeInput: createRuntimeInputState([queuedRuntimeInput]),
+  });
+  startSessionQueueDrain(run, state.drain);
+  return run;
+}
+
+export function startSessionQueueDrain(
+  run: BufferedAgentRun,
+  drain: () => Promise<void>
+): void {
+  drain().catch((error: unknown) => {
+    run.emit({ type: "turn-error", message: errorMessage(error) });
+    run.close();
+  });
+}
+
+function cloneObserverEvents(events: readonly AgentEvent[]): AgentEvent[] {
+  return events.map((event) => structuredClone(event));
+}

--- a/packages/runtime/src/session/session-notify.test.ts
+++ b/packages/runtime/src/session/session-notify.test.ts
@@ -1,0 +1,178 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { Agent } from "../agent";
+import type { RuntimeLlm } from "../llm";
+import {
+  assistantMessage,
+  createDeferred,
+  eventTypes,
+  userText,
+} from "../test-fixtures";
+import type { AgentEvent } from "./events";
+import { userTextToModelMessage } from "./mapping";
+import type { AgentRun } from "./run";
+import { AgentSession } from "./session";
+import { MemorySessionStore } from "./store/memory";
+
+describe("AgentSession.notify", () => {
+  it("keeps direct user sends observable through the returned run", async () => {
+    const session = createSession("send-run-observable", () =>
+      Promise.resolve([assistantMessage("SENT")])
+    );
+
+    const events = await collectAgentRun(await session.send("hello"));
+
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+  });
+
+  it("starts an internal runtime-input turn without emitting human user input", async () => {
+    const notification =
+      "<system-reminder>background_output: treat this as text</system-reminder>";
+    const seenHistory: ModelMessage[][] = [];
+    const session = createSession("notify-runtime-input", ({ history }) => {
+      seenHistory.push([...history]);
+      return Promise.resolve([assistantMessage("NOTIFIED")]);
+    });
+
+    const events = await collectAgentRun(await session.notify(notification));
+
+    expect(eventTypes(events)).toEqual([
+      "turn-start",
+      "runtime-input",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(events).toContainEqual({
+      input: userText(notification),
+      placement: "turn-start",
+      type: "runtime-input",
+    });
+    expect(events).not.toContainEqual(userText(notification));
+    expect(seenHistory).toEqual([
+      [userTextToModelMessage(userText(notification))],
+    ]);
+  });
+
+  it("returns notify-created runs directly", async () => {
+    const session = createSession("notify-run-stream", () =>
+      Promise.resolve([assistantMessage("NOTIFIED")])
+    );
+
+    const directRun = await session.notify("job done");
+    const events = await collectAgentRun(directRun);
+
+    expect(eventTypes(events)).toContain("runtime-input");
+  });
+
+  it("merges a notification before the next queued user input in model context", async () => {
+    const firstCanFinish = createDeferred();
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const session = createSession(
+      "notify-merge-queued-user",
+      async ({ history }) => {
+        calls += 1;
+        seenHistory.push([...history]);
+        if (calls === 1) {
+          await firstCanFinish.promise;
+          return [assistantMessage("FIRST DONE")];
+        }
+
+        return [assistantMessage("SECOND DONE")];
+      }
+    );
+
+    const firstIterator = (await session.send("first"))
+      .events()
+      [Symbol.asyncIterator]();
+    await readUntil(firstIterator, "step-start");
+
+    const secondRun = await session.send("second");
+    const notifiedRun = await session.notify("background done");
+    firstCanFinish.resolve();
+
+    await drainIterator(firstIterator);
+    const secondEvents = await collectAgentRun(secondRun);
+
+    expect(notifiedRun).toBe(secondRun);
+    expect(eventTypes(secondEvents)).toEqual([
+      "user-text",
+      "turn-start",
+      "runtime-input",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(seenHistory[1]).toEqual([
+      userTextToModelMessage(userText("first")),
+      assistantMessage("FIRST DONE"),
+      userTextToModelMessage(userText("background done")),
+      userTextToModelMessage(userText("second")),
+    ]);
+  });
+
+  it("does not expose notify on public Agent session handles", () => {
+    const session = new Agent({
+      model: () => Promise.resolve([assistantMessage("DONE")]),
+    }).session("public-notify-hidden");
+
+    expect(
+      getProperty(session, "notify"),
+      "public session.notify is not exposed"
+    ).toBeUndefined();
+  });
+});
+
+function createSession(key: string, llm: RuntimeLlm): AgentSession {
+  return new AgentSession(llm, { key, store: new MemorySessionStore() });
+}
+
+function getProperty(value: unknown, property: "notify"): unknown {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+
+  return property in value ? value[property] : undefined;
+}
+
+async function collectAgentRun(run: AgentRun): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of run.events()) {
+    events.push(event);
+  }
+  return events;
+}
+
+async function readUntil(
+  iterator: AsyncIterator<AgentEvent>,
+  type: AgentEvent["type"]
+): Promise<void> {
+  while (true) {
+    const next = await iterator.next();
+    expect(next.done).toBe(false);
+    if (!next.done && next.value.type === type) {
+      return;
+    }
+  }
+}
+
+async function drainIterator(
+  iterator: AsyncIterator<AgentEvent>
+): Promise<void> {
+  while (true) {
+    const next = await iterator.next();
+    if (next.done) {
+      return;
+    }
+  }
+}

--- a/packages/runtime/src/session/session-persistence.test.ts
+++ b/packages/runtime/src/session/session-persistence.test.ts
@@ -41,18 +41,18 @@ describe("Agent session persistence", () => {
     const store = new FileSessionStore(directory);
 
     const first = new Agent({
-      llm: () => Promise.resolve([assistantMessage("stored")]),
-      sessions: { store },
+      host: { sessionStore: store },
+      model: () => Promise.resolve([assistantMessage("stored")]),
     });
     await collect(await first.session("images").send(input));
 
     const seenHistory: ModelMessage[][] = [];
     const second = new Agent({
-      llm: ({ history }) => {
+      host: { sessionStore: store },
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
-      sessions: { store },
     });
 
     await collect(await second.session("images").send("next"));
@@ -87,11 +87,11 @@ describe("Agent session persistence", () => {
     store.conflictOnCommit = 2;
     const seenHistory: ModelMessage[][] = [];
     const session = new Agent({
-      llm: ({ history }) => {
+      host: { sessionStore: store },
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
-      sessions: { store },
     }).session("runtime-conflict");
     const run = await session.send("initial");
     const events: AgentEvent[] = [];
@@ -115,7 +115,7 @@ describe("Agent session persistence", () => {
   it("uses default and explicit default session state interchangeably", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
@@ -135,7 +135,7 @@ describe("Agent session persistence", () => {
     const seenHistory: Record<string, ModelMessage[][]> = { a: [], b: [] };
     let currentKey = "a";
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory[currentKey]?.push([...history]);
         return Promise.resolve([assistantMessage(`DONE ${currentKey}`)]);
       },
@@ -163,7 +163,7 @@ describe("Agent session persistence", () => {
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
     const agent = new Agent({
-      llm: async ({ history }) => {
+      model: async ({ history }) => {
         calls += 1;
         seenHistory.push([...history]);
         if (calls === 1) {
@@ -197,13 +197,13 @@ describe("Agent session persistence", () => {
     const store = new SpyStore();
     store.loadGate = loadGate.promise;
     const agent = new Agent({
-      llm: ({ history }) => {
+      host: { sessionStore: store },
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([
           assistantMessage(`DONE ${seenHistory.length}`),
         ]);
       },
-      sessions: { store },
     });
     const session = agent.session("race");
 
@@ -227,8 +227,8 @@ describe("Agent session persistence", () => {
   it("persists versioned runtime-owned session snapshots through SessionStore", async () => {
     const store = new SpyStore();
     const agent = new Agent({
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
-      sessions: { store },
+      host: { sessionStore: store },
+      model: () => Promise.resolve([assistantMessage("DONE")]),
     });
 
     await collect(await agent.session("spy").send("hello"));
@@ -256,11 +256,11 @@ describe("Agent session persistence", () => {
       version: "1",
     });
     const session = new Agent({
-      llm: ({ history }) => {
+      host: { sessionStore: store },
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
-      sessions: { store },
     }).session("shared");
 
     expect(eventTypes(await collect(await session.send("loses")))).toContain(

--- a/packages/runtime/src/session/session-plugin-events.test.ts
+++ b/packages/runtime/src/session/session-plugin-events.test.ts
@@ -1,0 +1,161 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { Agent } from "../agent";
+import { assistantMessage, eventTypes, userText } from "../test-fixtures";
+import { userTextToModelMessage } from "./mapping";
+import { AgentSession } from "./session";
+import { collect } from "./session.test-support";
+import { MemorySessionStore } from "./store/memory";
+
+describe("Agent session plugin events", () => {
+  it("calls event plugins for queued turn events", async () => {
+    const pluginCalls: string[] = [];
+    const agent = new Agent({
+      plugins: [
+        {
+          events: {
+            on: ({ event, history }) => {
+              pluginCalls.push(`${event.type}:${history.length}`);
+            },
+          },
+        },
+      ],
+      model: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+
+    const events = await collect(await agent.send("hello"));
+
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(pluginCalls).toEqual([
+      "user-text:0",
+      "turn-start:1",
+      "step-start:1",
+      "assistant-text:2",
+      "step-end:2",
+      "turn-end:2",
+    ]);
+  });
+
+  it("lets plugins branch on emitted run events", async () => {
+    const pluginEventTypes: string[] = [];
+    const agent = new Agent({
+      plugins: [
+        {
+          events: {
+            on: async ({ event }) => {
+              if (event.type === "subagent-job-start") {
+                await Promise.resolve();
+              }
+              pluginEventTypes.push(event.type);
+            },
+          },
+        },
+      ],
+      model: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+
+    const events = await collect(await agent.send("hello"));
+
+    expect(pluginEventTypes).toEqual(eventTypes(events));
+  });
+
+  it("routes observer events through event plugins", async () => {
+    const pluginEventTypes: string[] = [];
+    const session = new AgentSession(
+      () => Promise.resolve([assistantMessage("DONE")]),
+      { key: "observer-events", store: new MemorySessionStore() },
+      [
+        {
+          events: {
+            on: ({ event }) => {
+              pluginEventTypes.push(event.type);
+            },
+          },
+        },
+      ]
+    );
+
+    const run = await session.send("hello");
+    const iterator = run.events()[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value).toEqual({
+      type: "user-text",
+      text: "hello",
+    });
+    expect((await iterator.next()).value).toEqual({ type: "turn-start" });
+
+    await session.emitObserverEvent({
+      run_in_background: false,
+      subagent: "researcher",
+      type: "subagent-job-start",
+    });
+
+    const events = [
+      (await iterator.next()).value,
+      (await iterator.next()).value,
+    ];
+    await iterator.return?.();
+
+    expect(eventTypes(events)).toContain("subagent-job-start");
+    expect(pluginEventTypes).toContain("subagent-job-start");
+  });
+
+  it("commits successful output before terminal event plugin failures", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = new Agent({
+      plugins: [
+        {
+          events: {
+            on: ({ event }) => {
+              if (event.type === "turn-end") {
+                throw new Error("turn-end plugin failed");
+              }
+            },
+          },
+        },
+      ],
+      model: ({ history }) => {
+        calls += 1;
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage(`DONE ${calls}`)]);
+      },
+    });
+
+    const firstEvents = await collect(
+      await agent.session("terminal-event").send("first")
+    );
+    const secondEvents = await collect(
+      await agent.session("terminal-event").send("second")
+    );
+
+    expect(eventTypes(firstEvents)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-error",
+    ]);
+    expect(eventTypes(secondEvents)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-error",
+    ]);
+    expect(seenHistory[1]).toEqual([
+      userTextToModelMessage(userText("first")),
+      assistantMessage("DONE 1"),
+      userTextToModelMessage(userText("second")),
+    ]);
+  });
+});

--- a/packages/runtime/src/session/session-public-api.test.ts
+++ b/packages/runtime/src/session/session-public-api.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "../agent";
+
+describe("SessionHandle public API", () => {
+  it("does not expose session runs", () => {
+    const session = new Agent({
+      model: () => Promise.resolve([]),
+    }).session("default");
+
+    expect(getProperty(session, "runs")).toBeUndefined();
+  });
+});
+
+function getProperty(value: unknown, property: "runs"): unknown {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+
+  return property in value ? value[property] : undefined;
+}

--- a/packages/runtime/src/session/session-runtime-continuation.test.ts
+++ b/packages/runtime/src/session/session-runtime-continuation.test.ts
@@ -10,7 +10,7 @@ describe("Agent session runtime input continuation", () => {
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         calls += 1;
         seenHistory.push([...history]);
         return Promise.resolve([
@@ -60,7 +60,7 @@ describe("Agent session runtime input continuation", () => {
   it("normalizes multipart image and file session.steer input like session.send", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },

--- a/packages/runtime/src/session/session-runtime-plugins.test.ts
+++ b/packages/runtime/src/session/session-runtime-plugins.test.ts
@@ -42,7 +42,7 @@ describe("Agent session runtime input plugins", () => {
           },
         },
       ],
-      llm: ({ history }) => {
+      model: ({ history }) => {
         step += 1;
         seenHistory.push([...history]);
         return Promise.resolve([

--- a/packages/runtime/src/session/session-runtime-queue.test.ts
+++ b/packages/runtime/src/session/session-runtime-queue.test.ts
@@ -10,7 +10,7 @@ describe("Agent session runtime input queueing", () => {
   it("active session.steer preserves FIFO order for multiple additions in one window", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
@@ -55,7 +55,7 @@ describe("Agent session runtime input queueing", () => {
   it("active session.steer preserves FIFO order for concurrent additions in one window", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
@@ -111,7 +111,7 @@ describe("Agent session runtime input queueing", () => {
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
     const session = new Agent({
-      llm: async ({ history }) => {
+      model: async ({ history }) => {
         calls += 1;
         seenHistory.push([...history]);
         if (calls === 1) {

--- a/packages/runtime/src/session/session-runtime-windows.test.ts
+++ b/packages/runtime/src/session/session-runtime-windows.test.ts
@@ -23,7 +23,7 @@ describe("Agent session runtime input windows", () => {
           },
         },
       ],
-      llm: ({ history }) => {
+      model: ({ history }) => {
         trace.push(`llm:${calls}`);
         seenHistory.push([...history]);
         calls += 1;
@@ -169,7 +169,7 @@ describe("Agent session runtime input windows", () => {
   it("active session.steer at turn-start and step-start is visible before the first LLM snapshot", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },

--- a/packages/runtime/src/session/session-terminal-state.test.ts
+++ b/packages/runtime/src/session/session-terminal-state.test.ts
@@ -1,0 +1,174 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { Agent } from "../agent";
+import {
+  assistantMessage,
+  createDeferred,
+  eventTypes,
+  userText,
+} from "../test-fixtures";
+import { userTextToModelMessage } from "./mapping";
+import { collect, SpyStore } from "./session.test-support";
+
+const timeoutMarker = Symbol("timeout");
+
+describe("Agent session terminal state", () => {
+  it("rejects runtime input after kill and settles queued runs", async () => {
+    const llmStarted = createDeferred();
+    const llmGate = createDeferred();
+    const session = new Agent({
+      model: async () => {
+        llmStarted.resolve();
+        await llmGate.promise;
+        return [assistantMessage("DONE")];
+      },
+    }).session("kill-terminal");
+    const firstRun = await session.send("first");
+    const secondRun = await session.send("second");
+    const firstEvents = collect(firstRun);
+    const secondEvents = collect(secondRun);
+
+    await llmStarted.promise;
+    session.kill();
+    llmGate.resolve();
+
+    expect(eventTypes(await firstEvents)).toContain("turn-error");
+    expect(eventTypes(await secondEvents)).toEqual(["user-text", "turn-error"]);
+    await expect(session.steer("late")).rejects.toThrow("Session killed");
+  });
+
+  it("closes the active run when a killed session has a pending model call", async () => {
+    const llmStarted = createDeferred();
+    const agent = new Agent({
+      model: () => {
+        llmStarted.resolve();
+        return new Promise<never>(() => undefined);
+      },
+    });
+    const session = agent.session("kill-pending-model");
+    const collecting = collect(await session.send("hello"));
+    await llmStarted.promise;
+
+    session.kill();
+
+    const events = await withShortTimeout(collecting);
+    if (events === timeoutMarker) {
+      throw new Error("session.kill() did not close the active run");
+    }
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "turn-error",
+    ]);
+  });
+
+  it("closes the active run when a killed session has a pending terminal event plugin", async () => {
+    const terminalPluginStarted = createDeferred();
+    const agent = new Agent({
+      plugins: [
+        {
+          events: {
+            on: ({ event }) => {
+              if (event.type === "turn-end") {
+                terminalPluginStarted.resolve();
+                return new Promise<never>(() => undefined);
+              }
+            },
+          },
+        },
+      ],
+      model: () => Promise.resolve([assistantMessage("DONE")]),
+    });
+    const session = agent.session("kill-pending-terminal-event");
+    const collecting = collect(await session.send("hello"));
+    await terminalPluginStarted.promise;
+
+    session.kill();
+
+    const events = await withShortTimeout(collecting);
+    if (events === timeoutMarker) {
+      throw new Error("session.kill() did not close the terminal event run");
+    }
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-error",
+    ]);
+  });
+
+  it("does not persist an active turn after session delete", async () => {
+    const llmStarted = createDeferred();
+    const llmGate = createDeferred();
+    const seenHistory: ModelMessage[][] = [];
+    const agent = new Agent({
+      model: async ({ history }) => {
+        seenHistory.push([...history]);
+        if (seenHistory.length === 1) {
+          llmStarted.resolve();
+          await llmGate.promise;
+        }
+        return [assistantMessage("DONE")];
+      },
+    });
+    const session = agent.session("delete-active");
+    const deletedRun = collect(await session.send("first"));
+
+    await llmStarted.promise;
+    await session.delete();
+    llmGate.resolve();
+    await deletedRun;
+    await collect(await agent.session("delete-active").send("fresh"));
+
+    expect(seenHistory.at(-1)).toEqual([
+      userTextToModelMessage(userText("fresh")),
+    ]);
+  });
+
+  it("rejects new input while session delete is pending", async () => {
+    const store = new BlockingDeleteStore();
+    const session = new Agent({
+      host: { sessionStore: store },
+      model: () => Promise.resolve([assistantMessage("DONE")]),
+    }).session("delete-pending");
+
+    await collect(await session.send("before"));
+    const deletion = session.delete();
+    await store.deleteStarted.promise;
+    await expect(session.send("during")).rejects.toThrow(
+      "Session delete in progress"
+    );
+    await expect(session.steer("during")).rejects.toThrow(
+      "Session delete in progress"
+    );
+    store.allowDelete.resolve();
+    await deletion;
+
+    await expect(session.send("after")).rejects.toThrow("Session killed");
+  });
+});
+
+function withShortTimeout<T>(
+  promise: Promise<T>
+): Promise<T | typeof timeoutMarker> {
+  return Promise.race([
+    promise,
+    new Promise<typeof timeoutMarker>((resolve) => {
+      setTimeout(() => resolve(timeoutMarker), 100);
+    }),
+  ]);
+}
+
+class BlockingDeleteStore extends SpyStore {
+  readonly allowDelete = createDeferred();
+  readonly deleteStarted = createDeferred();
+
+  override async delete(key: string): Promise<void> {
+    this.deleteStarted.resolve();
+    await this.allowDelete.promise;
+    await super.delete(key);
+  }
+}

--- a/packages/runtime/src/session/session-terminal-state.test.ts
+++ b/packages/runtime/src/session/session-terminal-state.test.ts
@@ -128,6 +128,37 @@ describe("Agent session terminal state", () => {
     ]);
   });
 
+  it("closes the active run while session delete is pending", async () => {
+    const llmStarted = createDeferred();
+    const store = new BlockingDeleteStore();
+    const agent = new Agent({
+      host: { sessionStore: store },
+      model: () => {
+        llmStarted.resolve();
+        return new Promise<never>(() => undefined);
+      },
+    });
+    const session = agent.session("delete-pending-active");
+    const collecting = collect(await session.send("hello"));
+
+    await llmStarted.promise;
+    const deletion = session.delete();
+    await store.deleteStarted.promise;
+    const events = await withShortTimeout(collecting);
+    store.allowDelete.resolve();
+    await deletion;
+
+    if (events === timeoutMarker) {
+      throw new Error("session.delete() did not close the active run");
+    }
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "turn-error",
+    ]);
+  });
+
   it("rejects new input while session delete is pending", async () => {
     const store = new BlockingDeleteStore();
     const session = new Agent({
@@ -138,12 +169,8 @@ describe("Agent session terminal state", () => {
     await collect(await session.send("before"));
     const deletion = session.delete();
     await store.deleteStarted.promise;
-    await expect(session.send("during")).rejects.toThrow(
-      "Session delete in progress"
-    );
-    await expect(session.steer("during")).rejects.toThrow(
-      "Session delete in progress"
-    );
+    await expect(session.send("during")).rejects.toThrow("Session killed");
+    await expect(session.steer("during")).rejects.toThrow("Session killed");
     store.allowDelete.resolve();
     await deletion;
 

--- a/packages/runtime/src/session/session-tool-loop.test.ts
+++ b/packages/runtime/src/session/session-tool-loop.test.ts
@@ -15,7 +15,7 @@ describe("Agent session tool loop", () => {
     const seenHistory: ModelMessage[][] = [];
     let calls = 0;
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         calls += 1;
         seenHistory.push([...history]);
 

--- a/packages/runtime/src/session/session-turn-processor.ts
+++ b/packages/runtime/src/session/session-turn-processor.ts
@@ -1,0 +1,225 @@
+import { runAgentLoop } from "../agent-loop";
+import type { RuntimeLlm } from "../llm";
+import { ToolExecutionNeedsRecoveryError } from "../llm-tool-execution";
+import type { AgentEvent } from "./events";
+import type { BufferedAgentRun } from "./run";
+import {
+  closeRuntimeInput,
+  type QueuedInput,
+  type QueuedRuntimeInput,
+  type RuntimeInputState,
+  withRuntimeInputWindow,
+} from "./runtime-input";
+import { errorMessage } from "./session-errors";
+import type { SessionEventDispatcher } from "./session-events";
+import {
+  type SessionExecutionOptions,
+  type SessionExecutionRun,
+  type SessionExecutionTerminalStatus,
+  startSessionExecutionRun,
+} from "./session-execution";
+import { drainRuntimeInput } from "./session-runtime-drain";
+import type { SessionState } from "./session-state";
+import { emitTurnErrorAfterRecovery } from "./session-turn-error";
+
+interface ActiveTurn {
+  readonly abort: AbortController;
+  readonly run: BufferedAgentRun;
+  readonly runtimeInput: RuntimeInputState;
+  readonly turnId: string;
+}
+
+interface ProcessQueuedInputOptions {
+  readonly activate: (turn: ActiveTurn) => void;
+  readonly deactivateRun: () => void;
+  readonly events: SessionEventDispatcher;
+  readonly execution: SessionExecutionOptions;
+  readonly item: QueuedInput;
+  readonly llm: RuntimeLlm;
+  readonly release: () => void;
+  readonly sessionKey: string;
+  readonly state: SessionState;
+}
+
+export async function processQueuedInput({
+  activate,
+  deactivateRun,
+  events,
+  execution,
+  item,
+  llm,
+  release,
+  sessionKey,
+  state,
+}: ProcessQueuedInputOptions): Promise<void> {
+  const activeAbort = new AbortController();
+  const { initialEvents, input, preUserRuntimeInputs, run, runtimeInput } =
+    item;
+  const turnId = crypto.randomUUID();
+  activate({
+    abort: activeAbort,
+    run,
+    runtimeInput,
+    turnId,
+  });
+  const historySnapshot = state.modelSnapshot();
+  let executionRun: SessionExecutionRun | undefined;
+
+  try {
+    executionRun = await startSessionExecutionRun({
+      executionHost: execution.executionHost,
+      sessionKey,
+      state,
+      turnId,
+    });
+    for (const event of initialEvents) {
+      await events.emitRunEvent(run, event);
+    }
+    await appendRuntimeInputsToHistory(state, preUserRuntimeInputs);
+    if (input) {
+      state.appendUserInput(input);
+      await state.commit();
+    }
+    await withRuntimeInputWindow(runtimeInput, "turn-start", async () => {
+      await events.emitRunBoundaryEvent(run, { type: "turn-start" });
+    });
+    await emitPreUserRuntimeInputs(events, run, preUserRuntimeInputs);
+    await drainRuntimeInput({
+      emit: (event) => events.emitRunEvent(run, event),
+      placement: "turn-start",
+      runtimeInput,
+      state,
+    });
+
+    const result = await runAgentLoop({
+      emit: async (event) =>
+        emitTurnEvent({
+          event,
+          events,
+          run,
+          runtimeInput,
+          state,
+        }),
+      history: state.history,
+      llm,
+      captureObserverEvents: (callback) =>
+        events.captureObserverEvents(run, callback),
+      signal: activeAbort.signal,
+      toolExecution: executionRun?.toolExecution,
+    });
+
+    await state.commit();
+    await executionRun?.complete(executionStatusForResult(result));
+    await closeSuccessfulTurn({
+      deactivateRun,
+      events,
+      result,
+      run,
+      runtimeInput,
+    });
+  } catch (error) {
+    const turnError = error instanceof Error ? error : new Error(String(error));
+    await executionRun?.complete(executionStatusForError(turnError));
+    await emitTurnErrorAfterRecovery({
+      error: turnError,
+      historySnapshot,
+      run,
+      runtimeInput,
+      state,
+    });
+  } finally {
+    closeRuntimeInput(runtimeInput);
+    release();
+    run.close(undefined, runtimeInput.closedReason);
+  }
+}
+
+function executionStatusForResult(
+  result: "aborted" | "completed"
+): SessionExecutionTerminalStatus {
+  return result === "aborted" ? "cancelled" : "completed";
+}
+
+function executionStatusForError(error: Error): SessionExecutionTerminalStatus {
+  return error instanceof ToolExecutionNeedsRecoveryError
+    ? "needs-recovery"
+    : "error";
+}
+
+async function appendRuntimeInputsToHistory(
+  state: SessionState,
+  runtimeInputs: readonly QueuedRuntimeInput[]
+): Promise<void> {
+  for (const runtimeInput of runtimeInputs) {
+    state.appendUserInput(runtimeInput.input);
+    await state.commit();
+  }
+}
+
+async function closeSuccessfulTurn({
+  deactivateRun,
+  events,
+  result,
+  run,
+  runtimeInput,
+}: {
+  readonly deactivateRun: () => void;
+  readonly events: SessionEventDispatcher;
+  readonly result: "aborted" | "completed";
+  readonly run: BufferedAgentRun;
+  readonly runtimeInput: RuntimeInputState;
+}): Promise<void> {
+  const terminalEvent = result === "aborted" ? "turn-abort" : "turn-end";
+  closeRuntimeInput(runtimeInput, terminalEvent);
+  deactivateRun();
+  try {
+    await events.emitRunEvent(run, { type: terminalEvent });
+  } catch (terminalError) {
+    run.emit({ type: "turn-error", message: errorMessage(terminalError) });
+    closeRuntimeInput(runtimeInput, "turn-error");
+  }
+}
+
+async function emitPreUserRuntimeInputs(
+  events: SessionEventDispatcher,
+  run: BufferedAgentRun,
+  runtimeInputs: readonly QueuedRuntimeInput[]
+): Promise<void> {
+  for (const runtimeInput of runtimeInputs) {
+    await events.emitRunEvent(run, {
+      input: runtimeInput.input,
+      placement: runtimeInput.placement,
+      type: "runtime-input",
+    });
+  }
+}
+
+async function emitTurnEvent({
+  event,
+  events,
+  run,
+  runtimeInput,
+  state,
+}: {
+  readonly event: AgentEvent;
+  readonly events: SessionEventDispatcher;
+  readonly run: BufferedAgentRun;
+  readonly runtimeInput: RuntimeInputState;
+  readonly state: SessionState;
+}): Promise<{ readonly runtimeInputAdded: boolean } | undefined> {
+  if (event.type !== "step-start" && event.type !== "step-end") {
+    await events.emitRunEvent(run, event);
+    return;
+  }
+
+  await withRuntimeInputWindow(runtimeInput, event.type, async () => {
+    await events.emitRunBoundaryEvent(run, event);
+  });
+  const runtimeInputAdded = await drainRuntimeInput({
+    emit: (runtimeInputEvent) => events.emitRunEvent(run, runtimeInputEvent),
+    placement: event.type,
+    runtimeInput,
+    state,
+  });
+  return event.type === "step-end" ? { runtimeInputAdded } : undefined;
+}

--- a/packages/runtime/src/session/session.test.ts
+++ b/packages/runtime/src/session/session.test.ts
@@ -1,22 +1,15 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { Agent } from "../agent";
-import {
-  assistantMessage,
-  eventTypes,
-  userMessage,
-  userText,
-} from "../test-fixtures";
+import { assistantMessage, userMessage, userText } from "../test-fixtures";
 import { userTextToModelMessage } from "./mapping";
-import { AgentSession } from "./session";
 import { collect } from "./session.test-support";
-import { MemorySessionStore } from "./store/memory";
 
 describe("Agent session API", () => {
   it("agent.send accepts string input and streams one run", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
@@ -34,162 +27,10 @@ describe("Agent session API", () => {
       { type: "turn-end" },
     ]);
   });
-
-  it("calls event plugins for queued turn events", async () => {
-    const pluginCalls: string[] = [];
-    const agent = new Agent({
-      plugins: [
-        {
-          events: {
-            on: ({ event, history }) => {
-              pluginCalls.push(`${event.type}:${history.length}`);
-            },
-          },
-        },
-      ],
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
-    });
-
-    const events = await collect(await agent.send("hello"));
-
-    expect(eventTypes(events)).toEqual([
-      "user-text",
-      "turn-start",
-      "step-start",
-      "assistant-text",
-      "step-end",
-      "turn-end",
-    ]);
-    expect(pluginCalls).toEqual([
-      "user-text:0",
-      "turn-start:1",
-      "step-start:1",
-      "assistant-text:2",
-      "step-end:2",
-      "turn-end:2",
-    ]);
-  });
-
-  it("lets plugins branch on emitted run events", async () => {
-    const pluginEventTypes: string[] = [];
-    const agent = new Agent({
-      plugins: [
-        {
-          events: {
-            on: async ({ event }) => {
-              if (event.type === "subagent-job-start") {
-                await Promise.resolve();
-              }
-              pluginEventTypes.push(event.type);
-            },
-          },
-        },
-      ],
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
-    });
-
-    const events = await collect(await agent.send("hello"));
-
-    expect(pluginEventTypes).toEqual(eventTypes(events));
-  });
-
-  it("routes observer events through event plugins", async () => {
-    const pluginEventTypes: string[] = [];
-    const session = new AgentSession(
-      () => Promise.resolve([assistantMessage("DONE")]),
-      { key: "observer-events", store: new MemorySessionStore() },
-      [
-        {
-          events: {
-            on: ({ event }) => {
-              pluginEventTypes.push(event.type);
-            },
-          },
-        },
-      ]
-    );
-
-    const run = await session.send("hello");
-    const iterator = run.events()[Symbol.asyncIterator]();
-
-    expect((await iterator.next()).value).toEqual({
-      type: "user-text",
-      text: "hello",
-    });
-    expect((await iterator.next()).value).toEqual({ type: "turn-start" });
-
-    await session.emitObserverEvent({
-      run_in_background: false,
-      subagent: "researcher",
-      type: "subagent-job-start",
-    });
-
-    const events = [
-      (await iterator.next()).value,
-      (await iterator.next()).value,
-    ];
-    await iterator.return?.();
-
-    expect(eventTypes(events)).toContain("subagent-job-start");
-    expect(pluginEventTypes).toContain("subagent-job-start");
-  });
-
-  it("commits successful output before terminal event plugin failures", async () => {
-    const seenHistory: ModelMessage[][] = [];
-    let calls = 0;
-    const agent = new Agent({
-      plugins: [
-        {
-          events: {
-            on: ({ event }) => {
-              if (event.type === "turn-end") {
-                throw new Error("turn-end plugin failed");
-              }
-            },
-          },
-        },
-      ],
-      llm: ({ history }) => {
-        calls += 1;
-        seenHistory.push([...history]);
-        return Promise.resolve([assistantMessage(`DONE ${calls}`)]);
-      },
-    });
-
-    const firstEvents = await collect(
-      await agent.session("terminal-event").send("first")
-    );
-    const secondEvents = await collect(
-      await agent.session("terminal-event").send("second")
-    );
-
-    expect(eventTypes(firstEvents)).toEqual([
-      "user-text",
-      "turn-start",
-      "step-start",
-      "assistant-text",
-      "step-end",
-      "turn-error",
-    ]);
-    expect(eventTypes(secondEvents)).toEqual([
-      "user-text",
-      "turn-start",
-      "step-start",
-      "assistant-text",
-      "step-end",
-      "turn-error",
-    ]);
-    expect(seenHistory[1]).toEqual([
-      userTextToModelMessage(userText("first")),
-      assistantMessage("DONE 1"),
-      userTextToModelMessage(userText("second")),
-    ]);
-  });
-
   it("agent.send accepts multipart string input without lossy joining", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
@@ -211,7 +52,7 @@ describe("Agent session API", () => {
   it("agent.send accepts JSON-serializable user content parts", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([assistantMessage("DONE")]);
       },
@@ -254,7 +95,7 @@ describe("Agent session API", () => {
 
   it("rejects malformed multipart input before queueing", async () => {
     const agent = new Agent({
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
+      model: () => Promise.resolve([assistantMessage("DONE")]),
     });
 
     await expect(
@@ -267,7 +108,7 @@ describe("Agent session API", () => {
   it("rejects sparse text arrays before queueing", async () => {
     const sparseInput = new Array<string>(1);
     const agent = new Agent({
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
+      model: () => Promise.resolve([assistantMessage("DONE")]),
     });
 
     await expect(agent.send(sparseInput)).rejects.toThrow(
@@ -277,7 +118,7 @@ describe("Agent session API", () => {
 
   it("rejects malformed explicit user-message input before queueing", async () => {
     const agent = new Agent({
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
+      model: () => Promise.resolve([assistantMessage("DONE")]),
     });
 
     await expect(
@@ -292,7 +133,7 @@ describe("Agent session API", () => {
 
   it("rejects explicit user-message content that is not an array", async () => {
     const agent = new Agent({
-      llm: () => Promise.resolve([assistantMessage("DONE")]),
+      model: () => Promise.resolve([assistantMessage("DONE")]),
     });
 
     await expect(
@@ -308,7 +149,7 @@ describe("Agent session API", () => {
   it("session.send accepts user-message events", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([]);
       },
@@ -339,7 +180,7 @@ describe("Agent session API", () => {
   it("session.send accepts user-text events", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
-      llm: ({ history }) => {
+      model: ({ history }) => {
         seenHistory.push([...history]);
         return Promise.resolve([]);
       },

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -1,43 +1,46 @@
-import { runAgentLoop } from "../agent-loop";
 import type { RuntimeLlm } from "../llm";
-import { type AgentPlugin, runEventPlugins } from "../plugins";
+import type { AgentPlugin } from "../plugins";
 import type { AgentEvent } from "./events";
 import type { AgentInput, UserInput } from "./input";
 import { normalizeAgentInput } from "./input-normalization";
 import { type AgentRun, BufferedAgentRun } from "./run";
 import {
   addSteeringInput,
-  closeRuntimeInput,
   createRuntimeInputState,
   type QueuedInput,
   type QueuedRuntimeInput,
+  queueRuntimeInput,
   type RuntimeInputPlacement,
   type RuntimeInputState,
-  withRuntimeInputWindow,
 } from "./runtime-input";
-import {
-  errorMessage,
-  sessionKilledError,
-  sessionTerminalError,
-} from "./session-errors";
+import { sessionKilledError, sessionTerminalError } from "./session-errors";
+import { SessionEventDispatcher } from "./session-events";
+import type { SessionExecutionOptions } from "./session-execution";
 import { closeKilledRuntimeInputs } from "./session-kill";
-import { drainRuntimeInput } from "./session-runtime-drain";
+import {
+  type NotifyOptions,
+  queueSessionNotification,
+  startSessionQueueDrain,
+} from "./session-notification";
 import { type SessionPersistenceOptions, SessionState } from "./session-state";
-import { emitTurnErrorAfterRecovery } from "./session-turn-error";
+import { processQueuedInput } from "./session-turn-processor";
 
 export type { AgentInput, SessionInput, UserInput } from "./input";
 export type { AgentRun } from "./run";
+export type { NotifyOptions } from "./session-notification";
 
 export class AgentSession {
+  readonly #events: SessionEventDispatcher;
+  readonly #execution: SessionExecutionOptions;
   readonly #inputQueue: QueuedInput[] = [];
   readonly #llm: RuntimeLlm;
   readonly #pendingRuntimeInputs: QueuedRuntimeInput[] = [];
-  readonly #plugins: readonly AgentPlugin[];
+  readonly #sessionKey: string;
   readonly #state: SessionState;
   #activeAbort?: AbortController;
-  #observerEventBuffer?: AgentEvent[];
   #activeRun?: BufferedAgentRun;
   #activeRuntimeInput?: RuntimeInputState;
+  #activeTurnId?: string;
   #deletePromise?: Promise<void>;
   #killed = false;
   #running = false;
@@ -46,11 +49,18 @@ export class AgentSession {
   constructor(
     llm: RuntimeLlm,
     persistence: SessionPersistenceOptions,
-    plugins: readonly AgentPlugin[] = []
+    plugins: readonly AgentPlugin[] = [],
+    execution: SessionExecutionOptions = {}
   ) {
     this.#llm = llm;
-    this.#plugins = plugins;
+    this.#execution = execution;
+    this.#sessionKey = persistence.key;
     this.#state = new SessionState(persistence);
+    this.#events = new SessionEventDispatcher({
+      history: () => this.#state.modelSnapshot(),
+      plugins,
+      signal: () => this.#activeAbort?.signal,
+    });
   }
 
   async send(input: AgentInput): Promise<AgentRun> {
@@ -69,17 +79,39 @@ export class AgentSession {
     );
     const acceptedInput = normalizeAgentInput(input);
     const run = new BufferedAgentRun();
-    await this.#emitRunEvent(run, acceptedInput);
+    await this.#events.emitRunEvent(run, acceptedInput);
     this.#inputQueue.push({
+      initialEvents: [],
       input: structuredClone(acceptedInput),
+      preUserRuntimeInputs: [],
       run,
       runtimeInput,
     });
-    this.#drainInputQueue().catch((error: unknown) => {
-      run.emit({ type: "turn-error", message: errorMessage(error) });
-      run.close();
-    });
+    startSessionQueueDrain(run, () => this.#drainInputQueue());
     return run;
+  }
+
+  async notify(
+    input: AgentInput,
+    options: NotifyOptions = {}
+  ): Promise<AgentRun> {
+    if (this.#killed || this.#deletePromise) {
+      throw sessionTerminalError(this.#killed);
+    }
+
+    await this.#state.ensureLoaded();
+
+    if (this.#killed || this.#deletePromise) {
+      throw sessionTerminalError(this.#killed);
+    }
+
+    return queueSessionNotification(input, options, {
+      activeRun: this.#activeRun,
+      activeRuntimeInput: this.#activeRuntimeInput,
+      drain: () => this.#drainInputQueue(),
+      inputQueue: this.#inputQueue,
+      pendingRuntimeInputs: this.#pendingRuntimeInputs,
+    });
   }
 
   async steer(input: AgentInput): Promise<AgentRun> {
@@ -99,6 +131,10 @@ export class AgentSession {
 
   interrupt(): void {
     this.#activeAbort?.abort();
+  }
+
+  currentTurnId(): string | undefined {
+    return this.#activeTurnId;
   }
 
   delete(): Promise<void> {
@@ -127,7 +163,7 @@ export class AgentSession {
         return;
       }
 
-      runtimeInput.queue.push({ input, placement });
+      queueRuntimeInput(runtimeInput, { input, placement });
       return;
     }
 
@@ -135,24 +171,13 @@ export class AgentSession {
   }
 
   emitObserverEvent(event: AgentEvent): Promise<void> {
-    const observerEventBuffer = this.#observerEventBuffer;
-    if (observerEventBuffer) {
-      observerEventBuffer.push(structuredClone(event));
-      return Promise.resolve();
-    }
-
-    const run = this.#activeRun;
-    if (!run) {
-      return Promise.resolve();
-    }
-
-    return this.#emitRunEvent(run, event);
+    return this.#events.emitObserverEvent(this.#activeRun, event);
   }
 
   #enqueuePendingRuntimeInput(input: QueuedRuntimeInput): void {
     const queuedTurn = this.#inputQueue[0];
     if (input.placement === "turn-start" && queuedTurn) {
-      queuedTurn.runtimeInput.queue.push(input);
+      queueRuntimeInput(queuedTurn.runtimeInput, input);
       return;
     }
 
@@ -186,147 +211,36 @@ export class AgentSession {
       while (!this.#killed && this.#inputQueue.length > 0) {
         const item = this.#inputQueue.shift();
         if (item) {
-          await this.#processQueuedInput(item);
+          await processQueuedInput({
+            activate: ({ abort, run, runtimeInput, turnId }) => {
+              this.#activeAbort = abort;
+              this.#activeRun = run;
+              this.#activeRuntimeInput = runtimeInput;
+              this.#activeTurnId = turnId;
+              this.#runToCloseOnKill = run;
+            },
+            deactivateRun: () => {
+              this.#activeRun = undefined;
+              this.#activeRuntimeInput = undefined;
+            },
+            events: this.#events,
+            execution: this.#execution,
+            item,
+            llm: this.#llm,
+            release: () => {
+              this.#activeAbort = undefined;
+              this.#activeRun = undefined;
+              this.#activeRuntimeInput = undefined;
+              this.#activeTurnId = undefined;
+              this.#runToCloseOnKill = undefined;
+            },
+            sessionKey: this.#sessionKey,
+            state: this.#state,
+          });
         }
       }
     } finally {
       this.#running = false;
-    }
-  }
-
-  async #processQueuedInput({
-    input,
-    run,
-    runtimeInput,
-  }: QueuedInput): Promise<void> {
-    const activeAbort = new AbortController();
-    this.#activeAbort = activeAbort;
-    this.#activeRun = run;
-    this.#activeRuntimeInput = runtimeInput;
-    this.#runToCloseOnKill = run;
-    const historySnapshot = this.#state.modelSnapshot();
-
-    try {
-      this.#state.appendUserInput(input);
-      await this.#state.commit();
-      await withRuntimeInputWindow(runtimeInput, "turn-start", async () => {
-        await this.#emitRunBoundaryEvent(run, { type: "turn-start" });
-      });
-      await drainRuntimeInput({
-        emit: (event) => this.#emitRunEvent(run, event),
-        placement: "turn-start",
-        runtimeInput,
-        state: this.#state,
-      });
-
-      const result = await runAgentLoop({
-        emit: async (event) => {
-          if (event.type === "step-start" || event.type === "step-end") {
-            await withRuntimeInputWindow(runtimeInput, event.type, async () => {
-              await this.#emitRunBoundaryEvent(run, event);
-            });
-            const runtimeInputAdded = await drainRuntimeInput({
-              emit: (runtimeInputEvent) =>
-                this.#emitRunEvent(run, runtimeInputEvent),
-              placement: event.type,
-              runtimeInput,
-              state: this.#state,
-            });
-
-            return event.type === "step-end"
-              ? { runtimeInputAdded }
-              : undefined;
-          }
-
-          await this.#emitRunEvent(run, event);
-        },
-        history: this.#state.history,
-        llm: this.#llm,
-        captureObserverEvents: (callback) =>
-          this.#captureObserverEvents(run, callback),
-        signal: activeAbort.signal,
-      });
-
-      await this.#state.commit();
-      const terminalEvent = result === "aborted" ? "turn-abort" : "turn-end";
-      closeRuntimeInput(runtimeInput, terminalEvent);
-      this.#activeRuntimeInput = undefined;
-      this.#activeRun = undefined;
-      try {
-        await this.#emitRunEvent(run, { type: terminalEvent });
-      } catch (terminalError) {
-        run.emit({ type: "turn-error", message: errorMessage(terminalError) });
-        closeRuntimeInput(runtimeInput, "turn-error");
-      }
-    } catch (error) {
-      const turnError =
-        error instanceof Error ? error : new Error(String(error));
-      await emitTurnErrorAfterRecovery({
-        error: turnError,
-        historySnapshot,
-        run,
-        runtimeInput,
-        state: this.#state,
-      });
-    } finally {
-      closeRuntimeInput(runtimeInput);
-      this.#activeAbort = undefined;
-      this.#activeRun = undefined;
-      this.#activeRuntimeInput = undefined;
-      this.#runToCloseOnKill = undefined;
-      run.close(undefined, runtimeInput.closedReason);
-    }
-  }
-
-  async #emitRunBoundaryEvent(
-    run: BufferedAgentRun,
-    event: AgentEvent
-  ): Promise<void> {
-    await runEventPlugins(this.#plugins, {
-      event,
-      history: this.#state.modelSnapshot(),
-      signal: this.#activeAbort?.signal,
-    });
-    await run.emitBoundary(event);
-  }
-
-  async #emitRunEvent(run: BufferedAgentRun, event: AgentEvent): Promise<void> {
-    await runEventPlugins(this.#plugins, {
-      event,
-      history: this.#state.modelSnapshot(),
-      signal: this.#activeAbort?.signal,
-    });
-    run.emit(event);
-  }
-
-  async #captureObserverEvents<T>(
-    run: BufferedAgentRun,
-    callback: () => Promise<T>
-  ): Promise<{
-    readonly events: AgentEvent[];
-    readonly release: () => void;
-    readonly value: T;
-  }> {
-    const previousBuffer = this.#observerEventBuffer;
-    const buffer: AgentEvent[] = [];
-    this.#observerEventBuffer = buffer;
-    try {
-      const value = await callback();
-      return {
-        events: buffer,
-        release: () => {
-          if (this.#observerEventBuffer === buffer) {
-            this.#observerEventBuffer = previousBuffer;
-          }
-        },
-        value,
-      };
-    } catch (error) {
-      for (const event of buffer.splice(0)) {
-        await this.#emitRunEvent(run, event);
-      }
-      this.#observerEventBuffer = previousBuffer;
-      throw error;
     }
   }
 }

--- a/packages/runtime/src/session/session.ts
+++ b/packages/runtime/src/session/session.ts
@@ -138,13 +138,13 @@ export class AgentSession {
   }
 
   delete(): Promise<void> {
-    this.#deletePromise ??= this.#state.delete().then(
-      () => this.kill(),
-      (error: unknown) => {
+    if (!this.#deletePromise) {
+      this.kill();
+      this.#deletePromise = this.#state.delete().catch((error: unknown) => {
         this.#deletePromise = undefined;
         throw error;
-      }
-    );
+      });
+    }
     return this.#deletePromise;
   }
 

--- a/packages/runtime/src/session/store/session-store-contract.test.ts
+++ b/packages/runtime/src/session/store/session-store-contract.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import type { SessionStore } from "./types";
+
+type AssertFalse<T extends false> = T;
+type RejectsExecutionCapabilities = AssertFalse<
+  "capabilities" extends keyof SessionStore ? true : false
+>;
+
+const rejectsExecutionCapabilities: RejectsExecutionCapabilities = false;
+
+describe("SessionStore contract", () => {
+  it("session store exposes no execution capabilities", () => {
+    expect(rejectsExecutionCapabilities).toBe(false);
+  });
+});

--- a/packages/runtime/src/subagent-background-cancel-tool.test.ts
+++ b/packages/runtime/src/subagent-background-cancel-tool.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost } from "./execution/types";
+import {
+  drainRun,
+  executableTool,
+  fakeModel,
+  getGenerateTextMock,
+  lastGenerateTextTools,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import { resumeBackgroundTask } from "./subagent-background-test-support";
+import { assistantMessage, createDeferred, userText } from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("subagent background cancel tool", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("background_cancel aborts active job", async () => {
+    const Agent = await loadAgent();
+    const childGate = new Promise<void>(() => undefined);
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => {
+        await childGate;
+        return [assistantMessage("CHILD DONE")];
+      },
+      name: "researcher",
+    });
+    const agent = new Agent({ model: fakeModel, subagents: [researcher] });
+
+    await drainRun(await agent.send(userText("delegate")));
+
+    const tools = lastGenerateTextTools();
+    const launch = (await executableTool(
+      tools,
+      "delegate_to_researcher"
+    ).execute?.(
+      { prompt: "research this", run_in_background: true },
+      toolExecutionOptions()
+    )) as { task_id: string };
+
+    expect(
+      await executableTool(tools, "background_cancel").execute?.(
+        { task_id: launch.task_id },
+        toolExecutionOptions()
+      )
+    ).toEqual({
+      status: "cancelled",
+      task_id: launch.task_id,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(
+      await executableTool(tools, "background_output").execute?.(
+        { block: true, task_id: launch.task_id, timeout: 50 },
+        toolExecutionOptions()
+      )
+    ).toEqual(
+      expect.objectContaining({
+        result: undefined,
+        status: "cancelled",
+        task_id: launch.task_id,
+      })
+    );
+  });
+
+  it("background_cancel cancels durable child runs when the local job map is empty", async () => {
+    const Agent = await loadAgent();
+    const host = {
+      ...createInMemoryExecutionHost(),
+      capabilities: { backgroundSubagents: "durable" },
+    } satisfies ExecutionHost;
+    const taskId = "bg_durable_cancel";
+    await host.store.runs.create({
+      checkpointVersion: 0,
+      kind: "background-subagent",
+      parentRunId: "parent",
+      publicTaskId: taskId,
+      rootRunId: "parent",
+      runId: `background:${taskId}`,
+      sessionKey:
+        "parent:agent:cancel-parent:session:default:generation:0:default:subagent:researcher",
+      status: "running",
+    });
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: () => Promise.resolve([assistantMessage("CHILD DONE")]),
+      name: "researcher",
+    });
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      namespace: "cancel-parent",
+      subagents: [researcher],
+    });
+
+    await drainRun(await agent.send(userText("delegate")));
+
+    expect(
+      await executableTool(
+        lastGenerateTextTools(),
+        "background_cancel"
+      ).execute?.({ task_id: taskId }, toolExecutionOptions())
+    ).toEqual({
+      status: "cancelled",
+      task_id: taskId,
+    });
+    await expect(
+      host.store.runs.get(`background:${taskId}`)
+    ).resolves.toMatchObject({
+      status: "cancelled",
+    });
+  });
+
+  it("background_cancel returns the durable terminal state for a stale local job", async () => {
+    const Agent = await loadAgent();
+    const host = {
+      ...createInMemoryExecutionHost(),
+      capabilities: { backgroundSubagents: "durable" as const },
+    } satisfies ExecutionHost;
+    const childGate = createDeferred();
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => {
+        await childGate.promise;
+        return [assistantMessage("STALE CHILD")];
+      },
+      name: "researcher",
+    });
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      namespace: "cancel-stale-parent",
+      subagents: [researcher],
+    });
+
+    await drainRun(await agent.send(userText("delegate")));
+    const tools = lastGenerateTextTools();
+    const launch = (await executableTool(
+      tools,
+      "delegate_to_researcher"
+    ).execute?.(
+      { prompt: "research this", run_in_background: true },
+      toolExecutionOptions()
+    )) as { task_id: string };
+    const record = await host.store.runs.get(`background:${launch.task_id}`);
+    if (!record) {
+      throw new Error("Expected background run record.");
+    }
+    await host.store.runs.update({
+      ...record,
+      output: {
+        eventCount: 1,
+        result: "completed",
+        run_in_background: false,
+        subagent: "researcher",
+        text: "ALREADY DONE",
+      },
+      status: "completed",
+    });
+
+    await expect(
+      executableTool(tools, "background_cancel").execute?.(
+        { task_id: launch.task_id },
+        toolExecutionOptions()
+      )
+    ).resolves.toEqual({
+      status: "completed",
+      task_id: launch.task_id,
+    });
+    await expect(
+      host.store.runs.get(`background:${launch.task_id}`)
+    ).resolves.toMatchObject({
+      status: "completed",
+    });
+  });
+
+  it("durable background tools reject task ids owned by another parent namespace", async () => {
+    const Agent = await loadAgent();
+    const host = {
+      ...createInMemoryExecutionHost(),
+      capabilities: { backgroundSubagents: "durable" as const },
+    } satisfies ExecutionHost;
+    const childGate = createDeferred();
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => {
+        await childGate.promise;
+        return [assistantMessage("CHILD DONE")];
+      },
+      name: "researcher",
+      namespace: "owner-researcher",
+    });
+    const owner = new Agent({
+      host,
+      model: fakeModel,
+      namespace: "owner-parent",
+      subagents: [researcher],
+    });
+    const stranger = new Agent({
+      host,
+      model: fakeModel,
+      namespace: "stranger-parent",
+      subagents: [researcher],
+    });
+
+    await drainRun(await owner.session("parent").send(userText("delegate")));
+    const ownerTools = lastGenerateTextTools();
+    const launch = (await executableTool(
+      ownerTools,
+      "delegate_to_researcher"
+    ).execute?.(
+      { prompt: "research this", run_in_background: true },
+      toolExecutionOptions()
+    )) as { task_id: string };
+
+    await drainRun(await stranger.session("parent").send(userText("delegate")));
+    const strangerTools = lastGenerateTextTools();
+
+    await expect(
+      executableTool(strangerTools, "background_output").execute?.(
+        { task_id: launch.task_id },
+        toolExecutionOptions()
+      )
+    ).rejects.toThrow(`Unknown background subagent task ${launch.task_id}.`);
+    await expect(
+      executableTool(strangerTools, "background_cancel").execute?.(
+        { task_id: launch.task_id },
+        toolExecutionOptions()
+      )
+    ).rejects.toThrow(`Unknown background subagent task ${launch.task_id}.`);
+    await expect(
+      host.store.runs.get(`background:${launch.task_id}`)
+    ).resolves.toEqual(expect.objectContaining({ status: "queued" }));
+
+    childGate.resolve();
+    await drainRun(await resumeBackgroundTask(owner, launch.task_id));
+    await expect(
+      executableTool(ownerTools, "background_output").execute?.(
+        { block: true, task_id: launch.task_id },
+        toolExecutionOptions()
+      )
+    ).resolves.toEqual(expect.objectContaining({ status: "completed" }));
+  });
+});

--- a/packages/runtime/src/subagent-background-capability.test.ts
+++ b/packages/runtime/src/subagent-background-capability.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  drainRun,
+  executableTool,
+  fakeModel,
+  getGenerateTextMock,
+  lastGenerateTextTools,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import { MemorySessionStore } from "./session/store/memory";
+import type {
+  CommitResult,
+  ExpectedSessionVersion,
+  SessionStore,
+  SessionStoreCommit,
+  StoredSession,
+} from "./session/store/types";
+import { assistantMessage, userText } from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+class SessionOnlyStore implements SessionStore {
+  readonly #store = new MemorySessionStore();
+
+  commit(
+    key: string,
+    next: SessionStoreCommit,
+    options: { readonly expectedVersion: ExpectedSessionVersion }
+  ): Promise<CommitResult> {
+    return this.#store.commit(key, next, options);
+  }
+
+  delete(key: string): Promise<void> {
+    return this.#store.delete(key);
+  }
+
+  load(key: string): Promise<StoredSession | null> {
+    return this.#store.load(key);
+  }
+}
+
+describe("subagent background capability", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hides background tools when the host has no background capability", async () => {
+    const Agent = await loadAgent();
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => [assistantMessage("CHILD DONE")],
+      name: "researcher",
+    });
+    const agent = new Agent({
+      host: { sessionStore: new SessionOnlyStore() },
+      model: fakeModel,
+      subagents: [researcher],
+    });
+
+    await drainRun(await agent.send(userText("delegate")));
+
+    const tools = lastGenerateTextTools();
+    expect(Object.keys(tools).sort()).toEqual(["delegate_to_researcher"]);
+
+    const delegate = executableTool(tools, "delegate_to_researcher");
+    await expect(
+      delegate.execute?.(
+        { prompt: "research this", run_in_background: true },
+        toolExecutionOptions()
+      )
+    ).rejects.toThrow(
+      "Background subagent delegation is not available for this host."
+    );
+  });
+
+  it("hides background tools when a durable host lacks execution storage", async () => {
+    const Agent = await loadAgent();
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => [assistantMessage("CHILD DONE")],
+      name: "researcher",
+    });
+    const agent = new Agent({
+      host: {
+        capabilities: { backgroundSubagents: "durable" },
+        sessionStore: new SessionOnlyStore(),
+      },
+      model: fakeModel,
+      subagents: [researcher],
+    });
+
+    await drainRun(await agent.send(userText("delegate")));
+
+    const tools = lastGenerateTextTools();
+    expect(Object.keys(tools).sort()).toEqual(["delegate_to_researcher"]);
+
+    const delegate = executableTool(tools, "delegate_to_researcher");
+    await expect(
+      delegate.execute?.(
+        { prompt: "research this", run_in_background: true },
+        toolExecutionOptions()
+      )
+    ).rejects.toThrow(
+      "Background subagent delegation is not available for this host."
+    );
+  });
+});

--- a/packages/runtime/src/subagent-background-child-run-durable.test.ts
+++ b/packages/runtime/src/subagent-background-child-run-durable.test.ts
@@ -1,0 +1,232 @@
+import type { Tool } from "ai";
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import {
+  drainRun,
+  executableTool,
+  fakeModel,
+  lastGenerateTextTools,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import type { AgentEvent } from "./session/events";
+import type { AgentRun } from "./session/run";
+import { startBackgroundJob } from "./subagent-jobs";
+import type { RuntimeInputSink, Subagent, SubagentJob } from "./subagent-types";
+import { assistantMessage, userText } from "./test-fixtures";
+
+describe("durable background subagent child runs", () => {
+  it("queued durable background launches replay without rerunning child work", async () => {
+    const Agent = await loadAgent();
+    const host = {
+      ...createInMemoryExecutionHost(),
+      capabilities: { backgroundSubagents: "durable" as const },
+    };
+    let childCalls = 0;
+    const makeAgent = () => {
+      const researcher = new Agent({
+        description: "Researches facts.",
+        model: () => {
+          childCalls += 1;
+          return Promise.resolve([assistantMessage("CHILD DONE")]);
+        },
+        name: "researcher",
+        namespace: "qa-active-researcher",
+      });
+      return new Agent({
+        host,
+        model: fakeModel,
+        namespace: "qa-active-parent",
+        subagents: [researcher],
+      });
+    };
+    const options = {
+      ...toolExecutionOptions(),
+      toolCallId: "call_bg_active_replay",
+    };
+
+    const agent = makeAgent();
+    await drainRun(await agent.session("parent").send(userText("delegate")));
+    const tools = lastGenerateTextTools();
+    const first = await executeTool(
+      executableTool(tools, "delegate_to_researcher"),
+      { prompt: "research this", run_in_background: true },
+      options
+    );
+    expect(childCalls).toBe(0);
+
+    const replayedAgent = makeAgent();
+    await drainRun(
+      await replayedAgent.session("parent").send(userText("delegate"))
+    );
+    const replayed = await executeTool(
+      executableTool(lastGenerateTextTools(), "delegate_to_researcher"),
+      { prompt: "research this", run_in_background: true },
+      options
+    );
+
+    expect(replayed).toMatchObject({
+      status: "pending",
+      task_id: first.task_id,
+    });
+    expect(childCalls).toBe(0);
+  });
+
+  it("terminal durable background launches replay without rerunning child work", async () => {
+    const Agent = await loadAgent();
+    const host = {
+      ...createInMemoryExecutionHost(),
+      capabilities: { backgroundSubagents: "durable" as const },
+    };
+    let childCalls = 0;
+    const makeAgent = () => {
+      const researcher = new Agent({
+        description: "Researches facts.",
+        model: () => {
+          childCalls += 1;
+          return Promise.resolve([assistantMessage("CHILD DONE")]);
+        },
+        name: "researcher",
+        namespace: "qa-researcher",
+      });
+      return new Agent({
+        host,
+        model: fakeModel,
+        namespace: "qa-parent",
+        subagents: [researcher],
+      });
+    };
+    const options = {
+      ...toolExecutionOptions(),
+      toolCallId: "call_bg_terminal_replay",
+    };
+
+    const agent = makeAgent();
+    await drainRun(await agent.session("parent").send(userText("delegate")));
+    const tools = lastGenerateTextTools();
+    const first = await executeTool(
+      executableTool(tools, "delegate_to_researcher"),
+      { prompt: "research this", run_in_background: true },
+      options
+    );
+    const resumedRun = await agent.resume(`background:${first.task_id}`);
+    if (resumedRun) {
+      await drainRun(resumedRun);
+    }
+
+    const replayedAgent = makeAgent();
+    await drainRun(
+      await replayedAgent.session("parent").send(userText("delegate"))
+    );
+    const replayedTools = lastGenerateTextTools();
+    const replayed = await executeTool(
+      executableTool(replayedTools, "delegate_to_researcher"),
+      { prompt: "research this", run_in_background: true },
+      options
+    );
+    const output = await executeTool(
+      executableTool(replayedTools, "background_output"),
+      { task_id: first.task_id },
+      toolExecutionOptions()
+    );
+
+    expect(replayed).toMatchObject({
+      status: "completed",
+      task_id: first.task_id,
+    });
+    expect(output).toMatchObject({
+      result: {
+        result: "completed",
+        subagent: "researcher",
+        text: "CHILD DONE",
+      },
+      status: "completed",
+      task_id: first.task_id,
+    });
+    expect(childCalls).toBe(1);
+  });
+
+  it("pre-aborted background launches do not persist durable child runs", async () => {
+    const host = createInMemoryExecutionHost();
+    const jobs = new Map<string, SubagentJob>();
+    const abortController = new AbortController();
+    abortController.abort();
+    const subagent: Subagent = {
+      name: "researcher",
+      session: () => ({
+        delete: async () => undefined,
+        interrupt: () => undefined,
+        send: () => Promise.reject(new Error("should not run")),
+      }),
+    };
+
+    const launch = await startBackgroundJob({
+      abortSignal: abortController.signal,
+      delegateToolCallId: "call_aborted_bg",
+      executionHost: host,
+      jobs,
+      parentSession: parentSession(),
+      prompt: { text: "research", type: "user-text" },
+      registerCleanup: () => () => undefined,
+      sessionKey: "parent:default:subagent:researcher",
+      subagent,
+    });
+
+    expect(launch).toMatchObject({
+      status: "cancelled",
+      subagent: "researcher",
+    });
+    expect(jobs.size).toBe(0);
+    await expect(
+      host.store.runs.get(`background:${launch.task_id}`)
+    ).resolves.toBeNull();
+  });
+});
+
+async function executeTool(
+  candidate: Tool,
+  input: unknown,
+  options: ReturnType<typeof toolExecutionOptions>
+): Promise<{
+  readonly result?: unknown;
+  readonly status?: unknown;
+  readonly task_id: string;
+}> {
+  const output = await candidate.execute?.(input, options);
+  if (
+    typeof output === "object" &&
+    output !== null &&
+    "task_id" in output &&
+    typeof output.task_id === "string"
+  ) {
+    return output as {
+      readonly result?: unknown;
+      readonly status?: unknown;
+      readonly task_id: string;
+    };
+  }
+
+  throw new Error("Expected background tool output with task_id.");
+}
+
+function parentSession(): RuntimeInputSink {
+  return {
+    emitObserverEvent: () => Promise.resolve(),
+    enqueueRuntimeInput: () => undefined,
+    notify: () => Promise.resolve(emptyRun()),
+  };
+}
+
+function emptyRun(): AgentRun {
+  const events = () => ({
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    next: () =>
+      Promise.resolve({
+        done: true as const,
+        value: undefined as never as AgentEvent,
+      }),
+  });
+  return { events };
+}

--- a/packages/runtime/src/subagent-background-child-run-state.ts
+++ b/packages/runtime/src/subagent-background-child-run-state.ts
@@ -1,0 +1,112 @@
+import type { RunCheckpoint } from "./execution/types";
+import type { AgentInput } from "./session/input";
+
+export interface DurableBackgroundChildRunState {
+  readonly delegateToolCallId?: string;
+  readonly description?: string;
+  readonly groupId?: string;
+  readonly kind: "background-subagent";
+  readonly parentSessionKey?: string;
+  readonly prompt: AgentInput;
+  readonly subagent: string;
+}
+
+export function durableBackgroundChildRunState({
+  delegateToolCallId,
+  description,
+  groupId,
+  parentSessionKey,
+  prompt,
+  subagent,
+}: {
+  readonly delegateToolCallId?: string;
+  readonly description?: string;
+  readonly groupId?: string;
+  readonly parentSessionKey?: string;
+  readonly prompt: AgentInput;
+  readonly subagent?: string;
+}): DurableBackgroundChildRunState {
+  return {
+    ...(delegateToolCallId ? { delegateToolCallId } : {}),
+    ...(description ? { description } : {}),
+    ...(groupId ? { groupId } : {}),
+    kind: "background-subagent",
+    ...(parentSessionKey ? { parentSessionKey } : {}),
+    prompt: structuredClone(prompt),
+    subagent: subagent ?? "subagent",
+  };
+}
+
+export function readDurableBackgroundChildRunState(
+  checkpoint: RunCheckpoint | null
+): DurableBackgroundChildRunState | null {
+  const state = checkpoint?.runtimeState;
+  if (!isRecord(state) || state.kind !== "background-subagent") {
+    return null;
+  }
+
+  if (!isAgentInput(state.prompt) || typeof state.subagent !== "string") {
+    return null;
+  }
+
+  return {
+    ...(typeof state.delegateToolCallId === "string"
+      ? { delegateToolCallId: state.delegateToolCallId }
+      : {}),
+    ...(typeof state.description === "string"
+      ? { description: state.description }
+      : {}),
+    ...(typeof state.groupId === "string" ? { groupId: state.groupId } : {}),
+    kind: "background-subagent",
+    ...(typeof state.parentSessionKey === "string"
+      ? { parentSessionKey: state.parentSessionKey }
+      : {}),
+    prompt: state.prompt,
+    subagent: state.subagent,
+  };
+}
+
+function isAgentInput(value: unknown): value is AgentInput {
+  return (
+    typeof value === "string" ||
+    isStringArray(value) ||
+    isUserInput(value) ||
+    isMessageContent(value)
+  );
+}
+
+function isUserInput(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (value.type === "user-text") {
+    return typeof value.text === "string" || isStringArray(value.text);
+  }
+
+  return value.type === "user-message" && isMessageContent(value.content);
+}
+
+function isMessageContent(value: unknown): boolean {
+  return Array.isArray(value) && value.every(isMessageContentPart);
+}
+
+function isMessageContentPart(value: unknown): boolean {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return false;
+  }
+
+  return (
+    value.type === "text" || value.type === "image" || value.type === "file"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}

--- a/packages/runtime/src/subagent-background-child-run-status.test.ts
+++ b/packages/runtime/src/subagent-background-child-run-status.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, RunRecord } from "./execution/types";
+import { updateBackgroundRunStatus } from "./subagent-background-child-run";
+import type { SubagentJob } from "./subagent-types";
+
+describe("background child run status updates", () => {
+  it("does not overwrite a durable cancellation observed before completion update", async () => {
+    const run = createBackgroundRun("bg_race_cancel");
+    const updates: RunRecord[] = [];
+    const host = createRaceCancelHost({
+      onUpdate: (record) => updates.push(record),
+      readRun: () => ({ ...run, status: "cancelled" }),
+    });
+    const job: SubagentJob = {
+      abort: () => undefined,
+      childRunId: run.runId,
+      cleanup: () => Promise.resolve(),
+      executionHost: host,
+      id: "bg_race_cancel",
+      promise: Promise.resolve(),
+      result: {
+        eventCount: 1,
+        result: "completed",
+        run_in_background: false,
+        subagent: "researcher",
+        text: "done",
+      },
+      sessionKey: run.sessionKey,
+      settled: true,
+      status: "completed",
+      subagent: "researcher",
+    };
+
+    await updateBackgroundRunStatus(job, "completed");
+
+    expect(updates).toEqual([]);
+  });
+
+  it("does not publish output from a stale worker after another lease wins", async () => {
+    const host = createInMemoryExecutionHost();
+    const run = {
+      ...createBackgroundRun("bg_stale_lease"),
+      lease: {
+        attempt: 2,
+        leaseId: "new-lease",
+        leaseUntilMs: Date.now() + 60_000,
+      },
+      status: "leased" as const,
+    };
+    await host.store.runs.create(run);
+    const job = createCompletedJob({
+      host,
+      leaseId: "old-lease",
+      run,
+    });
+
+    await expect(updateBackgroundRunStatus(job, "completed")).resolves.toBe(
+      false
+    );
+    await expect(host.store.runs.get(run.runId)).resolves.toEqual(run);
+  });
+});
+
+function createCompletedJob({
+  host,
+  leaseId,
+  run,
+}: {
+  readonly host: ExecutionHost;
+  readonly leaseId: string;
+  readonly run: RunRecord;
+}): SubagentJob {
+  return {
+    abort: () => undefined,
+    childRunId: run.runId,
+    childRunLeaseId: leaseId,
+    cleanup: () => Promise.resolve(),
+    executionHost: host,
+    id: run.publicTaskId ?? "bg_unknown",
+    promise: Promise.resolve(),
+    result: {
+      eventCount: 1,
+      result: "completed",
+      run_in_background: false,
+      subagent: "researcher",
+      text: "done",
+    },
+    sessionKey: run.sessionKey,
+    settled: true,
+    status: "completed",
+    subagent: "researcher",
+  };
+}
+
+function createBackgroundRun(taskId: string): RunRecord {
+  return {
+    checkpointVersion: 0,
+    kind: "background-subagent",
+    parentRunId: "parent",
+    publicTaskId: taskId,
+    rootRunId: "parent",
+    runId: `background:${taskId}`,
+    sessionKey: `parent:task:${taskId}`,
+    status: "running",
+  };
+}
+
+function createRaceCancelHost({
+  onUpdate,
+  readRun,
+}: {
+  readonly onUpdate: (record: RunRecord) => void;
+  readonly readRun: () => RunRecord;
+}): ExecutionHost {
+  const base = createInMemoryExecutionHost();
+  const runs = {
+    claim: base.store.runs.claim.bind(base.store.runs),
+    create: base.store.runs.create.bind(base.store.runs),
+    get: () => Promise.resolve(readRun()),
+    getByDedupeKey: base.store.runs.getByDedupeKey.bind(base.store.runs),
+    listByParentRunId: base.store.runs.listByParentRunId.bind(base.store.runs),
+    update: (record: RunRecord) => {
+      onUpdate(record);
+      return Promise.resolve(record);
+    },
+  };
+  return {
+    ...base,
+    store: {
+      checkpoints: base.store.checkpoints,
+      events: base.store.events,
+      notifications: base.store.notifications,
+      runs,
+      sessions: base.store.sessions,
+      transaction: async (fn) =>
+        await fn({
+          checkpoints: base.store.checkpoints,
+          events: base.store.events,
+          notifications: base.store.notifications,
+          runs,
+          sessions: base.store.sessions,
+        }),
+    },
+  };
+}

--- a/packages/runtime/src/subagent-background-child-run.test.ts
+++ b/packages/runtime/src/subagent-background-child-run.test.ts
@@ -1,0 +1,188 @@
+import type { Tool } from "ai";
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import {
+  drainRun,
+  executableTool,
+  fakeModel,
+  lastGenerateTextTools,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import type { AgentEvent } from "./session/events";
+import type { AgentRun } from "./session/run";
+import { cancelJob } from "./subagent-job-state";
+import { startBackgroundJob } from "./subagent-jobs";
+import type { RuntimeInputSink, Subagent, SubagentJob } from "./subagent-types";
+import { assistantMessage, createDeferred, userText } from "./test-fixtures";
+
+describe("background subagent child runs", () => {
+  it("background launch can be replayed without duplicate child run", async () => {
+    const Agent = await loadAgent();
+    const childGate = createDeferred();
+    const host = createInMemoryExecutionHost();
+    let childCalls = 0;
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => {
+        childCalls += 1;
+        await childGate.promise;
+        return [assistantMessage("CHILD DONE")];
+      },
+      name: "researcher",
+    });
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      subagents: [researcher],
+    });
+
+    await drainRun(await agent.session("parent").send(userText("delegate")));
+    const tools = lastGenerateTextTools();
+    const delegate = executableTool(tools, "delegate_to_researcher");
+    const options = {
+      ...toolExecutionOptions(),
+      toolCallId: "call_bg_dedupe",
+    };
+
+    const first = await executeTool(
+      delegate,
+      {
+        prompt: "research this",
+        run_in_background: true,
+      },
+      options
+    );
+    const second = await executeTool(
+      delegate,
+      {
+        prompt: "research this",
+        run_in_background: true,
+      },
+      options
+    );
+
+    expect(second).toMatchObject({
+      task_id: first.task_id,
+    });
+    childGate.resolve();
+    await executeTool(
+      executableTool(tools, "background_output"),
+      {
+        block: true,
+        task_id: first.task_id,
+      },
+      toolExecutionOptions()
+    );
+
+    expect(childCalls).toBe(1);
+    await expect(
+      host.store.runs.get(`background:${first.task_id}`)
+    ).resolves.toMatchObject({
+      kind: "background-subagent",
+      publicTaskId: first.task_id,
+      status: "completed",
+    });
+  });
+
+  it("cancelled child completion does not enqueue stale notification", async () => {
+    const host = createInMemoryExecutionHost();
+    const jobs = new Map<string, SubagentJob>();
+    const childGate = createDeferred();
+    const notifications: string[] = [];
+    const subagent: Subagent = {
+      name: "researcher",
+      session: () => ({
+        delete: async () => undefined,
+        interrupt: () => undefined,
+        send: async () => delayedTextRun(childGate, "STALE CHILD DONE"),
+      }),
+    };
+
+    const launch = await startBackgroundJob({
+      abortSignal: new AbortController().signal,
+      delegateToolCallId: "call_cancel_bg",
+      executionHost: host,
+      jobs,
+      parentSession: parentSession(notifications),
+      prompt: { text: "research", type: "user-text" },
+      registerCleanup: () => () => undefined,
+      sessionKey: "parent:default:subagent:researcher",
+      subagent,
+    });
+    const job = mustGetJob(jobs, launch.task_id);
+
+    cancelJob(job);
+    childGate.resolve();
+    await job.promise;
+
+    expect(notifications).toEqual([]);
+    await expect(
+      host.store.runs.get(`background:${launch.task_id}`)
+    ).resolves.toMatchObject({
+      status: "cancelled",
+    });
+  });
+});
+
+async function executeTool(
+  candidate: Tool,
+  input: unknown,
+  options: ReturnType<typeof toolExecutionOptions>
+): Promise<{
+  readonly result?: unknown;
+  readonly status?: unknown;
+  readonly task_id: string;
+}> {
+  const output = await candidate.execute?.(input, options);
+  if (
+    typeof output === "object" &&
+    output !== null &&
+    "task_id" in output &&
+    typeof output.task_id === "string"
+  ) {
+    return output as {
+      readonly result?: unknown;
+      readonly status?: unknown;
+      readonly task_id: string;
+    };
+  }
+
+  throw new Error("Expected background tool output with task_id.");
+}
+
+function delayedTextRun(
+  gate: ReturnType<typeof createDeferred>,
+  text: string
+): AgentRun {
+  async function* events(): AsyncIterable<AgentEvent> {
+    await gate.promise;
+    yield { text, type: "assistant-text" };
+  }
+
+  return { events };
+}
+
+function parentSession(notifications: string[]): RuntimeInputSink {
+  return {
+    emitObserverEvent: () => Promise.resolve(),
+    enqueueRuntimeInput: () => undefined,
+    notify: (input) => {
+      if (input.type === "user-text" && typeof input.text === "string") {
+        notifications.push(input.text);
+      }
+      return Promise.resolve(delayedTextRun(createDeferred(), "NOTIFIED"));
+    },
+  };
+}
+
+function mustGetJob(
+  jobs: ReadonlyMap<string, SubagentJob>,
+  taskId: string
+): SubagentJob {
+  const job = jobs.get(taskId);
+  if (!job) {
+    throw new Error(`Expected job ${taskId}.`);
+  }
+  return job;
+}

--- a/packages/runtime/src/subagent-background-child-run.ts
+++ b/packages/runtime/src/subagent-background-child-run.ts
@@ -1,0 +1,191 @@
+import type { ExecutionHost, RunRecord, RunStatus } from "./execution/types";
+import type { AgentInput } from "./session/input";
+import { durableBackgroundChildRunState } from "./subagent-background-child-run-state";
+import type { SubagentJob } from "./subagent-types";
+
+interface BackgroundChildRunInput {
+  readonly delegateToolCallId?: string;
+  readonly description?: string;
+  readonly executionHost?: ExecutionHost;
+  readonly groupId?: string;
+  readonly ownerNamespace?: string;
+  readonly parentRunId?: string;
+  readonly parentSessionKey?: string;
+  readonly prompt: AgentInput;
+  readonly publicTaskId?: string;
+  readonly sessionKey: string;
+  readonly subagent?: string;
+}
+
+export function createBackgroundTaskId(): string {
+  return `bg_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+export async function createDurableBackgroundTaskId({
+  delegateToolCallId,
+  prompt,
+  sessionKey,
+}: Pick<
+  BackgroundChildRunInput,
+  "delegateToolCallId" | "prompt" | "sessionKey"
+>): Promise<string> {
+  const digestInput = backgroundSubagentDedupeKey({
+    delegateToolCallId,
+    prompt,
+    sessionKey,
+  });
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(digestInput)
+  );
+  const bytes = [...new Uint8Array(digest.slice(0, 16))];
+  const hex = bytes.map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `bg_${hex}`;
+}
+
+export async function getBackgroundChildRun({
+  delegateToolCallId,
+  executionHost,
+  prompt,
+  sessionKey,
+}: BackgroundChildRunInput): Promise<RunRecord | undefined> {
+  if (!executionHost) {
+    return;
+  }
+
+  const dedupeKey = backgroundSubagentDedupeKey({
+    delegateToolCallId,
+    prompt,
+    sessionKey,
+  });
+  return (
+    (await executionHost.store.runs.getByDedupeKey(dedupeKey)) ?? undefined
+  );
+}
+
+export async function getOrCreateBackgroundChildRun(
+  input: BackgroundChildRunInput
+): Promise<RunRecord | undefined> {
+  if (!input.executionHost) {
+    return;
+  }
+
+  const id = input.publicTaskId ?? createBackgroundTaskId();
+  const dedupeKey = backgroundSubagentDedupeKey(input);
+  return await input.executionHost.store.transaction(async (tx) => {
+    const existing = await tx.runs.getByDedupeKey(dedupeKey);
+    if (existing) {
+      return existing;
+    }
+
+    const parentRunId =
+      input.parentRunId ?? input.parentSessionKey ?? input.sessionKey;
+    const runtimeState = durableBackgroundChildRunState(input);
+    const run: RunRecord = {
+      checkpointVersion: 0,
+      dedupeKey,
+      kind: "background-subagent",
+      ...(input.ownerNamespace ? { ownerNamespace: input.ownerNamespace } : {}),
+      parentRunId,
+      publicTaskId: id,
+      rootRunId: parentRunId,
+      runId: `background:${id}`,
+      sessionKey: `${input.sessionKey}:task:${id}`,
+      status: "queued",
+    };
+    await tx.runs.create(run);
+    await tx.checkpoints.append(
+      {
+        checkpointId: crypto.randomUUID(),
+        phase: "before-child-run",
+        runId: run.runId,
+        runtimeState,
+        sessionSnapshot: {},
+        version: 1,
+      },
+      { expectedVersion: 0 }
+    );
+    await tx.checkpoints.append(
+      {
+        checkpointId: crypto.randomUUID(),
+        childRunId: run.runId,
+        phase: "child-linked",
+        runId: run.runId,
+        runtimeState,
+        sessionSnapshot: {},
+        version: 2,
+      },
+      { expectedVersion: 1 }
+    );
+    return (await tx.runs.get(run.runId)) ?? run;
+  });
+}
+
+export async function updateBackgroundRunStatus(
+  job: SubagentJob,
+  status: Extract<RunStatus, "cancelled" | "completed" | "error">
+): Promise<boolean> {
+  if (!(job.executionHost && job.childRunId)) {
+    return true;
+  }
+
+  return await job.executionHost.store.transaction(async (tx) => {
+    const run = await tx.runs.get(job.childRunId ?? "");
+    if (!run || isTerminalBackgroundRunStatus(run.status)) {
+      return false;
+    }
+    if (job.childRunLeaseId && run.lease?.leaseId !== job.childRunLeaseId) {
+      return false;
+    }
+
+    await tx.runs.update({
+      ...run,
+      output: job.result ?? run.output,
+      status,
+    });
+    return true;
+  });
+}
+
+export async function cancelBackgroundChildRun({
+  executionHost,
+  runId,
+}: {
+  readonly executionHost: ExecutionHost;
+  readonly runId: string;
+}): Promise<RunRecord | null> {
+  return await executionHost.store.transaction(async (tx) => {
+    const run = await tx.runs.get(runId);
+    if (!run || isTerminalBackgroundRunStatus(run.status)) {
+      return run;
+    }
+
+    return await tx.runs.update({ ...run, status: "cancelled" });
+  });
+}
+
+export function childRunStatus(
+  result: Exclude<SubagentJob["status"], "cancelled" | "pending" | "running">
+): Extract<RunStatus, "cancelled" | "completed" | "error"> {
+  if (result === "aborted") {
+    return "cancelled";
+  }
+
+  return result;
+}
+
+function backgroundSubagentDedupeKey({
+  delegateToolCallId,
+  prompt,
+  sessionKey,
+}: {
+  readonly delegateToolCallId?: string;
+  readonly prompt: AgentInput;
+  readonly sessionKey: string;
+}): string {
+  return `background-subagent:${sessionKey}:${delegateToolCallId ?? "unknown"}:${JSON.stringify(prompt)}`;
+}
+
+function isTerminalBackgroundRunStatus(status: RunStatus): boolean {
+  return status === "cancelled" || status === "completed" || status === "error";
+}

--- a/packages/runtime/src/subagent-background-cleanup.test.ts
+++ b/packages/runtime/src/subagent-background-cleanup.test.ts
@@ -34,12 +34,12 @@ describe("subagent background cleanup", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
+      host: { sessionStore: childStore },
       name: "researcher",
-      sessions: { store: childStore },
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
 

--- a/packages/runtime/src/subagent-background-durable-cancel-race.test.ts
+++ b/packages/runtime/src/subagent-background-durable-cancel-race.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost } from "./execution/types";
+import { toolExecutionOptions } from "./llm-test-utils";
+import type { AgentEvent } from "./session/events";
+import type { AgentRun } from "./session/run";
+import { runBackgroundJob } from "./subagent-background-runner";
+import { settlesWithin } from "./subagent-background-test-support";
+import { createBackgroundCancelTool } from "./subagent-job-cancel";
+import { startBackgroundJob } from "./subagent-jobs";
+import type { RuntimeInputSink, Subagent, SubagentJob } from "./subagent-types";
+import { createDeferred } from "./test-fixtures";
+
+describe("durable background cancellation races", () => {
+  it("interrupts a live child run when another process cancels its durable task", async () => {
+    const host = createDurableHost();
+    const jobs = new Map<string, SubagentJob>();
+    const childStarted = createDeferred();
+    const childInterrupted = createDeferred();
+    const notifications: string[] = [];
+    let interrupted = false;
+    const subagent: Subagent = {
+      name: "researcher",
+      session: () => ({
+        delete: async () => undefined,
+        interrupt: () => {
+          interrupted = true;
+          childInterrupted.resolve();
+        },
+        send: () => {
+          childStarted.resolve();
+          return Promise.resolve(interruptibleRun(childInterrupted));
+        },
+      }),
+    };
+    const launch = await startBackgroundJob({
+      abortSignal: new AbortController().signal,
+      delegateToolCallId: "call_cross_process_cancel",
+      executionHost: host,
+      jobs,
+      parentSession: parentSession(notifications),
+      parentSessionKey: "parent",
+      prompt: { text: "research", type: "user-text" },
+      registerCleanup: () => () => undefined,
+      sessionKey:
+        "parent:agent:qa:session:parent:generation:0:parent:subagent:researcher",
+      subagent,
+    });
+    const job = jobs.get(launch.task_id);
+    if (!job) {
+      throw new Error("Expected background job to be registered.");
+    }
+
+    const runId = `background:${launch.task_id}`;
+    const claim = await host.store.runs.claim(runId, {
+      attempt: 1,
+      leaseId: "lease-cross-process-cancel",
+      leaseMs: 300_000,
+      nowMs: Date.now(),
+    });
+    if (!claim.ok) {
+      throw new Error(
+        `Expected background run to be claimable: ${claim.reason}`
+      );
+    }
+
+    const childSession = subagent.session(claim.record.sessionKey);
+    const runningJob: SubagentJob = {
+      abort: () => childSession.interrupt(),
+      childRunId: claim.record.runId,
+      childRunLeaseId: claim.record.lease?.leaseId,
+      cleanup: () => Promise.resolve(),
+      dedupeKey: claim.record.dedupeKey,
+      executionHost: host,
+      id: launch.task_id,
+      parentRunId: claim.record.parentRunId,
+      parentSessionKey: "parent",
+      promise: Promise.resolve(),
+      sessionKey: claim.record.sessionKey,
+      settled: false,
+      status: "running",
+      subagent: "researcher",
+    };
+    const runningJobs = new Map([[runningJob.id, runningJob]]);
+    runningJob.promise = runBackgroundJob({
+      childSession,
+      groups: new Map(),
+      job: runningJob,
+      jobs: runningJobs,
+      parentSession: parentSession(notifications),
+      prompt: { text: "research", type: "user-text" },
+    });
+
+    await childStarted.promise;
+    await createBackgroundCancelTool(new Map(), host).execute?.(
+      { task_id: launch.task_id },
+      { ...toolExecutionOptions(), context: {} }
+    );
+
+    await expect(settlesWithin(runningJob.promise, 500)).resolves.toBe(true);
+    expect(interrupted).toBe(true);
+    expect(runningJob.status).toBe("cancelled");
+    expect(notifications).toEqual([]);
+    await expect(
+      host.store.runs.get(`background:${launch.task_id}`)
+    ).resolves.toMatchObject({ status: "cancelled" });
+  });
+});
+
+function createDurableHost(): ExecutionHost {
+  const base = createInMemoryExecutionHost();
+  return {
+    ...base,
+    capabilities: { backgroundSubagents: "durable" },
+  };
+}
+
+function parentSession(notifications: string[]): RuntimeInputSink {
+  return {
+    emitObserverEvent: () => Promise.resolve(),
+    enqueueRuntimeInput: () => undefined,
+    notify: (input) => {
+      if (input.type === "user-text") {
+        notifications.push("notified");
+      }
+      return Promise.resolve(emptyRun());
+    },
+  };
+}
+
+function interruptibleRun(childInterrupted: ReturnType<typeof createDeferred>) {
+  return {
+    events: () => ({
+      async *[Symbol.asyncIterator]() {
+        await childInterrupted.promise;
+        yield { type: "turn-abort" } satisfies AgentEvent;
+      },
+    }),
+  } satisfies AgentRun;
+}
+
+function emptyRun(): AgentRun {
+  return {
+    events: () => {
+      const iterator: AsyncIterator<AgentEvent> & AsyncIterable<AgentEvent> = {
+        next: () =>
+          Promise.resolve({
+            done: true as const,
+            value: undefined as never as AgentEvent,
+          }),
+        [Symbol.asyncIterator]: () => iterator,
+      };
+      return iterator;
+    },
+  };
+}

--- a/packages/runtime/src/subagent-background-durable-cancel-race.test.ts
+++ b/packages/runtime/src/subagent-background-durable-cancel-race.test.ts
@@ -1,17 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createInMemoryExecutionHost } from "./execution/memory";
 import type { ExecutionHost } from "./execution/types";
 import { toolExecutionOptions } from "./llm-test-utils";
 import type { AgentEvent } from "./session/events";
 import type { AgentRun } from "./session/run";
 import { runBackgroundJob } from "./subagent-background-runner";
-import { settlesWithin } from "./subagent-background-test-support";
 import { createBackgroundCancelTool } from "./subagent-job-cancel";
 import { startBackgroundJob } from "./subagent-jobs";
 import type { RuntimeInputSink, Subagent, SubagentJob } from "./subagent-types";
 import { createDeferred } from "./test-fixtures";
 
 describe("durable background cancellation races", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("interrupts a live child run when another process cancels its durable task", async () => {
     const host = createDurableHost();
     const jobs = new Map<string, SubagentJob>();
@@ -82,6 +85,7 @@ describe("durable background cancellation races", () => {
       subagent: "researcher",
     };
     const runningJobs = new Map([[runningJob.id, runningJob]]);
+    vi.useFakeTimers();
     runningJob.promise = runBackgroundJob({
       childSession,
       groups: new Map(),
@@ -97,7 +101,8 @@ describe("durable background cancellation races", () => {
       { ...toolExecutionOptions(), context: {} }
     );
 
-    await expect(settlesWithin(runningJob.promise, 500)).resolves.toBe(true);
+    await vi.advanceTimersByTimeAsync(1000);
+    await runningJob.promise;
     expect(interrupted).toBe(true);
     expect(runningJob.status).toBe("cancelled");
     expect(notifications).toEqual([]);

--- a/packages/runtime/src/subagent-background-durable-cancel-race.test.ts
+++ b/packages/runtime/src/subagent-background-durable-cancel-race.test.ts
@@ -101,7 +101,7 @@ describe("durable background cancellation races", () => {
       { ...toolExecutionOptions(), context: {} }
     );
 
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(250);
     await runningJob.promise;
     expect(interrupted).toBe(true);
     expect(runningJob.status).toBe("cancelled");

--- a/packages/runtime/src/subagent-background-durable-scheduler.test.ts
+++ b/packages/runtime/src/subagent-background-durable-scheduler.test.ts
@@ -1,0 +1,266 @@
+import type { ToolSet } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Agent } from "./agent";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, ResumeSessionOptions } from "./execution/types";
+import {
+  drainRun,
+  executableTool,
+  fakeModel,
+  getGenerateTextMock,
+  lastGenerateTextTools,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import type { AgentRun } from "./session/run";
+import { assistantMessage, userText } from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+const notificationRunPattern = /^notification:/;
+const parentRunPattern = /^agent:durable-parent:session:parent:generation:0$/;
+
+interface DurableSchedulerHost extends ExecutionHost {
+  readonly enqueuedRunIds: string[];
+  readonly resumedSessions: {
+    readonly options?: ResumeSessionOptions;
+    readonly sessionKey: string;
+  }[];
+}
+
+interface ResumeAgent {
+  resume(runId: string): Promise<AgentRun | null>;
+}
+
+describe("durable background subagent scheduling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("PARENT DONE")],
+    });
+  });
+
+  it("enqueues durable background child runs without executing child work in the launch invocation", async () => {
+    const AgentClass = await loadAgent();
+    const host = createDurableSchedulerHost();
+    let childCalls = 0;
+    const researcher = new AgentClass({
+      description: "Researches facts.",
+      model: () => {
+        childCalls += 1;
+        return Promise.resolve([assistantMessage("CHILD DONE")]);
+      },
+      name: "researcher",
+      namespace: "durable-scheduled-researcher",
+    });
+    const parent = createParentAgent(AgentClass, host, researcher);
+    let launch: { readonly task_id: string } | undefined;
+    generateTextMock.mockImplementationOnce(async (options: unknown) => {
+      launch = await executeBackgroundDelegate(toolsFromOptions(options));
+      return { responseMessages: [assistantMessage("PARENT DONE")] };
+    });
+
+    await drainRun(await parent.session("parent").send(userText("delegate")));
+    await Promise.resolve();
+
+    const launched = requireLaunch(launch);
+    const runId = `background:${launched.task_id}`;
+    await expect(host.store.runs.get(runId)).resolves.toMatchObject({
+      kind: "background-subagent",
+      parentRunId: expect.stringMatching(parentRunPattern),
+      publicTaskId: launched.task_id,
+      status: "queued",
+    });
+    expect(host.enqueuedRunIds).toEqual([runId]);
+    expect(childCalls).toBe(0);
+  });
+
+  it("parent delete cancels live-path queued durable background child runs", async () => {
+    const AgentClass = await loadAgent();
+    const host = createDurableSchedulerHost();
+    const researcher = new AgentClass({
+      description: "Researches facts.",
+      model: async () => [assistantMessage("CHILD DONE")],
+      name: "researcher",
+      namespace: "durable-delete-researcher",
+    });
+    const parent = createParentAgent(AgentClass, host, researcher);
+    let launch: { readonly task_id: string } | undefined;
+    generateTextMock.mockImplementationOnce(async (options: unknown) => {
+      launch = await executeBackgroundDelegate(toolsFromOptions(options));
+      return { responseMessages: [assistantMessage("PARENT DONE")] };
+    });
+
+    await drainRun(await parent.session("parent").send(userText("delegate")));
+    const launched = requireLaunch(launch);
+    const runId = `background:${launched.task_id}`;
+
+    await parent.session("parent").delete();
+
+    await expect(host.store.runs.get(runId)).resolves.toMatchObject({
+      parentRunId: expect.stringMatching(parentRunPattern),
+      status: "cancelled",
+    });
+  });
+
+  it("resumes a queued durable background child run in a later invocation", async () => {
+    const AgentClass = await loadAgent();
+    const host = createDurableSchedulerHost();
+    let childCalls = 0;
+    const makeResearcher = () =>
+      new AgentClass({
+        description: "Researches facts.",
+        model: () => {
+          childCalls += 1;
+          return Promise.resolve([assistantMessage("CHILD DONE")]);
+        },
+        name: "researcher",
+        namespace: "durable-resume-researcher",
+      });
+    const parent = createParentAgent(AgentClass, host, makeResearcher());
+    let launch: { readonly task_id: string } | undefined;
+    generateTextMock.mockImplementationOnce(async (options: unknown) => {
+      launch = await executeBackgroundDelegate(toolsFromOptions(options));
+      return { responseMessages: [assistantMessage("PARENT DONE")] };
+    });
+
+    await drainRun(await parent.session("parent").send(userText("delegate")));
+    const launched = requireLaunch(launch);
+    const runId = `background:${launched.task_id}`;
+    const resumedParent = createParentAgent(AgentClass, host, makeResearcher());
+
+    expectResumeSurface(resumedParent);
+    const resumedRun = await resumedParent.resume(runId);
+    expect(resumedRun).not.toBeNull();
+    if (resumedRun) {
+      await drainRun(resumedRun);
+    }
+
+    expect(childCalls).toBe(1);
+    await expect(host.store.runs.get(runId)).resolves.toMatchObject({
+      output: expect.objectContaining({
+        result: "completed",
+        subagent: "researcher",
+        text: "CHILD DONE",
+      }),
+      status: "completed",
+    });
+    expect(host.resumedSessions).toEqual([
+      {
+        options: expect.objectContaining({
+          idempotencyKey: `background-complete:parent:${launched.task_id}`,
+          runId: expect.stringMatching(notificationRunPattern),
+        }),
+        sessionKey: "parent",
+      },
+    ]);
+  });
+});
+
+async function executeBackgroundDelegate(
+  tools: ToolSet = lastGenerateTextTools()
+): Promise<{ readonly task_id: string }> {
+  const delegate = executableTool(tools, "delegate_to_researcher");
+  const output = await delegate.execute?.(
+    { prompt: "research this", run_in_background: true },
+    {
+      ...toolExecutionOptions(),
+      toolCallId: "call_durable_schedule",
+    }
+  );
+  return assertBackgroundLaunch(output);
+}
+
+function requireLaunch(launch: { readonly task_id: string } | undefined): {
+  readonly task_id: string;
+} {
+  if (launch) {
+    return launch;
+  }
+
+  throw new Error("Expected model mock to launch background work.");
+}
+
+function assertBackgroundLaunch(value: unknown): { readonly task_id: string } {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "task_id" in value &&
+    typeof value.task_id === "string"
+  ) {
+    return { task_id: value.task_id };
+  }
+
+  throw new Error("Expected background launch output with task_id.");
+}
+
+function createParentAgent(
+  AgentClass: typeof Agent,
+  host: ExecutionHost,
+  researcher: Agent
+): Agent {
+  return new AgentClass({
+    host,
+    model: fakeModel,
+    namespace: "durable-parent",
+    subagents: [researcher],
+  });
+}
+
+function createDurableSchedulerHost(): DurableSchedulerHost {
+  const base = createInMemoryExecutionHost();
+  const enqueuedRunIds: string[] = [];
+  const resumedSessions: {
+    readonly options?: ResumeSessionOptions;
+    readonly sessionKey: string;
+  }[] = [];
+  return {
+    ...base,
+    capabilities: {
+      ...base.capabilities,
+      backgroundSubagents: "durable",
+    },
+    enqueuedRunIds,
+    scheduler: {
+      enqueueRun: async (runId, options) => {
+        enqueuedRunIds.push(runId);
+        await base.scheduler.enqueueRun(runId, options);
+      },
+      resumeSession: async (sessionKey, options) => {
+        resumedSessions.push({ options, sessionKey });
+        await base.scheduler.resumeSession(sessionKey, options);
+      },
+    },
+    resumedSessions,
+  };
+}
+
+function toolsFromOptions(options: unknown): ToolSet {
+  if (
+    typeof options === "object" &&
+    options !== null &&
+    "tools" in options &&
+    isToolSet(options.tools)
+  ) {
+    return options.tools;
+  }
+
+  return {};
+}
+
+function isToolSet(value: unknown): value is ToolSet {
+  return typeof value === "object" && value !== null;
+}
+
+function expectResumeSurface(
+  agent: Agent
+): asserts agent is Agent & ResumeAgent {
+  const maybeResume =
+    typeof agent === "object" && agent !== null && "resume" in agent
+      ? agent.resume
+      : undefined;
+  expect(
+    typeof maybeResume,
+    "Agent must expose resume(runId) for host-scheduled durable runs"
+  ).toBe("function");
+}

--- a/packages/runtime/src/subagent-background-hardening.test.ts
+++ b/packages/runtime/src/subagent-background-hardening.test.ts
@@ -17,6 +17,7 @@ vi.mock("ai", async (importOriginal) => {
 });
 
 const fakeModel = {} as LanguageModel;
+const messageLimitAttackKey = ["message", "limit"].join("_");
 
 async function loadAgent() {
   const { Agent } = await import("./agent");
@@ -79,7 +80,7 @@ describe("subagent background hardening", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -103,7 +104,7 @@ describe("subagent background hardening", () => {
         full_session: true,
         include_thinking: true,
         include_tool_results: true,
-        message_limit: 0,
+        [messageLimitAttackKey]: 0,
         block: true,
         task_id: launch.task_id,
       },
@@ -125,19 +126,19 @@ describe("subagent background hardening", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [],
+      model: async () => [],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
 
     await drainRun(await agent.send(userText("delegate")));
 
-    expect(() =>
+    await expect(
       executableTool(lastGenerateTextTools(), "background_cancel").execute?.(
         { task_id: "parent:default:subagent:researcher" },
         toolExecutionOptions()
       )
-    ).toThrow("background_cancel expects a background task_id");
+    ).rejects.toThrow("background_cancel expects a background task_id");
   });
 
   it("delivers late turn-start reminders to an already queued next turn", async () => {
@@ -148,7 +149,7 @@ describe("subagent background hardening", () => {
     let launchedTaskId = "";
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => {
+      model: async () => {
         await childCanFinish.promise;
         return [assistantMessage("CHILD DONE")];
       },

--- a/packages/runtime/src/subagent-background-in-process.ts
+++ b/packages/runtime/src/subagent-background-in-process.ts
@@ -1,0 +1,169 @@
+import type { ExecutionHost, RunRecord } from "./execution/types";
+import type { AgentInput } from "./session/input";
+import { cancelBackgroundChildRun } from "./subagent-background-child-run";
+import { registerBackgroundJobGroup } from "./subagent-background-notify";
+import { runBackgroundJob } from "./subagent-background-runner";
+import {
+  backgroundCancelledLaunchOutput,
+  backgroundLaunchOutput,
+  backgroundReplayOutput,
+  backgroundRunJobStatus,
+} from "./subagent-job-state";
+import type {
+  RuntimeInputSink,
+  Subagent,
+  SubagentJob,
+  SubagentJobGroup,
+} from "./subagent-types";
+
+export async function startInProcessBackgroundJob({
+  abortSignal,
+  childRun,
+  delegateToolCallId,
+  description,
+  executionHost,
+  groupId,
+  groups,
+  id,
+  jobs,
+  parentRunId,
+  parentSession,
+  parentSessionKey,
+  ownerNamespace,
+  prompt,
+  registerCleanup,
+  sessionKey,
+  subagent,
+}: {
+  readonly abortSignal: AbortSignal;
+  readonly childRun?: RunRecord;
+  readonly delegateToolCallId?: string;
+  readonly description?: string;
+  readonly executionHost?: ExecutionHost;
+  readonly groupId?: string;
+  readonly groups: Map<string, SubagentJobGroup>;
+  readonly id: string;
+  readonly jobs: Map<string, SubagentJob>;
+  readonly parentRunId?: string;
+  readonly parentSession: RuntimeInputSink;
+  readonly parentSessionKey?: string;
+  readonly ownerNamespace?: string;
+  readonly prompt: AgentInput;
+  readonly registerCleanup: (cleanup: () => Promise<void>) => () => void;
+  readonly sessionKey: string;
+  readonly subagent: Subagent;
+}) {
+  const subagentName = subagent.name ?? "subagent";
+  const claimedChildRun = childRun
+    ? await claimBackgroundChildRun({
+        executionHost,
+        run: childRun,
+        subagent: subagentName,
+      })
+    : undefined;
+  if (claimedChildRun?.replay) {
+    return claimedChildRun.replay;
+  }
+  if (abortSignal.aborted) {
+    if (executionHost && claimedChildRun?.run) {
+      await cancelBackgroundChildRun({
+        executionHost,
+        runId: claimedChildRun.run.runId,
+      });
+    }
+    return backgroundCancelledLaunchOutput({ id, subagent: subagent.name });
+  }
+
+  const childSessionKey =
+    claimedChildRun?.run.sessionKey ?? `${sessionKey}:task:${id}`;
+  const childSession = subagent.session(childSessionKey);
+  const abort = () => childSession.interrupt();
+  abortSignal.addEventListener("abort", abort, { once: true });
+  const cleanup = () => childSession.delete();
+  const unregisterCleanup = registerCleanup(cleanup);
+  const job: SubagentJob = {
+    abort,
+    childRunId: claimedChildRun?.run.runId,
+    childRunLeaseId: claimedChildRun?.run.lease?.leaseId,
+    cleanup,
+    dedupeKey: claimedChildRun?.run.dedupeKey,
+    description,
+    id,
+    delegateToolCallId,
+    executionHost,
+    ownerNamespace,
+    parentSessionKey,
+    parentRunId,
+    promise: Promise.resolve(),
+    groupId,
+    sessionKey: childSessionKey,
+    settled: false,
+    status: "pending",
+    subagent: subagentName,
+    unregisterCleanup,
+  };
+  jobs.set(id, job);
+  registerBackgroundJobGroup({ groupId, groups, job });
+  await parentSession.emitObserverEvent({
+    description,
+    delegateToolCallId,
+    run_in_background: true,
+    subagent: subagentName,
+    task_id: id,
+    type: "subagent-job-start",
+  });
+  job.status = "running";
+  job.promise = runBackgroundJob({
+    childSession,
+    groups,
+    jobs,
+    job,
+    parentSession,
+    prompt,
+  }).finally(() => {
+    abortSignal.removeEventListener("abort", abort);
+    job.settled = true;
+  });
+
+  return backgroundLaunchOutput(job);
+}
+
+async function claimBackgroundChildRun({
+  executionHost,
+  run,
+  subagent,
+}: {
+  readonly executionHost: ExecutionHost | undefined;
+  readonly run: RunRecord;
+  readonly subagent: string;
+}): Promise<
+  | { readonly replay?: never; readonly run: RunRecord }
+  | {
+      readonly replay: ReturnType<typeof backgroundReplayOutput>;
+      readonly run?: never;
+    }
+> {
+  if (!executionHost) {
+    return { run };
+  }
+
+  const claim = await executionHost.store.runs.claim(run.runId, {
+    attempt: (run.lease?.attempt ?? 0) + 1,
+    leaseId: crypto.randomUUID(),
+    leaseMs: 300_000,
+    nowMs: Date.now(),
+  });
+  if (claim.ok) {
+    return { run: claim.record };
+  }
+
+  const latestRun = await executionHost.store.runs.get(run.runId);
+  const status = backgroundRunJobStatus(latestRun?.status) ?? "pending";
+  return {
+    replay: backgroundReplayOutput({
+      id: run.publicTaskId ?? run.runId,
+      status,
+      subagent,
+    }),
+  };
+}

--- a/packages/runtime/src/subagent-background-launch-abort.test.ts
+++ b/packages/runtime/src/subagent-background-launch-abort.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, RunRecord } from "./execution/types";
+import type { AgentEvent } from "./session/events";
+import type { AgentRun } from "./session/run";
+import { startBackgroundJob } from "./subagent-jobs";
+import type { RuntimeInputSink, Subagent, SubagentJob } from "./subagent-types";
+import { createDeferred } from "./test-fixtures";
+
+describe("durable background launch aborts", () => {
+  it("aborts when the signal fires while creating the durable child run", async () => {
+    const baseHost = createInMemoryExecutionHost();
+    const createStarted = createDeferred();
+    const createCanFinish = createDeferred();
+    const host = createDelayedRunCreateHost({
+      baseHost,
+      createCanFinish,
+      createStarted,
+    });
+    const jobs = new Map<string, SubagentJob>();
+    const abortController = new AbortController();
+    let childSends = 0;
+    const subagent: Subagent = {
+      name: "researcher",
+      session: () => ({
+        delete: async () => undefined,
+        interrupt: () => undefined,
+        send: () => {
+          childSends += 1;
+          return Promise.resolve(emptyRun());
+        },
+      }),
+    };
+
+    const launchPromise = startBackgroundJob({
+      abortSignal: abortController.signal,
+      delegateToolCallId: "call_abort_during_create",
+      executionHost: host,
+      jobs,
+      parentSession: parentSession(),
+      parentSessionKey: "parent",
+      prompt: { text: "research", type: "user-text" },
+      registerCleanup: () => () => undefined,
+      sessionKey:
+        "parent:agent:qa:session:parent:generation:0:parent:subagent:researcher",
+      subagent,
+    });
+
+    await createStarted.promise;
+    abortController.abort();
+    createCanFinish.resolve();
+
+    await expect(launchPromise).resolves.toMatchObject({
+      status: "cancelled",
+      subagent: "researcher",
+    });
+    expect(childSends).toBe(0);
+    expect(jobs.size).toBe(0);
+    const launch = await launchPromise;
+    await expect(
+      host.store.runs.get(`background:${launch.task_id}`)
+    ).resolves.toMatchObject({ status: "cancelled" });
+  });
+});
+
+function parentSession(): RuntimeInputSink {
+  return {
+    emitObserverEvent: () => Promise.resolve(),
+    enqueueRuntimeInput: () => undefined,
+    notify: () => Promise.resolve(emptyRun()),
+  };
+}
+
+function createDelayedRunCreateHost({
+  baseHost,
+  createCanFinish,
+  createStarted,
+}: {
+  readonly baseHost: ExecutionHost;
+  readonly createCanFinish: ReturnType<typeof createDeferred>;
+  readonly createStarted: ReturnType<typeof createDeferred>;
+}): ExecutionHost {
+  return {
+    ...baseHost,
+    store: {
+      checkpoints: baseHost.store.checkpoints,
+      events: baseHost.store.events,
+      notifications: baseHost.store.notifications,
+      runs: {
+        claim: baseHost.store.runs.claim.bind(baseHost.store.runs),
+        create: async (record: RunRecord) => {
+          createStarted.resolve();
+          await createCanFinish.promise;
+          return await baseHost.store.runs.create(record);
+        },
+        get: baseHost.store.runs.get.bind(baseHost.store.runs),
+        getByDedupeKey: baseHost.store.runs.getByDedupeKey.bind(
+          baseHost.store.runs
+        ),
+        listByParentRunId: baseHost.store.runs.listByParentRunId.bind(
+          baseHost.store.runs
+        ),
+        update: baseHost.store.runs.update.bind(baseHost.store.runs),
+      },
+      sessions: baseHost.store.sessions,
+      transaction: (fn) =>
+        baseHost.store.transaction((tx) =>
+          fn({
+            checkpoints: tx.checkpoints,
+            events: tx.events,
+            notifications: tx.notifications,
+            runs: {
+              claim: tx.runs.claim.bind(tx.runs),
+              create: async (record: RunRecord) => {
+                createStarted.resolve();
+                await createCanFinish.promise;
+                return await tx.runs.create(record);
+              },
+              get: tx.runs.get.bind(tx.runs),
+              getByDedupeKey: tx.runs.getByDedupeKey.bind(tx.runs),
+              listByParentRunId: tx.runs.listByParentRunId.bind(tx.runs),
+              update: tx.runs.update.bind(tx.runs),
+            },
+            sessions: tx.sessions,
+          })
+        ),
+    },
+  };
+}
+
+function emptyRun(): AgentRun {
+  const events = () => ({
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    next: () =>
+      Promise.resolve({
+        done: true as const,
+        value: undefined as never as AgentEvent,
+      }),
+  });
+  return { events };
+}

--- a/packages/runtime/src/subagent-background-notification-inbox.ts
+++ b/packages/runtime/src/subagent-background-notification-inbox.ts
@@ -27,7 +27,7 @@ export async function enqueueDurableBackgroundNotification({
     return "inline";
   }
 
-  if (await hasCancelledChildRun({ host, jobs })) {
+  if (await allChildRunsCancelled({ host, jobs })) {
     return "queued-only";
   }
 
@@ -74,25 +74,27 @@ export async function enqueueDurableBackgroundNotification({
   return "queued-only";
 }
 
-async function hasCancelledChildRun({
+async function allChildRunsCancelled({
   host,
   jobs,
 }: {
   readonly host: ExecutionHost;
   readonly jobs: readonly SubagentJob[];
 }): Promise<boolean> {
+  let childRunCount = 0;
   for (const job of jobs) {
     if (!job.childRunId) {
       continue;
     }
 
+    childRunCount += 1;
     const run = await host.store.runs.get(job.childRunId);
-    if (run?.status === "cancelled") {
-      return true;
+    if (run?.status !== "cancelled") {
+      return false;
     }
   }
 
-  return false;
+  return childRunCount > 0;
 }
 
 function findExecutionHost(

--- a/packages/runtime/src/subagent-background-notification-inbox.ts
+++ b/packages/runtime/src/subagent-background-notification-inbox.ts
@@ -1,0 +1,205 @@
+import type { ExecutionHost } from "./execution/types";
+import type { AgentEvent } from "./session/events";
+import type { UserInput } from "./session/input";
+import type { SubagentJob } from "./subagent-types";
+
+type InlineNotificationMode = "inline" | "queued-only";
+
+interface NotificationResumePayload {
+  readonly idempotencyKey: string;
+  readonly notificationId: string;
+  readonly runId: string;
+}
+
+export async function enqueueDurableBackgroundNotification({
+  input,
+  jobs,
+  observerEvents,
+}: {
+  readonly input: UserInput;
+  readonly jobs: readonly SubagentJob[];
+  readonly observerEvents: readonly AgentEvent[];
+}): Promise<InlineNotificationMode> {
+  const host = findExecutionHost(jobs);
+  const parentSessionKey = findParentSessionKey(jobs);
+  const ownerNamespace = findOwnerNamespace(jobs);
+  if (!host) {
+    return "inline";
+  }
+
+  if (await hasCancelledChildRun({ host, jobs })) {
+    return "queued-only";
+  }
+
+  if (!(parentSessionKey && ownerNamespace)) {
+    return "inline";
+  }
+
+  if (host.capabilities.backgroundSubagents !== "durable") {
+    return "inline";
+  }
+
+  const idempotencyKey = backgroundNotificationIdempotencyKey({
+    jobs,
+    parentSessionKey,
+  });
+  const existing =
+    await host.store.notifications.getByIdempotencyKey(idempotencyKey);
+  if (existing) {
+    if (
+      existing.status === "pending" &&
+      host.capabilities.backgroundSubagents === "durable"
+    ) {
+      await host.scheduler.resumeSession(
+        existing.sessionKey,
+        resumePayloadFromNotification(existing)
+      );
+    }
+    return "queued-only";
+  }
+
+  const created = await createNotificationRecord({
+    host,
+    idempotencyKey,
+    input,
+    jobs,
+    observerEvents,
+    ownerNamespace,
+    parentSessionKey,
+  });
+  if (created) {
+    await host.scheduler.resumeSession(parentSessionKey, created);
+  }
+
+  return "queued-only";
+}
+
+async function hasCancelledChildRun({
+  host,
+  jobs,
+}: {
+  readonly host: ExecutionHost;
+  readonly jobs: readonly SubagentJob[];
+}): Promise<boolean> {
+  for (const job of jobs) {
+    if (!job.childRunId) {
+      continue;
+    }
+
+    const run = await host.store.runs.get(job.childRunId);
+    if (run?.status === "cancelled") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function findExecutionHost(
+  jobs: readonly SubagentJob[]
+): ExecutionHost | undefined {
+  return jobs.find((job) => job.executionHost)?.executionHost;
+}
+
+function findParentSessionKey(
+  jobs: readonly SubagentJob[]
+): string | undefined {
+  return jobs.find((job) => job.parentSessionKey)?.parentSessionKey;
+}
+
+function findOwnerNamespace(jobs: readonly SubagentJob[]): string | undefined {
+  return jobs.find((job) => job.ownerNamespace)?.ownerNamespace;
+}
+
+function backgroundNotificationIdempotencyKey({
+  jobs,
+  parentSessionKey,
+}: {
+  readonly jobs: readonly SubagentJob[];
+  readonly parentSessionKey: string;
+}): string {
+  const taskIds = jobs
+    .map((job) => job.id)
+    .sort()
+    .join(",");
+  return `background-complete:${parentSessionKey}:${taskIds}`;
+}
+
+async function createNotificationRecord({
+  host,
+  idempotencyKey,
+  input,
+  jobs,
+  observerEvents,
+  ownerNamespace,
+  parentSessionKey,
+}: {
+  readonly host: ExecutionHost;
+  readonly idempotencyKey: string;
+  readonly input: UserInput;
+  readonly jobs: readonly SubagentJob[];
+  readonly observerEvents: readonly AgentEvent[];
+  readonly ownerNamespace: string;
+  readonly parentSessionKey: string;
+}): Promise<NotificationResumePayload | undefined> {
+  const notificationId = `ntf_${crypto.randomUUID().replaceAll("-", "")}`;
+  const runId = `notification:${notificationId}`;
+  return await host.store.transaction(async (tx) => {
+    const duplicate =
+      await tx.notifications.getByIdempotencyKey(idempotencyKey);
+    if (duplicate) {
+      return;
+    }
+
+    const enqueued = await tx.notifications.enqueue({
+      idempotencyKey,
+      input,
+      notificationId,
+      observerEvents,
+      ownerNamespace,
+      runId,
+      sessionKey: parentSessionKey,
+      status: "pending",
+    });
+    if (!enqueued.ok) {
+      return;
+    }
+
+    await tx.runs.create({
+      checkpointVersion: 0,
+      dedupeKey: idempotencyKey,
+      kind: "notification",
+      ownerNamespace,
+      parentRunId: jobs.length === 1 ? jobs[0]?.childRunId : undefined,
+      rootRunId: runId,
+      runId,
+      sessionKey: parentSessionKey,
+      status: "queued",
+    });
+    const checkpoint = await tx.checkpoints.append(
+      {
+        checkpointId: crypto.randomUUID(),
+        phase: "before-notification",
+        runId,
+        runtimeState: {},
+        sessionSnapshot: {},
+        version: 1,
+      },
+      { expectedVersion: 0 }
+    );
+    if (!checkpoint.ok) {
+      throw new Error("Failed to write background notification checkpoint.");
+    }
+    return { idempotencyKey, notificationId, runId };
+  });
+}
+
+function resumePayloadFromNotification(
+  notification: NotificationResumePayload
+): NotificationResumePayload {
+  return {
+    idempotencyKey: notification.idempotencyKey,
+    notificationId: notification.notificationId,
+    runId: notification.runId,
+  };
+}

--- a/packages/runtime/src/subagent-background-notify.ts
+++ b/packages/runtime/src/subagent-background-notify.ts
@@ -77,12 +77,19 @@ export async function notifyBackgroundCompletion({
   const groupJobs = [...group.jobIds]
     .map((id) => jobs.get(id))
     .filter(isDefinedJob);
+  const notifyableGroupJobs = groupJobs.filter(
+    (groupJob) => !group.failedNotifiedJobIds.has(groupJob.id)
+  );
+  if (notifyableGroupJobs.length === 0) {
+    groups.delete(group.id);
+    return;
+  }
   const observerEvents = group.completedEvents.filter(
     (event) => !group.failedNotifiedJobIds.has(event.task_id ?? "")
   );
   await notifyParentSession({
-    input: buildBackgroundReminder(groupJobs),
-    jobs: groupJobs,
+    input: buildBackgroundReminder(notifyableGroupJobs),
+    jobs: notifyableGroupJobs,
     observerEvents: [...observerEvents],
     parentSession,
   });

--- a/packages/runtime/src/subagent-background-notify.ts
+++ b/packages/runtime/src/subagent-background-notify.ts
@@ -1,0 +1,218 @@
+import type { AgentEvent } from "./session/events";
+import type { UserInput } from "./session/input";
+import { enqueueDurableBackgroundNotification } from "./subagent-background-notification-inbox";
+import type {
+  RuntimeInputSink,
+  SubagentJob,
+  SubagentJobGroup,
+} from "./subagent-types";
+
+export function registerBackgroundJobGroup({
+  groupId,
+  groups,
+  job,
+}: {
+  readonly groupId: string | undefined;
+  readonly groups: Map<string, SubagentJobGroup>;
+  readonly job: SubagentJob;
+}): void {
+  if (!groupId) {
+    return;
+  }
+
+  let group = groups.get(groupId);
+  if (!group) {
+    group = {
+      completedEvents: [],
+      failedNotifiedJobIds: new Set(),
+      finalNotified: false,
+      id: groupId,
+      jobIds: new Set(),
+    };
+    groups.set(groupId, group);
+  }
+  group.jobIds.add(job.id);
+}
+
+export async function notifyBackgroundCompletion({
+  endEvent,
+  groups,
+  job,
+  jobs,
+  parentSession,
+}: {
+  readonly endEvent: Extract<AgentEvent, { type: "subagent-job-end" }>;
+  readonly groups: Map<string, SubagentJobGroup>;
+  readonly job: SubagentJob;
+  readonly jobs: Map<string, SubagentJob>;
+  readonly parentSession: RuntimeInputSink;
+}): Promise<void> {
+  const group = job.groupId ? groups.get(job.groupId) : undefined;
+  if (!group) {
+    await notifyParentSession({
+      input: buildBackgroundReminder([job]),
+      jobs: [job],
+      observerEvents: [endEvent],
+      parentSession,
+    });
+    return;
+  }
+
+  group.completedEvents.push(endEvent);
+  if (isFailureStatus(endEvent.status)) {
+    group.failedNotifiedJobIds.add(job.id);
+    await notifyParentSession({
+      input: buildBackgroundReminder([job]),
+      jobs: [job],
+      observerEvents: [endEvent],
+      parentSession,
+    });
+  }
+
+  if (!isGroupSettled(group, jobs) || group.finalNotified) {
+    return;
+  }
+
+  group.finalNotified = true;
+  const groupJobs = [...group.jobIds]
+    .map((id) => jobs.get(id))
+    .filter(isDefinedJob);
+  const observerEvents = group.completedEvents.filter(
+    (event) => !group.failedNotifiedJobIds.has(event.task_id ?? "")
+  );
+  await notifyParentSession({
+    input: buildBackgroundReminder(groupJobs),
+    jobs: groupJobs,
+    observerEvents: [...observerEvents],
+    parentSession,
+  });
+  groups.delete(group.id);
+}
+
+async function notifyParentSession({
+  input,
+  jobs,
+  observerEvents,
+  parentSession,
+}: {
+  readonly input: UserInput;
+  readonly jobs: readonly SubagentJob[];
+  readonly observerEvents: readonly AgentEvent[];
+  readonly parentSession: RuntimeInputSink;
+}): Promise<void> {
+  try {
+    const mode = await enqueueDurableBackgroundNotification({
+      input,
+      jobs,
+      observerEvents,
+    });
+    if (mode === "queued-only") {
+      return;
+    }
+
+    await Promise.all(
+      observerEvents.map((event) => parentSession.emitObserverEvent(event))
+    );
+    await parentSession.notify(input, {
+      deferWhenUnobserved: true,
+      observerEvents,
+    });
+  } catch (error) {
+    await parentSession.emitObserverEvent({
+      message: errorMessage(error),
+      type: "turn-error",
+    });
+  }
+}
+
+function buildBackgroundReminder(jobs: readonly SubagentJob[]): UserInput {
+  const text =
+    jobs.length === 1
+      ? buildSingleJobReminder(jobs[0])
+      : buildGroupReminder(jobs);
+  return { text, type: "user-text" };
+}
+
+function buildSingleJobReminder(job: SubagentJob | undefined): string {
+  if (!job) {
+    return [
+      "<system-reminder>",
+      "[BACKGROUND TASK COMPLETED]",
+      "[SUBAGENT JOB RESULT READY]",
+      "A background task completed, but its task metadata is no longer available.",
+      "</system-reminder>",
+    ].join("\n");
+  }
+
+  return [
+    "<system-reminder>",
+    "[BACKGROUND TASK COMPLETED]",
+    "[SUBAGENT JOB RESULT READY]",
+    `Task ID: ${job.id}`,
+    `Subagent: ${job.subagent}`,
+    `Status: ${job.status}`,
+    `Description: ${sanitizeReminderField(job.description ?? "")}`,
+    `Use background_output({ task_id: "${job.id}" }) to retrieve the result.`,
+    "</system-reminder>",
+  ].join("\n");
+}
+
+function buildGroupReminder(jobs: readonly SubagentJob[]): string {
+  return [
+    "<system-reminder>",
+    "[ALL BACKGROUND TASKS COMPLETE]",
+    `Completed task count: ${jobs.length}`,
+    "Tasks:",
+    ...jobs.map(
+      (job) =>
+        `- ${job.id} (${job.subagent}): ${job.status}. Description: ${sanitizeReminderField(
+          job.description ?? ""
+        )}. Use background_output({ task_id: "${job.id}" }) to retrieve the result.`
+    ),
+    "</system-reminder>",
+  ].join("\n");
+}
+
+function isGroupSettled(
+  group: SubagentJobGroup,
+  jobs: Map<string, SubagentJob>
+): boolean {
+  for (const id of group.jobIds) {
+    const job = jobs.get(id);
+    if (!job || isActiveJobStatus(job.status) || !job.settled) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isActiveJobStatus(status: SubagentJob["status"]): boolean {
+  return status === "pending" || status === "running";
+}
+
+function isFailureStatus(
+  status: Extract<AgentEvent, { type: "subagent-job-end" }>["status"]
+): boolean {
+  return status === "aborted" || status === "cancelled" || status === "error";
+}
+
+function isDefinedJob(job: SubagentJob | undefined): job is SubagentJob {
+  return job !== undefined;
+}
+
+function sanitizeReminderField(value: string): string {
+  return value
+    .replaceAll("\r", " ")
+    .replaceAll("\n", " ")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/packages/runtime/src/subagent-background-output-durable.test.ts
+++ b/packages/runtime/src/subagent-background-output-durable.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost } from "./execution/types";
+import {
+  drainRun,
+  executableTool,
+  fakeModel,
+  getGenerateTextMock,
+  lastGenerateTextTools,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import { assistantMessage, createDeferred, userText } from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("durable subagent background output", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retains durable completed output after retrieval", async () => {
+    const Agent = await loadAgent();
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => [assistantMessage("CHILD DONE")],
+      name: "researcher",
+    });
+    const agent = new Agent({ model: fakeModel, subagents: [researcher] });
+
+    await drainRun(await agent.send(userText("delegate")));
+
+    const tools = lastGenerateTextTools();
+    const launch = (await executableTool(
+      tools,
+      "delegate_to_researcher"
+    ).execute?.(
+      { prompt: "research this", run_in_background: true },
+      toolExecutionOptions()
+    )) as { task_id: string };
+    await executableTool(tools, "background_output").execute?.(
+      { block: true, task_id: launch.task_id },
+      toolExecutionOptions()
+    );
+
+    await expect(
+      executableTool(tools, "background_output").execute?.(
+        { task_id: launch.task_id },
+        toolExecutionOptions()
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        result: expect.objectContaining({
+          result: "completed",
+          text: "CHILD DONE",
+        }),
+        status: "completed",
+        task_id: launch.task_id,
+      })
+    );
+  });
+
+  it("prefers durable output over a stale local job", async () => {
+    const Agent = await loadAgent();
+    const host = {
+      ...createInMemoryExecutionHost(),
+      capabilities: { backgroundSubagents: "durable" as const },
+    } satisfies ExecutionHost;
+    const childGate = createDeferred();
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => {
+        await childGate.promise;
+        return [assistantMessage("STALE CHILD")];
+      },
+      name: "researcher",
+    });
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      namespace: "output-stale-parent",
+      subagents: [researcher],
+    });
+
+    await drainRun(await agent.send(userText("delegate")));
+    const tools = lastGenerateTextTools();
+    const launch = (await executableTool(
+      tools,
+      "delegate_to_researcher"
+    ).execute?.(
+      { prompt: "research this", run_in_background: true },
+      toolExecutionOptions()
+    )) as { task_id: string };
+    const record = await host.store.runs.get(`background:${launch.task_id}`);
+    if (!record) {
+      throw new Error("Expected background run record.");
+    }
+    await host.store.runs.update({
+      ...record,
+      output: {
+        eventCount: 1,
+        result: "completed",
+        run_in_background: false,
+        subagent: "researcher",
+        text: "DURABLE DONE",
+      },
+      status: "completed",
+    });
+
+    await expect(
+      executableTool(tools, "background_output").execute?.(
+        { task_id: launch.task_id },
+        toolExecutionOptions()
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        result: expect.objectContaining({
+          result: "completed",
+          text: "DURABLE DONE",
+        }),
+        status: "completed",
+        task_id: launch.task_id,
+      })
+    );
+  });
+});

--- a/packages/runtime/src/subagent-background-reminders.test.ts
+++ b/packages/runtime/src/subagent-background-reminders.test.ts
@@ -32,7 +32,7 @@ describe("subagent background reminders", () => {
     const childGate = new Promise<void>(() => undefined);
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => {
+      model: async () => {
         await childGate;
         return [assistantMessage("CHILD DONE")];
       },
@@ -69,7 +69,7 @@ describe("subagent background reminders", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ signal }) =>
+      model: ({ signal }) =>
         new Promise((resolve) => {
           signal.addEventListener("abort", () => resolve([]), { once: true });
         }),
@@ -112,7 +112,7 @@ describe("subagent background reminders", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -170,7 +170,7 @@ describe("subagent background reminders", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -246,7 +246,7 @@ describe("subagent background reminders", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD TRACE SECRET")],
+      model: async () => [assistantMessage("CHILD TRACE SECRET")],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });

--- a/packages/runtime/src/subagent-background-resume-group.test.ts
+++ b/packages/runtime/src/subagent-background-resume-group.test.ts
@@ -1,0 +1,189 @@
+import type { ToolSet } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fakeModel,
+  getGenerateTextMock,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import {
+  backgroundNotificationKey,
+  collectAgentRun,
+  createDurableTestHost,
+  resumeBackgroundTask,
+  settlesWithin,
+  waitForSessionPromptResume,
+} from "./subagent-background-test-support";
+import {
+  assistantMessage,
+  createDeferred,
+  eventTypes,
+  toolCallPart,
+  userText,
+} from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("subagent background group resume", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("waits for every same-turn background job before sending the success notification", async () => {
+    const Agent = await loadAgent();
+    const firstCanFinish = createDeferred();
+    const secondCanFinish = createDeferred();
+    const firstFinished = createDeferred();
+    let launchedTaskIds: readonly string[] = [];
+    let parentCalls = 0;
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async ({ history }) => {
+        const serializedHistory = JSON.stringify(history);
+        if (serializedHistory.includes("research first")) {
+          await firstCanFinish.promise;
+          firstFinished.resolve();
+          return [assistantMessage("FIRST CHILD DONE")];
+        }
+
+        await secondCanFinish.promise;
+        return [assistantMessage("SECOND CHILD DONE")];
+      },
+      name: "researcher",
+    });
+
+    generateTextMock.mockImplementation(
+      async ({
+        messages,
+        tools,
+      }: {
+        readonly messages: unknown;
+        readonly tools?: ToolSet;
+      }) => {
+        parentCalls += 1;
+        if (parentCalls === 1) {
+          const firstToolCall = toolCallPart(
+            "call-delegate-first",
+            "delegate_to_researcher",
+            {
+              prompt: "research first",
+              run_in_background: true,
+            }
+          );
+          const secondToolCall = toolCallPart(
+            "call-delegate-second",
+            "delegate_to_researcher",
+            {
+              prompt: "research second",
+              run_in_background: true,
+            }
+          );
+          const firstLaunch = (await tools?.delegate_to_researcher?.execute?.(
+            {
+              prompt: "research first",
+              run_in_background: true,
+            },
+            toolExecutionOptions()
+          )) as { readonly task_id: string };
+          const secondLaunch = (await tools?.delegate_to_researcher?.execute?.(
+            {
+              prompt: "research second",
+              run_in_background: true,
+            },
+            toolExecutionOptions()
+          )) as { readonly task_id: string };
+          launchedTaskIds = [firstLaunch.task_id, secondLaunch.task_id];
+
+          return {
+            responseMessages: [
+              assistantMessage([firstToolCall, secondToolCall]),
+              {
+                content: [
+                  {
+                    output: { type: "json", value: firstLaunch },
+                    toolCallId: firstToolCall.toolCallId,
+                    toolName: firstToolCall.toolName,
+                    type: "tool-result",
+                  },
+                  {
+                    output: { type: "json", value: secondLaunch },
+                    toolCallId: secondToolCall.toolCallId,
+                    toolName: secondToolCall.toolName,
+                    type: "tool-result",
+                  },
+                ],
+                role: "tool",
+              },
+            ],
+          };
+        }
+
+        const serializedMessages = JSON.stringify(messages);
+        if (!serializedMessages.includes("[ALL BACKGROUND TASKS COMPLETE]")) {
+          return {
+            responseMessages: [
+              assistantMessage("Background tasks started; waiting."),
+            ],
+          };
+        }
+
+        for (const taskId of launchedTaskIds) {
+          expect(serializedMessages).toContain(taskId);
+        }
+
+        return {
+          responseMessages: [assistantMessage("ALL NOTIFIED")],
+        };
+      }
+    );
+    const host = createDurableTestHost();
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      subagents: [researcher],
+    });
+    const session = agent.session("default");
+
+    await collectAgentRun(await session.send(userText("delegate")));
+    const firstTaskId = launchedTaskIds[0];
+    const secondTaskId = launchedTaskIds[1];
+    if (!(firstTaskId && secondTaskId)) {
+      throw new Error("Expected both background tasks to launch.");
+    }
+
+    firstCanFinish.resolve();
+    await collectAgentRun(await resumeBackgroundTask(agent, firstTaskId));
+    await firstFinished.promise;
+    const pendingNotifyRun = waitForSessionPromptResume(
+      agent,
+      host,
+      backgroundNotificationKey(...launchedTaskIds)
+    );
+    await expect(settlesWithin(pendingNotifyRun, 20)).resolves.toBe(false);
+
+    secondCanFinish.resolve();
+    await collectAgentRun(await resumeBackgroundTask(agent, secondTaskId));
+    const notifyEvents = await collectAgentRun(await pendingNotifyRun);
+    const runtimeInput = notifyEvents.find(
+      (event) => event.type === "runtime-input"
+    );
+    const reminderText =
+      runtimeInput?.type === "runtime-input" &&
+      runtimeInput.input.type === "user-text"
+        ? runtimeInput.input.text
+        : "";
+
+    expect(eventTypes(notifyEvents)).toContain("runtime-input");
+    expect(reminderText).toEqual(
+      expect.stringContaining("[ALL BACKGROUND TASKS COMPLETE]")
+    );
+    for (const taskId of launchedTaskIds) {
+      expect(reminderText).toEqual(expect.stringContaining(taskId));
+    }
+  });
+});

--- a/packages/runtime/src/subagent-background-resume-group.ts
+++ b/packages/runtime/src/subagent-background-resume-group.ts
@@ -93,7 +93,11 @@ async function addSiblingToGroup({
     return;
   }
   group.completedEvents.push(endEvent);
-  if (endEvent.status === "aborted" || endEvent.status === "error") {
+  if (
+    endEvent.status === "aborted" ||
+    endEvent.status === "cancelled" ||
+    endEvent.status === "error"
+  ) {
     group.failedNotifiedJobIds.add(siblingJob.id);
   }
 }

--- a/packages/runtime/src/subagent-background-resume-group.ts
+++ b/packages/runtime/src/subagent-background-resume-group.ts
@@ -1,0 +1,188 @@
+import type { ExecutionHost, RunRecord } from "./execution/types";
+import type { AgentEvent } from "./session/events";
+import type { DurableBackgroundChildRunState } from "./subagent-background-child-run-state";
+import { readDurableBackgroundChildRunState } from "./subagent-background-child-run-state";
+import { backgroundRunJobStatus, isActiveJob } from "./subagent-job-state";
+import type {
+  CompactSubagentResult,
+  SubagentJob,
+  SubagentJobGroup,
+} from "./subagent-types";
+
+export async function buildDurableResumeGroups({
+  currentJob,
+  host,
+  jobs,
+  run,
+  state,
+}: {
+  readonly currentJob: SubagentJob;
+  readonly host: ExecutionHost;
+  readonly jobs: Map<string, SubagentJob>;
+  readonly run: RunRecord;
+  readonly state: DurableBackgroundChildRunState;
+}): Promise<Map<string, SubagentJobGroup>> {
+  const groups = new Map<string, SubagentJobGroup>();
+  if (!(state.groupId && run.parentRunId)) {
+    return groups;
+  }
+
+  const group: SubagentJobGroup = {
+    completedEvents: [],
+    failedNotifiedJobIds: new Set(),
+    finalNotified: false,
+    id: state.groupId,
+    jobIds: new Set(),
+  };
+  groups.set(group.id, group);
+
+  for (const sibling of await host.store.runs.listByParentRunId(
+    run.parentRunId
+  )) {
+    await addSiblingToGroup({
+      currentJob,
+      group,
+      host,
+      jobs,
+      run,
+      sibling,
+      state,
+    });
+  }
+
+  return groups;
+}
+
+async function addSiblingToGroup({
+  currentJob,
+  group,
+  host,
+  jobs,
+  run,
+  sibling,
+  state,
+}: {
+  readonly currentJob: SubagentJob;
+  readonly group: SubagentJobGroup;
+  readonly host: ExecutionHost;
+  readonly jobs: Map<string, SubagentJob>;
+  readonly run: RunRecord;
+  readonly sibling: RunRecord;
+  readonly state: DurableBackgroundChildRunState;
+}): Promise<void> {
+  if (sibling.kind !== "background-subagent") {
+    return;
+  }
+
+  const siblingState = readDurableBackgroundChildRunState(
+    await host.store.checkpoints.latest(sibling.runId)
+  );
+  if (!siblingState || siblingState.groupId !== state.groupId) {
+    return;
+  }
+
+  const siblingJob =
+    sibling.runId === run.runId
+      ? currentJob
+      : durableSiblingJob({ host, run: sibling, state: siblingState });
+  jobs.set(siblingJob.id, siblingJob);
+  group.jobIds.add(siblingJob.id);
+
+  const endEvent = durableTerminalEvent(siblingJob, sibling.output);
+  if (!endEvent || sibling.runId === run.runId) {
+    return;
+  }
+  group.completedEvents.push(endEvent);
+  if (endEvent.status === "aborted" || endEvent.status === "error") {
+    group.failedNotifiedJobIds.add(siblingJob.id);
+  }
+}
+
+function durableSiblingJob({
+  host,
+  run,
+  state,
+}: {
+  readonly host: ExecutionHost;
+  readonly run: RunRecord;
+  readonly state: DurableBackgroundChildRunState;
+}): SubagentJob {
+  const status = backgroundRunJobStatus(run.status) ?? "pending";
+  const compactResult = compactSubagentResult(run.output);
+  return {
+    abort: () => undefined,
+    childRunId: run.runId,
+    cleanup: () => Promise.resolve(),
+    dedupeKey: run.dedupeKey,
+    delegateToolCallId: state.delegateToolCallId,
+    description: state.description,
+    executionHost: host,
+    groupId: state.groupId,
+    id: run.publicTaskId ?? run.runId,
+    parentRunId: run.parentRunId,
+    parentSessionKey: state.parentSessionKey,
+    promise: Promise.resolve(),
+    result: compactResult,
+    sessionKey: run.sessionKey,
+    settled: !isActiveJob(status),
+    status,
+    subagent: state.subagent,
+  };
+}
+
+function durableTerminalEvent(
+  job: SubagentJob,
+  output: unknown
+): Extract<AgentEvent, { type: "subagent-job-end" }> | null {
+  if (job.status !== "completed" && job.status !== "cancelled") {
+    return null;
+  }
+
+  const result = compactSubagentResult(output);
+  return {
+    error: result?.error,
+    eventCount: result?.eventCount ?? 0,
+    delegateToolCallId: job.delegateToolCallId,
+    status: job.status,
+    subagent: job.subagent,
+    task_id: job.id,
+    type: "subagent-job-end",
+  };
+}
+
+function compactSubagentResult(
+  output: unknown
+): CompactSubagentResult | undefined {
+  if (!isRecord(output)) {
+    return;
+  }
+
+  if (
+    typeof output.eventCount !== "number" ||
+    output.run_in_background !== false ||
+    typeof output.subagent !== "string" ||
+    typeof output.text !== "string" ||
+    !isCompactResultStatus(output.result)
+  ) {
+    return;
+  }
+
+  return {
+    ...(typeof output.error === "string" ? { error: output.error } : {}),
+    eventCount: output.eventCount,
+    result: output.result,
+    run_in_background: false,
+    subagent: output.subagent,
+    text: output.text,
+  };
+}
+
+function isCompactResultStatus(
+  value: unknown
+): value is CompactSubagentResult["result"] {
+  return value === "aborted" || value === "completed" || value === "error";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/runtime/src/subagent-background-resume.test.ts
+++ b/packages/runtime/src/subagent-background-resume.test.ts
@@ -1,0 +1,180 @@
+import type { ToolSet } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fakeModel,
+  getGenerateTextMock,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import {
+  backgroundNotificationKey,
+  collectAgentRun,
+  createDurableTestHost,
+  resumeBackgroundTask,
+  waitForSessionPromptResume,
+} from "./subagent-background-test-support";
+import {
+  assistantMessage,
+  createDeferred,
+  eventTypes,
+  toolCallPart,
+  userText,
+} from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("subagent background resume", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a notify run only after the background job finishes", async () => {
+    const Agent = await loadAgent();
+    const childCanFinish = createDeferred();
+    let childFinished = false;
+    let launchedTaskId = "";
+    let parentCalls = 0;
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => {
+        await childCanFinish.promise;
+        childFinished = true;
+        return [assistantMessage("CHILD DONE")];
+      },
+      name: "researcher",
+    });
+
+    generateTextMock.mockImplementation(
+      async ({
+        messages,
+        tools,
+      }: {
+        readonly messages: unknown;
+        readonly tools?: ToolSet;
+      }) => {
+        parentCalls += 1;
+        if (parentCalls === 1) {
+          const toolCall = toolCallPart(
+            "call-delegate",
+            "delegate_to_researcher",
+            {
+              prompt: "research this",
+              run_in_background: true,
+            }
+          );
+          const launch = (await tools?.delegate_to_researcher?.execute?.(
+            {
+              description: "Research facts",
+              prompt: "research this",
+              run_in_background: true,
+            },
+            toolExecutionOptions()
+          )) as { readonly message: string; readonly task_id: string };
+          launchedTaskId = launch.task_id;
+          expect(launch.message).toContain("wait for <system-reminder>");
+          expect(launch.message).toContain(
+            `background_output({ task_id: "${launch.task_id}" })`
+          );
+
+          return {
+            responseMessages: [
+              assistantMessage([toolCall]),
+              {
+                content: [
+                  {
+                    output: { type: "json", value: launch },
+                    toolCallId: toolCall.toolCallId,
+                    toolName: toolCall.toolName,
+                    type: "tool-result",
+                  },
+                ],
+                role: "tool",
+              },
+            ],
+          };
+        }
+
+        if (!childFinished) {
+          return {
+            responseMessages: [
+              assistantMessage("Background task started; waiting."),
+            ],
+          };
+        }
+
+        expect(childFinished).toBe(true);
+        const serializedMessages = JSON.stringify(messages);
+        expect(serializedMessages).toContain("<system-reminder>");
+        expect(serializedMessages).toContain("[BACKGROUND TASK COMPLETED]");
+        expect(serializedMessages).toContain(launchedTaskId);
+
+        return {
+          responseMessages: [assistantMessage("NOTIFIED CHILD DONE")],
+        };
+      }
+    );
+    const host = createDurableTestHost();
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      subagents: [researcher],
+    });
+    const session = agent.session("default");
+
+    const firstRun = await session.send(userText("delegate"));
+    const firstEvents = await collectAgentRun(firstRun);
+    const callsBeforeNotify = parentCalls;
+    const firstEventTypes = eventTypes(firstEvents);
+
+    expect(childFinished).toBe(false);
+    expect(callsBeforeNotify).toBeGreaterThanOrEqual(1);
+    expect(firstEventTypes).toContain("tool-call");
+    expect(firstEventTypes).toContain("subagent-job-start");
+    expect(firstEventTypes).toContain("tool-result");
+    expect(firstEventTypes).toContain("turn-end");
+    expect(firstEventTypes).not.toContain("runtime-input");
+    expect(firstEventTypes).not.toContain("subagent-job-end");
+
+    childCanFinish.resolve();
+    await collectAgentRun(await resumeBackgroundTask(agent, launchedTaskId));
+    await expect(
+      host.store.notifications.getByIdempotencyKey(
+        backgroundNotificationKey(launchedTaskId)
+      )
+    ).resolves.toMatchObject({ status: "pending" });
+
+    const notifyRun = await waitForSessionPromptResume(
+      agent,
+      host,
+      backgroundNotificationKey(launchedTaskId)
+    );
+    const notifyEvents = await collectAgentRun(notifyRun);
+    expect(parentCalls).toBe(callsBeforeNotify + 1);
+    expect(eventTypes(notifyEvents)).toEqual([
+      "subagent-job-end",
+      "turn-start",
+      "runtime-input",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(notifyEvents).toContainEqual(
+      expect.objectContaining({
+        input: {
+          text: expect.stringContaining(
+            `Use background_output({ task_id: "${launchedTaskId}" })`
+          ),
+          type: "user-text",
+        },
+        placement: "turn-start",
+        type: "runtime-input",
+      })
+    );
+  });
+});

--- a/packages/runtime/src/subagent-background-runner.ts
+++ b/packages/runtime/src/subagent-background-runner.ts
@@ -1,0 +1,191 @@
+import type { AgentInput } from "./session/input";
+import {
+  childRunStatus,
+  updateBackgroundRunStatus,
+} from "./subagent-background-child-run";
+import { notifyBackgroundCompletion } from "./subagent-background-notify";
+import { emitBackgroundJobUpdate } from "./subagent-job-observer";
+import { collectSubagentRunWithEvents } from "./subagent-run";
+import type {
+  RuntimeInputSink,
+  Subagent,
+  SubagentJob,
+  SubagentJobGroup,
+} from "./subagent-types";
+
+type BackgroundChildSession = ReturnType<Subagent["session"]>;
+
+const durableCancelPollMs = 25;
+
+export async function runBackgroundJob({
+  childSession,
+  groups,
+  jobs,
+  job,
+  parentSession,
+  prompt,
+}: {
+  readonly childSession: BackgroundChildSession;
+  readonly groups: Map<string, SubagentJobGroup>;
+  readonly jobs: Map<string, SubagentJob>;
+  readonly job: SubagentJob;
+  readonly parentSession: RuntimeInputSink;
+  readonly prompt: AgentInput;
+}): Promise<void> {
+  if (job.status === "cancelled") {
+    return;
+  }
+  job.status = "running";
+  if (await syncDurableCancellation(job, childSession)) {
+    return;
+  }
+
+  const stopCancelWatcher = startDurableCancellationWatcher(job, childSession);
+  try {
+    const { result } = await collectSubagentRunWithEvents(
+      await childSession.send(prompt),
+      job.subagent,
+      (event) => emitBackgroundJobUpdate(parentSession, job, event)
+    );
+    if (await syncDurableCancellation(job, childSession)) {
+      return;
+    }
+    const previousResult = job.result;
+    job.result = result;
+    const updated = await updateBackgroundRunStatus(
+      job,
+      childRunStatus(result.result)
+    );
+    if (!updated) {
+      job.result = previousResult;
+      job.status = "cancelled";
+      childSession.interrupt();
+      return;
+    }
+    job.status = result.result;
+  } catch (error) {
+    if (await syncDurableCancellation(job, childSession)) {
+      return;
+    }
+    const jobError = error instanceof Error ? error : new Error(String(error));
+    const previousResult = job.result;
+    job.result = {
+      error: errorMessage(jobError),
+      eventCount: 0,
+      result: "error",
+      run_in_background: false,
+      subagent: job.subagent,
+      text: "",
+    };
+    const updated = await updateBackgroundRunStatus(job, "error");
+    if (!updated) {
+      job.result = previousResult;
+      job.status = "cancelled";
+      childSession.interrupt();
+      return;
+    }
+    job.status = "error";
+  } finally {
+    stopCancelWatcher();
+  }
+
+  if (await syncDurableCancellation(job, childSession)) {
+    return;
+  }
+
+  job.settled = true;
+  await notifyBackgroundCompletion({
+    endEvent: {
+      error: job.result?.error,
+      eventCount: job.result?.eventCount ?? 0,
+      delegateToolCallId: job.delegateToolCallId,
+      status: job.result?.result ?? "error",
+      subagent: job.subagent,
+      task_id: job.id,
+      type: "subagent-job-end",
+    },
+    groups,
+    job,
+    jobs,
+    parentSession,
+  });
+}
+
+function startDurableCancellationWatcher(
+  job: SubagentJob,
+  childSession: BackgroundChildSession
+): () => void {
+  let stopped = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const poll = async (): Promise<void> => {
+    if (stopped) {
+      return;
+    }
+    await syncDurableCancellation(job, childSession);
+    if (stopped || job.status === "cancelled") {
+      return;
+    }
+    timeoutId = setTimeout(() => {
+      queueCancelPoll(poll, job, childSession);
+    }, durableCancelPollMs);
+  };
+
+  queueCancelPoll(poll, job, childSession);
+  return () => {
+    stopped = true;
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  };
+}
+
+function queueCancelPoll(
+  poll: () => Promise<void>,
+  job: SubagentJob,
+  childSession: BackgroundChildSession
+): void {
+  poll().catch((error: unknown) => {
+    job.status = "error";
+    job.result = {
+      error: errorMessage(error),
+      eventCount: 0,
+      result: "error",
+      run_in_background: false,
+      subagent: job.subagent,
+      text: "",
+    };
+    childSession.interrupt();
+  });
+}
+
+async function syncDurableCancellation(
+  job: SubagentJob,
+  childSession: BackgroundChildSession
+): Promise<boolean> {
+  if (job.status === "cancelled") {
+    childSession.interrupt();
+    return true;
+  }
+  if (!(job.executionHost && job.childRunId)) {
+    return false;
+  }
+
+  const run = await job.executionHost.store.runs.get(job.childRunId);
+  const leaseLost =
+    job.childRunLeaseId && run?.lease?.leaseId !== job.childRunLeaseId;
+  if (run?.status !== "cancelled" && !leaseLost) {
+    return false;
+  }
+
+  job.status = "cancelled";
+  childSession.interrupt();
+  return true;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/packages/runtime/src/subagent-background-runner.ts
+++ b/packages/runtime/src/subagent-background-runner.ts
@@ -15,7 +15,7 @@ import type {
 
 type BackgroundChildSession = ReturnType<Subagent["session"]>;
 
-const durableCancelPollMs = 1000;
+const durableCancelPollMs = 250;
 
 export async function runBackgroundJob({
   childSession,

--- a/packages/runtime/src/subagent-background-runner.ts
+++ b/packages/runtime/src/subagent-background-runner.ts
@@ -15,7 +15,7 @@ import type {
 
 type BackgroundChildSession = ReturnType<Subagent["session"]>;
 
-const durableCancelPollMs = 25;
+const durableCancelPollMs = 1000;
 
 export async function runBackgroundJob({
   childSession,

--- a/packages/runtime/src/subagent-background-schedule.ts
+++ b/packages/runtime/src/subagent-background-schedule.ts
@@ -1,0 +1,69 @@
+import type { RunRecord } from "./execution/types";
+import { registerBackgroundJobGroup } from "./subagent-background-notify";
+import type {
+  RuntimeInputSink,
+  SubagentJob,
+  SubagentJobGroup,
+} from "./subagent-types";
+
+export async function scheduleDurableBackgroundJob({
+  childRun,
+  delegateToolCallId,
+  description,
+  executionHost,
+  groupId,
+  groups,
+  id,
+  jobs,
+  parentRunId,
+  parentSession,
+  parentSessionKey,
+  ownerNamespace,
+  subagent,
+}: {
+  readonly childRun: RunRecord;
+  readonly delegateToolCallId?: string;
+  readonly description?: string;
+  readonly executionHost: NonNullable<SubagentJob["executionHost"]>;
+  readonly groupId?: string;
+  readonly groups: Map<string, SubagentJobGroup>;
+  readonly id: string;
+  readonly jobs: Map<string, SubagentJob>;
+  readonly parentRunId?: string;
+  readonly parentSession: RuntimeInputSink;
+  readonly parentSessionKey?: string;
+  readonly ownerNamespace?: string;
+  readonly subagent: string;
+}): Promise<SubagentJob> {
+  const job: SubagentJob = {
+    abort: () => undefined,
+    childRunId: childRun.runId,
+    cleanup: () => Promise.resolve(),
+    dedupeKey: childRun.dedupeKey,
+    description,
+    id,
+    delegateToolCallId,
+    executionHost,
+    ownerNamespace,
+    parentSessionKey,
+    parentRunId,
+    promise: Promise.resolve(),
+    groupId,
+    sessionKey: childRun.sessionKey,
+    settled: true,
+    status: "pending",
+    subagent,
+  };
+  jobs.set(id, job);
+  registerBackgroundJobGroup({ groupId, groups, job });
+  await parentSession.emitObserverEvent({
+    description,
+    delegateToolCallId,
+    run_in_background: true,
+    subagent,
+    task_id: id,
+    type: "subagent-job-start",
+  });
+  await executionHost.scheduler.enqueueRun(childRun.runId);
+  return job;
+}

--- a/packages/runtime/src/subagent-background-test-support.test.ts
+++ b/packages/runtime/src/subagent-background-test-support.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { backgroundNotificationKey } from "./subagent-background-test-support";
+
+describe("subagent background test support", () => {
+  it("builds stable background notification keys when task ids arrive out of order", () => {
+    expect(backgroundNotificationKey("bg_2", "bg_1")).toBe(
+      "background-complete:default:bg_1,bg_2"
+    );
+  });
+});

--- a/packages/runtime/src/subagent-background-test-support.ts
+++ b/packages/runtime/src/subagent-background-test-support.ts
@@ -1,0 +1,84 @@
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost } from "./execution/types";
+import type { AgentEvent } from "./session/events";
+import type { AgentRun } from "./session/run";
+
+interface DurableResumeAgent {
+  resume(runId: string): Promise<AgentRun | null>;
+}
+
+export function backgroundNotificationKey(
+  ...taskIds: readonly string[]
+): string {
+  return `background-complete:default:${[...taskIds].sort().join(",")}`;
+}
+
+export function createDurableTestHost(): ExecutionHost {
+  const base = createInMemoryExecutionHost();
+  return {
+    ...base,
+    capabilities: {
+      ...base.capabilities,
+      backgroundSubagents: "durable",
+    },
+  };
+}
+
+export async function collectAgentRun(run: AgentRun): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of run.events()) {
+    events.push(event);
+  }
+
+  return events;
+}
+
+export async function resumeBackgroundTask(
+  agent: DurableResumeAgent,
+  taskId: string
+): Promise<AgentRun> {
+  const run = await agent.resume(`background:${taskId}`);
+  if (!run) {
+    throw new Error(`Expected background run for ${taskId} to resume.`);
+  }
+  return run;
+}
+
+export async function settlesWithin(
+  promise: Promise<unknown>,
+  timeoutMs: number
+): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeoutId = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export async function waitForSessionPromptResume(
+  agent: DurableResumeAgent,
+  host: ExecutionHost,
+  idempotencyKey: string
+): Promise<AgentRun> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const notification =
+      await host.store.notifications.getByIdempotencyKey(idempotencyKey);
+    if (notification) {
+      const run = await agent.resume(notification.runId);
+      if (run) {
+        return run;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  throw new Error(`Expected session prompt resume for ${idempotencyKey}.`);
+}

--- a/packages/runtime/src/subagent-background-tools.test.ts
+++ b/packages/runtime/src/subagent-background-tools.test.ts
@@ -10,12 +10,11 @@ import {
 } from "./llm-test-utils";
 import { assistantMessage, createDeferred, userText } from "./test-fixtures";
 
+const generateTextMock = getGenerateTextMock();
 const activeJobStatusPattern = /pending|running/;
 const backgroundTaskIdPattern = /^bg_/;
 const backgroundTaskIdErrorPattern =
   /expects a background task_id starting with bg_/;
-const unknownBackgroundTaskPattern = /Unknown background subagent task/;
-const generateTextMock = getGenerateTextMock();
 
 describe("subagent background tools", () => {
   beforeEach(() => {
@@ -34,7 +33,7 @@ describe("subagent background tools", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [],
+      model: async () => [],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -66,7 +65,7 @@ describe("subagent background tools", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ signal }) =>
+      model: ({ signal }) =>
         new Promise((_, reject) => {
           signal.addEventListener(
             "abort",
@@ -102,7 +101,7 @@ describe("subagent background tools", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -133,45 +132,12 @@ describe("subagent background tools", () => {
       })
     );
   });
-
-  it("background_output forgets completed jobs after retrieval", async () => {
-    const Agent = await loadAgent();
-    const researcher = new Agent({
-      description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
-      name: "researcher",
-    });
-    const agent = new Agent({ model: fakeModel, subagents: [researcher] });
-
-    await drainRun(await agent.send(userText("delegate")));
-
-    const tools = lastGenerateTextTools();
-    const launch = (await executableTool(
-      tools,
-      "delegate_to_researcher"
-    ).execute?.(
-      { prompt: "research this", run_in_background: true },
-      toolExecutionOptions()
-    )) as { task_id: string };
-    await executableTool(tools, "background_output").execute?.(
-      { block: true, task_id: launch.task_id },
-      toolExecutionOptions()
-    );
-
-    await expect(
-      executableTool(tools, "background_output").execute?.(
-        { task_id: launch.task_id },
-        toolExecutionOptions()
-      )
-    ).rejects.toThrow(unknownBackgroundTaskPattern);
-  });
-
   it("background_output can block until completion", async () => {
     const Agent = await loadAgent();
     const childGate = createDeferred();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => {
+      model: async () => {
         await childGate.promise;
         return [assistantMessage("CHILD DONE")];
       },
@@ -212,7 +178,7 @@ describe("subagent background tools", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [],
+      model: async () => [],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -225,54 +191,5 @@ describe("subagent background tools", () => {
         toolExecutionOptions()
       )
     ).rejects.toThrow(backgroundTaskIdErrorPattern);
-  });
-
-  it("background_cancel aborts active job", async () => {
-    const Agent = await loadAgent();
-    const childGate = new Promise<void>(() => undefined);
-    const researcher = new Agent({
-      description: "Researches facts.",
-      llm: async () => {
-        await childGate;
-        return [assistantMessage("CHILD DONE")];
-      },
-      name: "researcher",
-    });
-    const agent = new Agent({ model: fakeModel, subagents: [researcher] });
-
-    await drainRun(await agent.send(userText("delegate")));
-
-    const tools = lastGenerateTextTools();
-    const launch = (await executableTool(
-      tools,
-      "delegate_to_researcher"
-    ).execute?.(
-      { prompt: "research this", run_in_background: true },
-      toolExecutionOptions()
-    )) as { task_id: string };
-
-    expect(
-      await executableTool(tools, "background_cancel").execute?.(
-        { task_id: launch.task_id },
-        toolExecutionOptions()
-      )
-    ).toEqual({
-      status: "cancelled",
-      task_id: launch.task_id,
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(
-      await executableTool(tools, "background_output").execute?.(
-        { block: true, task_id: launch.task_id, timeout: 50 },
-        toolExecutionOptions()
-      )
-    ).toEqual(
-      expect.objectContaining({
-        result: undefined,
-        status: "cancelled",
-        task_id: launch.task_id,
-      })
-    );
   });
 });

--- a/packages/runtime/src/subagent-child-cleanup-durable-failure.test.ts
+++ b/packages/runtime/src/subagent-child-cleanup-durable-failure.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "./agent";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, RunStore } from "./execution/types";
+
+describe("durable subagent child cleanup failures", () => {
+  it("evicts the parent handle when durable child cancellation fails", async () => {
+    const host = createListRejectingHost();
+    const agent = new Agent({
+      host,
+      model: async () => [],
+      namespace: "cleanup-delete-failure",
+    });
+    const firstSession = agent.session("default");
+
+    await expect(firstSession.delete()).rejects.toThrow(
+      "durable child cancellation failed"
+    );
+
+    expect(agent.session("default")).not.toBe(firstSession);
+  });
+});
+
+function createListRejectingHost(): ExecutionHost {
+  const base = createInMemoryExecutionHost();
+  const runs: RunStore = {
+    claim: (runId, options) => base.store.runs.claim(runId, options),
+    create: (record) => base.store.runs.create(record),
+    get: (runId) => base.store.runs.get(runId),
+    getByDedupeKey: (dedupeKey) => base.store.runs.getByDedupeKey(dedupeKey),
+    listByParentRunId: () =>
+      Promise.reject(new Error("durable child cancellation failed")),
+    update: (record) => base.store.runs.update(record),
+  };
+
+  return {
+    ...base,
+    store: {
+      checkpoints: base.store.checkpoints,
+      events: base.store.events,
+      notifications: base.store.notifications,
+      runs,
+      sessions: base.store.sessions,
+      transaction: (fn) => base.store.transaction(fn),
+    },
+  };
+}

--- a/packages/runtime/src/subagent-child-cleanup-durable.test.ts
+++ b/packages/runtime/src/subagent-child-cleanup-durable.test.ts
@@ -6,7 +6,10 @@ import {
 } from "./agent-namespace";
 import { createInMemoryExecutionHost } from "./execution/memory";
 import type { ExecutionHost, RunRecord, RunStore } from "./execution/types";
-import { createDeferred } from "./test-fixtures";
+import { collect } from "./session/session.test-support";
+import { createDeferred, eventTypes } from "./test-fixtures";
+
+const timeoutMarker = Symbol("timeout");
 
 describe("durable subagent child cleanup", () => {
   it("reconstructed parent delete cancels linked child runs", async () => {
@@ -97,7 +100,59 @@ describe("durable subagent child cleanup", () => {
       status: "cancelled",
     });
   });
+
+  it("kill closes the active parent run before durable child cancellation resolves", async () => {
+    const { host, releaseList } = createListBlockingHost();
+    const namespace = "cleanup-kill-active";
+    await host.store.runs.create(
+      createChildRun({
+        kind: "background-subagent",
+        parentRunId: testParentRunId(namespace),
+        publicTaskId: "bg_kill_active",
+        runId: "background:bg_kill_active",
+        status: "running",
+      })
+    );
+    const llmStarted = createDeferred();
+    const agent = new Agent({
+      host,
+      model: () => {
+        llmStarted.resolve();
+        return new Promise<never>(() => undefined);
+      },
+      namespace,
+    });
+    const session = agent.session("default");
+    const collecting = collect(await session.send("hello"));
+
+    await llmStarted.promise;
+    const killPromise = session.kill();
+    const events = await withShortTimeout(collecting);
+    releaseList.resolve();
+    await killPromise;
+
+    if (events === timeoutMarker) {
+      throw new Error("session.kill() waited for durable child cleanup");
+    }
+    expect(eventTypes(events)).toEqual([
+      "user-text",
+      "turn-start",
+      "step-start",
+      "turn-error",
+    ]);
+  });
 });
+
+function withShortTimeout<T>(
+  promise: Promise<T>
+): Promise<T | typeof timeoutMarker> {
+  return Promise.race([
+    promise,
+    new Promise<typeof timeoutMarker>((resolve) => {
+      setTimeout(() => resolve(timeoutMarker), 100);
+    }),
+  ]);
+}
 
 function createListBlockingHost(): {
   readonly host: ExecutionHost;

--- a/packages/runtime/src/subagent-child-cleanup-durable.test.ts
+++ b/packages/runtime/src/subagent-child-cleanup-durable.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "./agent";
+import {
+  parentSessionNamespace,
+  stableAgentNamespace,
+} from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, RunRecord, RunStore } from "./execution/types";
+import { createDeferred } from "./test-fixtures";
+
+describe("durable subagent child cleanup", () => {
+  it("reconstructed parent delete cancels linked child runs", async () => {
+    const host = createInMemoryExecutionHost();
+    const namespace = "cleanup-delete";
+    const parentRunId = testParentRunId(namespace);
+    await host.store.runs.create(
+      createChildRun({
+        kind: "subagent",
+        parentRunId,
+        runId: "child:blocking",
+        status: "running",
+      })
+    );
+    await host.store.runs.create(
+      createChildRun({
+        kind: "background-subagent",
+        parentRunId,
+        publicTaskId: "bg_1",
+        runId: "background:bg_1",
+        status: "leased",
+      })
+    );
+    await host.store.runs.create(
+      createChildRun({
+        kind: "background-subagent",
+        parentRunId,
+        publicTaskId: "bg_done",
+        runId: "background:bg_done",
+        status: "completed",
+      })
+    );
+    const reconstructed = new Agent({
+      host,
+      model: async () => [],
+      namespace,
+    });
+
+    await reconstructed.session("default").delete();
+
+    await expect(host.store.runs.get("child:blocking")).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    await expect(host.store.runs.get("background:bg_1")).resolves.toMatchObject(
+      {
+        status: "cancelled",
+      }
+    );
+    await expect(
+      host.store.runs.get("background:bg_done")
+    ).resolves.toMatchObject({
+      status: "completed",
+    });
+  });
+
+  it("kill waits for durable child cancellation before resolving", async () => {
+    const { host, releaseList } = createListBlockingHost();
+    const namespace = "cleanup-kill";
+    await host.store.runs.create(
+      createChildRun({
+        kind: "background-subagent",
+        parentRunId: testParentRunId(namespace),
+        publicTaskId: "bg_kill",
+        runId: "background:bg_kill",
+        status: "running",
+      })
+    );
+    const agent = new Agent({
+      host,
+      model: async () => [],
+      namespace,
+    });
+
+    const killPromise = agent.session("default").kill();
+    let resolved = false;
+    const resolution = killPromise.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releaseList.resolve();
+    await resolution;
+
+    await expect(
+      host.store.runs.get("background:bg_kill")
+    ).resolves.toMatchObject({
+      status: "cancelled",
+    });
+  });
+});
+
+function createListBlockingHost(): {
+  readonly host: ExecutionHost;
+  readonly releaseList: ReturnType<typeof createDeferred>;
+} {
+  const base = createInMemoryExecutionHost();
+  const releaseList = createDeferred();
+  const runs: RunStore = {
+    claim: (runId, options) => base.store.runs.claim(runId, options),
+    create: (record) => base.store.runs.create(record),
+    get: (runId) => base.store.runs.get(runId),
+    getByDedupeKey: (dedupeKey) => base.store.runs.getByDedupeKey(dedupeKey),
+    listByParentRunId: async (parentRunId) => {
+      await releaseList.promise;
+      return await base.store.runs.listByParentRunId(parentRunId);
+    },
+    update: (record) => base.store.runs.update(record),
+  };
+
+  return {
+    host: {
+      ...base,
+      store: {
+        checkpoints: base.store.checkpoints,
+        events: base.store.events,
+        notifications: base.store.notifications,
+        runs,
+        sessions: base.store.sessions,
+        transaction: (fn) => base.store.transaction(fn),
+      },
+    },
+    releaseList,
+  };
+}
+
+function createChildRun(
+  input: Pick<RunRecord, "kind" | "runId" | "status"> &
+    Pick<Partial<RunRecord>, "parentRunId" | "publicTaskId">
+): RunRecord {
+  const parentRunId = input.parentRunId ?? testParentRunId("cleanup");
+  return {
+    checkpointVersion: 0,
+    kind: input.kind,
+    parentRunId,
+    publicTaskId: input.publicTaskId,
+    rootRunId: parentRunId,
+    runId: input.runId,
+    sessionKey: `${input.runId}:session`,
+    status: input.status,
+  };
+}
+
+function testParentRunId(namespace: string): string {
+  return parentSessionNamespace({
+    generation: 0,
+    sessionKey: "default",
+    sessionNamespace: stableAgentNamespace({ namespace }),
+  });
+}

--- a/packages/runtime/src/subagent-child-cleanup-durable.test.ts
+++ b/packages/runtime/src/subagent-child-cleanup-durable.test.ts
@@ -101,6 +101,34 @@ describe("durable subagent child cleanup", () => {
     });
   });
 
+  it("keeps the parent handle until durable child cancellation finishes", async () => {
+    const { host, releaseList } = createListBlockingHost();
+    const namespace = "cleanup-handle-order";
+    await host.store.runs.create(
+      createChildRun({
+        kind: "background-subagent",
+        parentRunId: testParentRunId(namespace),
+        publicTaskId: "bg_delete_order",
+        runId: "background:bg_delete_order",
+        status: "running",
+      })
+    );
+    const agent = new Agent({
+      host,
+      model: async () => [],
+      namespace,
+    });
+    const firstSession = agent.session("default");
+
+    const deletion = firstSession.delete();
+    await Promise.resolve();
+
+    expect(agent.session("default")).toBe(firstSession);
+    releaseList.resolve();
+    await deletion;
+    expect(agent.session("default")).not.toBe(firstSession);
+  });
+
   it("kill closes the active parent run before durable child cancellation resolves", async () => {
     const { host, releaseList } = createListBlockingHost();
     const namespace = "cleanup-kill-active";

--- a/packages/runtime/src/subagent-child-cleanup-notification.test.ts
+++ b/packages/runtime/src/subagent-child-cleanup-notification.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { ExecutionHost, RunRecord } from "./execution/types";
+import type { UserInput } from "./session/input";
+import type { AgentRun } from "./session/run";
+import { updateBackgroundRunStatus } from "./subagent-background-child-run";
+import { notifyBackgroundCompletion } from "./subagent-background-notify";
+import type { RuntimeInputSink, SubagentJob } from "./subagent-types";
+
+describe("durable subagent child cleanup notification", () => {
+  it("stale cancelled child completion cannot notify parent", async () => {
+    const host = createDurableHost();
+    await host.store.runs.create(
+      createChildRun({
+        kind: "background-subagent",
+        publicTaskId: "bg_1",
+        runId: "background:bg_1",
+        status: "cancelled",
+      })
+    );
+    const inlineNotifications: UserInput[] = [];
+    const job = createBackgroundJob(host);
+    const jobs = new Map([[job.id, job]]);
+
+    await updateBackgroundRunStatus(job, "completed");
+    await notifyBackgroundCompletion({
+      endEvent: {
+        eventCount: 1,
+        status: "completed",
+        subagent: "researcher",
+        task_id: job.id,
+        type: "subagent-job-end",
+      },
+      groups: new Map(),
+      job,
+      jobs,
+      parentSession: createParentSession(inlineNotifications),
+    });
+
+    await expect(host.store.runs.get("background:bg_1")).resolves.toMatchObject(
+      {
+        status: "cancelled",
+      }
+    );
+    await expect(
+      host.store.notifications.getByIdempotencyKey(
+        "background-complete:default:bg_1"
+      )
+    ).resolves.toBeNull();
+    expect(host.resumedSessionKeys).toEqual([]);
+    expect(inlineNotifications).toEqual([]);
+  });
+});
+
+interface DurableTestHost extends ExecutionHost {
+  readonly resumedSessionKeys: readonly string[];
+}
+
+function createDurableHost(): DurableTestHost {
+  const base = createInMemoryExecutionHost();
+  const resumedSessionKeys: string[] = [];
+  return {
+    ...base,
+    capabilities: {
+      backgroundSubagents: "durable",
+    },
+    scheduler: {
+      enqueueRun: () => Promise.resolve(),
+      resumeSession: (sessionKey) => {
+        resumedSessionKeys.push(sessionKey);
+        return Promise.resolve();
+      },
+    },
+    resumedSessionKeys,
+  };
+}
+
+function createChildRun(
+  input: Pick<RunRecord, "kind" | "runId" | "status"> &
+    Pick<Partial<RunRecord>, "publicTaskId">
+): RunRecord {
+  return {
+    checkpointVersion: 0,
+    kind: input.kind,
+    publicTaskId: input.publicTaskId,
+    rootRunId: "background-cleanup",
+    runId: input.runId,
+    sessionKey: `${input.runId}:session`,
+    status: input.status,
+  };
+}
+
+function createBackgroundJob(host: ExecutionHost): SubagentJob {
+  return {
+    abort: () => undefined,
+    childRunId: "background:bg_1",
+    cleanup: () => Promise.resolve(),
+    executionHost: host,
+    id: "bg_1",
+    parentSessionKey: "default",
+    promise: Promise.resolve(),
+    sessionKey: "background:bg_1:session",
+    settled: true,
+    status: "completed",
+    subagent: "researcher",
+  };
+}
+
+function createParentSession(notifications: UserInput[]): RuntimeInputSink {
+  return {
+    emitObserverEvent: () => Promise.resolve(),
+    enqueueRuntimeInput: () => undefined,
+    notify: (input) => {
+      notifications.push(input);
+      return Promise.resolve(createEmptyRun());
+    },
+  };
+}
+
+function createEmptyRun(): AgentRun {
+  return {
+    events: () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          next: () =>
+            Promise.resolve({
+              done: true,
+              value: undefined,
+            }),
+        };
+      },
+    }),
+  };
+}

--- a/packages/runtime/src/subagent-child-cleanup-notification.test.ts
+++ b/packages/runtime/src/subagent-child-cleanup-notification.test.ts
@@ -4,8 +4,15 @@ import type { ExecutionHost, RunRecord } from "./execution/types";
 import type { UserInput } from "./session/input";
 import type { AgentRun } from "./session/run";
 import { updateBackgroundRunStatus } from "./subagent-background-child-run";
-import { notifyBackgroundCompletion } from "./subagent-background-notify";
-import type { RuntimeInputSink, SubagentJob } from "./subagent-types";
+import {
+  notifyBackgroundCompletion,
+  registerBackgroundJobGroup,
+} from "./subagent-background-notify";
+import type {
+  RuntimeInputSink,
+  SubagentJob,
+  SubagentJobGroup,
+} from "./subagent-types";
 
 describe("durable subagent child cleanup notification", () => {
   it("stale cancelled child completion cannot notify parent", async () => {
@@ -50,6 +57,78 @@ describe("durable subagent child cleanup notification", () => {
     expect(host.resumedSessionKeys).toEqual([]);
     expect(inlineNotifications).toEqual([]);
   });
+
+  it("notifies completed siblings when a cancelled sibling is stale", async () => {
+    const host = createDurableHost();
+    await host.store.runs.create(
+      createChildRun({
+        kind: "background-subagent",
+        publicTaskId: "bg_cancelled",
+        runId: "background:bg_cancelled",
+        status: "cancelled",
+      })
+    );
+    await host.store.runs.create(
+      createChildRun({
+        kind: "background-subagent",
+        publicTaskId: "bg_done",
+        runId: "background:bg_done",
+        status: "completed",
+      })
+    );
+    const inlineNotifications: UserInput[] = [];
+    const groupId = "group-cleanup";
+    const cancelledJob = createBackgroundJob(host, {
+      childRunId: "background:bg_cancelled",
+      groupId,
+      id: "bg_cancelled",
+      status: "cancelled",
+    });
+    const completedJob = createBackgroundJob(host, {
+      childRunId: "background:bg_done",
+      groupId,
+      id: "bg_done",
+      status: "completed",
+    });
+    const jobs = new Map([
+      [cancelledJob.id, cancelledJob],
+      [completedJob.id, completedJob],
+    ]);
+    const groups = new Map<string, SubagentJobGroup>();
+    registerBackgroundJobGroup({ groupId, groups, job: cancelledJob });
+    registerBackgroundJobGroup({ groupId, groups, job: completedJob });
+
+    groups.get(groupId)?.failedNotifiedJobIds.add(cancelledJob.id);
+    await notifyBackgroundCompletion({
+      endEvent: {
+        eventCount: 1,
+        status: "completed",
+        subagent: "researcher",
+        task_id: completedJob.id,
+        type: "subagent-job-end",
+      },
+      groups,
+      job: completedJob,
+      jobs,
+      parentSession: createParentSession(inlineNotifications),
+    });
+
+    await expect(
+      host.store.notifications.getByIdempotencyKey(
+        "background-complete:default:bg_done"
+      )
+    ).resolves.toMatchObject({
+      sessionKey: "default",
+      status: "pending",
+    });
+    await expect(
+      host.store.notifications.getByIdempotencyKey(
+        "background-complete:default:bg_cancelled,bg_done"
+      )
+    ).resolves.toBeNull();
+    expect(host.resumedSessionKeys).toEqual(["default"]);
+    expect(inlineNotifications).toEqual([]);
+  });
 });
 
 interface DurableTestHost extends ExecutionHost {
@@ -90,18 +169,30 @@ function createChildRun(
   };
 }
 
-function createBackgroundJob(host: ExecutionHost): SubagentJob {
+function createBackgroundJob(
+  host: ExecutionHost,
+  options: {
+    readonly childRunId?: string;
+    readonly groupId?: string;
+    readonly id?: string;
+    readonly status?: SubagentJob["status"];
+  } = {}
+): SubagentJob {
+  const id = options.id ?? "bg_1";
+  const childRunId = options.childRunId ?? "background:bg_1";
   return {
     abort: () => undefined,
-    childRunId: "background:bg_1",
+    childRunId,
     cleanup: () => Promise.resolve(),
     executionHost: host,
-    id: "bg_1",
+    groupId: options.groupId,
+    id,
+    ownerNamespace: "owner",
     parentSessionKey: "default",
     promise: Promise.resolve(),
-    sessionKey: "background:bg_1:session",
+    sessionKey: `${childRunId}:session`,
     settled: true,
-    status: "completed",
+    status: options.status ?? "completed",
     subagent: "researcher",
   };
 }

--- a/packages/runtime/src/subagent-child-cleanup-scope.test.ts
+++ b/packages/runtime/src/subagent-child-cleanup-scope.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "./agent";
+import {
+  parentSessionNamespace,
+  stableAgentNamespace,
+} from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import type { RunRecord } from "./execution/types";
+
+describe("durable subagent child cleanup scope", () => {
+  it("does not cancel another agent using the same raw session key", async () => {
+    const host = createInMemoryExecutionHost();
+    await host.store.runs.create(
+      createChildRun({
+        namespace: "alpha",
+        publicTaskId: "bg_alpha",
+        runId: "background:bg_alpha",
+      })
+    );
+    await host.store.runs.create(
+      createChildRun({
+        namespace: "beta",
+        publicTaskId: "bg_beta",
+        runId: "background:bg_beta",
+      })
+    );
+
+    await new Agent({
+      host,
+      model: async () => [],
+      namespace: "alpha",
+    })
+      .session("default")
+      .delete();
+
+    await expect(
+      host.store.runs.get("background:bg_alpha")
+    ).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    await expect(
+      host.store.runs.get("background:bg_beta")
+    ).resolves.toMatchObject({
+      status: "running",
+    });
+  });
+});
+
+function createChildRun({
+  namespace,
+  publicTaskId,
+  runId,
+}: {
+  readonly namespace: string;
+  readonly publicTaskId: string;
+  readonly runId: string;
+}): RunRecord {
+  const parentRunId = parentSessionNamespace({
+    generation: 0,
+    sessionKey: "default",
+    sessionNamespace: stableAgentNamespace({ namespace }),
+  });
+  return {
+    checkpointVersion: 0,
+    kind: "background-subagent",
+    parentRunId,
+    publicTaskId,
+    rootRunId: parentRunId,
+    runId,
+    sessionKey: `${runId}:session`,
+    status: "running",
+  };
+}

--- a/packages/runtime/src/subagent-child-run.test.ts
+++ b/packages/runtime/src/subagent-child-run.test.ts
@@ -1,0 +1,180 @@
+import type { Tool } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  parentSessionNamespace,
+  stableAgentNamespace,
+} from "./agent-namespace";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import {
+  drainRun,
+  executableTool,
+  fakeModel,
+  getGenerateTextMock,
+  lastGenerateTextTools,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import { assistantMessage, createDeferred, userText } from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("subagent child runs", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("blocking delegation resumes existing child run by dedupe key", async () => {
+    const Agent = await loadAgent();
+    const childGate = createDeferred();
+    const host = createInMemoryExecutionHost();
+    let childCalls = 0;
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => {
+        childCalls += 1;
+        await childGate.promise;
+        return [assistantMessage("CHILD DONE")];
+      },
+      name: "researcher",
+    });
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      namespace: "dedupe-parent",
+      subagents: [researcher],
+    });
+
+    const parentRunId = testParentRunId("dedupe-parent", "parent");
+    await drainRun(await agent.session("parent").send(userText("delegate")));
+    const delegate = executableTool(
+      lastGenerateTextTools(),
+      "delegate_to_researcher"
+    );
+
+    const options = {
+      ...toolExecutionOptions(),
+      toolCallId: "call_child_dedupe",
+    };
+    const first = executeDelegate(
+      delegate,
+      { prompt: "research this" },
+      options
+    );
+    const second = executeDelegate(
+      delegate,
+      { prompt: "research this" },
+      options
+    );
+
+    await Promise.resolve();
+    childGate.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        eventCount: expect.any(Number),
+        result: "completed",
+        run_in_background: false,
+        subagent: "researcher",
+        text: "CHILD DONE",
+      },
+      {
+        eventCount: expect.any(Number),
+        result: "completed",
+        run_in_background: false,
+        subagent: "researcher",
+        text: "CHILD DONE",
+      },
+    ]);
+    expect(childCalls).toBe(1);
+    await expect(
+      host.store.runs.getByDedupeKey(
+        `blocking-subagent:${parentRunId}:call_child_dedupe`
+      )
+    ).resolves.toMatchObject({
+      kind: "subagent",
+      parentRunId,
+      status: "completed",
+    });
+  });
+
+  it("blocking delegation scopes durable child runs by agent namespace", async () => {
+    const Agent = await loadAgent();
+    const host = createInMemoryExecutionHost();
+    let childCalls = 0;
+    const makeAgent = (namespace: string) => {
+      const researcher = new Agent({
+        description: "Researches facts.",
+        model: () => {
+          childCalls += 1;
+          return Promise.resolve([assistantMessage(`CHILD DONE ${namespace}`)]);
+        },
+        name: "researcher",
+      });
+      return new Agent({
+        host,
+        model: fakeModel,
+        namespace,
+        subagents: [researcher],
+      });
+    };
+    const alpha = makeAgent("alpha");
+    const beta = makeAgent("beta");
+    const options = {
+      ...toolExecutionOptions(),
+      toolCallId: "call_child_namespace",
+    };
+
+    await drainRun(await alpha.session("parent").send(userText("delegate")));
+    const alphaDelegate = executableTool(
+      lastGenerateTextTools(),
+      "delegate_to_researcher"
+    );
+    await drainRun(await beta.session("parent").send(userText("delegate")));
+    const betaDelegate = executableTool(
+      lastGenerateTextTools(),
+      "delegate_to_researcher"
+    );
+
+    await executeDelegate(alphaDelegate, { prompt: "research this" }, options);
+    await executeDelegate(betaDelegate, { prompt: "research this" }, options);
+
+    expect(childCalls).toBe(2);
+    await expect(
+      host.store.runs.listByParentRunId(testParentRunId("alpha", "parent"))
+    ).resolves.toHaveLength(1);
+    await expect(
+      host.store.runs.listByParentRunId(testParentRunId("beta", "parent"))
+    ).resolves.toHaveLength(1);
+  });
+});
+
+async function executeDelegate(
+  delegate: Tool,
+  input: unknown,
+  options: ReturnType<typeof toolExecutionOptions>
+): Promise<unknown> {
+  const result = delegate.execute?.(input, options);
+  if (!result) {
+    throw new Error("Expected executable delegate tool.");
+  }
+  return await result;
+}
+
+function testParentRunId(
+  namespace: string | undefined,
+  sessionKey: string
+): string {
+  return parentSessionNamespace({
+    generation: 0,
+    sessionKey,
+    sessionNamespace: stableAgentNamespace({ namespace }),
+  });
+}

--- a/packages/runtime/src/subagent-child-run.ts
+++ b/packages/runtime/src/subagent-child-run.ts
@@ -1,0 +1,127 @@
+import type { ExecutionHost, RunRecord, RunStatus } from "./execution/types";
+import type { AgentInput } from "./session/input";
+import { runBlockingDelegation } from "./subagent-run";
+import type { CompactSubagentResult, Subagent } from "./subagent-types";
+
+export type BlockingSubagentRunCache = Map<
+  string,
+  Promise<CompactSubagentResult>
+>;
+
+export async function runBlockingChild({
+  abortSignal,
+  dedupeKey,
+  executionHost,
+  parentRunId,
+  prompt,
+  sessionKey,
+  subagent,
+}: {
+  readonly abortSignal?: AbortSignal;
+  readonly dedupeKey: string;
+  readonly executionHost?: ExecutionHost;
+  readonly parentRunId: string;
+  readonly prompt: AgentInput;
+  readonly sessionKey: string;
+  readonly subagent: Subagent;
+}): Promise<CompactSubagentResult> {
+  const run = await getOrCreateBlockingChildRun({
+    dedupeKey,
+    executionHost,
+    parentRunId,
+    sessionKey,
+  });
+  const result = await runBlockingDelegation({
+    abortSignal,
+    prompt,
+    sessionKey,
+    subagent,
+  });
+  if (executionHost && run) {
+    await executionHost.store.runs.update({
+      ...run,
+      checkpointVersion: run.checkpointVersion,
+      status: childRunStatus(result.result),
+    });
+  }
+  return result;
+}
+
+export function blockingSubagentDedupeKey(
+  parentRunId: string,
+  toolCallId: string | undefined
+): string {
+  return `blocking-subagent:${parentRunId}:${toolCallId ?? "unknown"}`;
+}
+
+async function getOrCreateBlockingChildRun({
+  dedupeKey,
+  executionHost,
+  parentRunId,
+  sessionKey,
+}: {
+  readonly dedupeKey: string;
+  readonly executionHost?: ExecutionHost;
+  readonly parentRunId: string;
+  readonly sessionKey: string;
+}): Promise<RunRecord | undefined> {
+  if (!executionHost) {
+    return;
+  }
+
+  const existing = await executionHost.store.runs.getByDedupeKey(dedupeKey);
+  if (existing) {
+    return existing;
+  }
+
+  const run: RunRecord = {
+    checkpointVersion: 0,
+    dedupeKey,
+    kind: "subagent",
+    parentRunId,
+    rootRunId: parentRunId,
+    runId: `child:${dedupeKey}`,
+    sessionKey,
+    status: "queued",
+  };
+  await executionHost.store.runs.create(run);
+  await executionHost.store.checkpoints.append(
+    {
+      checkpointId: crypto.randomUUID(),
+      phase: "before-child-run",
+      runId: run.runId,
+      runtimeState: {},
+      sessionSnapshot: {},
+      version: 1,
+    },
+    { expectedVersion: 0 }
+  );
+  await executionHost.store.checkpoints.append(
+    {
+      checkpointId: crypto.randomUUID(),
+      childRunId: run.runId,
+      phase: "child-linked",
+      runId: run.runId,
+      runtimeState: {},
+      sessionSnapshot: {},
+      version: 2,
+    },
+    { expectedVersion: 1 }
+  );
+  const linked = await executionHost.store.runs.get(run.runId);
+  return linked ?? run;
+}
+
+function childRunStatus(
+  result: CompactSubagentResult["result"]
+): Extract<RunStatus, "cancelled" | "completed" | "error"> {
+  if (result === "aborted") {
+    return "cancelled";
+  }
+
+  if (result === "error") {
+    return "error";
+  }
+
+  return "completed";
+}

--- a/packages/runtime/src/subagent-generated-tools.test.ts
+++ b/packages/runtime/src/subagent-generated-tools.test.ts
@@ -29,7 +29,7 @@ describe("generated subagent tools", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [],
+      model: async () => [],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -53,7 +53,7 @@ describe("generated subagent tools", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -83,7 +83,7 @@ describe("generated subagent tools", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
@@ -109,7 +109,7 @@ describe("generated subagent tools", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
@@ -130,7 +130,7 @@ describe("generated subagent tools", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
@@ -166,7 +166,7 @@ describe("generated subagent tools", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
@@ -190,7 +190,7 @@ describe("generated subagent tools", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
@@ -213,7 +213,7 @@ describe("generated subagent tools", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });

--- a/packages/runtime/src/subagent-hardening.test.ts
+++ b/packages/runtime/src/subagent-hardening.test.ts
@@ -72,7 +72,7 @@ describe("subagent hardening", () => {
     const childAborted = createDeferred();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ signal }) =>
+      model: ({ signal }) =>
         new Promise((resolve) => {
           childStarted.resolve();
           signal.addEventListener(
@@ -113,7 +113,7 @@ describe("subagent hardening", () => {
     let childStarts = 0;
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: () => {
+      model: () => {
         childStarts += 1;
         return Promise.resolve([assistantMessage("SHOULD NOT START")]);
       },
@@ -146,7 +146,7 @@ describe("subagent hardening", () => {
     let childStarts = 0;
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: () => {
+      model: () => {
         childStarts += 1;
         return Promise.resolve([assistantMessage("SHOULD NOT START")]);
       },

--- a/packages/runtime/src/subagent-job-cancel.ts
+++ b/packages/runtime/src/subagent-job-cancel.ts
@@ -1,19 +1,44 @@
 import { jsonSchema, tool } from "ai";
+import type { ExecutionHost } from "./execution/types";
+import { cancelBackgroundChildRun } from "./subagent-background-child-run";
 import {
   assertBackgroundTaskId,
+  backgroundRunJobStatus,
   cancelJob,
   isActiveJob,
-} from "./subagent-jobs";
+} from "./subagent-job-state";
 import type { BackgroundCancelInput, SubagentJob } from "./subagent-types";
 
-export function createBackgroundCancelTool(jobs: Map<string, SubagentJob>) {
+interface BackgroundToolScope {
+  readonly childSessionKeyPrefix: string;
+}
+
+export function createBackgroundCancelTool(
+  jobs: Map<string, SubagentJob>,
+  executionHost?: ExecutionHost,
+  scope?: BackgroundToolScope
+) {
   return tool<BackgroundCancelInput, unknown, Record<string, unknown>>({
     description: "Cancel an active background subagent job.",
-    execute: (input: BackgroundCancelInput) => {
+    execute: async (input: BackgroundCancelInput) => {
       assertBackgroundTaskId(input.task_id, "background_cancel");
       const job = jobs.get(input.task_id);
       if (!job) {
+        const durableCancel = await durableBackgroundCancel(
+          input.task_id,
+          executionHost,
+          scope
+        );
+        if (durableCancel) {
+          return durableCancel;
+        }
+
         throw new Error(`Unknown background subagent task ${input.task_id}.`);
+      }
+
+      const durableLocalCancel = await cancelDurableLocalJob(job, scope);
+      if (durableLocalCancel) {
+        return durableLocalCancel;
       }
 
       if (isActiveJob(job.status)) {
@@ -34,4 +59,78 @@ export function createBackgroundCancelTool(jobs: Map<string, SubagentJob>) {
       type: "object",
     }),
   });
+}
+
+async function cancelDurableLocalJob(
+  job: SubagentJob,
+  scope: BackgroundToolScope | undefined
+): Promise<Record<string, unknown> | null> {
+  if (!(job.executionHost && job.childRunId)) {
+    return null;
+  }
+
+  const record = await job.executionHost.store.runs.get(job.childRunId);
+  if (record?.kind !== "background-subagent") {
+    return null;
+  }
+  if (scope && !record.sessionKey.startsWith(scope.childSessionKeyPrefix)) {
+    return null;
+  }
+
+  const currentStatus = backgroundRunJobStatus(record.status);
+  if (!currentStatus) {
+    return null;
+  }
+  if (currentStatus === "pending" || currentStatus === "running") {
+    const cancelled = await cancelBackgroundChildRun({
+      executionHost: job.executionHost,
+      runId: record.runId,
+    });
+    const nextStatus = backgroundRunJobStatus(cancelled?.status);
+    if (nextStatus === "cancelled") {
+      cancelJob(job);
+      return { status: "cancelled", task_id: job.id };
+    }
+
+    return { status: nextStatus ?? currentStatus, task_id: job.id };
+  }
+
+  return { status: currentStatus, task_id: job.id };
+}
+
+async function durableBackgroundCancel(
+  taskId: string,
+  executionHost: ExecutionHost | undefined,
+  scope: BackgroundToolScope | undefined
+): Promise<Record<string, unknown> | null> {
+  if (!executionHost) {
+    return null;
+  }
+  const host = executionHost;
+
+  const record = await host.store.runs.get(`background:${taskId}`);
+  if (record?.kind !== "background-subagent") {
+    return null;
+  }
+  if (scope && !record.sessionKey.startsWith(scope.childSessionKeyPrefix)) {
+    return null;
+  }
+
+  const currentStatus = backgroundRunJobStatus(record.status);
+  if (!currentStatus) {
+    return null;
+  }
+
+  if (currentStatus === "pending" || currentStatus === "running") {
+    const cancelled = await cancelBackgroundChildRun({
+      executionHost: host,
+      runId: record.runId,
+    });
+    return {
+      status: backgroundRunJobStatus(cancelled?.status) ?? currentStatus,
+      task_id: taskId,
+    };
+  }
+
+  return { status: currentStatus, task_id: taskId };
 }

--- a/packages/runtime/src/subagent-job-events-background.test.ts
+++ b/packages/runtime/src/subagent-job-events-background.test.ts
@@ -1,0 +1,247 @@
+import type { ToolSet } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  collectRun,
+  fakeModel,
+  getGenerateTextMock,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import {
+  backgroundNotificationKey,
+  createDurableTestHost,
+  resumeBackgroundTask,
+  waitForSessionPromptResume,
+} from "./subagent-background-test-support";
+import {
+  assistantMessage,
+  createDeferred,
+  eventTypes,
+  toolCallPart,
+  toolResultFor,
+  userText,
+} from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+const backgroundDelegateToolCallId = "call_KeYrzFNLHiz0yjKPQd04vBD5";
+
+describe("background subagent job events", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("orders background subagent launch after parent tool-call while streaming later updates live", async () => {
+    const Agent = await loadAgent();
+    const childGate = createDeferred();
+    const toolCall = toolCallPart(
+      "call-background-order",
+      "delegate_to_researcher",
+      {
+        prompt: "research this",
+        run_in_background: true,
+      }
+    );
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => {
+        await childGate.promise;
+        return [assistantMessage("CHILD DONE")];
+      },
+      name: "researcher",
+    });
+    let launchedTaskId = "";
+    generateTextMock.mockImplementationOnce(
+      async ({ tools }: { tools?: ToolSet }) => {
+        const launch = (await tools?.delegate_to_researcher?.execute?.(
+          {
+            prompt: "research this",
+            run_in_background: true,
+          },
+          {
+            ...toolExecutionOptions(),
+            toolCallId: "call_EQKLyqCmMocIZh6LPbCAb7ts",
+          }
+        )) as { readonly task_id: string };
+        launchedTaskId = launch.task_id;
+        return {
+          responseMessages: [
+            assistantMessage([toolCall]),
+            toolResultFor(toolCall),
+          ],
+        };
+      }
+    );
+    const host = createDurableTestHost();
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      subagents: [researcher],
+    });
+    const session = agent.session("default");
+
+    const iterator = (await session.send(userText("delegate")))
+      .events()
+      [Symbol.asyncIterator]();
+    const events: string[] = [];
+    while (!events.includes("tool-result")) {
+      const next = await iterator.next();
+      expect(next.done).toBe(false);
+      if (!next.done) {
+        events.push(next.value.type);
+      }
+    }
+
+    expect(events.indexOf("tool-call")).toBeLessThan(
+      events.indexOf("subagent-job-start")
+    );
+    expect(events.indexOf("subagent-job-start")).toBeLessThan(
+      events.indexOf("tool-result")
+    );
+
+    childGate.resolve();
+
+    while (!events.includes("turn-end")) {
+      const next = await iterator.next();
+      if (next.done) {
+        break;
+      }
+      events.push(next.value.type);
+    }
+    await collectRun(await resumeBackgroundTask(agent, launchedTaskId));
+
+    const notifyEvents = eventTypes(
+      await collectRun(
+        await waitForSessionPromptResume(
+          agent,
+          host,
+          backgroundNotificationKey(launchedTaskId)
+        )
+      )
+    );
+    expect(notifyEvents.indexOf("subagent-job-end")).toBeGreaterThanOrEqual(0);
+  });
+
+  it("correlates background subagent lifecycle events to the parent tool call", async () => {
+    const Agent = await loadAgent();
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => [assistantMessage("CHILD DONE")],
+      name: "researcher",
+    });
+    let launchedTaskId = "";
+    generateTextMock.mockImplementationOnce(
+      async ({ tools }: { tools?: ToolSet }) => {
+        const launch = (await tools?.delegate_to_researcher?.execute?.(
+          {
+            prompt: "research this",
+            run_in_background: true,
+          },
+          {
+            ...toolExecutionOptions(),
+            toolCallId: backgroundDelegateToolCallId,
+          }
+        )) as { readonly task_id: string };
+        launchedTaskId = launch.task_id;
+        return { responseMessages: [assistantMessage("PARENT DONE")] };
+      }
+    );
+    const host = createDurableTestHost();
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      subagents: [researcher],
+    });
+    const session = agent.session("default");
+
+    const firstEvents = await collectRun(
+      await session.send(userText("delegate"))
+    );
+    const resumeEvents = await collectRun(
+      await resumeBackgroundTask(agent, launchedTaskId)
+    );
+    const notificationEvents = await collectRun(
+      await waitForSessionPromptResume(
+        agent,
+        host,
+        backgroundNotificationKey(launchedTaskId)
+      )
+    );
+    const events = [...firstEvents, ...resumeEvents, ...notificationEvents];
+    const lifecycleEvents = events.filter(
+      (event) =>
+        event.type === "subagent-job-start" ||
+        event.type === "subagent-job-update" ||
+        event.type === "subagent-job-end"
+    );
+
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          delegateToolCallId: backgroundDelegateToolCallId,
+          type: "subagent-job-start",
+        }),
+        expect.objectContaining({
+          delegateToolCallId: backgroundDelegateToolCallId,
+          type: "subagent-job-end",
+        }),
+      ])
+    );
+    expect(JSON.stringify(lifecycleEvents)).not.toContain("parentToolCallId");
+    expect(JSON.stringify(lifecycleEvents)).not.toContain(
+      "delegate_to_researcher:0"
+    );
+  });
+
+  it("emits compact background subagent job updates while collecting child events", async () => {
+    const Agent = await loadAgent();
+    const researcher = new Agent({
+      description: "Researches facts.",
+      model: async () => [assistantMessage("CHILD DONE")],
+      name: "researcher",
+    });
+    generateTextMock.mockImplementationOnce(
+      async ({ tools }: { tools?: ToolSet }) => {
+        const launch = (await tools?.delegate_to_researcher?.execute?.(
+          {
+            prompt: "research this",
+            run_in_background: true,
+          },
+          toolExecutionOptions()
+        )) as { task_id: string };
+        await tools?.background_output?.execute?.(
+          { block: true, task_id: launch.task_id },
+          toolExecutionOptions()
+        );
+        return { responseMessages: [assistantMessage("PARENT DONE")] };
+      }
+    );
+    const agent = new Agent({ model: fakeModel, subagents: [researcher] });
+
+    const events = await collectRun(await agent.send(userText("delegate")));
+    const update = events.find(
+      (event) =>
+        event.type === "subagent-job-update" &&
+        event.eventType === "assistant-text"
+    );
+
+    expect(update).toEqual(
+      expect.objectContaining({
+        eventType: "assistant-text",
+        status: "running",
+        subagent: "researcher",
+        type: "subagent-job-update",
+      })
+    );
+    expect(update).not.toHaveProperty("textPreview");
+    expect(JSON.stringify(update)).not.toContain("CHILD DONE");
+    expect(eventTypes(events)).toContain("subagent-job-update");
+  });
+});

--- a/packages/runtime/src/subagent-job-events.test.ts
+++ b/packages/runtime/src/subagent-job-events.test.ts
@@ -9,7 +9,6 @@ import {
 } from "./llm-test-utils";
 import {
   assistantMessage,
-  createDeferred,
   eventTypes,
   toolCallPart,
   toolResultFor,
@@ -18,7 +17,6 @@ import {
 
 const generateTextMock = getGenerateTextMock();
 const blockingDelegateToolCallId = "call_7eTeYjF9tUaDKah9T3mwUQpA";
-const backgroundDelegateToolCallId = "call_KeYrzFNLHiz0yjKPQd04vBD5";
 
 describe("subagent job events", () => {
   beforeEach(() => {
@@ -37,7 +35,7 @@ describe("subagent job events", () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     generateTextMock.mockImplementationOnce(
@@ -97,7 +95,7 @@ describe("subagent job events", () => {
     );
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     generateTextMock.mockImplementationOnce(
@@ -137,147 +135,11 @@ describe("subagent job events", () => {
     ]);
   });
 
-  it("orders background subagent launch after parent tool-call while streaming later updates live", async () => {
-    const Agent = await loadAgent();
-    const childGate = createDeferred();
-    const toolCall = toolCallPart(
-      "call-background-order",
-      "delegate_to_researcher",
-      {
-        prompt: "research this",
-        run_in_background: true,
-      }
-    );
-    const researcher = new Agent({
-      description: "Researches facts.",
-      llm: async () => {
-        await childGate.promise;
-        return [assistantMessage("CHILD DONE")];
-      },
-      name: "researcher",
-    });
-    generateTextMock.mockImplementationOnce(
-      async ({ tools }: { tools?: ToolSet }) => {
-        await tools?.delegate_to_researcher?.execute?.(
-          {
-            prompt: "research this",
-            run_in_background: true,
-          },
-          {
-            ...toolExecutionOptions(),
-            toolCallId: "call_EQKLyqCmMocIZh6LPbCAb7ts",
-          }
-        );
-        return {
-          responseMessages: [
-            assistantMessage([toolCall]),
-            toolResultFor(toolCall),
-          ],
-        };
-      }
-    );
-    const agent = new Agent({ model: fakeModel, subagents: [researcher] });
-
-    const iterator = (await agent.send(userText("delegate")))
-      .events()
-      [Symbol.asyncIterator]();
-    const events: string[] = [];
-    while (!events.includes("tool-result")) {
-      const next = await iterator.next();
-      expect(next.done).toBe(false);
-      if (!next.done) {
-        events.push(next.value.type);
-      }
-    }
-
-    expect(events.indexOf("tool-call")).toBeLessThan(
-      events.indexOf("subagent-job-start")
-    );
-    expect(events.indexOf("subagent-job-start")).toBeLessThan(
-      events.indexOf("tool-result")
-    );
-
-    childGate.resolve();
-
-    while (!events.includes("turn-end")) {
-      const next = await iterator.next();
-      if (next.done) {
-        break;
-      }
-      events.push(next.value.type);
-    }
-
-    expect(events.indexOf("subagent-job-update")).toBeGreaterThan(
-      events.indexOf("tool-result")
-    );
-    expect(events.indexOf("subagent-job-end")).toBeGreaterThan(
-      events.indexOf("tool-result")
-    );
-  });
-
-  it("correlates background subagent lifecycle events to the parent tool call", async () => {
-    const Agent = await loadAgent();
-    const researcher = new Agent({
-      description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
-      name: "researcher",
-    });
-    generateTextMock.mockImplementationOnce(
-      async ({ tools }: { tools?: ToolSet }) => {
-        const launch = (await tools?.delegate_to_researcher?.execute?.(
-          {
-            prompt: "research this",
-            run_in_background: true,
-          },
-          {
-            ...toolExecutionOptions(),
-            toolCallId: backgroundDelegateToolCallId,
-          }
-        )) as { task_id: string };
-        await tools?.background_output?.execute?.(
-          { block: true, task_id: launch.task_id },
-          toolExecutionOptions()
-        );
-        return { responseMessages: [assistantMessage("PARENT DONE")] };
-      }
-    );
-    const agent = new Agent({ model: fakeModel, subagents: [researcher] });
-
-    const events = await collectRun(await agent.send(userText("delegate")));
-    const lifecycleEvents = events.filter(
-      (event) =>
-        event.type === "subagent-job-start" ||
-        event.type === "subagent-job-update" ||
-        event.type === "subagent-job-end"
-    );
-
-    expect(lifecycleEvents).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          delegateToolCallId: backgroundDelegateToolCallId,
-          type: "subagent-job-start",
-        }),
-        expect.objectContaining({
-          delegateToolCallId: backgroundDelegateToolCallId,
-          type: "subagent-job-update",
-        }),
-        expect.objectContaining({
-          delegateToolCallId: backgroundDelegateToolCallId,
-          type: "subagent-job-end",
-        }),
-      ])
-    );
-    expect(JSON.stringify(lifecycleEvents)).not.toContain("parentToolCallId");
-    expect(JSON.stringify(lifecycleEvents)).not.toContain(
-      "delegate_to_researcher:0"
-    );
-  });
-
   it("keeps buffered subagent lifecycle events visible when the parent model call fails", async () => {
     const Agent = await loadAgent();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
+      model: async () => [assistantMessage("CHILD DONE")],
       name: "researcher",
     });
     generateTextMock.mockImplementationOnce(
@@ -301,50 +163,5 @@ describe("subagent job events", () => {
       "subagent-job-end",
       "turn-error",
     ]);
-  });
-
-  it("emits compact background subagent job updates while collecting child events", async () => {
-    const Agent = await loadAgent();
-    const researcher = new Agent({
-      description: "Researches facts.",
-      llm: async () => [assistantMessage("CHILD DONE")],
-      name: "researcher",
-    });
-    generateTextMock.mockImplementationOnce(
-      async ({ tools }: { tools?: ToolSet }) => {
-        const launch = (await tools?.delegate_to_researcher?.execute?.(
-          {
-            prompt: "research this",
-            run_in_background: true,
-          },
-          toolExecutionOptions()
-        )) as { task_id: string };
-        await tools?.background_output?.execute?.(
-          { block: true, task_id: launch.task_id },
-          toolExecutionOptions()
-        );
-        return { responseMessages: [assistantMessage("PARENT DONE")] };
-      }
-    );
-    const agent = new Agent({ model: fakeModel, subagents: [researcher] });
-
-    const events = await collectRun(await agent.send(userText("delegate")));
-    const update = events.find(
-      (event) =>
-        event.type === "subagent-job-update" &&
-        event.eventType === "assistant-text"
-    );
-
-    expect(update).toEqual(
-      expect.objectContaining({
-        eventType: "assistant-text",
-        status: "running",
-        subagent: "researcher",
-        type: "subagent-job-update",
-      })
-    );
-    expect(update).not.toHaveProperty("textPreview");
-    expect(JSON.stringify(update)).not.toContain("CHILD DONE");
-    expect(eventTypes(events)).toContain("subagent-job-update");
   });
 });

--- a/packages/runtime/src/subagent-job-observer.ts
+++ b/packages/runtime/src/subagent-job-observer.ts
@@ -1,0 +1,31 @@
+import type { AgentEvent } from "./session/events";
+import type { RuntimeInputSink, SubagentJob } from "./subagent-types";
+
+export function emitBackgroundJobUpdate(
+  parentSession: RuntimeInputSink,
+  job: SubagentJob,
+  event: AgentEvent
+): Promise<void> {
+  if (!isParentVisibleJobUpdate(event)) {
+    return Promise.resolve();
+  }
+
+  return parentSession.emitObserverEvent({
+    eventType: event.type,
+    delegateToolCallId: job.delegateToolCallId,
+    status: job.status,
+    subagent: job.subagent,
+    task_id: job.id,
+    type: "subagent-job-update" as const,
+  });
+}
+
+function isParentVisibleJobUpdate(event: AgentEvent): boolean {
+  return (
+    event.type === "assistant-text" ||
+    event.type === "tool-call" ||
+    event.type === "tool-result" ||
+    event.type === "turn-abort" ||
+    event.type === "turn-error"
+  );
+}

--- a/packages/runtime/src/subagent-job-output.ts
+++ b/packages/runtime/src/subagent-job-output.ts
@@ -1,18 +1,36 @@
 import { jsonSchema, tool } from "ai";
+import type { ExecutionHost, RunStatus } from "./execution/types";
 import {
   assertBackgroundTaskId,
   cleanupJob,
   isActiveJob,
-} from "./subagent-jobs";
+} from "./subagent-job-state";
 import type { BackgroundOutputInput, SubagentJob } from "./subagent-types";
 
-export function createBackgroundOutputTool(jobs: Map<string, SubagentJob>) {
+interface BackgroundToolScope {
+  readonly childSessionKeyPrefix: string;
+}
+
+export function createBackgroundOutputTool(
+  jobs: Map<string, SubagentJob>,
+  executionHost?: ExecutionHost,
+  scope?: BackgroundToolScope
+) {
   return tool<BackgroundOutputInput, unknown, Record<string, unknown>>({
     description: "Retrieve compact output for a background subagent job.",
     execute: async (input: BackgroundOutputInput, { abortSignal }) => {
       assertBackgroundTaskId(input.task_id, "background_output");
       const job = jobs.get(input.task_id);
       if (!job) {
+        const durableOutput = await durableBackgroundOutput(
+          input.task_id,
+          executionHost,
+          scope
+        );
+        if (durableOutput) {
+          return durableOutput;
+        }
+
         throw new Error(`Unknown background subagent task ${input.task_id}.`);
       }
 
@@ -20,7 +38,13 @@ export function createBackgroundOutputTool(jobs: Map<string, SubagentJob>) {
         await waitForJob(job, input.timeout, abortSignal);
       }
 
-      const output = {
+      const durableOutput = await durableBackgroundOutput(
+        input.task_id,
+        job.executionHost ?? executionHost,
+        scope,
+        job.subagent
+      );
+      const output = durableOutput ?? {
         result: job.result,
         status: job.status,
         subagent: job.subagent,
@@ -49,6 +73,53 @@ export function createBackgroundOutputTool(jobs: Map<string, SubagentJob>) {
       type: "object",
     }),
   });
+}
+
+async function durableBackgroundOutput(
+  taskId: string,
+  executionHost: ExecutionHost | undefined,
+  scope: BackgroundToolScope | undefined,
+  fallbackSubagent = "subagent"
+): Promise<Record<string, unknown> | null> {
+  const record = await executionHost?.store.runs.get(`background:${taskId}`);
+  if (record?.kind !== "background-subagent") {
+    return null;
+  }
+  if (scope && !record.sessionKey.startsWith(scope.childSessionKeyPrefix)) {
+    return null;
+  }
+
+  return {
+    result: record.output,
+    status: backgroundStatus(record.status),
+    subagent: subagentName(record.output, fallbackSubagent),
+    task_id: taskId,
+  };
+}
+
+function backgroundStatus(status: RunStatus): string {
+  if (status === "completed" || status === "cancelled" || status === "error") {
+    return status;
+  }
+
+  if (status === "running" || status === "leased") {
+    return "running";
+  }
+
+  return "pending";
+}
+
+function subagentName(output: unknown, fallback: string): string {
+  if (
+    typeof output === "object" &&
+    output !== null &&
+    "subagent" in output &&
+    typeof output.subagent === "string"
+  ) {
+    return output.subagent;
+  }
+
+  return fallback;
 }
 
 async function waitForJob(

--- a/packages/runtime/src/subagent-job-state.ts
+++ b/packages/runtime/src/subagent-job-state.ts
@@ -1,0 +1,124 @@
+import type { RunStatus } from "./execution/types";
+import { updateBackgroundRunStatus } from "./subagent-background-child-run";
+import type { SubagentJob } from "./subagent-types";
+
+export function assertBackgroundTaskId(value: string, toolName: string): void {
+  if (value.startsWith("bg_")) {
+    return;
+  }
+
+  throw new Error(
+    `${toolName} expects a background task_id starting with bg_, not a session key: ${value}`
+  );
+}
+
+export function isActiveJob(status: SubagentJob["status"]): boolean {
+  return status === "pending" || status === "running";
+}
+
+export function hasBackgroundJobCapacity({
+  jobs,
+  maxActiveJobs,
+  maxRetainedJobs,
+}: {
+  readonly jobs: Map<string, SubagentJob>;
+  readonly maxActiveJobs: number;
+  readonly maxRetainedJobs: number;
+}): boolean {
+  if (jobs.size >= maxRetainedJobs) {
+    return false;
+  }
+
+  let activeJobs = 0;
+  for (const job of jobs.values()) {
+    if (isActiveJob(job.status) || !job.settled) {
+      activeJobs += 1;
+    }
+  }
+
+  return activeJobs < maxActiveJobs;
+}
+
+export function cancelJob(job: SubagentJob): void {
+  job.status = "cancelled";
+  job.abort();
+  const statusUpdate = updateBackgroundRunStatus(job, "cancelled");
+  job.promise = Promise.allSettled([job.promise, statusUpdate]).then(
+    () => undefined
+  );
+}
+
+export async function cleanupJob(job: SubagentJob): Promise<void> {
+  await job.cleanup();
+  job.unregisterCleanup?.();
+}
+
+export function backgroundLaunchOutput(job: SubagentJob) {
+  return {
+    message: [
+      `Background subagent job ${job.id} started.`,
+      `Please wait for <system-reminder> before checking task ${job.id}.`,
+      `Do NOT call background_output({ task_id: "${job.id}" }) now; wait for <system-reminder> first.`,
+    ].join(" "),
+    run_in_background: true,
+    status: job.status,
+    subagent: job.subagent,
+    task_id: job.id,
+  };
+}
+
+export function backgroundCancelledLaunchOutput({
+  id,
+  subagent,
+}: {
+  readonly id: string;
+  readonly subagent?: string;
+}) {
+  return {
+    message: `Background subagent job ${id} was cancelled before it started.`,
+    run_in_background: true,
+    status: "cancelled",
+    subagent,
+    task_id: id,
+  };
+}
+
+export function backgroundRunJobStatus(
+  status: RunStatus | undefined
+): Exclude<SubagentJob["status"], "aborted"> | null {
+  if (status === "cancelled" || status === "completed" || status === "error") {
+    return status;
+  }
+
+  if (status === "leased" || status === "running") {
+    return "running";
+  }
+
+  if (
+    status === "needs-recovery" ||
+    status === "queued" ||
+    status === "suspended"
+  ) {
+    return "pending";
+  }
+
+  return null;
+}
+
+export function backgroundReplayOutput({
+  id,
+  status,
+  subagent,
+}: {
+  readonly id: string;
+  readonly status: Exclude<SubagentJob["status"], "aborted">;
+  readonly subagent: string;
+}) {
+  return {
+    message: `Background subagent job ${id} was already ${status}. Reuse the existing task_id instead of launching it again.`,
+    run_in_background: true,
+    status,
+    subagent,
+    task_id: id,
+  };
+}

--- a/packages/runtime/src/subagent-jobs.test.ts
+++ b/packages/runtime/src/subagent-jobs.test.ts
@@ -11,14 +11,7 @@ describe("subagent background jobs", () => {
     const jobs = new Map<string, SubagentJob>();
     const runtimeInputs: string[] = [];
     let interruptCount = 0;
-    const parentSession: RuntimeInputSink = {
-      emitObserverEvent: () => Promise.resolve(),
-      enqueueRuntimeInput: (input) => {
-        if (input.type === "user-text" && typeof input.text === "string") {
-          runtimeInputs.push(input.text);
-        }
-      },
-    };
+    const parentSession = createParentSession(runtimeInputs);
     const subagent: Subagent = {
       name: "researcher",
       session: () => ({
@@ -55,10 +48,7 @@ describe("subagent background jobs", () => {
 
   it("allows new background jobs when retained jobs are completed", async () => {
     const jobs = new Map<string, SubagentJob>();
-    const parentSession: RuntimeInputSink = {
-      emitObserverEvent: () => Promise.resolve(),
-      enqueueRuntimeInput: () => undefined,
-    };
+    const parentSession = createParentSession();
     const subagent: Subagent = {
       name: "researcher",
       session: () => ({
@@ -99,10 +89,7 @@ describe("subagent background jobs", () => {
 
   it("rejects new background jobs when retained jobs reach the total limit", async () => {
     const jobs = new Map<string, SubagentJob>();
-    const parentSession: RuntimeInputSink = {
-      emitObserverEvent: () => Promise.resolve(),
-      enqueueRuntimeInput: () => undefined,
-    };
+    const parentSession = createParentSession();
     const subagent: Subagent = {
       name: "researcher",
       session: () => ({
@@ -140,10 +127,7 @@ describe("subagent background jobs", () => {
 
   it("counts cancelled unsettled jobs toward the active job limit", async () => {
     const jobs = new Map<string, SubagentJob>();
-    const parentSession: RuntimeInputSink = {
-      emitObserverEvent: () => Promise.resolve(),
-      enqueueRuntimeInput: () => undefined,
-    };
+    const parentSession = createParentSession();
     const subagent: Subagent = {
       name: "researcher",
       session: () => ({
@@ -179,6 +163,24 @@ describe("subagent background jobs", () => {
     expect(rejected).toEqual(expect.objectContaining({ status: "cancelled" }));
   });
 });
+
+function createParentSession(runtimeInputs: string[] = []): RuntimeInputSink {
+  return {
+    emitObserverEvent: () => Promise.resolve(),
+    enqueueRuntimeInput: (input) => {
+      if (input.type === "user-text" && typeof input.text === "string") {
+        runtimeInputs.push(input.text);
+      }
+    },
+    notify: (input) => {
+      if (input.type === "user-text" && typeof input.text === "string") {
+        runtimeInputs.push(input.text);
+      }
+
+      return Promise.resolve(createImmediateTextRun("NOTIFIED"));
+    },
+  };
+}
 
 function createDelayedTextRun(text: string): AgentRun {
   async function* events(): AsyncIterable<AgentEvent> {

--- a/packages/runtime/src/subagent-jobs.ts
+++ b/packages/runtime/src/subagent-jobs.ts
@@ -1,7 +1,26 @@
-import type { AgentEvent } from "./session/events";
+import type { ExecutionHost } from "./execution/types";
 import type { AgentInput } from "./session/input";
-import { collectSubagentRunWithEvents } from "./subagent-run";
-import type { RuntimeInputSink, Subagent, SubagentJob } from "./subagent-types";
+import {
+  createBackgroundTaskId,
+  createDurableBackgroundTaskId,
+  getBackgroundChildRun,
+  getOrCreateBackgroundChildRun,
+} from "./subagent-background-child-run";
+import { startInProcessBackgroundJob } from "./subagent-background-in-process";
+import { scheduleDurableBackgroundJob } from "./subagent-background-schedule";
+import {
+  backgroundCancelledLaunchOutput,
+  backgroundLaunchOutput,
+  backgroundReplayOutput,
+  backgroundRunJobStatus,
+  hasBackgroundJobCapacity,
+} from "./subagent-job-state";
+import type {
+  RuntimeInputSink,
+  Subagent,
+  SubagentJob,
+  SubagentJobGroup,
+} from "./subagent-types";
 
 const maxBackgroundJobs = 64;
 const maxRetainedBackgroundJobs = maxBackgroundJobs * 4;
@@ -9,9 +28,15 @@ const maxRetainedBackgroundJobs = maxBackgroundJobs * 4;
 export async function startBackgroundJob({
   abortSignal,
   description,
+  executionHost,
   jobs,
+  groupId,
+  groups = new Map<string, SubagentJobGroup>(),
   delegateToolCallId,
   parentSession,
+  parentRunId,
+  parentSessionKey,
+  ownerNamespace,
   prompt,
   registerCleanup,
   sessionKey,
@@ -19,17 +44,57 @@ export async function startBackgroundJob({
 }: {
   readonly abortSignal: AbortSignal;
   readonly description?: string;
+  readonly executionHost?: ExecutionHost;
   readonly jobs: Map<string, SubagentJob>;
+  readonly groupId?: string;
+  readonly groups?: Map<string, SubagentJobGroup>;
   readonly delegateToolCallId?: string;
   readonly parentSession: RuntimeInputSink;
+  readonly parentRunId?: string;
+  readonly parentSessionKey?: string;
+  readonly ownerNamespace?: string;
   readonly prompt: AgentInput;
   readonly registerCleanup: (cleanup: () => Promise<void>) => () => void;
   readonly sessionKey: string;
   readonly subagent: Subagent;
 }) {
-  const id = `bg_${crypto.randomUUID().replaceAll("-", "")}`;
-  const childSessionKey = `${sessionKey}:task:${id}`;
-  if (!hasJobCapacity(jobs)) {
+  const existingChildRun = await getBackgroundChildRun({
+    delegateToolCallId,
+    executionHost,
+    parentRunId,
+    parentSessionKey,
+    prompt,
+    sessionKey,
+  });
+  const id =
+    existingChildRun?.publicTaskId ??
+    (executionHost
+      ? await createDurableBackgroundTaskId({
+          delegateToolCallId,
+          prompt,
+          sessionKey,
+        })
+      : createBackgroundTaskId());
+  const existingJob = jobs.get(id);
+  if (existingJob) {
+    return backgroundLaunchOutput(existingJob);
+  }
+  const replayedStatus = backgroundRunJobStatus(existingChildRun?.status);
+  if (existingChildRun?.publicTaskId && replayedStatus) {
+    return backgroundReplayOutput({
+      id: existingChildRun.publicTaskId,
+      status: replayedStatus,
+      subagent: subagent.name ?? "subagent",
+    });
+  }
+
+  if (
+    !hasBackgroundJobCapacity({
+      jobs,
+      maxActiveJobs: maxBackgroundJobs,
+      maxRetainedJobs: maxRetainedBackgroundJobs,
+    })
+  ) {
     return {
       message:
         "Background subagent job was not started because the background job limit is full.",
@@ -41,219 +106,63 @@ export async function startBackgroundJob({
   }
 
   if (abortSignal.aborted) {
-    return {
-      message: `Background subagent job ${id} was cancelled before it started.`,
-      run_in_background: true,
-      status: "cancelled",
-      subagent: subagent.name,
-      task_id: id,
-    };
+    return backgroundCancelledLaunchOutput({ id, subagent: subagent.name });
   }
 
-  const childSession = subagent.session(childSessionKey);
-  const abort = () => childSession.interrupt();
-  abortSignal.addEventListener("abort", abort, { once: true });
-  const cleanup = () => childSession.delete();
-  const unregisterCleanup = registerCleanup(cleanup);
-
-  const job: SubagentJob = {
-    abort,
-    cleanup,
+  const childRun = executionHost
+    ? (existingChildRun ??
+      (await getOrCreateBackgroundChildRun({
+        delegateToolCallId,
+        description,
+        executionHost,
+        groupId,
+        ownerNamespace,
+        parentRunId,
+        parentSessionKey,
+        prompt,
+        publicTaskId: id,
+        sessionKey,
+        subagent: subagent.name ?? "subagent",
+      })))
+    : undefined;
+  if (
+    executionHost?.capabilities.backgroundSubagents === "durable" &&
+    childRun
+  ) {
+    const job = await scheduleDurableBackgroundJob({
+      childRun,
+      delegateToolCallId,
+      description,
+      executionHost,
+      groupId,
+      groups,
+      id,
+      jobs,
+      parentRunId,
+      parentSession,
+      parentSessionKey,
+      ownerNamespace,
+      subagent: subagent.name ?? "subagent",
+    });
+    return backgroundLaunchOutput(job);
+  }
+  return await startInProcessBackgroundJob({
+    abortSignal,
+    childRun,
+    delegateToolCallId,
     description,
+    executionHost,
+    groupId,
+    groups,
     id,
-    delegateToolCallId,
-    promise: Promise.resolve(),
-    sessionKey: childSessionKey,
-    settled: false,
-    status: "pending",
-    subagent: subagent.name ?? "subagent",
-    unregisterCleanup,
-  };
-  jobs.set(id, job);
-  await parentSession.emitObserverEvent({
-    description,
-    delegateToolCallId,
-    run_in_background: true,
-    subagent: subagent.name ?? "subagent",
-    task_id: id,
-    type: "subagent-job-start",
-  });
-  job.promise = runBackgroundJob({
-    childSession,
-    job,
+    jobs,
+    parentRunId,
     parentSession,
+    parentSessionKey,
+    ownerNamespace,
     prompt,
-  }).finally(() => {
-    abortSignal.removeEventListener("abort", abort);
-    job.settled = true;
+    registerCleanup,
+    sessionKey,
+    subagent,
   });
-
-  return {
-    message: `Background subagent job ${id} started. Use background_output({ task_id: "${id}" }) to retrieve the result.`,
-    run_in_background: true,
-    status: job.status,
-    subagent: subagent.name,
-    task_id: id,
-  };
-}
-
-async function runBackgroundJob({
-  childSession,
-  job,
-  parentSession,
-  prompt,
-}: {
-  readonly childSession: ReturnType<Subagent["session"]>;
-  readonly job: SubagentJob;
-  readonly parentSession: RuntimeInputSink;
-  readonly prompt: AgentInput;
-}): Promise<void> {
-  if (job.status === "cancelled") {
-    return;
-  }
-
-  job.status = "running";
-  try {
-    const { result } = await collectSubagentRunWithEvents(
-      await childSession.send(prompt),
-      job.subagent,
-      (event) => emitJobUpdate(parentSession, job, event)
-    );
-    if (isCancelledJob(job)) {
-      return;
-    }
-    job.result = result;
-    job.status = result.result;
-  } catch (error) {
-    if (isCancelledJob(job)) {
-      return;
-    }
-    const jobError = error instanceof Error ? error : new Error(String(error));
-    job.status = "error";
-    job.result = {
-      error: errorMessage(jobError),
-      eventCount: 0,
-      result: "error",
-      run_in_background: false,
-      subagent: job.subagent,
-      text: "",
-    };
-  }
-
-  if (isCancelledJob(job)) {
-    return;
-  }
-
-  parentSession.enqueueRuntimeInput(
-    {
-      text: [
-        "<system-reminder>",
-        "[SUBAGENT JOB RESULT READY]",
-        `Task ID: ${job.id}`,
-        `Subagent: ${job.subagent}`,
-        `Description: ${sanitizeReminderField(job.description ?? "")}`,
-        `Use background_output({ task_id: "${job.id}" }) to retrieve the result.`,
-        "</system-reminder>",
-      ].join("\n"),
-      type: "user-text",
-    },
-    "turn-start"
-  );
-  await parentSession.emitObserverEvent({
-    error: job.result?.error,
-    eventCount: job.result?.eventCount ?? 0,
-    delegateToolCallId: job.delegateToolCallId,
-    status: job.result?.result ?? "error",
-    subagent: job.subagent,
-    task_id: job.id,
-    type: "subagent-job-end",
-  });
-}
-
-function emitJobUpdate(
-  parentSession: RuntimeInputSink,
-  job: SubagentJob,
-  event: AgentEvent
-): Promise<void> {
-  if (!isParentVisibleJobUpdate(event)) {
-    return Promise.resolve();
-  }
-
-  return parentSession.emitObserverEvent({
-    eventType: event.type,
-    delegateToolCallId: job.delegateToolCallId,
-    status: job.status,
-    subagent: job.subagent,
-    task_id: job.id,
-    type: "subagent-job-update" as const,
-  });
-}
-
-function isParentVisibleJobUpdate(event: AgentEvent): boolean {
-  return (
-    event.type === "assistant-text" ||
-    event.type === "tool-call" ||
-    event.type === "tool-result" ||
-    event.type === "turn-abort" ||
-    event.type === "turn-error"
-  );
-}
-
-export function assertBackgroundTaskId(value: string, toolName: string): void {
-  if (value.startsWith("bg_")) {
-    return;
-  }
-
-  throw new Error(
-    `${toolName} expects a background task_id starting with bg_, not a session key: ${value}`
-  );
-}
-
-function errorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return String(error);
-}
-
-export function isActiveJob(status: SubagentJob["status"]): boolean {
-  return status === "pending" || status === "running";
-}
-
-function isCancelledJob(job: SubagentJob): boolean {
-  return job.status === "cancelled";
-}
-
-function hasJobCapacity(jobs: Map<string, SubagentJob>): boolean {
-  if (jobs.size >= maxRetainedBackgroundJobs) {
-    return false;
-  }
-
-  let activeJobs = 0;
-  for (const job of jobs.values()) {
-    if (isActiveJob(job.status) || !job.settled) {
-      activeJobs += 1;
-    }
-  }
-
-  return activeJobs < maxBackgroundJobs;
-}
-
-export function cancelJob(job: SubagentJob): void {
-  job.status = "cancelled";
-  job.abort();
-}
-
-export async function cleanupJob(job: SubagentJob): Promise<void> {
-  await job.cleanup();
-  job.unregisterCleanup?.();
-}
-
-function sanitizeReminderField(value: string): string {
-  return value
-    .replaceAll("\r", " ")
-    .replaceAll("\n", " ")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
 }

--- a/packages/runtime/src/subagent-run.test.ts
+++ b/packages/runtime/src/subagent-run.test.ts
@@ -22,7 +22,7 @@ describe("subagent run collection", () => {
     await expect(
       collectSubagentRunWithEvents(run, "researcher")
     ).resolves.toEqual({
-      events: [{ text: "partial", type: "assistant-text" }],
+      retainedEvents: [{ text: "partial", type: "assistant-text" }],
       result: {
         error: "stream failed",
         eventCount: 1,
@@ -51,7 +51,7 @@ describe("subagent run collection", () => {
 
     const collected = await collectSubagentRunWithEvents(run, "researcher");
 
-    expect(collected.events).toHaveLength(200);
+    expect(collected.retainedEvents).toHaveLength(200);
     expect(collected.result).toEqual({
       eventCount: 250,
       result: "completed",

--- a/packages/runtime/src/subagent-run.ts
+++ b/packages/runtime/src/subagent-run.ts
@@ -79,7 +79,7 @@ export async function collectSubagentRunWithEvents(
         result = "aborted";
       } else if (event.type === "turn-error") {
         return {
-          events,
+          retainedEvents: events,
           result: {
             error: event.message,
             eventCount,
@@ -93,7 +93,7 @@ export async function collectSubagentRunWithEvents(
     }
   } catch (error) {
     return {
-      events,
+      retainedEvents: events,
       result: {
         error: errorMessage(error),
         eventCount,
@@ -106,7 +106,7 @@ export async function collectSubagentRunWithEvents(
   }
 
   return {
-    events,
+    retainedEvents: events,
     result: {
       eventCount,
       result,

--- a/packages/runtime/src/subagent-session-delete.test.ts
+++ b/packages/runtime/src/subagent-session-delete.test.ts
@@ -31,7 +31,7 @@ describe("subagent session deletion", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
@@ -64,7 +64,7 @@ describe("subagent session deletion", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
@@ -105,7 +105,7 @@ describe("subagent session deletion", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
@@ -125,7 +125,7 @@ describe("subagent session deletion", () => {
       },
       toolExecutionOptions()
     );
-    agent.session("default").kill();
+    await agent.session("default").kill();
     await drainRun(await agent.send(userText("delegate second")));
     await executableTool(
       lastGenerateTextTools(),
@@ -147,12 +147,12 @@ describe("subagent session deletion", () => {
     const childHistories: unknown[] = [];
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: ({ history }) => {
+      model: ({ history }) => {
         childHistories.push(history);
         return Promise.resolve([assistantMessage("CHILD DONE")]);
       },
+      host: { sessionStore: childStore },
       name: "researcher",
-      sessions: { store: childStore },
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
     const firstSession = agent.session("default");
@@ -181,9 +181,9 @@ describe("subagent session deletion", () => {
     const childStore = new BlockingDeleteStore();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: () => Promise.resolve([assistantMessage("CHILD DONE")]),
+      host: { sessionStore: childStore },
+      model: () => Promise.resolve([assistantMessage("CHILD DONE")]),
       name: "researcher",
-      sessions: { store: childStore },
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
 
@@ -192,7 +192,7 @@ describe("subagent session deletion", () => {
       lastGenerateTextTools(),
       "delegate_to_researcher"
     ).execute?.({ prompt: "first child work" }, toolExecutionOptions());
-    agent.session("default").kill();
+    const killPromise = agent.session("default").kill();
     await childStore.deleteStarted.promise;
     await drainRun(await agent.send(userText("delegate second")));
     await executableTool(
@@ -200,7 +200,7 @@ describe("subagent session deletion", () => {
       "delegate_to_researcher"
     ).execute?.({ prompt: "second child work" }, toolExecutionOptions());
     childStore.allowDelete.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await killPromise;
     await agent.session("default").delete();
 
     expect(childStore.deleteCount).toBe(2);
@@ -211,9 +211,9 @@ describe("subagent session deletion", () => {
     const childStore = new BlockingDeleteStore();
     const researcher = new Agent({
       description: "Researches facts.",
-      llm: () => Promise.resolve([assistantMessage("CHILD DONE")]),
+      host: { sessionStore: childStore },
+      model: () => Promise.resolve([assistantMessage("CHILD DONE")]),
       name: "researcher",
-      sessions: { store: childStore },
     });
     const agent = new Agent({ model: fakeModel, subagents: [researcher] });
     const firstSession = agent.session("default");
@@ -230,55 +230,6 @@ describe("subagent session deletion", () => {
     await deletion;
 
     expect(secondSession).not.toBe(firstSession);
-  });
-
-  it("keeps child session keys stable across reconstructed parent agents", async () => {
-    const Agent = await loadAgent();
-    const childStore = new SpyStore();
-    const childHistories: unknown[] = [];
-    const createResearcher = () =>
-      new Agent({
-        description: "Researches facts.",
-        llm: ({ history }) => {
-          childHistories.push(history);
-          return Promise.resolve([assistantMessage("CHILD DONE")]);
-        },
-        name: "researcher",
-        sessions: { store: childStore },
-      });
-    const createParent = () =>
-      new Agent({
-        model: fakeModel,
-        sessions: { namespace: "parent" },
-        subagents: [createResearcher()],
-      });
-
-    const firstParent = createParent();
-    await drainRun(await firstParent.session("default").send(userText("one")));
-    await executableTool(
-      lastGenerateTextTools(),
-      "delegate_to_researcher"
-    ).execute?.(
-      { prompt: "first durable child work", sessionKey: "durable-topic" },
-      toolExecutionOptions()
-    );
-
-    const secondParent = createParent();
-    await drainRun(await secondParent.session("default").send(userText("two")));
-    await executableTool(
-      lastGenerateTextTools(),
-      "delegate_to_researcher"
-    ).execute?.(
-      { prompt: "second durable child work", sessionKey: "durable-topic" },
-      toolExecutionOptions()
-    );
-
-    expect(JSON.stringify(childHistories.at(-1))).toContain(
-      "first durable child work"
-    );
-    expect(JSON.stringify(childHistories.at(-1))).toContain(
-      "second durable child work"
-    );
   });
 });
 

--- a/packages/runtime/src/subagent-session-key.test.ts
+++ b/packages/runtime/src/subagent-session-key.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  drainRun,
+  executableTool,
+  fakeModel,
+  getGenerateTextMock,
+  lastGenerateTextTools,
+  loadAgent,
+  toolExecutionOptions,
+} from "./llm-test-utils";
+import { SpyStore } from "./session/session.test-support";
+import { assistantMessage, userText } from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("subagent child session keys", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps child session keys stable across reconstructed parent agents", async () => {
+    const Agent = await loadAgent();
+    const childStore = new SpyStore();
+    const childHistories: unknown[] = [];
+    const createResearcher = () =>
+      new Agent({
+        description: "Researches facts.",
+        model: ({ history }) => {
+          childHistories.push(history);
+          return Promise.resolve([assistantMessage("CHILD DONE")]);
+        },
+        host: { sessionStore: childStore },
+        name: "researcher",
+      });
+    const createParent = () =>
+      new Agent({
+        model: fakeModel,
+        namespace: "parent",
+        subagents: [createResearcher()],
+      });
+
+    const firstParent = createParent();
+    await drainRun(await firstParent.session("default").send(userText("one")));
+    await executableTool(
+      lastGenerateTextTools(),
+      "delegate_to_researcher"
+    ).execute?.(
+      { prompt: "first durable child work", sessionKey: "durable-topic" },
+      toolExecutionOptions()
+    );
+
+    const secondParent = createParent();
+    await drainRun(await secondParent.session("default").send(userText("two")));
+    await executableTool(
+      lastGenerateTextTools(),
+      "delegate_to_researcher"
+    ).execute?.(
+      { prompt: "second durable child work", sessionKey: "durable-topic" },
+      toolExecutionOptions()
+    );
+
+    expect(JSON.stringify(childHistories.at(-1))).toContain(
+      "first durable child work"
+    );
+    expect(JSON.stringify(childHistories.at(-1))).toContain(
+      "second durable child work"
+    );
+  });
+});

--- a/packages/runtime/src/subagent-types.ts
+++ b/packages/runtime/src/subagent-types.ts
@@ -1,6 +1,8 @@
+import type { ExecutionHost } from "./execution/types";
 import type { AgentEvent } from "./session/events";
 import type { AgentInput, UserInput } from "./session/input";
 import type { AgentRun } from "./session/run";
+import type { NotifyOptions } from "./session/session";
 
 export interface Subagent {
   readonly description?: string;
@@ -13,11 +15,16 @@ export interface Subagent {
 }
 
 export interface RuntimeInputSink {
+  currentBackgroundGroupId?(): string | undefined;
+  currentRunId?(): string | undefined;
   emitObserverEvent(event: AgentEvent): Promise<void>;
   enqueueRuntimeInput(input: UserInput, placement?: "turn-start"): void;
+  notify(input: UserInput, options?: NotifyOptions): Promise<AgentRun>;
 }
 
 export interface CreateSubagentToolsOptions {
+  readonly backgroundSubagents: boolean;
+  readonly executionHost?: ExecutionHost;
   readonly parentAgentNamespace: string;
   readonly parentSession: RuntimeInputSink;
   readonly parentSessionKey: string;
@@ -46,16 +53,24 @@ export interface CompactSubagentResult {
 }
 
 export interface SubagentRunResult {
-  readonly events: readonly AgentEvent[];
   readonly result: CompactSubagentResult;
+  readonly retainedEvents: readonly AgentEvent[];
 }
 
 export interface SubagentJob {
   readonly abort: () => void;
+  readonly childRunId?: string;
+  readonly childRunLeaseId?: string;
   readonly cleanup: () => Promise<void>;
+  readonly dedupeKey?: string;
   readonly delegateToolCallId?: string;
   readonly description?: string;
+  readonly executionHost?: ExecutionHost;
+  readonly groupId?: string;
   readonly id: string;
+  readonly ownerNamespace?: string;
+  readonly parentRunId?: string;
+  readonly parentSessionKey?: string;
   promise: Promise<void>;
   result?: CompactSubagentResult;
   readonly sessionKey: string;
@@ -63,6 +78,14 @@ export interface SubagentJob {
   status: JobStatus;
   readonly subagent: string;
   readonly unregisterCleanup?: () => void;
+}
+
+export interface SubagentJobGroup {
+  readonly completedEvents: Extract<AgentEvent, { type: "subagent-job-end" }>[];
+  readonly failedNotifiedJobIds: Set<string>;
+  finalNotified: boolean;
+  readonly id: string;
+  readonly jobIds: Set<string>;
 }
 
 export interface DelegateInput {

--- a/packages/runtime/src/subagents.ts
+++ b/packages/runtime/src/subagents.ts
@@ -1,19 +1,28 @@
 import { jsonSchema, type ToolSet, tool } from "ai";
+import type { ExecutionHost } from "./execution/types";
 import { normalizeAgentInput } from "./session/input-normalization";
+import {
+  type BlockingSubagentRunCache,
+  blockingSubagentDedupeKey,
+  runBlockingChild,
+} from "./subagent-child-run";
 import { createBackgroundCancelTool } from "./subagent-job-cancel";
 import { createBackgroundOutputTool } from "./subagent-job-output";
 import { startBackgroundJob } from "./subagent-jobs";
 import { delegatePromptSchema } from "./subagent-prompt-schema";
-import { runBlockingDelegation, scopedChildSessionKey } from "./subagent-run";
+import { scopedChildSessionKey } from "./subagent-run";
 import type {
   CreateSubagentToolsOptions,
   DelegateInput,
   RuntimeInputSink,
   Subagent,
   SubagentJob,
+  SubagentJobGroup,
 } from "./subagent-types";
 
 export function createSubagentTools({
+  backgroundSubagents,
+  executionHost,
   parentAgentNamespace,
   parentSession,
   parentSessionKey,
@@ -25,10 +34,25 @@ export function createSubagentTools({
   }
 
   const jobs = new Map<string, SubagentJob>();
-  const generatedTools: Record<string, unknown> = {
-    background_cancel: createBackgroundCancelTool(jobs),
-    background_output: createBackgroundOutputTool(jobs),
+  const groups = new Map<string, SubagentJobGroup>();
+  const blockingRuns: BlockingSubagentRunCache = new Map();
+  const backgroundToolScope = {
+    childSessionKeyPrefix: `parent:${parentAgentNamespace}:${parentSessionKey}:subagent:`,
   };
+  const generatedTools: Record<string, unknown> = backgroundSubagents
+    ? {
+        background_cancel: createBackgroundCancelTool(
+          jobs,
+          executionHost,
+          backgroundToolScope
+        ),
+        background_output: createBackgroundOutputTool(
+          jobs,
+          executionHost,
+          backgroundToolScope
+        ),
+      }
+    : {};
 
   for (const subagent of subagents) {
     const name = subagent.name;
@@ -39,6 +63,10 @@ export function createSubagentTools({
     generatedTools[`delegate_to_${name.replaceAll("-", "_")}`] =
       createDelegateTool({
         jobs,
+        groups,
+        backgroundSubagents,
+        blockingRuns,
+        executionHost,
         parentAgentNamespace,
         parentSession,
         parentSessionKey,
@@ -52,6 +80,10 @@ export function createSubagentTools({
 
 function createDelegateTool({
   jobs,
+  groups,
+  backgroundSubagents,
+  blockingRuns,
+  executionHost,
   parentAgentNamespace,
   parentSession,
   parentSessionKey,
@@ -59,6 +91,10 @@ function createDelegateTool({
   subagent,
 }: {
   readonly jobs: Map<string, SubagentJob>;
+  readonly groups: Map<string, SubagentJobGroup>;
+  readonly backgroundSubagents: boolean;
+  readonly blockingRuns: BlockingSubagentRunCache;
+  readonly executionHost?: ExecutionHost;
   readonly parentAgentNamespace: string;
   readonly parentSession: RuntimeInputSink;
   readonly parentSessionKey: string;
@@ -76,12 +112,24 @@ function createDelegateTool({
         subagent: subagent.name ?? "subagent",
       });
       if (input.run_in_background === true) {
+        if (!backgroundSubagents) {
+          throw new Error(
+            "Background subagent delegation is not available for this host."
+          );
+        }
+
         return await startBackgroundJob({
           abortSignal: abortSignal ?? new AbortController().signal,
           description: input.description,
+          executionHost,
+          groupId: parentSession.currentBackgroundGroupId?.(),
+          groups,
           jobs,
           delegateToolCallId: toolCallId,
           parentSession,
+          parentRunId: parentSession.currentRunId?.() ?? parentAgentNamespace,
+          parentSessionKey,
+          ownerNamespace: parentAgentNamespace,
           prompt,
           registerCleanup: (cleanup) =>
             registerChildSession(parentSessionKey, cleanup),
@@ -100,32 +148,56 @@ function createDelegateTool({
         subagent: subagent.name ?? "subagent",
         type: "subagent-job-start",
       });
-      const result = await runBlockingDelegation({
-        abortSignal,
-        prompt,
-        sessionKey,
-        subagent,
-      });
+      const dedupeKey = blockingSubagentDedupeKey(
+        parentAgentNamespace,
+        toolCallId
+      );
+      const existing = blockingRuns.get(dedupeKey);
+      const result =
+        existing ??
+        runBlockingChild({
+          abortSignal,
+          dedupeKey,
+          executionHost,
+          parentRunId: parentSession.currentRunId?.() ?? parentAgentNamespace,
+          prompt,
+          sessionKey,
+          subagent,
+        });
+      blockingRuns.set(dedupeKey, result);
+      const awaitedResult = await result;
       await parentSession.emitObserverEvent({
-        error: result.error,
-        eventCount: result.eventCount,
+        error: awaitedResult.error,
+        eventCount: awaitedResult.eventCount,
         delegateToolCallId: toolCallId,
-        status: result.result,
+        status: awaitedResult.result,
         subagent: subagent.name ?? "subagent",
         type: "subagent-job-end",
       });
-      return result;
+      return awaitedResult;
     },
     inputSchema: jsonSchema<DelegateInput>({
       additionalProperties: false,
-      properties: {
-        description: { type: "string" },
-        prompt: delegatePromptSchema,
-        run_in_background: { default: false, type: "boolean" },
-        sessionKey: { type: "string" },
-      },
+      properties: createDelegateToolProperties(backgroundSubagents),
       required: ["prompt"],
       type: "object",
     }),
   });
+}
+
+function createDelegateToolProperties(backgroundSubagents: boolean) {
+  const baseProperties = {
+    description: { type: "string" },
+    prompt: delegatePromptSchema,
+    sessionKey: { type: "string" },
+  };
+
+  if (!backgroundSubagents) {
+    return baseProperties;
+  }
+
+  return {
+    ...baseProperties,
+    run_in_background: { default: false, type: "boolean" },
+  };
 }

--- a/packages/runtime/src/tool-checkpointing-agent.test.ts
+++ b/packages/runtime/src/tool-checkpointing-agent.test.ts
@@ -40,7 +40,10 @@ describe("tool checkpointing through Agent", () => {
         await executableTool(
           options.tools ?? {},
           "checkpointed_tool"
-        ).execute?.({}, toolOptions("call_sdk-tool-call-1", signal));
+        ).execute?.(
+          { secret: "raw input must not persist" },
+          toolOptions("call_sdk-tool-call-1", signal)
+        );
 
         return {
           responseMessages: [
@@ -75,11 +78,13 @@ describe("tool checkpointing through Agent", () => {
       policy: "idempotent",
       toolName: "checkpointed_tool",
     });
+    expect(beforeTool?.pendingToolCall).not.toHaveProperty("input");
     expect(afterTool?.pendingToolCall).toMatchObject({
-      output: { ok: true },
       toolCallId: "call_sdk-tool-call-1",
       toolName: "checkpointed_tool",
     });
+    expect(afterTool?.pendingToolCall).not.toHaveProperty("input");
+    expect(afterTool?.pendingToolCall).not.toHaveProperty("output");
     await expect(
       host.store.runs.get(beforeTool?.runId ?? "")
     ).resolves.toMatchObject({

--- a/packages/runtime/src/tool-checkpointing-agent.test.ts
+++ b/packages/runtime/src/tool-checkpointing-agent.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  checkpointedTool,
+  createCheckpointSpyHost,
+  type GenerateTextToolOptions,
+  toolOptions,
+} from "./execution-checkpoint-test-support";
+import {
+  collectRun,
+  executableTool,
+  fakeModel,
+  getGenerateTextMock,
+  loadAgent,
+} from "./llm-test-utils";
+import { assistantMessage, toolCallPart, toolResultFor } from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("tool checkpointing through Agent", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("threads execution-host tool checkpoints through high-level Agent", async () => {
+    const Agent = await loadAgent();
+    const { checkpoints, host } = createCheckpointSpyHost();
+    const signal = new AbortController().signal;
+
+    generateTextMock
+      .mockImplementationOnce(async (options: GenerateTextToolOptions) => {
+        const toolCall = toolCallPart(
+          "call_sdk-tool-call-1",
+          "checkpointed_tool"
+        );
+        await executableTool(
+          options.tools ?? {},
+          "checkpointed_tool"
+        ).execute?.({}, toolOptions("call_sdk-tool-call-1", signal));
+
+        return {
+          responseMessages: [
+            assistantMessage([toolCall]),
+            toolResultFor(toolCall),
+          ],
+        };
+      })
+      .mockImplementationOnce(async () => ({
+        responseMessages: [assistantMessage("DONE")],
+      }));
+
+    const agent = new Agent({
+      host,
+      model: fakeModel,
+      tools: {
+        checkpointed_tool: checkpointedTool("idempotent", () => ({
+          ok: true,
+        })),
+      },
+    });
+
+    await collectRun(await agent.send("use the tool"));
+
+    expect(checkpoints.map((checkpoint) => checkpoint.phase)).toEqual([
+      "before-tool",
+      "after-tool",
+    ]);
+    const [beforeTool, afterTool] = checkpoints;
+    expect(beforeTool?.pendingToolCall).toMatchObject({
+      idempotencyKey: `${beforeTool?.runId}:call_sdk-tool-call-1`,
+      policy: "idempotent",
+      toolName: "checkpointed_tool",
+    });
+    expect(afterTool?.pendingToolCall).toMatchObject({
+      output: { ok: true },
+      toolCallId: "call_sdk-tool-call-1",
+      toolName: "checkpointed_tool",
+    });
+    await expect(
+      host.store.runs.get(beforeTool?.runId ?? "")
+    ).resolves.toMatchObject({
+      checkpointVersion: 2,
+      kind: "user-turn",
+      status: "completed",
+    });
+  });
+});

--- a/packages/runtime/src/tool-checkpointing.test.ts
+++ b/packages/runtime/src/tool-checkpointing.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryExecutionHost } from "./execution/memory";
+import {
+  checkpointedTool,
+  createQueuedUserTurnRun,
+  type GenerateTextToolOptions,
+  toolOptions,
+} from "./execution-checkpoint-test-support";
+import {
+  executableTool,
+  fakeModel,
+  getGenerateTextMock,
+  loadCreateLlm,
+} from "./llm-test-utils";
+import { assistantMessage, toolCallPart, toolResultFor } from "./test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("tool checkpointing", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("persists before-tool before executing idempotent tool", async () => {
+    const createLlm = await loadCreateLlm();
+    const host = createInMemoryExecutionHost();
+    const order: string[] = [];
+    const signal = new AbortController().signal;
+    await host.store.runs.create(createQueuedUserTurnRun());
+
+    generateTextMock.mockImplementationOnce(
+      async (options: GenerateTextToolOptions) => {
+        const toolCall = toolCallPart(
+          "call_sdk-tool-call-1",
+          "checkpointed_tool"
+        );
+        await executableTool(
+          options.tools ?? {},
+          "checkpointed_tool"
+        ).execute?.({}, toolOptions("call_sdk-tool-call-1", signal));
+
+        return {
+          responseMessages: [
+            assistantMessage([toolCall]),
+            toolResultFor(toolCall),
+          ],
+        };
+      }
+    );
+
+    const llm = createLlm({
+      model: fakeModel,
+      tools: {
+        checkpointed_tool: checkpointedTool("idempotent", async () => {
+          order.push("execute");
+          await expect(
+            host.store.checkpoints.latest("run-1")
+          ).resolves.toMatchObject({
+            phase: "before-tool",
+            pendingToolCall: expect.objectContaining({
+              idempotencyKey: "run-1:call_sdk-tool-call-1",
+              policy: "idempotent",
+              toolName: "checkpointed_tool",
+            }),
+          });
+          return {};
+        }),
+      },
+    });
+
+    await expect(
+      llm({
+        history: [],
+        signal,
+        toolExecution: {
+          attempt: 2,
+          beforeTool: async (checkpoint) => {
+            order.push("before-tool");
+            await host.store.checkpoints.append(
+              {
+                checkpointId: "checkpoint-before-tool",
+                pendingToolCall: checkpoint,
+                phase: "before-tool",
+                runId: "run-1",
+                runtimeState: {},
+                sessionSnapshot: {},
+                version: 1,
+              },
+              { expectedVersion: 0 }
+            );
+          },
+          runId: "run-1",
+        },
+      })
+    ).resolves.toHaveLength(2);
+
+    expect(order).toEqual(["before-tool", "execute"]);
+  });
+
+  it("manual recovery tool is not retried after rollback", async () => {
+    const createLlm = await loadCreateLlm();
+    const host = createInMemoryExecutionHost();
+    const signal = new AbortController().signal;
+    let executions = 0;
+    await host.store.runs.create({
+      ...createQueuedUserTurnRun(),
+      checkpointVersion: 1,
+    });
+    await host.store.checkpoints.append(
+      {
+        checkpointId: "previous-before-tool",
+        pendingToolCall: {
+          idempotencyKey: "run-1:call_sdk-tool-call-1",
+          policy: "manual-recovery",
+          toolCallId: "call_sdk-tool-call-1",
+          toolName: "dangerous_tool",
+        },
+        phase: "before-tool",
+        runId: "run-1",
+        runtimeState: {},
+        sessionSnapshot: {},
+        version: 1,
+      },
+      { expectedVersion: 1 }
+    );
+
+    generateTextMock.mockImplementationOnce(
+      async (options: GenerateTextToolOptions) => {
+        await executableTool(options.tools ?? {}, "dangerous_tool").execute?.(
+          {},
+          toolOptions("call_sdk-tool-call-1", signal)
+        );
+
+        return {
+          responseMessages: [assistantMessage("SHOULD NOT FINISH")],
+        };
+      }
+    );
+
+    const llm = createLlm({
+      model: fakeModel,
+      tools: {
+        dangerous_tool: checkpointedTool("manual-recovery", () => {
+          executions += 1;
+          return {};
+        }),
+      },
+    });
+
+    await expect(
+      llm({
+        history: [],
+        signal,
+        toolExecution: {
+          attempt: 2,
+          beforeTool: async () => ({ status: "needs-recovery" }),
+          runId: "run-1",
+        },
+      })
+    ).rejects.toMatchObject({
+      status: "needs-recovery",
+      toolName: "dangerous_tool",
+    });
+    expect(executions).toBe(0);
+  });
+});

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: [
     "src/index.ts",
+    "src/execution/index.ts",
+    "src/execution/memory.ts",
     "src/session/store/memory.ts",
     "src/session/store/file.ts",
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,40 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  examples/cloudflare-edge-subagent:
+    dependencies:
+      '@ai-sdk/openai-compatible':
+        specifier: 3.0.0-canary.48
+        version: 3.0.0-canary.48(zod@4.4.3)
+      '@minpeter/pss-runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+      '@t3-oss/env-core':
+        specifier: ^0.13.11
+        version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
+      ai:
+        specifier: 7.0.0-canary.142
+        version: 7.0.0-canary.142(zod@4.4.3)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260608.1
+        version: 4.20260608.1
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      wrangler:
+        specifier: ^4.98.0
+        version: 4.98.0(@cloudflare/workers-types@4.20260608.1)
+
   examples/plugin:
     dependencies:
       '@ai-sdk/openai-compatible':
@@ -112,6 +146,9 @@ importers:
       '@t3-oss/env-core':
         specifier: ^0.13.11
         version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
+      ai:
+        specifier: 7.0.0-canary.142
+        version: 7.0.0-canary.142(zod@4.4.3)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -344,6 +381,56 @@ packages:
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
     engines: {node: '>= 20.12.0'}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260603.1':
+    resolution: {integrity: sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260603.1':
+    resolution: {integrity: sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260603.1':
+    resolution: {integrity: sha512-ht9l6/8Tk7Rp6kA4S9oFZ4X8u0VjnnFdmU/6B3fnABYKREYTKh2RdOqXqXxcp5eNJseireKnWik/hQOPK1CutQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260603.1':
+    resolution: {integrity: sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260603.1':
+    resolution: {integrity: sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260608.1':
+    resolution: {integrity: sha512-Yz90KXPZBB9K/AhsnLaA321s5+i5ZpWZRFbcGx9dWjyknQJXPAS1pK5CJSFEedwY6zoEr1cf2SkpBATL1idsWA==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@earendil-works/pi-tui@0.76.0':
     resolution: {integrity: sha512-TWQEWqc38gVRYr/VTrlfePQPpJk938gNNLL1xuv0M+9cTkVr880/Q3baZQrxKoLrmN/MmVx7TyR8knYZGxTqqg==}
     engines: {node: '>=22.19.0'}
@@ -357,16 +444,34 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.0':
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.0':
@@ -375,16 +480,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.0':
     resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
@@ -393,10 +516,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -405,10 +540,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
@@ -417,10 +564,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
@@ -429,10 +588,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -441,10 +612,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.0':
@@ -453,16 +636,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.0':
     resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.0':
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.0':
@@ -471,10 +672,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.0':
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -483,11 +696,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.0':
     resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
@@ -495,10 +720,22 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.0':
     resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.0':
@@ -507,9 +744,152 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.28.0':
     resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
@@ -534,6 +914,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -564,6 +947,15 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -749,6 +1141,13 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -903,6 +1302,9 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
@@ -931,6 +1333,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -976,8 +1382,16 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
@@ -1136,6 +1550,10 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -1233,6 +1651,11 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  miniflare@4.20260603.0:
+    resolution: {integrity: sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1295,6 +1718,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -1391,6 +1817,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1436,6 +1866,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -1532,6 +1966,13 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -1631,10 +2072,43 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  workerd@1.20260603.1:
+    resolution: {integrity: sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.98.0:
+    resolution: {integrity: sha512-cXfFUuF4rMIvE0hiMnXjEAB27ERryaCgquBJdUoPIjFzYYE1rbRdMUkEdQ18qDPUtsPvhJdqxLntixT9OfSzQw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260603.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -1886,6 +2360,35 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260603.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260603.1
+
+  '@cloudflare/workerd-darwin-64@1.20260603.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260603.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260603.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260603.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260603.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260608.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@earendil-works/pi-tui@0.76.0':
     dependencies:
       get-east-asian-width: 1.6.0
@@ -1907,82 +2410,256 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.0':
     optional: true
 
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
   '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@inquirer/external-editor@1.0.3(@types/node@25.9.1)':
@@ -2002,6 +2679,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2044,6 +2726,18 @@ snapshots:
   '@oxc-project/types@0.130.0': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -2148,6 +2842,10 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2278,6 +2976,8 @@ snapshots:
 
   birpc@4.0.0: {}
 
+  blake3-wasm@2.1.5: {}
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
@@ -2297,6 +2997,8 @@ snapshots:
   commander@14.0.3: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2327,7 +3029,38 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  error-stack-parser-es@1.0.5: {}
+
   es-module-lexer@2.1.0: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -2494,6 +3227,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  kleur@4.1.5: {}
+
   lightningcss-android-arm64@1.32.0:
     optional: true
 
@@ -2564,6 +3299,18 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  miniflare@4.20260603.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260603.1
+      ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -2612,6 +3359,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
       minipass: 7.1.3
+
+  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -2718,6 +3467,37 @@ snapshots:
 
   semver@7.8.1: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.1
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2750,6 +3530,8 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
+
+  supports-color@10.2.2: {}
 
   term-size@2.2.1: {}
 
@@ -2835,6 +3617,12 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici@7.24.8: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
   universalify@0.1.2: {}
 
   vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0):
@@ -2887,6 +3675,46 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  workerd@1.20260603.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260603.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260603.1
+      '@cloudflare/workerd-linux-64': 1.20260603.1
+      '@cloudflare/workerd-linux-arm64': 1.20260603.1
+      '@cloudflare/workerd-windows-64': 1.20260603.1
+
+  wrangler@4.98.0(@cloudflare/workers-types@4.20260608.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260603.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260603.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260603.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260608.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ws@8.20.1: {}
+
   yaml@2.9.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zod@4.4.3: {}

--- a/scripts/changeset-pre-mode.test.mjs
+++ b/scripts/changeset-pre-mode.test.mjs
@@ -8,6 +8,7 @@ describe("changeset prerelease mode", () => {
 
     expect(preState.mode).toBe("pre");
     expect(preState.tag).toBe("next");
+    expect(preState.changesets).not.toContain("background-notify-runs");
     expect(preState.changesets).not.toContain("runtime-plugin-constructor");
     expect(config.baseBranch).toBe("v0.1");
   });
@@ -17,6 +18,7 @@ describe("changeset prerelease mode", () => {
 
     expect(config.ignore).toEqual([
       "@minpeter/pss-example-basic",
+      "@minpeter/pss-example-cloudflare-edge-subagent",
       "@minpeter/pss-example-plugin",
       "@minpeter/pss-example-subagent",
     ]);

--- a/scripts/examples.test.mjs
+++ b/scripts/examples.test.mjs
@@ -210,6 +210,10 @@ describe("examples workspace packages", () => {
     expect(readme).not.toContain("in-memory fake");
     expect(readme).toContain("support-agent");
     expect(readme).toContain("dev:worker");
+    expect(source).toContain(
+      'import { workerStorePrefix } from "./worker-constants"'
+    );
+    expect(source).not.toContain('"cloudflare-edge-subagent-demo"');
     expect(hostSource).toContain("createCloudflareDurableObjectHost");
     expect(hostSource).toContain("createCloudflareAlarmScheduler");
     expect(storeSource).toContain("DurableObjectExecutionStore");

--- a/scripts/examples.test.mjs
+++ b/scripts/examples.test.mjs
@@ -28,6 +28,8 @@ const examplePackages = [
 ];
 const finalRunEventsLoopPattern =
   /for await \(const event of run\.events\(\)\) \{\s+console\.log\(event\);\s+\}$/;
+const legacyCloudflareSessionKeyPattern =
+  /`\$\{this\.#prefix\}:\$\{encodeURIComponent\(key\)\}`/;
 const removedTurnModeEnvName = ["PSS", "TURN", "MODE"].join("_");
 
 function readJson(path) {
@@ -177,6 +179,9 @@ describe("examples workspace packages", () => {
     const workerSource = readText(
       "examples/cloudflare-edge-subagent/src/worker.ts"
     );
+    const workerRouteSource = readText(
+      "examples/cloudflare-edge-subagent/src/worker-route.ts"
+    );
     const alarmDrainerSource = readText(
       "examples/cloudflare-edge-subagent/src/cloudflare-alarm-drainer.ts"
     );
@@ -210,6 +215,10 @@ describe("examples workspace packages", () => {
     expect(storeSource).toContain("DurableObjectExecutionStore");
     expect(workerSource).toContain("export class AgentDurableObject");
     expect(workerSource).toContain("alarm()");
+    expect(workerSource).toContain("routeWorkerRequest");
+    expect(workerRouteSource).toContain("sessionKeyFromRoute");
+    expect(workerSource).not.toContain('idFromName("default")');
+    expect(workerSource).not.toContain('url.pathname === "/alarm"');
     expect(alarmDrainerSource).toContain("agent.resume(");
     expect(alarmDrainerSource).toContain("ackScheduledCloudflareRun");
     expect(alarmDrainerSource).toContain("rescheduleCloudflareAlarm");
@@ -217,6 +226,11 @@ describe("examples workspace packages", () => {
     expect(workerTsconfig.compilerOptions.types).toEqual([
       "@cloudflare/workers-types",
     ]);
+    const sessionStoreSource = readText(
+      "examples/cloudflare-edge-subagent/src/durable-object-session-store.ts"
+    );
+    expect(sessionStoreSource).toContain('storeKey(this.#prefix, "session"');
+    expect(sessionStoreSource).not.toMatch(legacyCloudflareSessionKeyPattern);
   });
 
   it("drives Cloudflare scheduled runs and session prompts through stored alarms", async () => {

--- a/scripts/examples.test.mjs
+++ b/scripts/examples.test.mjs
@@ -9,6 +9,13 @@ const examplePackages = [
     requiredSource: "src/index.ts",
   },
   {
+    name: "@minpeter/pss-example-cloudflare-edge-subagent",
+    path: "examples/cloudflare-edge-subagent",
+    requiredSource: "src/index.ts",
+    startScript:
+      "tsx --conditions=@minpeter/pss-source src/worker-simulation.ts",
+  },
+  {
     name: "@minpeter/pss-example-plugin",
     path: "examples/plugin",
     requiredSource: "src/index.ts",
@@ -21,15 +28,7 @@ const examplePackages = [
 ];
 const finalRunEventsLoopPattern =
   /for await \(const event of run\.events\(\)\) \{\s+console\.log\(event\);\s+\}$/;
-const legacyLifecycleTerm = ["h", "o", "o", "k"].join("");
-const legacyLifecyclePlural = `${legacyLifecycleTerm}s`;
-const legacyLifecycleType = `Agent${["H", "o", "o", "k", "s"].join("")}`;
-const legacyLifecycleAdapter = `pluginsTo${["H", "o", "o", "k", "s"].join("")}`;
-const legacyRuntimeInputAdapter = `${legacyLifecyclePlural}ForRuntimeInput`;
-const legacyAfterTurnRunner = `runAfterTurn${["H", "o", "o", "k"].join("")}`;
-const legacyLifecycleOption = `${legacyLifecyclePlural}:`;
-const legacyBeforeTurnName = `before${["T", "u", "r", "n"].join("")}`;
-const legacyAfterTurnName = `after${["T", "u", "r", "n"].join("")}`;
+const removedTurnModeEnvName = ["PSS", "TURN", "MODE"].join("_");
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
@@ -52,12 +51,13 @@ describe("examples workspace packages", () => {
         examplePackage.requiredSource
       );
       const packageJson = readJson(packageJsonPath);
+      const startScript =
+        examplePackage.startScript ??
+        "tsx --conditions=@minpeter/pss-source src/index.ts";
 
       expect(packageJson.private).toBe(true);
       expect(packageJson.name).toBe(examplePackage.name);
-      expect(packageJson.scripts.start).toBe(
-        "tsx --conditions=@minpeter/pss-source src/index.ts"
-      );
+      expect(packageJson.scripts.start).toBe(startScript);
       expect(packageJson.dependencies["@minpeter/pss-runtime"]).toBe(
         "workspace:*"
       );
@@ -99,10 +99,6 @@ describe("examples workspace packages", () => {
     expect(pluginSource).toContain("plugins:");
     expect(pluginSource).toContain("events:");
     expect(pluginSource).toContain("event.type");
-    expect(pluginSource).not.toContain(legacyLifecycleOption);
-    expect(pluginSource).not.toContain(legacyLifecycleType);
-    expect(pluginSource).not.toContain(legacyBeforeTurnName);
-    expect(pluginSource).not.toContain(legacyAfterTurnName);
     expect(pluginSource).not.toContain("process.argv");
 
     expect(subagentSource).toContain("subagents: [researcher]");
@@ -114,52 +110,171 @@ describe("examples workspace packages", () => {
   it("includes a background subagent task example", () => {
     const packageJson = readJson("examples/subagent/package.json");
     const backgroundSource = readText("examples/subagent/src/background.ts");
+    const backgroundWaitSource = readText(
+      "examples/subagent/src/background-wait.ts"
+    );
+    const localBackgroundModelSource = readText(
+      "examples/subagent/src/local-background-model.ts"
+    );
 
     expect(packageJson.scripts["start:background"]).toBe(
       "tsx --conditions=@minpeter/pss-source src/background.ts"
+    );
+    expect(packageJson.scripts["start:background:wait"]).toBe(
+      "tsx --conditions=@minpeter/pss-source src/background-wait.ts"
     );
     expect(backgroundSource).toContain("subagents: [researcher]");
     expect(backgroundSource).toContain("run_in_background: true");
     expect(backgroundSource).toContain("background_output");
     expect(backgroundSource).toContain("task_id");
     expect(backgroundSource).toContain("background_cancel");
-    expect(backgroundSource).toContain("coordinator.send(");
+    expect(backgroundSource).toContain('coordinator.session("default")');
+    expect(backgroundSource).toContain("session.send(");
     expect(backgroundSource.trim()).toMatch(finalRunEventsLoopPattern);
     expect(backgroundSource).not.toContain("@minpeter/pss-coding-agent");
-  });
-});
 
-describe("runtime plugin source surface", () => {
-  it("does not keep the legacy lifecycle adapter as a runtime layer", () => {
-    const agentLoopSource = readText("packages/runtime/src/agent-loop.ts");
-    const agentSource = readText("packages/runtime/src/agent.ts");
-    const pluginSource = readText("packages/runtime/src/plugins.ts");
-    const runtimeInputSource = readText(
-      "packages/runtime/src/session/runtime-input.ts"
+    expect(backgroundWaitSource).toContain("subagents: [researcher]");
+    expect(backgroundWaitSource).toContain("run_in_background: true");
+    expect(backgroundWaitSource).toContain(
+      'import { localHost } from "./local-host"'
     );
-    const sessionSource = readText("packages/runtime/src/session/session.ts");
-    const pluginsSource = readText("packages/runtime/src/plugins.ts");
+    expect(backgroundWaitSource).toContain(
+      "localHost({ agent: createCoordinator })"
+    );
+    expect(backgroundWaitSource).toContain("host.resumeSession()");
+    expect(backgroundWaitSource).toContain("background_output");
+    expect(backgroundWaitSource).toContain("block: true");
+    expect(backgroundWaitSource).not.toContain("@minpeter/pss-coding-agent");
 
-    expect(existsSync(`packages/runtime/src/${legacyLifecyclePlural}.ts`)).toBe(
+    expect(existsSync("examples/subagent/src/local-host.ts")).toBe(true);
+    expect(existsSync("examples/subagent/src/local-background-host.ts")).toBe(
       false
     );
-    for (const source of [
-      agentLoopSource,
-      agentSource,
-      pluginSource,
-      runtimeInputSource,
-      sessionSource,
-      pluginsSource,
-    ]) {
-      expect(source).not.toContain(legacyLifecycleType);
-      expect(source).not.toContain(legacyLifecycleAdapter);
-      expect(source).not.toContain(legacyRuntimeInputAdapter);
-      expect(source).not.toContain(legacyAfterTurnRunner);
-      expect(source).not.toContain(legacyLifecycleOption);
-    }
+    const localHostSource = readText("examples/subagent/src/local-host.ts");
 
-    expect(pluginsSource).toContain("export interface AgentEventContext");
-    expect(pluginsSource).toContain("export interface AgentPlugin");
-    expect(pluginsSource).toContain("export function runEventPlugins");
+    expect(localHostSource).toContain("createInMemoryExecutionHost");
+    expect(localHostSource).toContain('backgroundSubagents: "durable"');
+    expect(localHostSource).toContain("resumeSession");
+    expect(localHostSource).toContain("agent().resume(");
+    expect(localHostSource).toContain("ResumeSessionOptions");
+
+    expect(localBackgroundModelSource).toContain('"delegate_to_researcher"');
+    expect(localBackgroundModelSource).toContain('"background_output"');
+    expect(localBackgroundModelSource).not.toContain("createOpenAICompatible");
+  });
+
+  it("uses a Cloudflare Worker/Durable Object adapter surface", () => {
+    const packageJson = readJson(
+      "examples/cloudflare-edge-subagent/package.json"
+    );
+    const source = readText("examples/cloudflare-edge-subagent/src/index.ts");
+    const hostSource = readText(
+      "examples/cloudflare-edge-subagent/src/cloudflare-host.ts"
+    );
+    const storeSource = readText(
+      "examples/cloudflare-edge-subagent/src/cloudflare-execution-store.ts"
+    );
+    const workerSource = readText(
+      "examples/cloudflare-edge-subagent/src/worker.ts"
+    );
+    const alarmDrainerSource = readText(
+      "examples/cloudflare-edge-subagent/src/cloudflare-alarm-drainer.ts"
+    );
+    const workerTsconfig = readJson(
+      "examples/cloudflare-edge-subagent/tsconfig.worker.json"
+    );
+    const readme = readText("examples/cloudflare-edge-subagent/README.md");
+
+    expect(packageJson.scripts["start:worker-sim"]).toBe(
+      "tsx --conditions=@minpeter/pss-source src/worker-simulation.ts"
+    );
+    expect(packageJson.scripts["start:cli"]).toBe(
+      "tsx --conditions=@minpeter/pss-source src/index.ts"
+    );
+    expect(packageJson.scripts["typecheck:worker"]).toBe(
+      "tsc -p tsconfig.worker.json --noEmit"
+    );
+    expect(packageJson.scripts["dev:worker"]).toBe("wrangler dev");
+    expect(packageJson.scripts["deploy:worker"]).toBe("wrangler deploy");
+    expect(packageJson.devDependencies.wrangler).toBeDefined();
+    expect(source).not.toContain("createFakeCloudflareDurableObjectHost");
+    expect(source).not.toContain(removedTurnModeEnvName);
+    expect(hostSource).not.toContain("createFakeCloudflareDurableObjectHost");
+    expect(readme).not.toContain(removedTurnModeEnvName);
+    expect(readme).not.toContain("fake host");
+    expect(readme).not.toContain("in-memory fake");
+    expect(readme).toContain("support-agent");
+    expect(readme).toContain("dev:worker");
+    expect(hostSource).toContain("createCloudflareDurableObjectHost");
+    expect(hostSource).toContain("createCloudflareAlarmScheduler");
+    expect(storeSource).toContain("DurableObjectExecutionStore");
+    expect(workerSource).toContain("export class AgentDurableObject");
+    expect(workerSource).toContain("alarm()");
+    expect(alarmDrainerSource).toContain("agent.resume(");
+    expect(alarmDrainerSource).toContain("ackScheduledCloudflareRun");
+    expect(alarmDrainerSource).toContain("rescheduleCloudflareAlarm");
+    expect(hostSource).toContain("setAlarm");
+    expect(workerTsconfig.compilerOptions.types).toEqual([
+      "@cloudflare/workers-types",
+    ]);
+  });
+
+  it("drives Cloudflare scheduled runs and session prompts through stored alarms", async () => {
+    const {
+      InMemoryCloudflareDurableObjectStorage,
+      ackScheduledCloudflareRun,
+      ackScheduledCloudflareSessionPrompt,
+      createCloudflareDurableObjectHost,
+      listScheduledCloudflareRuns,
+      listScheduledCloudflareSessionPrompts,
+    } = await import(
+      "../examples/cloudflare-edge-subagent/src/cloudflare-host.ts"
+    );
+    const storage = new InMemoryCloudflareDurableObjectStorage();
+    const host = createCloudflareDurableObjectHost({ storage });
+    const runId = "background:bg_cloudflare_delayed";
+    const idempotencyKey = "background-complete:example:bg_delayed";
+    const notificationRunId = "notification-run-delayed";
+
+    await host.scheduler.enqueueRun(runId);
+    await host.scheduler.resumeSession("example", {
+      idempotencyKey,
+      runId: notificationRunId,
+    });
+    await host.store.notifications.enqueue({
+      idempotencyKey,
+      input: { text: "ready", type: "user-text" },
+      notificationId: "notification-delayed",
+      runId: notificationRunId,
+      sessionKey: "example",
+      status: "pending",
+    });
+
+    await expect(listScheduledCloudflareRuns(storage)).resolves.toEqual([
+      runId,
+    ]);
+    await expect(listScheduledCloudflareRuns(storage)).resolves.toEqual([
+      runId,
+    ]);
+    await ackScheduledCloudflareRun(storage, runId);
+    await expect(listScheduledCloudflareRuns(storage)).resolves.toEqual([]);
+    const prompt = {
+      idempotencyKey,
+      runId: notificationRunId,
+      sessionKey: "example",
+    };
+    await expect(
+      listScheduledCloudflareSessionPrompts(storage)
+    ).resolves.toEqual([prompt]);
+    await expect(
+      listScheduledCloudflareSessionPrompts(storage)
+    ).resolves.toEqual([prompt]);
+    await ackScheduledCloudflareSessionPrompt(storage, prompt);
+    await expect(
+      listScheduledCloudflareSessionPrompts(storage)
+    ).resolves.toEqual([]);
+    await expect(
+      host.store.notifications.claimByIdempotencyKey(idempotencyKey)
+    ).resolves.toMatchObject({ ok: true });
   });
 });

--- a/scripts/examples.test.mjs
+++ b/scripts/examples.test.mjs
@@ -327,7 +327,7 @@ describe("examples workspace packages", () => {
     );
 
     expect(storage.transactionCount).toBe(1);
-    expect(runnerSource).toContain("const durableCancelPollMs = 1000;");
+    expect(runnerSource).toContain("const durableCancelPollMs = 250;");
     expect(runnerSource).not.toContain("const durableCancelPollMs = 25;");
     expect(resumeSource).toContain("}).finally(() => {");
     expect(resumeSource).toContain("job.settled = true;");

--- a/scripts/examples.test.mjs
+++ b/scripts/examples.test.mjs
@@ -295,4 +295,41 @@ describe("examples workspace packages", () => {
       host.store.notifications.claimByIdempotencyKey(idempotencyKey)
     ).resolves.toMatchObject({ ok: true });
   });
+
+  it("keeps durable runtime review fixes locked", async () => {
+    const runnerSource = readText(
+      "packages/runtime/src/subagent-background-runner.ts"
+    );
+    const resumeSource = readText("packages/runtime/src/agent-resume.ts");
+    const { InMemoryCloudflareDurableObjectStorage } = await import(
+      "../examples/cloudflare-edge-subagent/src/cloudflare-host.ts"
+    );
+    const { DurableObjectSessionStore } = await import(
+      "../examples/cloudflare-edge-subagent/src/durable-object-session-store.ts"
+    );
+
+    class CountingTransactionStorage extends InMemoryCloudflareDurableObjectStorage {
+      transactionCount = 0;
+
+      async transaction(fn) {
+        this.transactionCount += 1;
+        return await super.transaction(fn);
+      }
+    }
+
+    const storage = new CountingTransactionStorage();
+    const sessions = new DurableObjectSessionStore(storage);
+
+    await sessions.commit(
+      "session:review",
+      { state: { persisted: true } },
+      { expectedVersion: null }
+    );
+
+    expect(storage.transactionCount).toBe(1);
+    expect(runnerSource).toContain("const durableCancelPollMs = 1000;");
+    expect(runnerSource).not.toContain("const durableCancelPollMs = 25;");
+    expect(resumeSource).toContain("}).finally(() => {");
+    expect(resumeSource).toContain("job.settled = true;");
+  });
 });

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -12,6 +12,7 @@ const REQUIRED_PACKAGE_BINS = {
   },
 };
 const REQUIRED_RUNTIME_ROOT_EXPORTS = [
+  "AgentHost",
   "AgentRun",
   "RuntimeCreateLlmOptions",
   "RuntimeInput",
@@ -20,6 +21,25 @@ const REQUIRED_RUNTIME_ROOT_EXPORTS = [
   "RuntimeLlmOutput",
   "RuntimeLlmOutputPart",
 ];
+const REQUIRED_RUNTIME_EXECUTION_EXPORTS = [
+  "AgentHostCapabilities",
+  "CheckpointStore",
+  "createInMemoryExecutionHost",
+  "EventStore",
+  "ExecutionHost",
+  "ExecutionScheduler",
+  "ExecutionStore",
+  "ExecutionStoreTransaction",
+  "NotificationInbox",
+  "NotificationRecord",
+  "RunRecord",
+  "RunStore",
+  "RuntimeToolExecutionCheckpoint",
+  "RuntimeToolExecutionContext",
+  "RuntimeToolExecutionDecision",
+  "RuntimeToolRetryPolicy",
+  "ToolExecutionNeedsRecoveryError",
+];
 const FORBIDDEN_RUNTIME_ROOT_NAMES = [
   "AgentMessage",
   ["Agent", "Model"].join(""),
@@ -27,21 +47,38 @@ const FORBIDDEN_RUNTIME_ROOT_NAMES = [
   "AgentRunInput",
   "AgentTool",
   "AgentTools",
+  "AgentHostCapabilities",
+  "CheckpointStore",
+  "createInMemoryExecutionHost",
   "CreateLlmOptions",
+  "EventStore",
+  "ExecutionHost",
+  "ExecutionScheduler",
+  "ExecutionStore",
+  "ExecutionStoreTransaction",
   "Llm",
   "LlmContext",
   "LlmOutput",
   "LlmOutputPart",
+  "NotificationInbox",
+  "NotificationRecord",
+  "RunRecord",
   "RunInput",
+  "RunStore",
+  "RuntimeToolExecutionCheckpoint",
+  "RuntimeToolExecutionContext",
+  "RuntimeToolExecutionDecision",
+  "RuntimeToolRetryPolicy",
   "runAgentLoop",
+  "ToolExecutionNeedsRecoveryError",
 ];
 const FORBIDDEN_RUNTIME_PUBLIC_PATTERNS = [
   {
-    description: "removed AgentRun.stream() API",
+    description: "AgentRun.stream() API",
     pattern: /\bstream\(\): AsyncIterable(?:Iterator)?<AgentEvent>/,
   },
   {
-    description: "removed AgentRun.stream() member",
+    description: "AgentRun.stream() member",
     pattern: /(?:\bstream\(\)\s*\{|AgentRun\.stream\(\))/,
   },
 ];
@@ -327,9 +364,17 @@ function findRuntimeDeclarationLeaks({ cwd, packages }) {
   }
 
   return [
-    ...findRuntimeRootDeclarationLeaks({
+    ...findRuntimeDeclarationExportLeaks({
       cwd,
       file: join(packageDistPath(cwd, "runtime"), "index.d.ts"),
+      requiredExports: REQUIRED_RUNTIME_ROOT_EXPORTS,
+      surface: "root",
+    }),
+    ...findRuntimeDeclarationExportLeaks({
+      cwd,
+      file: join(packageDistPath(cwd, "runtime"), "execution", "index.d.ts"),
+      requiredExports: REQUIRED_RUNTIME_EXECUTION_EXPORTS,
+      surface: "execution",
     }),
     ...findRuntimePublicPatternLeaks({ cwd }),
   ];
@@ -354,22 +399,35 @@ function findRuntimePublicPatternLeaks({ cwd }) {
   return errors;
 }
 
-function findRuntimeRootDeclarationLeaks({ cwd, file }) {
+function findRuntimeDeclarationExportLeaks({
+  cwd,
+  file,
+  requiredExports,
+  surface,
+}) {
+  if (!existsSync(file)) {
+    return [
+      `${relativeToCwd(cwd, file)}: missing ${surface} runtime declaration`,
+    ];
+  }
+
   const text = readFileSync(file, "utf8");
   const errors = [];
 
-  for (const name of FORBIDDEN_RUNTIME_ROOT_NAMES) {
-    if (hasDeclarationToken(text, name)) {
-      errors.push(
-        `${relativeToCwd(cwd, file)}: root declaration exposes internal runtime name ${name}`
-      );
+  if (surface === "root") {
+    for (const name of FORBIDDEN_RUNTIME_ROOT_NAMES) {
+      if (hasDeclarationToken(text, name)) {
+        errors.push(
+          `${relativeToCwd(cwd, file)}: root declaration exposes internal runtime name ${name}`
+        );
+      }
     }
   }
 
-  for (const name of REQUIRED_RUNTIME_ROOT_EXPORTS) {
+  for (const name of requiredExports) {
     if (!text.includes(name)) {
       errors.push(
-        `${relativeToCwd(cwd, file)}: missing explicit runtime export ${name}`
+        `${relativeToCwd(cwd, file)}: missing explicit ${surface} runtime export ${name}`
       );
     }
   }

--- a/scripts/verify-release-artifacts.test.mjs
+++ b/scripts/verify-release-artifacts.test.mjs
@@ -16,9 +16,19 @@ import {
 
 const cliBinReadFailurePattern =
   /^packages\/coding-agent\/bin\/pss\.js: cannot read CLI bin target /;
-const removedModelAlias = ["Agent", "Model"].join("");
-const runtimeRootDeclaration =
-  'export type { AgentRun, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput, RuntimeLlmOutputPart } from "./llm";\n';
+const forbiddenModelName = ["Agent", "Model"].join("");
+const runtimeRootDeclaration = [
+  'export type { AgentHost } from "./execution/types";',
+  'export type { AgentRun, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput, RuntimeLlmOutputPart } from "./llm";',
+  "",
+].join("\n");
+const runtimeExecutionDeclaration = [
+  'export { createInMemoryExecutionHost } from "./memory";',
+  'export type { AgentHostCapabilities, CheckpointStore, EventStore, ExecutionHost, ExecutionScheduler, ExecutionStore, ExecutionStoreTransaction, NotificationInbox, NotificationRecord, RunRecord, RunStore } from "./types";',
+  'export type { RuntimeToolExecutionCheckpoint, RuntimeToolExecutionContext, RuntimeToolExecutionDecision, RuntimeToolRetryPolicy } from "../llm-tool-execution";',
+  'export { ToolExecutionNeedsRecoveryError } from "../llm-tool-execution";',
+  "",
+].join("\n");
 
 let tempRoots = [];
 
@@ -56,6 +66,13 @@ function createFixture() {
       declaration
     );
     if (packageName === "runtime") {
+      mkdirSync(join(cwd, "packages", packageName, "dist", "execution"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(cwd, "packages", packageName, "dist", "execution", "index.d.ts"),
+        runtimeExecutionDeclaration
+      );
       writeFileSync(
         join(cwd, "packages", packageName, "dist", "llm.d.ts"),
         "export declare const ok: true;\n"
@@ -219,7 +236,7 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'import type { LanguageModel, ToolSet } from "ai";\nexport interface AgentOptions { model: LanguageModel; tools?: ToolSet; }\nexport type { AgentRun, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput, RuntimeLlmOutputPart } from "./llm";\n'
+      `import type { LanguageModel, ToolSet } from "ai";\nexport interface AgentOptions { model: LanguageModel; tools?: ToolSet; }\n${runtimeRootDeclaration}`
     );
 
     expect(
@@ -243,14 +260,14 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      `export type { AgentMessage, ${removedModelAlias}, AgentRun, AgentTool, AgentTools, CreateLlmOptions, Llm, LlmContext, LlmOutput, LlmOutputPart, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput, RuntimeLlmOutputPart } from "./llm";\n`
+      `export type { AgentMessage, ${forbiddenModelName}, AgentRun, AgentTool, AgentTools, CreateLlmOptions, Llm, LlmContext, LlmOutput, LlmOutputPart, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput, RuntimeLlmOutputPart } from "./llm";\nexport type { AgentHost } from "./execution/types";\n`
     );
 
     expect(
       verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
     ).toEqual([
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name AgentMessage",
-      `packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name ${removedModelAlias}`,
+      `packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name ${forbiddenModelName}`,
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name AgentTool",
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name AgentTools",
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name CreateLlmOptions",
@@ -261,11 +278,11 @@ describe("verifyReleaseArtifacts", () => {
     ]);
   });
 
-  it("rejects removed runtime input names from root declarations", () => {
+  it("rejects internal runtime input names from root declarations", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'export type { AgentRun, AgentRunInput, RunInput, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput, RuntimeLlmOutputPart } from "./llm";\n'
+      `${runtimeRootDeclaration}export type { AgentRunInput, RunInput } from "./llm";\n`
     );
 
     expect(
@@ -280,7 +297,7 @@ describe("verifyReleaseArtifacts", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      'export { runAgentLoop, type AgentLoopResult } from "./agent-loop";\nexport type { AgentRun, RuntimeCreateLlmOptions, RuntimeInput, RuntimeLlm, RuntimeLlmContext, RuntimeLlmOutput, RuntimeLlmOutputPart } from "./llm";\n'
+      `export { runAgentLoop, type AgentLoopResult } from "./agent-loop";\n${runtimeRootDeclaration}`
     );
 
     expect(
@@ -291,7 +308,26 @@ describe("verifyReleaseArtifacts", () => {
     ]);
   });
 
-  it("rejects removed AgentRun stream API from runtime artifacts", () => {
+  it("rejects advanced execution contracts from root declarations", () => {
+    const cwd = createFixture();
+    writeFileSync(
+      join(cwd, "packages", "runtime", "dist", "index.d.ts"),
+      `${runtimeRootDeclaration}export type { ExecutionHost, ExecutionScheduler, ExecutionStore, RuntimeToolExecutionContext } from "./execution";\nexport { ToolExecutionNeedsRecoveryError, createInMemoryExecutionHost } from "./execution";\n`
+    );
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
+    ).toEqual([
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name createInMemoryExecutionHost",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name ExecutionHost",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name ExecutionScheduler",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name ExecutionStore",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name RuntimeToolExecutionContext",
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name ToolExecutionNeedsRecoveryError",
+    ]);
+  });
+
+  it("rejects AgentRun stream API from runtime artifacts", () => {
     const cwd = createFixture();
     mkdirSync(join(cwd, "packages", "runtime", "dist", "session"), {
       recursive: true,
@@ -308,8 +344,8 @@ describe("verifyReleaseArtifacts", () => {
     expect(
       verifyReleaseArtifacts({ cwd, packages: ["runtime", "coding-agent"] })
     ).toEqual([
-      "packages/runtime/dist/session/run.d.ts: exposes removed AgentRun.stream() API",
-      "packages/runtime/dist/session/run.js: exposes removed AgentRun.stream() member",
+      "packages/runtime/dist/session/run.d.ts: exposes AgentRun.stream() API",
+      "packages/runtime/dist/session/run.js: exposes AgentRun.stream() member",
     ]);
   });
 
@@ -340,13 +376,51 @@ describe("verifyReleaseArtifacts", () => {
       []
     );
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
-      "packages/runtime/dist/index.d.ts: missing explicit runtime export AgentRun",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime export RuntimeCreateLlmOptions",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime export RuntimeInput",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime export RuntimeLlm",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime export RuntimeLlmContext",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime export RuntimeLlmOutput",
-      "packages/runtime/dist/index.d.ts: missing explicit runtime export RuntimeLlmOutputPart",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentHost",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentRun",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeCreateLlmOptions",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeInput",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeLlm",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeLlmContext",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeLlmOutput",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeLlmOutputPart",
+    ]);
+  });
+
+  it("requires the runtime execution declaration entrypoint", () => {
+    const cwd = createFixture();
+    rmSync(join(cwd, "packages", "runtime", "dist", "execution", "index.d.ts"));
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
+      "packages/runtime/dist/execution/index.d.ts: missing execution runtime declaration",
+    ]);
+  });
+
+  it("checks advanced runtime contracts on the execution declaration subpath", () => {
+    const cwd = createFixture();
+    writeFileSync(
+      join(cwd, "packages", "runtime", "dist", "execution", "index.d.ts"),
+      "export {};\n"
+    );
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export AgentHostCapabilities",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export CheckpointStore",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export createInMemoryExecutionHost",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export EventStore",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export ExecutionHost",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export ExecutionScheduler",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export ExecutionStore",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export ExecutionStoreTransaction",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export NotificationInbox",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export NotificationRecord",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RunRecord",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RunStore",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RuntimeToolExecutionCheckpoint",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RuntimeToolExecutionContext",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RuntimeToolExecutionDecision",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RuntimeToolRetryPolicy",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export ToolExecutionNeedsRecoveryError",
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Add a host execution contract for resumable runs, notification inboxes, checkpoints, leases, and scheduler-driven background work.
- Route background subagents through host capabilities, durable child run state, cancellation, compact output retrieval, and `Agent.resume(runId)`.
- Add executable local and Cloudflare Worker/Durable Object shaped examples, plus public-surface cleanup for legacy/alias wording.

## Validation

- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-example-subagent typecheck`
- `pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent typecheck`
- `pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent typecheck:worker`
- `pnpm --filter @minpeter/pss-runtime exec vitest run src/agent.test.ts src/agent-host-api.test.ts src/host-notify-resume.test.ts src/index.test.ts src/notification-inbox-transaction.test.ts src/subagent-background-durable-scheduler.test.ts src/subagent-child-cleanup-notification.test.ts src/host-notify-durable.test.ts src/notification-inbox.test.ts src/edge-reconstruction-host.test.ts src/subagent-background-resume.test.ts src/subagent-background-resume-group.test.ts src/subagent-job-events-background.test.ts`
- `pnpm exec vitest run scripts/examples.test.mjs scripts/verify-release-artifacts.test.mjs`
- `pnpm --filter @minpeter/pss-example-subagent start:background:wait`
- `pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent start:worker-sim`
- `pnpm --filter @minpeter/pss-example-cloudflare-edge-subagent start:edge-cases`
- `pnpm lint`
- `git diff --check`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm verify:release`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a durable execution host with resumable runs, idempotent notification resume, and scheduler-driven background work for subagents. Also balances durable cancellation polling, tightens ownership checks, and ships local and Cloudflare Durable Objects examples.

- New Features
  - Public execution subpaths: `@minpeter/pss-runtime/execution` and `@minpeter/pss-runtime/execution/memory` with store contracts (runs, events, checkpoints, notifications, sessions), scheduler, and `createInMemoryExecutionHost`.
  - Durable background flow: enqueue child runs, leases/claiming, compact output retrieval, cancellation and child cleanup, and parent resume via idempotent notification claims; scheduler resume carries idempotency metadata.
  - Public API: `Agent.resume(runId)`, `host: { sessionStore }`, and `SessionHandle` with `send`, `steer`, `delete`, `interrupt`, `kill`.
  - Model options: single `model` accepts an AI SDK `LanguageModel` or a custom runtime model; subagents and background tools are exposed only when the host advertises `"durable"` or `"in-process"`.
  - Tool execution checkpoints and recovery: persisted checkpoints with retry policies (idempotent/manual/pure), resume-safe tool execution, and correct event replay for stored runs.
  - Examples: `@minpeter/pss-example-cloudflare-edge-subagent` with Worker/DO alarm resume, storage adapters, alarm drainer, and edge-case tests; local in-process examples including a wait-and-resume flow.
  - Stability: session delete failures kill the handle; stale handles are evicted on cancellation failure; balanced durable cancellation polling prevents hot loops; secure ownership prevents foreign background run claims; named `toolChoice` is passed through to model calls; notification enqueue/claim is transactional to avoid duplicate run creation.

- Migration
  - Replace `sessions: { store }` with `host: { sessionStore }` and set `namespace` if needed.
  - Replace `llm` with `model` (AI SDK `LanguageModel` or a custom runtime function). Subagents require an AI SDK model.
  - For durable background work, provide an execution host (`createInMemoryExecutionHost` or a Cloudflare host) and call `Agent.resume(runId)` from your scheduler/alarm handler.

<sup>Written for commit 46bed48b92718e608d925ef6085da59414d94158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

