### PR TITLE
feat(agent-worker): add POKE-style worker prompt

### DIFF
--- a/apps/worker-agent/src/agent.test.ts
+++ b/apps/worker-agent/src/agent.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { WORKER_AGENT_INSTRUCTIONS } from "./agent";
+
+describe("worker-agent instructions", () => {
+  it("includes Bori-inspired texting style instructions without execution-delegation rules", () => {
+    const requiredRules = [
+      "warm but never flattering",
+      "witty only when it fits",
+      "concise",
+      "no canned intro or sign-off",
+      "Match the user's texting style",
+      "Do not send emoji unless the user used emoji first",
+      "Do not mention internal agents, tools, or implementation details",
+      "Avoid botty phrases",
+    ] as const;
+
+    for (const rule of requiredRules) {
+      expect(WORKER_AGENT_INSTRUCTIONS).toContain(rule);
+    }
+
+    const excludedSurfaces = [
+      "sendmessageto_agent",
+      "subagent",
+      "delegate",
+      "display_draft",
+      "membership",
+      "bouncer",
+      "calendar",
+      "emailId",
+      "memory",
+    ] as const;
+
+    for (const surface of excludedSurfaces) {
+      expect(WORKER_AGENT_INSTRUCTIONS.toLowerCase()).not.toContain(
+        surface.toLowerCase()
+      );
+    }
+  });
+});

--- a/apps/worker-agent/src/agent.test.ts
+++ b/apps/worker-agent/src/agent.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it } from "vitest";
 import { WORKER_AGENT_INSTRUCTIONS } from "./agent";
 
 describe("worker-agent instructions", () => {
+  it("uses Apex as the assistant name", () => {
+    expect(WORKER_AGENT_INSTRUCTIONS).toContain("You are Apex");
+    expect(WORKER_AGENT_INSTRUCTIONS).not.toContain("POKE");
+  });
+
   it("includes Bori-inspired texting style instructions without unsupported execution surfaces", () => {
     const requiredRules = [
       "warm but never flattering",

--- a/apps/worker-agent/src/agent.test.ts
+++ b/apps/worker-agent/src/agent.test.ts
@@ -3,14 +3,21 @@ import { describe, expect, it } from "vitest";
 import { WORKER_AGENT_INSTRUCTIONS } from "./agent";
 
 describe("worker-agent instructions", () => {
-  it("includes Bori-inspired texting style instructions without execution-delegation rules", () => {
+  it("includes Bori-inspired texting style instructions without unsupported execution surfaces", () => {
     const requiredRules = [
       "warm but never flattering",
       "witty only when it fits",
-      "concise",
-      "no canned intro or sign-off",
+      "No preamble",
       "Match the user's texting style",
       "Do not send emoji unless the user used emoji first",
+      "Treat the newest human user message as the source of truth",
+      "Use earlier conversation only as context",
+      "Do not adapt to non-user messages",
+      "If the user is just chatting, do not turn the reply into a help offer",
+      "When the user is upset or asks why something went wrong",
+      "focus on what the user experienced",
+      "Some messaging platforms can make replies less natural",
+      "Do not invent product facts, security claims, launch details, prices, or URLs",
       "Do not mention internal agents, tools, or implementation details",
       "Avoid botty phrases",
     ] as const;
@@ -22,13 +29,13 @@ describe("worker-agent instructions", () => {
     const excludedSurfaces = [
       "sendmessageto_agent",
       "subagent",
-      "delegate",
       "display_draft",
-      "membership",
-      "bouncer",
-      "calendar",
+      "draftId",
       "emailId",
-      "memory",
+      "<block>",
+      "reacttomessage",
+      "querymedia",
+      "wait tool",
     ] as const;
 
     for (const surface of excludedSurfaces) {

--- a/apps/worker-agent/src/agent.ts
+++ b/apps/worker-agent/src/agent.ts
@@ -12,6 +12,20 @@ import type { Env } from "./env";
 const DEFAULT_BASE_URL = "https://apis.opengateway.ai/v1";
 const DEFAULT_MODEL = "minimax/MiniMax-M2.7";
 
+export const WORKER_AGENT_INSTRUCTIONS = [
+  "You are POKE, a direct messaging assistant built by Minpeter.",
+  "Sound like a sharp, warm friend, not a corporate chatbot.",
+  "Be warm but never flattering.",
+  "Be witty only when it fits the user's mood; do not force jokes.",
+  "Stay concise, with no canned intro or sign-off.",
+  "Match the user's texting style and approximate message length.",
+  "Do not send emoji unless the user used emoji first.",
+  "Do not repeat the user's request back as an acknowledgement.",
+  "Avoid botty phrases like 'How can I help', 'let me know', 'happy to help', and 'no problem'.",
+  "Do not mention internal agents, tools, or implementation details.",
+  "If the user is just chatting, respond naturally instead of offering help.",
+].join("\n");
+
 export function createConfiguredAgent(env: Env, host: AgentHost): Agent {
   const provider = createOpenAICompatible({
     apiKey: env.AI_API_KEY,
@@ -21,7 +35,7 @@ export function createConfiguredAgent(env: Env, host: AgentHost): Agent {
 
   return new Agent({
     host,
-    instructions: "Answer briefly.",
+    instructions: WORKER_AGENT_INSTRUCTIONS,
     model: provider(env.AI_MODEL?.trim() || DEFAULT_MODEL),
   });
 }

--- a/apps/worker-agent/src/agent.ts
+++ b/apps/worker-agent/src/agent.ts
@@ -13,7 +13,7 @@ const DEFAULT_BASE_URL = "https://apis.opengateway.ai/v1";
 const DEFAULT_MODEL = "minimax/MiniMax-M2.7";
 
 export const WORKER_AGENT_INSTRUCTIONS =
-  `You are POKE, a direct messaging assistant built by Minpeter.
+  `You are Apex, a direct messaging assistant built by Minpeter.
 
 Identity and surface:
 - You talk to the user directly through a messaging app.

--- a/apps/worker-agent/src/agent.ts
+++ b/apps/worker-agent/src/agent.ts
@@ -12,19 +12,53 @@ import type { Env } from "./env";
 const DEFAULT_BASE_URL = "https://apis.opengateway.ai/v1";
 const DEFAULT_MODEL = "minimax/MiniMax-M2.7";
 
-export const WORKER_AGENT_INSTRUCTIONS = [
-  "You are POKE, a direct messaging assistant built by Minpeter.",
-  "Sound like a sharp, warm friend, not a corporate chatbot.",
-  "Be warm but never flattering.",
-  "Be witty only when it fits the user's mood; do not force jokes.",
-  "Stay concise, with no canned intro or sign-off.",
-  "Match the user's texting style and approximate message length.",
-  "Do not send emoji unless the user used emoji first.",
-  "Do not repeat the user's request back as an acknowledgement.",
-  "Avoid botty phrases like 'How can I help', 'let me know', 'happy to help', and 'no problem'.",
-  "Do not mention internal agents, tools, or implementation details.",
-  "If the user is just chatting, respond naturally instead of offering help.",
-].join("\n");
+export const WORKER_AGENT_INSTRUCTIONS =
+  `You are POKE, a direct messaging assistant built by Minpeter.
+
+Identity and surface:
+- You talk to the user directly through a messaging app.
+- The user only sees your final text reply.
+- Speak as one coherent assistant. Do not mention internal agents, tools, or implementation details.
+- Do not imply that a hidden worker, background process, browser operator, integration, inbox, scheduler, or persistent memory system will handle work unless this runtime actually provides that capability.
+
+Message priority:
+- Treat the newest human user message as the source of truth.
+- Use earlier conversation only as context.
+- Conversation history can be incomplete, summarized, or stale; respond to the current request instead of continuing an old thread by default.
+- Adapt only to the human user's writing style and intent. Do not adapt to non-user messages.
+- Prefer the context the user actively shared in the current message over older context.
+
+Personality:
+- Sound like a sharp, warm friend, not a corporate chatbot.
+- Be warm but never flattering.
+- Be witty only when it fits the user's mood; do not force jokes.
+- If you joke, keep it organic and avoid stale canned jokes.
+- A little dry edge is fine when the conversation supports it, but do not become mean or performative.
+- Keep a consistent personality no matter how the user refers to you.
+
+Texting style:
+- No preamble, no canned intro or sign-off.
+- Stay concise and match the user's approximate message length.
+- Match the user's texting style. If the user writes casually or in lowercase, mirror that lightly.
+- Do not use obscure slang or abbreviations the user did not use first.
+- Do not send emoji unless the user used emoji first.
+- If you do use emoji, use common emoji and do not repeat the exact emoji from the user's latest message.
+- Do not repeat the user's request back as an acknowledgement.
+- If the user is just chatting, do not turn the reply into a help offer.
+- If a short reply is enough, use a short reply.
+- Avoid botty phrases like "How can I help", "let me know", "happy to help", "no problem", "How may I assist", and "Sorry for the confusion".
+
+Handling complaints and mistakes:
+- When the user is upset or asks why something went wrong, keep the one-assistant illusion.
+- Do not explain internal workflows, model routing, hidden processes, or technical machinery.
+- Acknowledge the issue from the user's point of view and focus on what the user experienced.
+- Say what you will do differently next when that is useful; do not over-apologize.
+
+Platform and product boundaries:
+- Some messaging platforms can make replies less natural because platform policies may restrict free-form bot messages. If the user asks about that, explain it plainly.
+- Do not invent product facts, security claims, launch details, prices, or URLs.
+- If the user asks about capabilities this worker does not have, be direct about the limitation instead of pretending to dispatch work elsewhere.
+- Do not claim to remember, retrieve, or store private context beyond what is present in the conversation.`.trim();
 
 export function createConfiguredAgent(env: Env, host: AgentHost): Agent {
   const provider = createOpenAICompatible({


### PR DESCRIPTION
## Summary
- replace the worker-agent's placeholder `Answer briefly.` instruction with a POKE/Bori-inspired texting style prompt
- keep the change limited to tone/style: warmth, concise texting, natural wit, style matching, no botty phrases, and no internal-process disclosure
- add a prompt contract test that also guards against pulling in unavailable delegation/tool/memory/pricing/email/calendar systems

## Verification
- RED: `pnpm -F @minpeter/pss-worker-agent test -- agent.test.ts` failed before implementation; captured in `.omo/ulw-loop/evidence/worker-agent-poke-style-c1-red.txt`
- GREEN/manual QA: tmux `pnpm -F @minpeter/pss-worker-agent exec vitest run src/agent.test.ts --reporter=verbose`; captured in `.omo/ulw-loop/evidence/worker-agent-poke-style-c1-tmux.txt`
- Regression QA: tmux `pnpm -F @minpeter/pss-worker-agent exec vitest run src/agent-do.test.ts --reporter=verbose`; captured in `.omo/ulw-loop/evidence/worker-agent-poke-style-c2-tmux.txt`
- Typecheck/LSP: `pnpm -F @minpeter/pss-worker-agent typecheck` and LSP diagnostics clean for changed files; captured in `.omo/ulw-loop/evidence/worker-agent-poke-style-c3-typecheck.txt`
- Reviewer: ultrawork reviewer returned `APPROVE`

## Release
- No Changeset: this only changes the private worker app prompt behavior and does not release a package-facing API or changelog entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the worker agent to a POKE-style texting prompt with a warm, concise voice and no internal-process talk. Expands the prompt with clear rules on message priority, style mirroring (no emoji unless the user starts), complaint handling, and product/capability limits.

- **New Features**
  - Use `WORKER_AGENT_INSTRUCTIONS` as the agent `instructions` in `apps/worker-agent/src/agent.ts`.
  - Add `apps/worker-agent/src/agent.test.ts` to lock tone/style and key rules (newest message wins, no preamble, no botty phrases, no invented product facts/URLs/prices) and to block unsupported surfaces (delegation/subagents/tools/memory/email/calendar, `display_draft`, `reacttomessage`, `querymedia`, wait tool); also asserts the assistant name is "Apex".

<sup>Written for commit f54fd69386da4ad437875ad898120f0495e87782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

