### PR TITLE
fix(runtime): append-only SQLite event/checkpoint stores (SQLITE_TOOBIG)

### DIFF
--- a/.changeset/sqlite-event-checkpoint-stores.md
+++ b/.changeset/sqlite-event-checkpoint-stores.md
@@ -1,0 +1,22 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add `DurableObjectSqliteEventStore` and `DurableObjectSqliteCheckpointStore`,
+the append-only SQLite counterparts to the legacy KV event/checkpoint stores.
+
+Like `DurableObjectSqliteSessionStore`, they persist one small SQLite row per
+event / per checkpoint instead of re-writing the whole per-run list into a
+single `storage.put` value on every append. A run with many large tool-result
+events or full-history checkpoints can no longer cross the Durable Object ~2MB
+per-value limit (`SQLITE_TOOBIG`) by accumulation — the failure that surfaced as
+`Error: string or blob too big: SQLITE_TOOBIG` on the `afterTool` checkpoint
+write after tools such as `web_search`.
+
+`createCloudflareDurableObjectHost` now selects these SQLite stores
+automatically when `storage.sql` is available (ChatRoom-style SQLite-backed
+Durable Objects), and keeps the legacy KV stores on non-SQLite storage, so no
+caller change is required. Event cursors (1-based skip offsets), checkpoint
+`stale-version` optimistic checks, and `latest()` semantics are preserved
+byte-for-byte. Both new stores are re-exported from
+`@minpeter/pss-runtime/cloudflare`.

--- a/packages/runtime/src/cloudflare/cloudflare-execution-store.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-execution-store.ts
@@ -12,7 +12,20 @@ import { DurableObjectEventStore } from "./cloudflare-event-store";
 import { DurableObjectExecutionSessionStore } from "./cloudflare-execution-session-store";
 import { DurableObjectNotificationInbox } from "./cloudflare-notification-store";
 import { DurableObjectRunStore } from "./cloudflare-run-store";
+import { DurableObjectSqliteCheckpointStore } from "./cloudflare-sqlite-checkpoint-store";
+import { DurableObjectSqliteEventStore } from "./cloudflare-sqlite-event-store";
 import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+import type { SqlStorage } from "./sql-storage";
+
+// `sql` is read structurally so the shared CloudflareDurableObjectStorage port
+// stays free of a `sql` member (see DurableObjectSqliteSessionStore). A
+// SQLite-backed Durable Object exposes `storage.sql` at runtime; a transaction
+// clone (or a non-SQLite DO) yields undefined and falls back to the legacy
+// KV-backed stores — which is correct because events/checkpoints are appended
+// directly (never inside a host transaction) on the production Cloudflare path.
+const sqliteOf = (
+  storage: CloudflareDurableObjectStorage
+): SqlStorage | undefined => (storage as { sql?: SqlStorage }).sql;
 
 export class DurableObjectExecutionStore implements ExecutionStore {
   readonly checkpoints: CheckpointStore;
@@ -32,8 +45,17 @@ export class DurableObjectExecutionStore implements ExecutionStore {
   }) {
     this.#prefix = prefix;
     this.#storage = storage;
-    this.checkpoints = new DurableObjectCheckpointStore(storage, prefix);
-    this.events = new DurableObjectEventStore(storage, prefix);
+    // SQLite-backed Durable Objects store events/checkpoints one row per entry
+    // (append-only). This avoids the ~2MB per-value `SQLITE_TOOBIG` failure the
+    // legacy KV stores hit when a run accumulates many large tool-call events or
+    // full-history checkpoints. Non-SQLite storage falls back to the KV stores.
+    const sql = sqliteOf(storage);
+    this.checkpoints = sql
+      ? new DurableObjectSqliteCheckpointStore(storage, prefix)
+      : new DurableObjectCheckpointStore(storage, prefix);
+    this.events = sql
+      ? new DurableObjectSqliteEventStore(storage, prefix)
+      : new DurableObjectEventStore(storage, prefix);
     this.notifications = new DurableObjectNotificationInbox(storage, prefix);
     this.runs = new DurableObjectRunStore(storage, prefix);
     this.sessions = new DurableObjectExecutionSessionStore(storage, prefix);

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-checkpoint-store.test.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-checkpoint-store.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import type { RunRecord } from "../execution";
+import { DurableObjectRunStore } from "./cloudflare-run-store";
+import {
+  type DurableObjectSqliteCheckpointStore as CheckpointStoreType,
+  DurableObjectSqliteCheckpointStore,
+} from "./cloudflare-sqlite-checkpoint-store";
+import { storeKey } from "./cloudflare-store-utils";
+import { InMemoryCloudflareDurableObjectStorage } from "./durable-object-storage";
+import { InMemorySqlStorage } from "./in-memory-sql-storage";
+
+const PREFIX = "pss-runtime";
+const REQUIRES_SQLITE = /SQLite-backed/;
+
+interface CheckpointRowProbe {
+  readonly checkpoint: string;
+  readonly version: number;
+}
+
+function checkpoint(
+  runId: string,
+  version: number,
+  overrides: Partial<{
+    checkpointId: string;
+    phase: "before-model" | "after-tool";
+    runtimeState: unknown;
+    sessionSnapshot: unknown;
+  }> = {}
+): Parameters<CheckpointStoreType["append"]>[0] {
+  return {
+    checkpointId: overrides.checkpointId ?? `checkpoint-${version}`,
+    phase: overrides.phase ?? "before-model",
+    runId,
+    runtimeState: overrides.runtimeState ?? {},
+    sessionSnapshot: overrides.sessionSnapshot ?? {},
+    version,
+  };
+}
+
+function createRun(runId = "run-1"): RunRecord {
+  return {
+    checkpointVersion: 0,
+    kind: "user-turn",
+    rootRunId: runId,
+    runId,
+    sessionKey: "session-1",
+    status: "queued",
+  };
+}
+
+async function createRanStore(runId = "run-1"): Promise<{
+  readonly storage: InMemoryCloudflareDurableObjectStorage;
+  readonly store: DurableObjectSqliteCheckpointStore;
+}> {
+  const storage = new InMemoryCloudflareDurableObjectStorage({
+    sql: new InMemorySqlStorage(),
+  });
+  const runs = new DurableObjectRunStore(storage, PREFIX);
+  await runs.create(createRun(runId));
+  const store = new DurableObjectSqliteCheckpointStore(storage, PREFIX);
+  return { storage, store };
+}
+
+function readRows(
+  storage: InMemoryCloudflareDurableObjectStorage,
+  runId: string
+): CheckpointRowProbe[] {
+  return (storage.sql as InMemorySqlStorage)
+    .exec<CheckpointRowProbe>(
+      "SELECT version, checkpoint FROM pss_checkpoint WHERE run_key = ? ORDER BY version",
+      storeKey(PREFIX, "checkpoints", runId)
+    )
+    .toArray();
+}
+
+describe("DurableObjectSqliteCheckpointStore", () => {
+  it("throws when the Durable Object is not SQLite-backed", () => {
+    expect(
+      () =>
+        new DurableObjectSqliteCheckpointStore(
+          new InMemoryCloudflareDurableObjectStorage(),
+          PREFIX
+        )
+    ).toThrow(REQUIRES_SQLITE);
+  });
+
+  it("appends a checkpoint as one row and returns the version", async () => {
+    const { store, storage } = await createRanStore();
+
+    const result = await store.append(checkpoint("run-1", 1), {
+      expectedVersion: 0,
+    });
+
+    expect(result).toEqual({ ok: true, version: 1 });
+    const rows = readRows(storage, "run-1");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].version).toBe(1);
+    expect(rows[0].checkpoint).toBe(JSON.stringify(checkpoint("run-1", 1)));
+  });
+
+  it("returns the latest checkpoint by version", async () => {
+    const { store } = await createRanStore();
+    await store.append(checkpoint("run-1", 1), { expectedVersion: 0 });
+    await store.append(checkpoint("run-1", 2), { expectedVersion: 1 });
+    await store.append(checkpoint("run-1", 3), { expectedVersion: 2 });
+
+    await expect(store.latest("run-1")).resolves.toMatchObject({
+      checkpointId: "checkpoint-3",
+      version: 3,
+    });
+  });
+
+  it("returns null for the latest checkpoint of an unknown run", async () => {
+    const { store } = await createRanStore();
+    await expect(store.latest("missing")).resolves.toBeNull();
+  });
+
+  it("rejects stale-version writes", async () => {
+    const { store, storage } = await createRanStore();
+
+    const first = await store.append(checkpoint("run-1", 1), {
+      expectedVersion: 0,
+    });
+    const stale = await store.append(checkpoint("run-1", 2), {
+      expectedVersion: 0,
+    });
+
+    expect(first).toEqual({ ok: true, version: 1 });
+    expect(stale).toEqual({
+      currentVersion: 1,
+      ok: false,
+      reason: "stale-version",
+    });
+    // Nothing was written for the rejected append: only the first checkpoint row exists.
+    expect(readRows(storage, "run-1")).toHaveLength(1);
+  });
+
+  it("appends many checkpoints without losing earlier ones", async () => {
+    const { store, storage } = await createRanStore();
+    for (let version = 1; version <= 5; version += 1) {
+      await store.append(checkpoint("run-1", version), {
+        expectedVersion: version - 1,
+      });
+    }
+
+    const rows = readRows(storage, "run-1");
+    expect(rows.map((row) => row.version)).toEqual([1, 2, 3, 4, 5]);
+    await expect(store.latest("run-1")).resolves.toMatchObject({ version: 5 });
+  });
+
+  it("isolates checkpoints by run id", async () => {
+    const { store } = await createRanStore("run-1");
+    const { storage } = await (async () => {
+      const storage = new InMemoryCloudflareDurableObjectStorage({
+        sql: new InMemorySqlStorage(),
+      });
+      await new DurableObjectRunStore(storage, PREFIX).create(
+        createRun("run-2")
+      );
+      return { storage };
+    })();
+    const secondStore = new DurableObjectSqliteCheckpointStore(storage, PREFIX);
+
+    await store.append(checkpoint("run-1", 1), { expectedVersion: 0 });
+    await secondStore.append(checkpoint("run-2", 1), { expectedVersion: 0 });
+
+    await expect(store.latest("run-1")).resolves.toMatchObject({ version: 1 });
+    expect(readRows(storage, "run-1")).toEqual([]);
+    expect(readRows(storage, "run-2")).toHaveLength(1);
+  });
+
+  it("round-trips checkpoints whose snapshot payload exceeds the 2MB blob limit", async () => {
+    // Reproduces the SQLITE_TOOBIG failure the legacy single-value KV store hit:
+    // each checkpoint embeds a full session snapshot, and many tool-call
+    // checkpoints past the ~2.2MB threshold blew up a single re-written value.
+    const { store } = await createRanStore();
+    const big = "x".repeat(120_000);
+
+    for (let version = 1; version <= 20; version += 1) {
+      await store.append(
+        checkpoint("run-1", version, {
+          sessionSnapshot: { history: [big] },
+        }),
+        { expectedVersion: version - 1 }
+      );
+    }
+
+    const latest = await store.latest("run-1");
+    expect(latest).toMatchObject({ version: 20 });
+    expect(
+      (latest?.sessionSnapshot as { history: string[] }).history[0]
+    ).toHaveLength(120_000);
+  });
+
+  it("preserves full checkpoint fidelity (runtime state, phase, id)", async () => {
+    const { store } = await createRanStore();
+    const full = checkpoint("run-1", 1, {
+      checkpointId: "cp-abc",
+      phase: "after-tool",
+      runtimeState: { toolCallId: "call_1", toolName: "web_search" },
+      sessionSnapshot: { history: [{ role: "user", content: "hi" }] },
+    });
+
+    await store.append(full, { expectedVersion: 0 });
+
+    await expect(store.latest("run-1")).resolves.toEqual(full);
+  });
+});

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-checkpoint-store.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-checkpoint-store.ts
@@ -1,0 +1,117 @@
+import type {
+  CheckpointStore,
+  CheckpointWriteResult,
+  RunCheckpoint,
+} from "../execution";
+import {
+  getRun,
+  putRun,
+  storeKey,
+  withTransaction,
+} from "./cloudflare-store-utils";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+import type { SqlStorage } from "./sql-storage";
+
+interface CheckpointRow {
+  readonly checkpoint: string;
+  readonly version: number;
+}
+
+/**
+ * Append-only SQLite-backed {@link CheckpointStore} for SQLite-backed Durable
+ * Objects.
+ *
+ * Unlike {@link DurableObjectCheckpointStore}, which accumulates every
+ * checkpoint for a run (each embedding a full session snapshot) into a single
+ * `storage.put` value and re-writes the whole list on every append, this store
+ * persists one small SQLite row per checkpoint. A run with many tool-call
+ * checkpoints can no longer reach the Durable Object ~2MB per-value limit
+ * (`SQLITE_TOOBIG`) by accumulation.
+ *
+ * The optimistic version check still reads the run record (`RunStore`) as the
+ * version authority, exactly like the legacy store. The check, the row
+ * `INSERT`, and the `RunStore` bump run inside a single `storage.transaction`
+ * so concurrent writes to the same run serialize — exactly one wins, the rest
+ * get `stale-version`. (`ctx.storage.sql.exec` issued inside a Durable Object
+ * transaction is part of that transaction, per the Cloudflare SQLite storage
+ * API.)
+ */
+export class DurableObjectSqliteCheckpointStore implements CheckpointStore {
+  readonly #prefix: string;
+  readonly #sql: SqlStorage;
+  readonly #storage: CloudflareDurableObjectStorage;
+  #schemaReady = false;
+
+  constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
+    const sql = (storage as { sql?: SqlStorage }).sql;
+    if (!sql) {
+      throw new Error(
+        "DurableObjectSqliteCheckpointStore requires a SQLite-backed Durable Object (storage.sql is unavailable)"
+      );
+    }
+    this.#prefix = prefix;
+    this.#sql = sql;
+    this.#storage = storage;
+  }
+
+  async append(
+    checkpoint: RunCheckpoint,
+    options: { readonly expectedVersion: number }
+  ): Promise<CheckpointWriteResult> {
+    this.#ensureSchema();
+    return await withTransaction(this.#storage, async (storage) => {
+      const run = await getRun(storage, this.#prefix, checkpoint.runId);
+      const currentVersion = run?.checkpointVersion ?? 0;
+      if (currentVersion !== options.expectedVersion) {
+        return {
+          currentVersion,
+          ok: false,
+          reason: "stale-version",
+        };
+      }
+
+      const key = this.#rowKey(checkpoint.runId);
+      this.#sql.exec(
+        "INSERT INTO pss_checkpoint (run_key, version, checkpoint) VALUES (?, ?, ?)",
+        key,
+        checkpoint.version,
+        JSON.stringify(checkpoint)
+      );
+      if (run) {
+        await putRun(storage, this.#prefix, {
+          ...run,
+          checkpointVersion: checkpoint.version,
+        });
+      }
+      return { ok: true, version: checkpoint.version };
+    });
+  }
+
+  latest(runId: string): Promise<RunCheckpoint | null> {
+    this.#ensureSchema();
+    const rows = this.#sql
+      .exec<CheckpointRow>(
+        "SELECT version, checkpoint FROM pss_checkpoint WHERE run_key = ? ORDER BY version DESC LIMIT 1",
+        this.#rowKey(runId)
+      )
+      .toArray();
+    const row = rows[0];
+    return Promise.resolve(
+      row ? (JSON.parse(row.checkpoint) as RunCheckpoint) : null
+    );
+  }
+
+  #rowKey(runId: string): string {
+    return storeKey(this.#prefix, "checkpoints", runId);
+  }
+
+  #ensureSchema(): void {
+    if (this.#schemaReady) {
+      return;
+    }
+    this.#sql.exec(
+      "CREATE TABLE IF NOT EXISTS pss_checkpoint (run_key TEXT NOT NULL, version INTEGER NOT NULL, checkpoint TEXT NOT NULL, PRIMARY KEY (run_key, version))"
+    );
+    this.#schemaReady = true;
+  }
+}

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-event-store.test.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-event-store.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  DurableObjectSqliteEventStore,
+  type DurableObjectSqliteEventStore as EventStoreType,
+} from "./cloudflare-sqlite-event-store";
+import { storeKey } from "./cloudflare-store-utils";
+import { InMemoryCloudflareDurableObjectStorage } from "./durable-object-storage";
+import { InMemorySqlStorage } from "./in-memory-sql-storage";
+
+const PREFIX = "pss-runtime";
+const REQUIRES_SQLITE = /SQLite-backed/;
+
+interface EventRowProbe {
+  readonly event: string;
+  readonly seq: number;
+}
+
+interface MetaRowProbe {
+  readonly next_seq: number;
+}
+
+function createStore() {
+  const storage = new InMemoryCloudflareDurableObjectStorage({
+    sql: new InMemorySqlStorage(),
+  });
+  const store = new DurableObjectSqliteEventStore(storage, PREFIX);
+  return { storage, store };
+}
+
+function collect(
+  store: EventStoreType,
+  runId: string
+): Promise<readonly { cursor: { offset: number }; event: unknown }[]> {
+  return (async () => {
+    const out: { cursor: { offset: number }; event: unknown }[] = [];
+    for await (const entry of store.read(runId)) {
+      out.push(entry);
+    }
+    return out;
+  })();
+}
+
+function readRows(
+  storage: InMemoryCloudflareDurableObjectStorage,
+  runId: string
+): EventRowProbe[] {
+  return (storage.sql as InMemorySqlStorage)
+    .exec<EventRowProbe>(
+      "SELECT seq, event FROM pss_event WHERE run_key = ? ORDER BY seq",
+      storeKey(PREFIX, "events", runId)
+    )
+    .toArray();
+}
+
+describe("DurableObjectSqliteEventStore", () => {
+  it("throws when the Durable Object is not SQLite-backed", () => {
+    expect(
+      () =>
+        new DurableObjectSqliteEventStore(
+          new InMemoryCloudflareDurableObjectStorage(),
+          PREFIX
+        )
+    ).toThrow(REQUIRES_SQLITE);
+  });
+
+  it("appends events as one row each and returns 1-based skip cursors", async () => {
+    const { store, storage } = createStore();
+
+    const first = await store.append("run-1", { type: "turn-start" });
+    const second = await store.append("run-1", { type: "turn-end" });
+
+    expect(first).toEqual({ offset: 1 });
+    expect(second).toEqual({ offset: 2 });
+
+    const rows = readRows(storage, "run-1");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.seq)).toEqual([0, 1]);
+    expect(rows[0].event).toBe(JSON.stringify({ type: "turn-start" }));
+  });
+
+  it("replays all events in order", async () => {
+    const { store } = createStore();
+    await store.append("run-1", { type: "turn-start" });
+    await store.append("run-1", { type: "step-start" });
+    await store.append("run-1", { type: "turn-end" });
+
+    const events = await collect(store, "run-1");
+    expect(events.map((entry) => entry.event)).toEqual([
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "turn-end" },
+    ]);
+    expect(events.map((entry) => entry.cursor.offset)).toEqual([1, 2, 3]);
+  });
+
+  it("replays from a cursor without duplicates", async () => {
+    const { store } = createStore();
+    const firstCursor = await store.append("run-1", { type: "turn-start" });
+    await store.append("run-1", { type: "turn-end" });
+
+    const replayed = await collect(store, "run-1");
+
+    // New entries appended after the first cursor are returned from that cursor.
+    await store.append("run-1", { type: "step-start" });
+    const fromCursor: unknown[] = [];
+    for await (const entry of store.read("run-1", firstCursor)) {
+      fromCursor.push(entry.event);
+    }
+    expect(fromCursor).toEqual([{ type: "turn-end" }, { type: "step-start" }]);
+
+    // Sanity: the full replay already matched the pre-step state.
+    expect(replayed.map((entry) => entry.event)).toEqual([
+      { type: "turn-start" },
+      { type: "turn-end" },
+    ]);
+  });
+
+  it("isolates events by run id", async () => {
+    const { store } = createStore();
+    await store.append("run-a", { type: "turn-start" });
+    await store.append("run-b", { type: "turn-start" });
+    await store.append("run-a", { type: "turn-end" });
+
+    expect((await collect(store, "run-a")).map((e) => e.event)).toEqual([
+      { type: "turn-start" },
+      { type: "turn-end" },
+    ]);
+    expect((await collect(store, "run-b")).map((e) => e.event)).toEqual([
+      { type: "turn-start" },
+    ]);
+  });
+
+  it("reads nothing for an unknown run", async () => {
+    const { store } = createStore();
+    expect(await collect(store, "missing")).toEqual([]);
+  });
+
+  it("round-trips a run whose total event payload exceeds the 2MB blob limit", async () => {
+    // Reproduces the SQLITE_TOOBIG failure the legacy single-value KV store hit:
+    // many ~120KB tool/result events past the ~2.2MB threshold.
+    const { store } = createStore();
+    const big = "x".repeat(120_000);
+    const event = {
+      output: big,
+      toolCallId: "call_1",
+      toolName: "web_search",
+      type: "tool-result",
+    } as const;
+
+    for (let index = 0; index < 20; index += 1) {
+      await store.append("big-run", event);
+    }
+
+    const events = await collect(store, "big-run");
+    expect(events).toHaveLength(20);
+    // Events round-trip through JSON, so compare the decoded payload by value.
+    expect(
+      events.every(
+        (entry) => (entry.event as { output: string }).output === big
+      )
+    ).toBe(true);
+  });
+
+  it("serializes concurrent appends without seq collisions", async () => {
+    const { store, storage } = createStore();
+    await Promise.all(
+      Array.from({ length: 50 }, () =>
+        store.append("run-1", { type: "step-start" })
+      )
+    );
+
+    const rows = readRows(storage, "run-1");
+    const seqs = rows.map((row) => row.seq);
+    expect(seqs).toHaveLength(50);
+    expect(new Set(seqs).size).toBe(50);
+    expect(Math.max(...seqs)).toBe(49);
+
+    // The monotonic next_seq counter never went backwards.
+    const meta = (storage.sql as InMemorySqlStorage)
+      .exec<MetaRowProbe>(
+        "SELECT next_seq FROM pss_event_meta WHERE run_key = ?",
+        storeKey(PREFIX, "events", "run-1")
+      )
+      .toArray()[0];
+    expect(meta?.next_seq).toBe(50);
+  });
+
+  it("reports the 1-based offset after each append", async () => {
+    const { store } = createStore();
+    for (let index = 1; index <= 5; index += 1) {
+      await expect(
+        store.append("run-1", { type: "turn-start" })
+      ).resolves.toEqual({ offset: index });
+    }
+  });
+});

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-event-store.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-event-store.ts
@@ -1,0 +1,125 @@
+import type { EventCursor, EventStore, StoredAgentEvent } from "../execution";
+import type { AgentEvent } from "../index";
+import { storeKey } from "./cloudflare-store-utils";
+import type { CloudflareDurableObjectStorage } from "./durable-object-storage";
+import type { SqlStorage } from "./sql-storage";
+
+interface EventRow {
+  readonly event: string;
+  readonly seq: number;
+}
+
+interface EventMetaRow {
+  readonly next_seq: number;
+}
+
+/**
+ * Append-only SQLite-backed {@link EventStore} for SQLite-backed Durable Objects.
+ *
+ * Unlike {@link DurableObjectEventStore}, which re-writes the entire event list
+ * for a run into a single `storage.put` value on every append (and eventually
+ * crosses the Durable Object ~2MB per-value limit — `SQLITE_TOOBIG` — on runs
+ * with many large tool/tool-result events), this store persists one small
+ * SQLite row per event. Each `append` only `INSERT`s the new event, so no single
+ * stored value grows with the run length.
+ *
+ * Mirrors the design of {@link DurableObjectSqliteSessionStore}: the per-run
+ * `next_seq` counter and the row `INSERT` form a single synchronous
+ * (await-free) read-modify-write section, so concurrent appends to the same run
+ * serialize on the JS event loop inside the single-threaded Durable Object and
+ * no `seq` collision can occur.
+ *
+ * Event cursors are 1-based skip counts (`offset = seq + 1`), matching the
+ * legacy list implementation so callers and replays are unaffected.
+ */
+export class DurableObjectSqliteEventStore implements EventStore {
+  readonly #prefix: string;
+  readonly #sql: SqlStorage;
+  #schemaReady = false;
+
+  constructor(storage: CloudflareDurableObjectStorage, prefix: string) {
+    // `sql` is read structurally so the shared CloudflareDurableObjectStorage
+    // port stays free of a `sql` member (see DurableObjectSqliteSessionStore).
+    const sql = (storage as { sql?: SqlStorage }).sql;
+    if (!sql) {
+      throw new Error(
+        "DurableObjectSqliteEventStore requires a SQLite-backed Durable Object (storage.sql is unavailable)"
+      );
+    }
+    this.#prefix = prefix;
+    this.#sql = sql;
+  }
+
+  append(runId: string, event: AgentEvent): Promise<EventCursor> {
+    this.#ensureSchema();
+    const key = this.#rowKey(runId);
+    // Synchronous read-modify-write critical section (no await): concurrent
+    // appends to the same run serialize on the JS event loop inside the
+    // single-threaded Durable Object, so no `seq` collision can occur.
+    const seq = this.#consumeNextSeq(key);
+    this.#sql.exec(
+      "INSERT INTO pss_event (run_key, seq, event) VALUES (?, ?, ?)",
+      key,
+      seq,
+      JSON.stringify(event)
+    );
+    return Promise.resolve({ offset: seq + 1 });
+  }
+
+  async *read(
+    runId: string,
+    cursor?: EventCursor
+  ): AsyncIterable<StoredAgentEvent> {
+    await Promise.resolve();
+    this.#ensureSchema();
+    const key = this.#rowKey(runId);
+    const start = cursor?.offset ?? 0;
+    const rows = this.#sql
+      .exec<EventRow>(
+        "SELECT seq, event FROM pss_event WHERE run_key = ? AND seq >= ? ORDER BY seq",
+        key,
+        start
+      )
+      .toArray();
+    for (const row of rows) {
+      yield {
+        cursor: { offset: row.seq + 1 },
+        event: JSON.parse(row.event) as AgentEvent,
+        runId,
+      };
+    }
+  }
+
+  #rowKey(runId: string): string {
+    return storeKey(this.#prefix, "events", runId);
+  }
+
+  #ensureSchema(): void {
+    if (this.#schemaReady) {
+      return;
+    }
+    this.#sql.exec(
+      "CREATE TABLE IF NOT EXISTS pss_event (run_key TEXT NOT NULL, seq INTEGER NOT NULL, event TEXT NOT NULL, PRIMARY KEY (run_key, seq))"
+    );
+    this.#sql.exec(
+      "CREATE TABLE IF NOT EXISTS pss_event_meta (run_key TEXT PRIMARY KEY, next_seq INTEGER NOT NULL)"
+    );
+    this.#schemaReady = true;
+  }
+
+  #consumeNextSeq(key: string): number {
+    const row = this.#sql
+      .exec<EventMetaRow>(
+        "SELECT next_seq FROM pss_event_meta WHERE run_key = ?",
+        key
+      )
+      .toArray()[0];
+    const seq = row?.next_seq ?? 0;
+    this.#sql.exec(
+      "INSERT INTO pss_event_meta (run_key, next_seq) VALUES (?, ?) ON CONFLICT(run_key) DO UPDATE SET next_seq = excluded.next_seq",
+      key,
+      seq + 1
+    );
+    return seq;
+  }
+}

--- a/packages/runtime/src/cloudflare/cloudflare-sqlite-stores-bootstrap.test.ts
+++ b/packages/runtime/src/cloudflare/cloudflare-sqlite-stores-bootstrap.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { RunRecord } from "../execution";
+import { storeKey } from "./cloudflare-store-utils";
+import { InMemorySqlStorage } from "./in-memory-sql-storage";
+import {
+  createCloudflareDurableObjectHost,
+  InMemoryCloudflareDurableObjectStorage,
+} from "./index";
+
+const PREFIX = "pss-runtime";
+
+const createRun = (runId = "run-1"): RunRecord => ({
+  checkpointVersion: 0,
+  kind: "user-turn",
+  rootRunId: runId,
+  runId,
+  sessionKey: "session-1",
+  status: "queued",
+});
+
+describe("createCloudflareDurableObjectHost store selection", () => {
+  it("uses SQLite row stores for events/checkpoints on a SQLite-backed Durable Object", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage({
+      sql: new InMemorySqlStorage(),
+    });
+    const host = createCloudflareDurableObjectHost({ storage });
+
+    await host.store.runs.create(createRun());
+
+    const big = "x".repeat(120_000);
+    // 20 events * ~120KB ~= ~2.4MB — past the 2MB per-value limit the legacy
+    // single-value KV store hit with SQLITE_TOOBIG.
+    for (let index = 0; index < 20; index += 1) {
+      await host.store.events.append("run-1", {
+        output: big,
+        toolCallId: "call_1",
+        toolName: "web_search",
+        type: "tool-result",
+      });
+    }
+    // 20 checkpoints, each embedding a full session snapshot — past 2MB too.
+    for (let version = 1; version <= 20; version += 1) {
+      await host.store.checkpoints.append(
+        {
+          checkpointId: `cp-${version}`,
+          phase: "after-tool",
+          runId: "run-1",
+          runtimeState: {},
+          sessionSnapshot: { history: [big] },
+          version,
+        },
+        { expectedVersion: version - 1 }
+      );
+    }
+
+    const events: unknown[] = [];
+    for await (const entry of host.store.events.read("run-1")) {
+      events.push(entry.event);
+    }
+    expect(events).toHaveLength(20);
+
+    await expect(host.store.checkpoints.latest("run-1")).resolves.toMatchObject(
+      { checkpointId: "cp-20", version: 20 }
+    );
+
+    // The SQLite-backed stores left no legacy single-value KV list behind.
+    expect(
+      await storage.get(storeKey(PREFIX, "events", "run-1"))
+    ).toBeUndefined();
+    expect(
+      await storage.get(storeKey(PREFIX, "checkpoints", "run-1"))
+    ).toBeUndefined();
+  });
+
+  it("keeps the legacy KV stores on a non-SQLite Durable Object", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage();
+    const host = createCloudflareDurableObjectHost({ storage });
+
+    await host.store.runs.create(createRun());
+
+    await host.store.events.append("run-1", { type: "turn-start" });
+
+    // The legacy store persists the whole run's events as one KV list value.
+    expect(
+      await storage.get(storeKey(PREFIX, "events", "run-1"))
+    ).toBeDefined();
+  });
+});

--- a/packages/runtime/src/cloudflare/index.ts
+++ b/packages/runtime/src/cloudflare/index.ts
@@ -48,5 +48,7 @@ export {
   listScheduledCloudflareSessionPrompts,
   rescheduleCloudflareAlarm,
 } from "./cloudflare-host";
+export { DurableObjectSqliteCheckpointStore } from "./cloudflare-sqlite-checkpoint-store";
+export { DurableObjectSqliteEventStore } from "./cloudflare-sqlite-event-store";
 export { DurableObjectSqliteSessionStore } from "./cloudflare-sqlite-session-store";
 export type { SqlStorage, SqlStorageCursorLike } from "./sql-storage";


### PR DESCRIPTION
## Problem

The Cloudflare `ChatRoom` Durable Object is SQLite-backed, but `@minpeter/pss-runtime`'s Cloudflare event/checkpoint stores (`DurableObjectEventStore` / `DurableObjectCheckpointStore`) still persist **the whole per-run list as a single `storage.put` value** on every append. As a run accumulates large tool-result events or full-history checkpoints, that single value crosses the Durable Object **~2MB per-value limit** and throws:

```
Error: string or blob too big: SQLITE_TOOBIG
```

This surfaced on the `afterTool` checkpoint write after tools such as `web_search` returned sizable result payloads (PostHog trace `a0cfe04e084d9f60`, conversation `rph_2942cd3803941309b206c7377b2f713f`, DO `7ba87398…e01e3a`).

bori PRs #638 (append-only SQLite **session** store) and #668 (DO payload hardening) shipped already but did not touch events/checkpoints, so the failure persisted.

## Fix

Add `DurableObjectSqliteEventStore` and `DurableObjectSqliteCheckpointStore`, the append-only SQLite counterparts to the KV stores — mirroring the existing `DurableObjectSqliteSessionStore` pattern (the append-only SQLite row store that already fixed this for sessions).

- **One small SQLite row per entry** instead of re-serializing the entire per-run list into a single value on every append. Accumulation can no longer trip the 2MB limit.
  - `pss_event(run_key, seq, event)` + `pss_event_meta(run_key, next_seq)`; `append` does a synchronous read-modify-write of `next_seq` + INSERT (no `await`), so concurrent appends to a run serialize on the JS event loop in the single-threaded DO.
  - `pss_checkpoint(run_key, version, checkpoint)`; `append` keeps the KV run record as the version authority via `withTransaction` + `getRun`/`putRun`, preserving optimistic `stale-version` checks.
- **Auto-selected** by `createCloudflareDurableObjectHost` when `storage.sql` is available (structurally, like `DurableObjectSqliteSessionStore`). Non-SQLite storage/tests keep the legacy KV stores unchanged — non-breaking.
- **Contract preserved byte-for-byte**: event cursors stay 1-based skip offsets (`offset = seq + 1`), `read(cursor)` yields remaining events, checkpoints return `{ok:false, reason:"stale-version", currentVersion}` on stale writes, `latest()` returns the highest-version row.
- Both stores re-exported from `@minpeter/pss-runtime/cloudflare`.

## Scope note

This fixes **accumulation** across many entries. A single event/checkpoint whose own serialized size exceeds ~2MB would still fail (same boundary every per-value store has); the production failure was an accumulation pattern, not a single oversized value.

## Tests

- `cloudflare-sqlite-event-store.test.ts` — requires `storage.sql`; append/read round-trip; 1-based cursor offset + replay; run isolation; concurrent-append `seq` collision safety; >2MB total payload round-trips; row-based storage verified (`pss_event` has N rows, legacy KV key absent).
- `cloudflare-sqlite-checkpoint-store.test.ts` — requires `storage.sql`; append→latest; stale-version rejection leaves no extra row; multiple checkpoints accumulate by version; fidelity of runtime/phase/id; row-based storage verified.
- `cloudflare-sqlite-stores-bootstrap.test.ts` — end-to-end: `createCloudflareDurableObjectHost` with SQLite storage appends 2MB+ of events **and** checkpoints without `SQLITE_TOOBIG`, and a non-SQLite host still uses the legacy KV path.

```
tasks: 10 successful, 10 total
runtime: typecheck pass, lint clean (zero ignores), 240 tests passing
```

## Changeset

`.changeset/sqlite-event-checkpoint-stores.md` — `@minpeter/pss-runtime`: patch


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `SQLITE_TOOBIG` errors by switching Cloudflare event and checkpoint persistence to append-only SQLite rows when `storage.sql` is available, avoiding the 2MB per-value limit without changing APIs. Non-SQLite Durable Objects keep the existing KV path.

- **Bug Fixes**
  - Added `DurableObjectSqliteEventStore` and `DurableObjectSqliteCheckpointStore` to store one small SQLite row per event/checkpoint, preventing the 2MB limit from being hit by accumulation.
  - Auto-selected by `createCloudflareDurableObjectHost` on SQLite-backed Durable Objects; falls back to legacy KV on non-SQLite. No caller changes.
  - Behavior preserved: 1-based event cursors, optimistic `stale-version` checks, and `latest()` semantics. Re-exported from `@minpeter/pss-runtime/cloudflare`.
  - Note: a single event/checkpoint > ~2MB can still fail; this fix targets accumulation.

<sup>Written for commit 0a1f55663fe239aa3341d30f3b4eaec6ae6639c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

