### PR TITLE
feat(runtime): append-only SQLite Durable Object session store (fix SQLITE_TOOBIG)

### DIFF
--- a/.changeset/sqlite-session-store.md
+++ b/.changeset/sqlite-session-store.md
@@ -1,0 +1,14 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add `DurableObjectSqliteSessionStore`, an append-only session store for
+SQLite-backed Durable Objects. It persists conversation history as one small
+SQLite row per message (delta-append on commit, reconstruct on load) instead of
+re-serializing the entire snapshot into a single `storage.put` value every turn,
+so long sessions no longer cross the Durable Object ~2MB per-value limit
+(`SQLITE_TOOBIG`). Rollbacks soft-delete the trailing rows, the optimistic
+version/conflict semantics are preserved byte-for-byte, and any pre-existing
+`storage.put` snapshot is lazily migrated into rows on first access. Opt in via
+the existing `sessionStore` option of `createCloudflareDurableObjectHost`; the
+default store is unchanged.

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.test.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import { decodeStoredSessionSnapshot } from "../session/snapshot";
+import { DurableObjectSqliteSessionStore } from "./cloudflare-sqlite-session-store";
+import { storeKey } from "./cloudflare-store-utils";
+import { InMemoryCloudflareDurableObjectStorage } from "./durable-object-storage";
+import { InMemorySqlStorage } from "./in-memory-sql-storage";
+
+const PREFIX = "pss-runtime";
+const REQUIRES_SQLITE = /SQLite-backed/;
+
+interface MessageRowProbe {
+  readonly active: number;
+  readonly message: string;
+  readonly seq: number;
+}
+
+function createStore() {
+  const storage = new InMemoryCloudflareDurableObjectStorage({
+    sql: new InMemorySqlStorage(),
+  });
+  const store = new DurableObjectSqliteSessionStore(storage, PREFIX);
+  return { storage, store };
+}
+
+function snapshot(history: unknown[]) {
+  return { state: { history, schemaVersion: 1 } };
+}
+
+function readRows(
+  storage: InMemoryCloudflareDurableObjectStorage,
+  sessionKey: string
+): MessageRowProbe[] {
+  return (storage.sql as InMemorySqlStorage)
+    .exec<MessageRowProbe>(
+      "SELECT seq, active, message FROM pss_session_message WHERE session_key = ? ORDER BY seq",
+      storeKey(PREFIX, "session", sessionKey)
+    )
+    .toArray();
+}
+
+describe("DurableObjectSqliteSessionStore", () => {
+  it("throws when the Durable Object is not SQLite-backed", () => {
+    expect(
+      () =>
+        new DurableObjectSqliteSessionStore(
+          new InMemoryCloudflareDurableObjectStorage(),
+          PREFIX
+        )
+    ).toThrow(REQUIRES_SQLITE);
+  });
+
+  it("loads null for unknown sessions", async () => {
+    const { store } = createStore();
+    await expect(store.load("missing")).resolves.toBeNull();
+  });
+
+  it("commits a v1 snapshot and increments versions", async () => {
+    const { store } = createStore();
+
+    const first = await store.commit(
+      "key",
+      snapshot([{ content: "hi", role: "user" }]),
+      { expectedVersion: null }
+    );
+    expect(first).toEqual({ ok: true, version: "1" });
+    await expect(store.load("key")).resolves.toEqual({
+      state: { history: [{ content: "hi", role: "user" }], schemaVersion: 1 },
+      version: "1",
+    });
+
+    const second = await store.commit(
+      "key",
+      snapshot([
+        { content: "hi", role: "user" },
+        { content: "yo", role: "assistant" },
+      ]),
+      { expectedVersion: "1" }
+    );
+    expect(second).toEqual({ ok: true, version: "2" });
+  });
+
+  it("appends only the new messages (delta-append, unchanged prefix kept)", async () => {
+    const { storage, store } = createStore();
+    await store.commit("k", snapshot([{ i: 0 }, { i: 1 }]), {
+      expectedVersion: null,
+    });
+    await store.commit(
+      "k",
+      snapshot([{ i: 0 }, { i: 1 }, { i: 2 }, { i: 3 }]),
+      { expectedVersion: "1" }
+    );
+
+    const rows = readRows(storage, "k");
+    expect(rows).toHaveLength(4);
+    expect(rows.every((row) => row.active === 1)).toBe(true);
+    expect(rows.map((row) => row.seq)).toEqual([0, 1, 2, 3]);
+    expect(rows[0].message).toBe(JSON.stringify({ i: 0 }));
+    expect(rows[1].message).toBe(JSON.stringify({ i: 1 }));
+  });
+
+  it("soft-deletes the trailing rows on rollback (history shrank)", async () => {
+    const { storage, store } = createStore();
+    await store.commit(
+      "k",
+      snapshot([{ i: 0 }, { i: 1 }, { i: 2 }, { i: 3 }]),
+      {
+        expectedVersion: null,
+      }
+    );
+    await store.commit("k", snapshot([{ i: 0 }, { i: 1 }]), {
+      expectedVersion: "1",
+    });
+
+    await expect(store.load("k")).resolves.toEqual({
+      state: { history: [{ i: 0 }, { i: 1 }], schemaVersion: 1 },
+      version: "2",
+    });
+    const rows = readRows(storage, "k");
+    expect(
+      rows.filter((row) => row.active === 1).map((row) => row.seq)
+    ).toEqual([0, 1]);
+    expect(
+      rows.filter((row) => row.active === 0).map((row) => row.seq)
+    ).toEqual([2, 3]);
+  });
+
+  it("regrows with divergent content without reusing soft-deleted seqs", async () => {
+    const { storage, store } = createStore();
+    await store.commit("k", snapshot([{ i: 0 }, { i: 1 }, { i: 2 }]), {
+      expectedVersion: null,
+    });
+    // Rollback to 1 message.
+    await store.commit("k", snapshot([{ i: 0 }]), { expectedVersion: "1" });
+    // Regrow with new, different content at index 1.
+    await store.commit("k", snapshot([{ i: 0 }, { x: 9 }]), {
+      expectedVersion: "2",
+    });
+
+    await expect(store.load("k")).resolves.toEqual({
+      state: { history: [{ i: 0 }, { x: 9 }], schemaVersion: 1 },
+      version: "3",
+    });
+    const activeSeqs = readRows(storage, "k")
+      .filter((row) => row.active === 1)
+      .map((row) => row.seq);
+    // seq 1 was soft-deleted; the new message must take a fresh seq (3), not reuse 1.
+    expect(activeSeqs).toEqual([0, 3]);
+  });
+
+  it("does not persist extra runtime payload fields", async () => {
+    const { store } = createStore();
+    await store.commit(
+      "key",
+      {
+        ignored: true,
+        state: { value: 1 },
+        version: "caller",
+      } as never,
+      { expectedVersion: null }
+    );
+
+    await expect(store.load("key")).resolves.toEqual({
+      state: { value: 1 },
+      version: "1",
+    });
+  });
+
+  it("detects stale expectedVersion conflicts", async () => {
+    const { store } = createStore();
+    await store.commit("key", snapshot([{ i: 0 }]), { expectedVersion: null });
+
+    await expect(
+      store.commit("key", snapshot([{ i: 1 }]), { expectedVersion: "stale" })
+    ).resolves.toEqual({ ok: false, reason: "conflict" });
+  });
+
+  it("detects expectedVersion null conflicts for existing sessions", async () => {
+    const { store } = createStore();
+    await store.commit("key", snapshot([{ i: 0 }]), { expectedVersion: null });
+
+    await expect(
+      store.commit("key", snapshot([{ i: 1 }]), { expectedVersion: null })
+    ).resolves.toEqual({ ok: false, reason: "conflict" });
+  });
+
+  it("deletes session state and resets the version counter", async () => {
+    const { store } = createStore();
+    await store.commit("key", snapshot([{ i: 0 }]), { expectedVersion: null });
+
+    await store.delete("key");
+
+    await expect(store.load("key")).resolves.toBeNull();
+    await expect(
+      store.commit("key", snapshot([{ i: 1 }]), { expectedVersion: null })
+    ).resolves.toEqual({ ok: true, version: "1" });
+  });
+
+  it("protects committed state from caller mutation", async () => {
+    const { store } = createStore();
+    const history = [{ nested: { value: 1 } }];
+    await store.commit("key", snapshot(history), { expectedVersion: null });
+    (history[0].nested as { value: number }).value = 2;
+
+    const loaded = await store.load("key");
+    expect(loaded).toEqual({
+      state: { history: [{ nested: { value: 1 } }], schemaVersion: 1 },
+      version: "1",
+    });
+
+    const loadedHistory = (
+      loaded?.state as { history: { nested: { value: number } }[] }
+    ).history;
+    loadedHistory[0].nested.value = 3;
+    await expect(store.load("key")).resolves.toEqual({
+      state: { history: [{ nested: { value: 1 } }], schemaVersion: 1 },
+      version: "1",
+    });
+  });
+
+  it("serializes expectedVersion checks across concurrent writers", async () => {
+    const { store } = createStore();
+    await store.commit("key", snapshot([{ i: 0 }]), { expectedVersion: null });
+
+    const results = await Promise.all([
+      store.commit("key", snapshot([{ i: 1 }]), { expectedVersion: "1" }),
+      store.commit("key", snapshot([{ i: 2 }]), { expectedVersion: "1" }),
+    ]);
+
+    expect(results.filter((result) => result.ok)).toHaveLength(1);
+    expect(results.filter((result) => !result.ok)).toEqual([
+      { ok: false, reason: "conflict" },
+    ]);
+    await expect(store.load("key")).resolves.toMatchObject({ version: "2" });
+  });
+
+  it("serializes first-write expectedVersion checks", async () => {
+    const { store } = createStore();
+
+    const results = await Promise.all([
+      store.commit("key", snapshot([{ i: 1 }]), { expectedVersion: null }),
+      store.commit("key", snapshot([{ i: 2 }]), { expectedVersion: null }),
+    ]);
+
+    expect(results.filter((result) => result.ok)).toHaveLength(1);
+    expect(results.filter((result) => !result.ok)).toEqual([
+      { ok: false, reason: "conflict" },
+    ]);
+  });
+
+  it("round-trips a session whose total size exceeds the 2MB blob limit", async () => {
+    const { store } = createStore();
+    const big = "x".repeat(60_000);
+    const history = Array.from({ length: 50 }, (_, index) => ({
+      content: `${index}:${big}`,
+      role: "assistant",
+    }));
+
+    await expect(
+      store.commit("big", snapshot(history), { expectedVersion: null })
+    ).resolves.toEqual({ ok: true, version: "1" });
+
+    const loaded = await store.load("big");
+    expect((loaded?.state as { history: unknown[] }).history).toHaveLength(50);
+  });
+
+  it("load output decodes via decodeStoredSessionSnapshot", async () => {
+    const { store } = createStore();
+    await store.commit("key", snapshot([{ content: "hi", role: "user" }]), {
+      expectedVersion: null,
+    });
+    const loaded = await store.load("key");
+    expect(decodeStoredSessionSnapshot(loaded)).toEqual([
+      { content: "hi", role: "user" },
+    ]);
+  });
+
+  it("lazily migrates a legacy KV snapshot into rows on first load", async () => {
+    const { storage, store } = createStore();
+    const sessionKey = "legacy";
+    await storage.put(storeKey(PREFIX, "session", sessionKey), {
+      state: { history: [{ a: 1 }, { b: 2 }], schemaVersion: 1 },
+      version: "3",
+    });
+    await storage.put(storeKey(PREFIX, "session-version", sessionKey), 3);
+
+    await expect(store.load(sessionKey)).resolves.toEqual({
+      state: { history: [{ a: 1 }, { b: 2 }], schemaVersion: 1 },
+      version: "3",
+    });
+
+    // Legacy KV keys are removed; rows now exist.
+    await expect(
+      storage.get(storeKey(PREFIX, "session", sessionKey))
+    ).resolves.toBeUndefined();
+    await expect(
+      storage.get(storeKey(PREFIX, "session-version", sessionKey))
+    ).resolves.toBeUndefined();
+    expect(readRows(storage, sessionKey)).toHaveLength(2);
+
+    // Version continuity: the next commit builds on the migrated version.
+    await expect(
+      store.commit(sessionKey, snapshot([{ a: 1 }, { b: 2 }, { c: 3 }]), {
+        expectedVersion: "3",
+      })
+    ).resolves.toEqual({ ok: true, version: "4" });
+  });
+});

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.test.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.test.ts
@@ -328,6 +328,42 @@ describe("DurableObjectSqliteSessionStore", () => {
     ).resolves.toEqual({ ok: true, version: "1" });
   });
 
+  it("normalizes a numeric meta version (INTEGER-affinity / schema drift) for the optimistic compare", async () => {
+    const sql = new InMemorySqlStorage();
+    const storage = new InMemoryCloudflareDurableObjectStorage({ sql });
+    const key = storeKey(PREFIX, "session", "num");
+    // Simulate an older meta table whose `version` column has INTEGER affinity,
+    // so it stores and returns a number rather than a string.
+    sql.exec(
+      "CREATE TABLE pss_session_meta (session_key TEXT PRIMARY KEY, version INTEGER NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
+    );
+    sql.exec(
+      "CREATE TABLE pss_session_message (session_key TEXT NOT NULL, seq INTEGER NOT NULL, active INTEGER NOT NULL DEFAULT 1, message TEXT NOT NULL, PRIMARY KEY (session_key, seq))"
+    );
+    sql.exec(
+      "INSERT INTO pss_session_message (session_key, seq, active, message) VALUES (?, 0, 1, ?)",
+      key,
+      JSON.stringify({ i: 0 })
+    );
+    sql.exec(
+      "INSERT INTO pss_session_meta (session_key, version, message_count, next_seq, state_blob) VALUES (?, 1, 1, 1, NULL)",
+      key
+    );
+
+    const store = new DurableObjectSqliteSessionStore(storage, PREFIX);
+    await expect(store.load("num")).resolves.toEqual({
+      state: { history: [{ i: 0 }], schemaVersion: 1 },
+      version: "1",
+    });
+    // The string expectedVersion must match the numeric stored value — no
+    // spurious conflict.
+    await expect(
+      store.commit("num", snapshot([{ i: 0 }, { i: 1 }]), {
+        expectedVersion: "1",
+      })
+    ).resolves.toEqual({ ok: true, version: "2" });
+  });
+
   it("re-checks legacy storage after a deleted session key is re-created", async () => {
     const { store } = createStore();
     await store.commit("key", snapshot([{ i: 0 }]), { expectedVersion: null });

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.test.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.test.ts
@@ -304,4 +304,38 @@ describe("DurableObjectSqliteSessionStore", () => {
       })
     ).resolves.toEqual({ ok: true, version: "4" });
   });
+
+  it("preserves a non-numeric (UUID) legacy version through migration", async () => {
+    const { storage, store } = createStore();
+    const sessionKey = "uuid-legacy";
+    await storage.put(storeKey(PREFIX, "session", sessionKey), {
+      state: { history: [{ a: 1 }], schemaVersion: 1 },
+      version: "9b1c-uuid-xyz",
+    });
+
+    // Migration preserves the version verbatim — no silent reset to "0".
+    await expect(store.load(sessionKey)).resolves.toEqual({
+      state: { history: [{ a: 1 }], schemaVersion: 1 },
+      version: "9b1c-uuid-xyz",
+    });
+
+    // Continuity: a commit using the preserved version succeeds; the numeric
+    // counter then starts at 1.
+    await expect(
+      store.commit(sessionKey, snapshot([{ a: 1 }, { b: 2 }]), {
+        expectedVersion: "9b1c-uuid-xyz",
+      })
+    ).resolves.toEqual({ ok: true, version: "1" });
+  });
+
+  it("re-checks legacy storage after a deleted session key is re-created", async () => {
+    const { store } = createStore();
+    await store.commit("key", snapshot([{ i: 0 }]), { expectedVersion: null });
+    await store.delete("key");
+    // After delete the key is evicted from the migration cache, so a fresh
+    // commit is treated as a brand-new session (version resets to "1").
+    await expect(
+      store.commit("key", snapshot([{ i: 1 }]), { expectedVersion: null })
+    ).resolves.toEqual({ ok: true, version: "1" });
+  });
 });

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.ts
@@ -13,7 +13,7 @@ interface MetaRow {
   readonly message_count: number;
   readonly next_seq: number;
   readonly state_blob: string | null;
-  readonly version: number;
+  readonly version: string;
 }
 
 interface MessageRow {
@@ -80,12 +80,12 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
 
     // --- begin synchronous read-modify-write critical section (no await) ---
     const meta = this.#readMeta(key);
-    const currentVersion = meta ? String(meta.version) : null;
+    const currentVersion = meta ? meta.version : null;
     if (options.expectedVersion !== currentVersion) {
       return { ok: false, reason: "conflict" };
     }
 
-    const version = (meta?.version ?? 0) + 1;
+    const version = String(versionCounter(meta?.version) + 1);
     const nextSeqStart = meta?.next_seq ?? 0;
 
     if (isSnapshotV1(next.state)) {
@@ -111,7 +111,7 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
     }
     // --- end critical section ---
 
-    return { ok: true, version: String(version) };
+    return { ok: true, version };
   }
 
   async delete(sessionKey: string): Promise<void> {
@@ -122,6 +122,9 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
       key
     );
     this.#sql.exec("DELETE FROM pss_session_meta WHERE session_key = ?", key);
+    // Evict from the migration cache so the key does not accumulate over the
+    // Durable Object's lifetime (a re-created session re-checks on next access).
+    this.#migrated.delete(key);
     await this.#storage.delete(key);
     await this.#storage.delete(
       storeKey(this.#prefix, "session-version", sessionKey)
@@ -137,7 +140,7 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
     if (!meta) {
       return null;
     }
-    const version = String(meta.version);
+    const version = meta.version;
     if (meta.state_blob !== null) {
       const state: unknown = JSON.parse(meta.state_blob);
       return { state, version };
@@ -163,7 +166,7 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
       "CREATE INDEX IF NOT EXISTS pss_session_message_active ON pss_session_message (session_key, active, seq)"
     );
     this.#sql.exec(
-      "CREATE TABLE IF NOT EXISTS pss_session_meta (session_key TEXT PRIMARY KEY, version INTEGER NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
+      "CREATE TABLE IF NOT EXISTS pss_session_meta (session_key TEXT PRIMARY KEY, version TEXT NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
     );
     this.#schemaReady = true;
   }
@@ -255,8 +258,11 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
       return;
     }
     if (legacy) {
-      const seedVersionRaw = Number(legacy.version);
-      const version = Number.isFinite(seedVersionRaw) ? seedVersionRaw : 0;
+      // Preserve the legacy version string verbatim so optimistic-version
+      // continuity holds for both numeric (execution store) and UUID-based
+      // (DurableObjectSessionStore) legacy sessions; the next commit derives its
+      // counter from it via versionCounter().
+      const version = legacy.version;
       if (isSnapshotV1(legacy.state)) {
         const nextSeq = this.#writeHistoryRows(key, legacy.state.history, 0);
         this.#writeMeta(key, {
@@ -282,6 +288,11 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
     }
     this.#migrated.add(key);
   }
+}
+
+function versionCounter(version: string | undefined): number {
+  const parsed = Number(version);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function isSnapshotV1(value: unknown): value is SessionSnapshotV1 {

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.ts
@@ -173,12 +173,25 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
 
   #readMeta(key: string): MetaRow | null {
     const rows = this.#sql
-      .exec<MetaRow>(
+      .exec<{
+        message_count: number;
+        next_seq: number;
+        state_blob: string | null;
+        version: number | string;
+      }>(
         "SELECT version, message_count, next_seq, state_blob FROM pss_session_meta WHERE session_key = ?",
         key
       )
       .toArray();
-    return rows[0] ?? null;
+    const row = rows[0];
+    if (!row) {
+      return null;
+    }
+    // Normalize the version to a string before the optimistic compare. A meta
+    // row written under an INTEGER-affinity column (older schema or schema
+    // drift — CREATE TABLE IF NOT EXISTS never alters an existing table) would
+    // otherwise read back as a number and spuriously reject a valid commit.
+    return { ...row, version: String(row.version) };
   }
 
   #readActiveMessages(key: string): MessageRow[] {

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.ts
@@ -54,13 +54,18 @@ export class DurableObjectSqliteSessionStore implements SessionStore {
   #schemaReady = false;
 
   constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
-    if (!storage.sql) {
+    // `sql` is read structurally so the shared CloudflareDurableObjectStorage
+    // port stays free of a `sql` member — otherwise a real `DurableObjectStorage`
+    // would stop being assignable to it. SQLite-backed Durable Objects expose
+    // `storage.sql` at runtime; a non-SQLite DO yields undefined and throws here.
+    const sql = (storage as { sql?: SqlStorage }).sql;
+    if (!sql) {
       throw new Error(
         "DurableObjectSqliteSessionStore requires a SQLite-backed Durable Object (storage.sql is unavailable)"
       );
     }
     this.#prefix = prefix;
-    this.#sql = storage.sql;
+    this.#sql = sql;
     this.#storage = storage;
   }
 

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-session-store.ts
@@ -1,0 +1,291 @@
+import type {
+  CommitResult,
+  ExpectedSessionVersion,
+  SessionStore,
+  SessionStoreCommit,
+  StoredSession,
+} from "../index";
+import { storeKey } from "./cloudflare-store-utils";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+import type { SqlStorage } from "./sql-storage";
+
+interface MetaRow {
+  readonly message_count: number;
+  readonly next_seq: number;
+  readonly state_blob: string | null;
+  readonly version: number;
+}
+
+interface MessageRow {
+  readonly message: string;
+  readonly seq: number;
+}
+
+interface SessionSnapshotV1 {
+  readonly history: unknown[];
+  readonly schemaVersion: 1;
+}
+
+/**
+ * Append-only session store for SQLite-backed Durable Objects.
+ *
+ * Unlike {@link DurableObjectExecutionSessionStore}, which re-serializes the
+ * entire session snapshot into a single `storage.put` value every commit (and
+ * eventually crosses the Durable Object ~2MB per-value limit on long sessions),
+ * this store persists the message history as one small SQLite row per message.
+ * Each commit only INSERTs the messages that are new since the last commit, so
+ * no single stored value grows with the conversation and `SQLITE_TOOBIG` can no
+ * longer be reached by accumulation.
+ *
+ * Snapshot v1 state (`{ schemaVersion: 1, history }`) is split into rows. Any
+ * other opaque state is stored verbatim in a single meta blob column, so the
+ * store remains a correct drop-in {@link SessionStore} for non-snapshot callers.
+ *
+ * Concurrency: the optimistic version check and the row writes form a single
+ * synchronous (await-free) read-modify-write section, so concurrent commits to
+ * the same key serialize on the JS event loop inside the single-threaded
+ * Durable Object — exactly one writer wins, the rest get a `conflict`.
+ */
+export class DurableObjectSqliteSessionStore implements SessionStore {
+  readonly #migrated = new Set<string>();
+  readonly #prefix: string;
+  readonly #sql: SqlStorage;
+  readonly #storage: CloudflareDurableObjectStorage;
+  #schemaReady = false;
+
+  constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
+    if (!storage.sql) {
+      throw new Error(
+        "DurableObjectSqliteSessionStore requires a SQLite-backed Durable Object (storage.sql is unavailable)"
+      );
+    }
+    this.#prefix = prefix;
+    this.#sql = storage.sql;
+    this.#storage = storage;
+  }
+
+  async commit(
+    sessionKey: string,
+    next: SessionStoreCommit,
+    options: { readonly expectedVersion: ExpectedSessionVersion }
+  ): Promise<CommitResult> {
+    this.#ensureSchema();
+    const key = this.#rowKey(sessionKey);
+    await this.#ensureMigrated(key, sessionKey);
+
+    // --- begin synchronous read-modify-write critical section (no await) ---
+    const meta = this.#readMeta(key);
+    const currentVersion = meta ? String(meta.version) : null;
+    if (options.expectedVersion !== currentVersion) {
+      return { ok: false, reason: "conflict" };
+    }
+
+    const version = (meta?.version ?? 0) + 1;
+    const nextSeqStart = meta?.next_seq ?? 0;
+
+    if (isSnapshotV1(next.state)) {
+      const nextSeq = this.#writeHistoryRows(
+        key,
+        next.state.history,
+        nextSeqStart
+      );
+      this.#writeMeta(key, {
+        message_count: next.state.history.length,
+        next_seq: nextSeq,
+        state_blob: null,
+        version,
+      });
+    } else {
+      this.#softDeleteActiveRows(key);
+      this.#writeMeta(key, {
+        message_count: 0,
+        next_seq: nextSeqStart,
+        state_blob: JSON.stringify(next.state ?? null),
+        version,
+      });
+    }
+    // --- end critical section ---
+
+    return { ok: true, version: String(version) };
+  }
+
+  async delete(sessionKey: string): Promise<void> {
+    this.#ensureSchema();
+    const key = this.#rowKey(sessionKey);
+    this.#sql.exec(
+      "DELETE FROM pss_session_message WHERE session_key = ?",
+      key
+    );
+    this.#sql.exec("DELETE FROM pss_session_meta WHERE session_key = ?", key);
+    await this.#storage.delete(key);
+    await this.#storage.delete(
+      storeKey(this.#prefix, "session-version", sessionKey)
+    );
+  }
+
+  async load(sessionKey: string): Promise<StoredSession | null> {
+    this.#ensureSchema();
+    const key = this.#rowKey(sessionKey);
+    await this.#ensureMigrated(key, sessionKey);
+
+    const meta = this.#readMeta(key);
+    if (!meta) {
+      return null;
+    }
+    const version = String(meta.version);
+    if (meta.state_blob !== null) {
+      const state: unknown = JSON.parse(meta.state_blob);
+      return { state, version };
+    }
+    const history: unknown[] = this.#readActiveMessages(key).map(
+      (row) => JSON.parse(row.message) as unknown
+    );
+    return { state: { history, schemaVersion: 1 }, version };
+  }
+
+  #rowKey(sessionKey: string): string {
+    return storeKey(this.#prefix, "session", sessionKey);
+  }
+
+  #ensureSchema(): void {
+    if (this.#schemaReady) {
+      return;
+    }
+    this.#sql.exec(
+      "CREATE TABLE IF NOT EXISTS pss_session_message (session_key TEXT NOT NULL, seq INTEGER NOT NULL, active INTEGER NOT NULL DEFAULT 1, message TEXT NOT NULL, PRIMARY KEY (session_key, seq))"
+    );
+    this.#sql.exec(
+      "CREATE INDEX IF NOT EXISTS pss_session_message_active ON pss_session_message (session_key, active, seq)"
+    );
+    this.#sql.exec(
+      "CREATE TABLE IF NOT EXISTS pss_session_meta (session_key TEXT PRIMARY KEY, version INTEGER NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
+    );
+    this.#schemaReady = true;
+  }
+
+  #readMeta(key: string): MetaRow | null {
+    const rows = this.#sql
+      .exec<MetaRow>(
+        "SELECT version, message_count, next_seq, state_blob FROM pss_session_meta WHERE session_key = ?",
+        key
+      )
+      .toArray();
+    return rows[0] ?? null;
+  }
+
+  #readActiveMessages(key: string): MessageRow[] {
+    return this.#sql
+      .exec<MessageRow>(
+        "SELECT seq, message FROM pss_session_message WHERE session_key = ? AND active = 1 ORDER BY seq",
+        key
+      )
+      .toArray();
+  }
+
+  #writeHistoryRows(
+    key: string,
+    history: readonly unknown[],
+    nextSeqStart: number
+  ): number {
+    const existing = this.#readActiveMessages(key);
+    let prefix = 0;
+    while (
+      prefix < existing.length &&
+      prefix < history.length &&
+      existing[prefix].message === JSON.stringify(history[prefix])
+    ) {
+      prefix += 1;
+    }
+    if (prefix < existing.length) {
+      // History diverged or shrank (rollback): soft-delete the divergent tail.
+      this.#sql.exec(
+        "UPDATE pss_session_message SET active = 0 WHERE session_key = ? AND active = 1 AND seq >= ?",
+        key,
+        existing[prefix].seq
+      );
+    }
+    let seq = nextSeqStart;
+    for (let index = prefix; index < history.length; index += 1) {
+      this.#sql.exec(
+        "INSERT INTO pss_session_message (session_key, seq, active, message) VALUES (?, ?, 1, ?)",
+        key,
+        seq,
+        JSON.stringify(history[index])
+      );
+      seq += 1;
+    }
+    return seq;
+  }
+
+  #softDeleteActiveRows(key: string): void {
+    this.#sql.exec(
+      "UPDATE pss_session_message SET active = 0 WHERE session_key = ? AND active = 1",
+      key
+    );
+  }
+
+  #writeMeta(key: string, meta: MetaRow): void {
+    this.#sql.exec(
+      "INSERT INTO pss_session_meta (session_key, version, message_count, next_seq, state_blob) VALUES (?, ?, ?, ?, ?) ON CONFLICT(session_key) DO UPDATE SET version = excluded.version, message_count = excluded.message_count, next_seq = excluded.next_seq, state_blob = excluded.state_blob",
+      key,
+      meta.version,
+      meta.message_count,
+      meta.next_seq,
+      meta.state_blob
+    );
+  }
+
+  async #ensureMigrated(key: string, sessionKey: string): Promise<void> {
+    if (this.#migrated.has(key)) {
+      return;
+    }
+    if (this.#readMeta(key)) {
+      this.#migrated.add(key);
+      return;
+    }
+    const legacy = await this.#storage.get<StoredSession>(key);
+    // Re-check after the await: a concurrent commit/load may have migrated.
+    if (this.#migrated.has(key) || this.#readMeta(key)) {
+      this.#migrated.add(key);
+      return;
+    }
+    if (legacy) {
+      const seedVersionRaw = Number(legacy.version);
+      const version = Number.isFinite(seedVersionRaw) ? seedVersionRaw : 0;
+      if (isSnapshotV1(legacy.state)) {
+        const nextSeq = this.#writeHistoryRows(key, legacy.state.history, 0);
+        this.#writeMeta(key, {
+          message_count: legacy.state.history.length,
+          next_seq: nextSeq,
+          state_blob: null,
+          version,
+        });
+      } else {
+        this.#writeMeta(key, {
+          message_count: 0,
+          next_seq: 0,
+          state_blob: JSON.stringify(legacy.state ?? null),
+          version,
+        });
+      }
+      this.#migrated.add(key);
+      await this.#storage.delete(key);
+      await this.#storage.delete(
+        storeKey(this.#prefix, "session-version", sessionKey)
+      );
+      return;
+    }
+    this.#migrated.add(key);
+  }
+}
+
+function isSnapshotV1(value: unknown): value is SessionSnapshotV1 {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "schemaVersion" in value &&
+    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
+    "history" in value &&
+    Array.isArray((value as { history?: unknown }).history)
+  );
+}

--- a/packages/runtime/src/cloudflare/durable-object-storage.ts
+++ b/packages/runtime/src/cloudflare/durable-object-storage.ts
@@ -5,7 +5,6 @@ export interface CloudflareDurableObjectStorage {
   get<T>(key: string): Promise<T | undefined>;
   put<T>(key: string, value: T): Promise<void>;
   setAlarm?(scheduledTime: Date | number): Promise<void>;
-  sql?: SqlStorage;
   transaction?<T>(
     fn: (storage: CloudflareDurableObjectStorage) => Promise<T>
   ): Promise<T>;

--- a/packages/runtime/src/cloudflare/durable-object-storage.ts
+++ b/packages/runtime/src/cloudflare/durable-object-storage.ts
@@ -1,8 +1,11 @@
+import type { SqlStorage } from "./sql-storage";
+
 export interface CloudflareDurableObjectStorage {
   delete(key: string): Promise<unknown>;
   get<T>(key: string): Promise<T | undefined>;
   put<T>(key: string, value: T): Promise<void>;
   setAlarm?(scheduledTime: Date | number): Promise<void>;
+  sql?: SqlStorage;
   transaction?<T>(
     fn: (storage: CloudflareDurableObjectStorage) => Promise<T>
   ): Promise<T>;
@@ -11,9 +14,16 @@ export interface CloudflareDurableObjectStorage {
 export class InMemoryCloudflareDurableObjectStorage
   implements CloudflareDurableObjectStorage
 {
+  readonly sql?: SqlStorage;
   #alarmTime: Date | number | undefined;
   #transactionChain: Promise<void> = Promise.resolve();
   #values = new Map<string, unknown>();
+
+  constructor(options?: { readonly sql?: SqlStorage }) {
+    if (options?.sql) {
+      this.sql = options.sql;
+    }
+  }
 
   alarmTime(): Date | number | undefined {
     return this.#alarmTime;

--- a/packages/runtime/src/cloudflare/in-memory-sql-storage.ts
+++ b/packages/runtime/src/cloudflare/in-memory-sql-storage.ts
@@ -1,0 +1,44 @@
+import { DatabaseSync } from "node:sqlite";
+import type { SqlStorage, SqlStorageCursorLike } from "./sql-storage";
+
+type SqlBinding = bigint | null | number | string;
+
+const RETURNS_ROWS = /^\s*(select|with|pragma)\b/i;
+const HAS_RETURNING = /\breturning\b/i;
+
+/**
+ * Test double for {@link SqlStorage} backed by Node's built-in `node:sqlite`
+ * (`DatabaseSync`, available in Node 24+ — no extra dependency). It mirrors the
+ * synchronous cursor shape of Cloudflare's real `ctx.storage.sql.exec`, so the
+ * session store can be exercised in plain vitest without a Workers runtime.
+ *
+ * This is test support only and is intentionally NOT re-exported from the
+ * package barrel.
+ */
+export class InMemorySqlStorage implements SqlStorage {
+  readonly #db = new DatabaseSync(":memory:");
+
+  exec<T = Record<string, unknown>>(
+    query: string,
+    ...bindings: unknown[]
+  ): SqlStorageCursorLike<T> {
+    const params = bindings as SqlBinding[];
+    if (RETURNS_ROWS.test(query) || HAS_RETURNING.test(query)) {
+      const rows = this.#db.prepare(query).all(...params) as T[];
+      return toCursor(rows);
+    }
+    if (params.length === 0) {
+      this.#db.exec(query);
+      return toCursor<T>([]);
+    }
+    this.#db.prepare(query).run(...params);
+    return toCursor<T>([]);
+  }
+}
+
+function toCursor<T>(rows: T[]): SqlStorageCursorLike<T> {
+  return {
+    toArray: () => rows,
+    [Symbol.iterator]: () => rows[Symbol.iterator](),
+  };
+}

--- a/packages/runtime/src/cloudflare/index.ts
+++ b/packages/runtime/src/cloudflare/index.ts
@@ -48,3 +48,5 @@ export {
   listScheduledCloudflareSessionPrompts,
   rescheduleCloudflareAlarm,
 } from "./cloudflare-host";
+export { DurableObjectSqliteSessionStore } from "./cloudflare-sqlite-session-store";
+export type { SqlStorage, SqlStorageCursorLike } from "./sql-storage";

--- a/packages/runtime/src/cloudflare/sql-storage.ts
+++ b/packages/runtime/src/cloudflare/sql-storage.ts
@@ -1,0 +1,17 @@
+/**
+ * Minimal structural subset of Cloudflare's `SqlStorage` that the SQLite-backed
+ * session store depends on. Keeping it narrow lets the store stay decoupled from
+ * `@cloudflare/workers-types` while remaining assignable from the real
+ * `ctx.storage.sql` (a SQLite-backed Durable Object) and from the in-memory
+ * `node:sqlite` test double.
+ */
+export interface SqlStorageCursorLike<T> extends Iterable<T> {
+  toArray(): T[];
+}
+
+export interface SqlStorage {
+  exec<T = Record<string, unknown>>(
+    query: string,
+    ...bindings: unknown[]
+  ): SqlStorageCursorLike<T>;
+}


### PR DESCRIPTION
## Why

`DurableObjectExecutionSessionStore` re-serializes the **entire** session
snapshot (`{ schemaVersion: 1, history: [...] }`) into a **single
`storage.put` value every commit**. The value grows monotonically with the
conversation, so long sessions eventually cross the Durable Object **~2MB
per-value limit and throw `SQLITE_TOOBIG: string or blob too big`** — even when
each individual tool/connector payload is tiny. The failure surfaces *after* a
tool already succeeded, so a successful turn is reported as a failure.

## What

Add **`DurableObjectSqliteSessionStore`**, an append-only session store for
SQLite-backed Durable Objects. History is persisted as **one small SQLite row
per message**, so no single stored value grows with the conversation and the
2MB ceiling can no longer be reached by accumulation.

| Method | Behavior |
| --- | --- |
| `commit` | Delta-appends **only the new messages** via a positional-prefix diff — unchanged prefix rows are untouched. |
| `load` | Reconstructs `{ schemaVersion: 1, history }` from `active = 1` rows `ORDER BY seq`. |
| rollback (history shrank / diverged) | Soft-deletes the trailing rows (`active = 0`); seqs are never reused. |
| non-snapshot opaque state | Falls back to a single meta `state_blob` column, so the store stays a correct drop-in `SessionStore`. |
| legacy data | A pre-existing `storage.put` snapshot is **lazily migrated into rows** on first access, then the legacy KV keys are removed. |

**Optimistic version/conflict semantics are preserved byte-for-byte.** The
read-version → check → write sequence is a single **synchronous, await-free
critical section**, so concurrent commits to the same key serialize on the JS
event loop inside the single-threaded Durable Object — exactly one writer wins,
the rest get `{ ok: false, reason: "conflict" }`.

## Blast radius (intentionally minimal)

- **No public contract change.** `SessionStore` / `StoredSession` (`session/store/types.ts`) are untouched.
- The internal `CloudflareDurableObjectStorage` port gains an **optional `sql?: SqlStorage`** member (narrow structural subset of Cloudflare's `SqlStorage`).
- **The default wiring is unchanged.** Consumers opt in via the existing `sessionStore` option of `createCloudflareDurableObjectHost` — so this is a no-op for everyone until they explicitly inject it (lets the downstream app gate it behind a flag for staged rollout).

## Verification

- ✅ `pnpm --filter @minpeter/pss-runtime lint` (ultracite, 124 files clean)
- ✅ `pnpm --filter @minpeter/pss-runtime typecheck`
- ✅ `pnpm --filter @minpeter/pss-runtime test` — **217 passed** (16 new, 0 regressions)
- ✅ `pnpm --filter @minpeter/pss-runtime build` (store emitted to `dist`, re-exported from the `./cloudflare` barrel; the test fake is not shipped)

New tests cover: delta-append (unchanged prefix kept), rollback soft-delete,
rollback-then-regrow (no seq reuse), the full optimistic-concurrency contract
(version increment, stale/null conflict, delete resets the counter, mutation
isolation, concurrent-writer serialization), lazy legacy migration with version
continuity, a >2MB-total round-trip, and `decodeStoredSessionSnapshot`
compatibility. Tests run against a `node:sqlite`-backed in-memory `SqlStorage`
fake (Node 24 built-in — **no new dependency**).

## Out of scope (follow-ups)

- Wiring the downstream app to inject this store (flag-gated rollout).
- In-loop context **compaction** (head + structured summary + token-budgeted tail) for the LLM context window — this PR fixes the *storage* limit, not the model context limit.
- `cloudflare-checkpoint-store.ts` is a **second** full-history-snapshot surface with the same `SQLITE_TOOBIG` risk and is not addressed here.
- A `wrangler dev` smoke test against a real DO `ctx.storage.sql` (the fake uses `node:sqlite`, whose dialect matches for these queries but does not exercise DO-specific limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an append‑only SQLite session store for Durable Objects that writes one row per message to avoid `SQLITE_TOOBIG` on long conversations. It’s opt‑in, preserves optimistic concurrency and legacy versions, and lazily migrates and cleans up old KV snapshots.

- New Features
  - `DurableObjectSqliteSessionStore`: per-message rows; delta-append on commit; reconstructs v1 history on load.
  - Rollbacks soft-delete trailing rows; seqs never reused; `delete()` also evicts the migration cache entry.
  - Non-snapshot state stored in a single meta blob; version/conflict semantics unchanged.
  - Reads `storage.sql` structurally at runtime; `CloudflareDurableObjectStorage` interface unchanged; normalizes SQLite meta `version` to a string to avoid false conflicts from INTEGER-affinity tables.

- Migration
  - Opt in via `createCloudflareDurableObjectHost({ sessionStore })`; default store is unchanged.
  - Requires a SQLite‑backed DO (`ctx.storage.sql`). Tables are created on first use.
  - Legacy KV snapshots are migrated on first load; old keys are removed. The legacy version string (including UUIDs) is preserved; the next numeric counter is derived on commit.

<sup>Written for commit 3939740526b2aad4bee6745ddcde08e45c28be2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

