### PR TITLE
fix(release): exclude bori symlink from workspace tooling

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,6 @@
     "@minpeter/pss-example-basic",
     "@minpeter/pss-example-plugin",
     "@minpeter/pss-example-sync-subagent",
-    "@minpeter/pss-example-background-subagent",
-    "@bori/agent-backend"
+    "@minpeter/pss-example-background-subagent"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@10.0.0",
   "workspaces": [
     "apps/*",
+    "!apps/bori-agent-backend",
     "packages/*",
     "examples/*"
   ],

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - "apps/*"
+  - "!apps/bori-agent-backend"
   - "packages/*"
   - "examples/*"

--- a/scripts/changeset-pre-mode.test.mjs
+++ b/scripts/changeset-pre-mode.test.mjs
@@ -13,6 +13,8 @@ describe("changeset prerelease mode", () => {
 
   it("ignores private and external packages for release status", () => {
     const config = JSON.parse(readFileSync(".changeset/config.json", "utf8"));
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+    const workspace = readFileSync("pnpm-workspace.yaml", "utf8");
 
     expect(config.ignore).toEqual([
       "@minpeter/pss-worker-agent",
@@ -20,7 +22,8 @@ describe("changeset prerelease mode", () => {
       "@minpeter/pss-example-plugin",
       "@minpeter/pss-example-sync-subagent",
       "@minpeter/pss-example-background-subagent",
-      "@bori/agent-backend",
     ]);
+    expect(packageJson.workspaces).toContain("!apps/bori-agent-backend");
+    expect(workspace).toContain('- "!apps/bori-agent-backend"');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,5 @@
     "apps/*/types/**/*.d.ts",
     "examples/*/src/**/*.ts"
   ],
-  "exclude": [
-    "apps/bori-agent-backend/**"
-  ]
+  "exclude": ["apps/bori-agent-backend/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,8 @@
     "apps/*/src/**/*.ts",
     "apps/*/types/**/*.d.ts",
     "examples/*/src/**/*.ts"
+  ],
+  "exclude": [
+    "apps/bori-agent-backend/**"
   ]
 }


### PR DESCRIPTION
## Summary
- Exclude the local `apps/bori-agent-backend` symlink from package workspaces and root TypeScript includes.
- Remove `@bori/agent-backend` from Changesets `ignore`, because the package is not present in CI and caused release config validation to fail.
- Update the prerelease-mode smoke test to cover the workspace exclusion.

## Validation
- `git diff --check`
- `pnpm exec changeset status`
- `pnpm exec vitest run scripts/changeset-pre-mode.test.mjs`
- `pnpm typecheck`

## Context
- Unblocks the failed `v0.1` Release workflow after PR #101.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the local `apps/bori-agent-backend` symlink from workspaces and TypeScript builds. Fixes Changesets validation and unblocks the `v0.1` release.

- **Bug Fixes**
  - Excluded `apps/bori-agent-backend` in `package.json` and `pnpm-workspace.yaml`, and via `tsconfig.json` `exclude` (normalized pattern formatting).
  - Removed `@bori/agent-backend` from `.changeset/config.json` `ignore` to match CI and pass release config validation.
  - Updated the prerelease smoke test to assert the workspace exclusion in both files.

<sup>Written for commit e5f6bd909db9b1208b01f63bf80c1f4d59dd7ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

