### PR TITLE
feat(runtime): expose Cloudflare notification source keys

### DIFF
--- a/.changeset/cloudflare-notification-source-keys.md
+++ b/.changeset/cloudflare-notification-source-keys.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Expose a Cloudflare notification idempotency helper so Durable Object alarm handlers can recover product-level source keys from runtime-scoped scheduled prompts.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,6 +12,7 @@
     "@minpeter/pss-example-basic",
     "@minpeter/pss-example-plugin",
     "@minpeter/pss-example-sync-subagent",
-    "@minpeter/pss-example-background-subagent"
+    "@minpeter/pss-example-background-subagent",
+    "@bori/agent-backend"
   ]
 }

--- a/packages/runtime/src/cloudflare/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/cloudflare/dispatch/notification-dispatch.test.ts
@@ -4,6 +4,7 @@ import {
   dispatchCloudflareAgentNotification,
   InMemoryCloudflareDurableObjectStorage,
   listScheduledCloudflareSessionPrompts,
+  sourceCloudflareAgentNotificationIdempotencyKey,
 } from "../index";
 import { InMemorySqlStorage } from "../sql/node-test/node-sqlite-storage";
 
@@ -67,6 +68,57 @@ describe("dispatchCloudflareAgentNotification", () => {
     });
     expect(prompt?.idempotencyKey).toEqual(expect.any(String));
     expect(prompt?.idempotencyKey).not.toBe("connector:oauth:done");
+    expect(
+      sourceCloudflareAgentNotificationIdempotencyKey({
+        idempotencyKey: prompt?.idempotencyKey,
+        namespace: "agent-a",
+        sessionKey: "room:1:user:2",
+      })
+    ).toBe("connector:oauth:done");
     expect(storage.alarmTime()).toEqual(expect.any(Number));
+  });
+
+  it("keeps raw and malformed notification idempotency keys unchanged", () => {
+    expect(
+      sourceCloudflareAgentNotificationIdempotencyKey({
+        idempotencyKey: "reminder:run:1",
+        namespace: "agent-a",
+        sessionKey: "room:1:user:2",
+      })
+    ).toBe("reminder:run:1");
+    expect(
+      sourceCloudflareAgentNotificationIdempotencyKey({
+        idempotencyKey: "agent%3Aagent-a:%E0%A4%A:connector%3Abad",
+        namespace: "agent-a",
+        sessionKey: "room:1:user:2",
+      })
+    ).toBe("agent%3Aagent-a:%E0%A4%A:connector%3Abad");
+  });
+
+  it("keeps scoped notification keys for a different session unchanged", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage({
+      sql: new InMemorySqlStorage(),
+    });
+
+    await dispatchCloudflareAgentNotification({
+      idempotencyKey: "connector:oauth:done",
+      input: { text: "Connector OAuth completed", type: "user-text" },
+      namespace: "agent-a",
+      prefix: "bori-agent",
+      sessionKey: "room:1:user:2",
+      storage,
+    });
+
+    const [prompt] = await listScheduledCloudflareSessionPrompts(storage, {
+      prefix: "bori-agent",
+    });
+
+    expect(
+      sourceCloudflareAgentNotificationIdempotencyKey({
+        idempotencyKey: prompt?.idempotencyKey,
+        namespace: "agent-a",
+        sessionKey: "room:2:user:2",
+      })
+    ).toBe(prompt?.idempotencyKey);
   });
 });

--- a/packages/runtime/src/cloudflare/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/cloudflare/dispatch/notification-dispatch.ts
@@ -1,3 +1,4 @@
+import { agentNamespace } from "../../agent/identity/namespace";
 import {
   type DispatchedAgentNotification,
   dispatchAgentNotification,
@@ -50,4 +51,75 @@ export function dispatchCloudflareAgentNotification({
     observerEvents,
     sessionKey,
   });
+}
+
+export interface SourceCloudflareAgentNotificationIdempotencyKeyInput {
+  readonly idempotencyKey: string | undefined;
+  readonly namespace?: string;
+  readonly sessionKey: string;
+}
+
+interface ScopedCloudflareAgentNotificationIdempotencyKey {
+  readonly ownerNamespace: string;
+  readonly sessionKey: string;
+  readonly sourceIdempotencyKey: string;
+}
+
+export function sourceCloudflareAgentNotificationIdempotencyKey(
+  input: SourceCloudflareAgentNotificationIdempotencyKeyInput
+): string | undefined {
+  if (!input.idempotencyKey) {
+    return;
+  }
+
+  const scoped = decodeScopedCloudflareAgentNotificationIdempotencyKey(
+    input.idempotencyKey
+  );
+  if (!scoped) {
+    return input.idempotencyKey;
+  }
+
+  if (scoped.sessionKey !== input.sessionKey) {
+    return input.idempotencyKey;
+  }
+
+  if (input.namespace) {
+    return scoped.ownerNamespace === agentNamespace(input.namespace)
+      ? scoped.sourceIdempotencyKey
+      : input.idempotencyKey;
+  }
+
+  return scoped.ownerNamespace.startsWith("agent:")
+    ? scoped.sourceIdempotencyKey
+    : input.idempotencyKey;
+}
+
+function decodeScopedCloudflareAgentNotificationIdempotencyKey(
+  idempotencyKey: string
+): ScopedCloudflareAgentNotificationIdempotencyKey | undefined {
+  const parts = idempotencyKey.split(":");
+  if (parts.length !== 3) {
+    return;
+  }
+
+  try {
+    const ownerNamespace = decodeURIComponent(parts[0] ?? "");
+    const sessionKey = decodeURIComponent(parts[1] ?? "");
+    const sourceIdempotencyKey = decodeURIComponent(parts[2] ?? "");
+    if (!ownerNamespace) {
+      return;
+    }
+    if (!sessionKey) {
+      return;
+    }
+    if (!sourceIdempotencyKey) {
+      return;
+    }
+    return { ownerNamespace, sessionKey, sourceIdempotencyKey };
+  } catch (error) {
+    if (error instanceof URIError) {
+      return;
+    }
+    throw error;
+  }
 }

--- a/packages/runtime/src/cloudflare/index.ts
+++ b/packages/runtime/src/cloudflare/index.ts
@@ -19,8 +19,14 @@ export {
 } from "./alarm/drainer";
 export type { CloudflareAgentRunDrainOptions } from "./alarm/run-drain";
 export { drainAgentRun } from "./alarm/run-drain";
-export type { DispatchCloudflareAgentNotificationInput } from "./dispatch/notification-dispatch";
-export { dispatchCloudflareAgentNotification } from "./dispatch/notification-dispatch";
+export type {
+  DispatchCloudflareAgentNotificationInput,
+  SourceCloudflareAgentNotificationIdempotencyKeyInput,
+} from "./dispatch/notification-dispatch";
+export {
+  dispatchCloudflareAgentNotification,
+  sourceCloudflareAgentNotificationIdempotencyKey,
+} from "./dispatch/notification-dispatch";
 export type {
   CloudflareAgentContext,
   CloudflareAgentContextFactoryOptions,

--- a/scripts/changeset-pre-mode.test.mjs
+++ b/scripts/changeset-pre-mode.test.mjs
@@ -11,7 +11,7 @@ describe("changeset prerelease mode", () => {
     expect(config.baseBranch).toBe("v0.1");
   });
 
-  it("ignores private example packages for release status", () => {
+  it("ignores private and external packages for release status", () => {
     const config = JSON.parse(readFileSync(".changeset/config.json", "utf8"));
 
     expect(config.ignore).toEqual([
@@ -20,6 +20,7 @@ describe("changeset prerelease mode", () => {
       "@minpeter/pss-example-plugin",
       "@minpeter/pss-example-sync-subagent",
       "@minpeter/pss-example-background-subagent",
+      "@bori/agent-backend",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- add a Cloudflare helper that maps runtime-scoped notification prompt idempotency keys back to product-level source keys
- cover raw, malformed, scoped, and wrong-session key behavior in runtime dispatch tests
- ignore the local Bori symlink package in pss-next changeset release calculations so local release checks do not try to version external client code

## Verification
- pnpm --filter @minpeter/pss-runtime exec vitest run src/cloudflare/dispatch/notification-dispatch.test.ts src/cloudflare/alarm/run-context.test.ts
- pnpm --filter @minpeter/pss-runtime typecheck
- pnpm --filter @minpeter/pss-runtime lint
- node scripts/verify-release-artifacts.mjs
- git diff --check

## Bori follow-up
- Related Bori PR: https://github.com/clawroid/bori/pull/698
- This enables Bori agent-backend to replace its local alarm idempotency decoder with the runtime-native helper after the next prerelease is published.