### PR TITLE
[codex] trim durable background changeset

### DIFF
--- a/.changeset/background-notify-runs.md
+++ b/.changeset/background-notify-runs.md
@@ -2,35 +2,14 @@
 "@minpeter/pss-runtime": patch
 ---
 
-Add the `host` execution contract for resumable runs, durable notification resume,
-and background subagent capability detection. Advanced execution host, store,
-and scheduler contracts live under `@minpeter/pss-runtime/execution`.
-Background delegation now exposes background tools only when the host advertises
-support, persists child run links for cleanup/cancellation, and resumes parents
-through an idempotent notification claim. Scheduler resume calls now carry the
-notification idempotency metadata adapters need to resume the parent without
-reconstructing internal keys.
+Add the `host` execution contract for resumable runs, durable notification
+resume, and background subagent capability detection. Advanced execution host,
+store, and scheduler contracts are available from
+`@minpeter/pss-runtime/execution`, and runtime-originated work can resume through
+`Agent.resume(runId)`.
 
-Agent construction now routes session persistence through
-`host: { sessionStore }` plus top-level `namespace`. App-facing `SessionHandle`
-objects expose `send`, `steer`, `delete`, `interrupt`, and `kill`;
-runtime-originated input resumes through `Agent.resume(runId)`. The public
-`Agent` constructor uses `model` for both AI SDK models and custom `RuntimeLlm`
-functions. High-level managed model turns on an execution host now record
-`user-turn` runs and before/after tool checkpoints. `AgentToolChoice` now
-preserves the AI SDK tool-choice shape, including named tool selection for
-providers that support it.
-
-Durable checkpoints store tool execution metadata only; raw tool input/output
-stays in the live execution callback path and is not persisted for resume.
-`delete()` and `kill()` now hard-stop the active session before durable child
-cleanup or store deletion is awaited, so killed work cannot keep running while
-cleanup is blocked. Grouped background notifications filter stale cancelled
-siblings without dropping completed sibling notifications.
-
-Durable adapters own actual scheduling/leases/resume workers; the Cloudflare
-example shows a Worker/Durable Object shaped host adapter with local `ctx.storage`
-simulation, alarm-driven resume, request-derived Durable Object/session/storage
-identity, and Wrangler entrypoints. This prerelease branch uses a patch changeset
-by default per repository release policy; no semver-major release level was
-requested for this work.
+Background subagent handling is now more durable: hosts can advertise background
+support, child runs are linked for cleanup/cancellation, killed sessions stop
+before cleanup waits, and stale cancelled sibling notifications are filtered
+without dropping completed work. The Cloudflare edge example shows one adapter
+implementation for Worker/Durable Object scheduling and resume.


### PR DESCRIPTION
## What changed
- Shortened the durable background host resume changeset to release-facing API and behavior notes.
- Removed internal checkpoint, metadata, and repository policy details from the package changelog text.

## Why
PR #70 was squash-merged before the final changeset trim could be included, leaving the long implementation-oriented changeset on `v0.1`.

## Impact
This keeps the upcoming `@minpeter/pss-runtime` patch changelog focused on consumer-visible runtime behavior without changing package code.

## Validation
- `pnpm exec vitest run scripts/examples.test.mjs`
- `pnpm changeset status --since origin/v0.1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the durable background host/resume changeset to keep the `@minpeter/pss-runtime` patch changelog focused on consumer-visible behavior. Removed internal checkpoint, metadata, and repo policy notes; no code changes.

<sup>Written for commit dbc4db8822b77314f439dda06bbeea67bd01a2c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

