### PR TITLE
Store runtime threads and runs in SQLite rows

### DIFF
--- a/.changeset/thread-sqlite-run-rows.md
+++ b/.changeset/thread-sqlite-run-rows.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Rename Cloudflare SQLite thread history tables from `pss_session_*` to `pss_thread_*` with legacy row migration, and store run records in SQLite rows instead of Durable Object KV values.

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/run-write.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/run-write.ts
@@ -1,0 +1,61 @@
+import {
+  nullableStringBinding,
+  numberBinding,
+  stringBinding,
+} from "./bindings";
+import type { InMemoryDurableObjectSqlState, RunRow } from "./state";
+
+export function writeRunStatement(
+  state: InMemoryDurableObjectSqlState,
+  query: string,
+  bindings: readonly unknown[]
+): boolean {
+  if (query.startsWith("insert into pss_run")) {
+    upsertRun(state, bindings);
+    return true;
+  }
+  if (query.startsWith("delete from pss_run")) {
+    deleteRun(state, bindings);
+    return true;
+  }
+  return false;
+}
+
+function upsertRun(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const row = createRunRow(bindings);
+  state.runs = state.runs.filter(
+    (existing) =>
+      !(existing.prefix === row.prefix && existing.run_id === row.run_id)
+  );
+  state.runs.push(row);
+}
+
+function deleteRun(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const prefix = stringBinding(bindings[0]);
+  const runId = stringBinding(bindings[1]);
+  state.runs = state.runs.filter(
+    (row) => !(row.prefix === prefix && row.run_id === runId)
+  );
+}
+
+function createRunRow(bindings: readonly unknown[]): RunRow {
+  return {
+    checkpoint_version: numberBinding(bindings[8]),
+    created_at: numberBinding(bindings[9]),
+    dedupe_key: nullableStringBinding(bindings[3]),
+    parent_run_id: nullableStringBinding(bindings[4]),
+    prefix: stringBinding(bindings[0]),
+    record: stringBinding(bindings[2]),
+    root_run_id: stringBinding(bindings[5]),
+    run_id: stringBinding(bindings[1]),
+    status: stringBinding(bindings[7]),
+    thread_key: stringBinding(bindings[6]),
+    updated_at: numberBinding(bindings[10]),
+  };
+}

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/select.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/select.ts
@@ -3,6 +3,7 @@ import type {
   CheckpointRow,
   EventRow,
   InMemoryDurableObjectSqlState,
+  RunRow,
   ScheduledWorkRow,
   ThreadMessageRow,
   ThreadMetaRow,
@@ -13,11 +14,23 @@ export function selectSqlRows(
   query: string,
   bindings: readonly unknown[]
 ): unknown[] {
-  if (query.includes("from pss_session_meta")) {
+  if (query.includes("from sqlite_master")) {
+    return [];
+  }
+  if (
+    query.includes("from pss_thread_meta") ||
+    query.includes("from pss_session_meta")
+  ) {
     return selectThreadMetaRows(state, query, bindings);
   }
-  if (query.includes("from pss_session_message")) {
+  if (
+    query.includes("from pss_thread_message") ||
+    query.includes("from pss_session_message")
+  ) {
     return selectThreadMessageRows(state, query, bindings);
+  }
+  if (query.includes("from pss_run")) {
+    return selectRunRows(state, query, bindings);
   }
   if (query.includes("from pss_event_meta")) {
     return selectEventMetaRows(state, bindings);
@@ -39,10 +52,18 @@ function selectThreadMetaRows(
   query: string,
   bindings: readonly unknown[]
 ): unknown[] {
-  if (query.includes("where session_key = ?")) {
+  if (
+    query.includes("where thread_key = ?") ||
+    query.includes("where session_key = ?")
+  ) {
     const key = stringBinding(bindings[0]);
     const row = state.threadMeta.get(key);
     return row ? [projectThreadMeta(row, query)] : [];
+  }
+  if (query === "select thread_key from pss_thread_meta") {
+    return [...state.threadMeta.keys()].map((thread_key) => ({
+      thread_key,
+    }));
   }
   if (query === "select session_key from pss_session_meta") {
     return [...state.threadMeta.keys()].map((session_key) => ({
@@ -59,7 +80,7 @@ function selectThreadMessageRows(
 ): unknown[] {
   const key = stringBinding(bindings[0]);
   const rows = state.threadMessages.filter((row) => {
-    if (row.session_key !== key) {
+    if (row.thread_key !== key) {
       return false;
     }
     return query.includes("active = 1") ? row.active === 1 : true;
@@ -69,6 +90,37 @@ function selectThreadMessageRows(
       (left: ThreadMessageRow, right: ThreadMessageRow) => left.seq - right.seq
     )
     .map((row) => projectThreadMessage(row, query));
+}
+
+function selectRunRows(
+  state: InMemoryDurableObjectSqlState,
+  query: string,
+  bindings: readonly unknown[]
+): unknown[] {
+  const prefix = stringBinding(bindings[0]);
+  if (query.includes("run_id = ?")) {
+    const runId = stringBinding(bindings[1]);
+    return state.runs
+      .filter((row) => row.prefix === prefix && row.run_id === runId)
+      .map(projectRun);
+  }
+  if (query.includes("dedupe_key = ?")) {
+    const dedupeKey = stringBinding(bindings[1]);
+    return state.runs
+      .filter((row) => row.prefix === prefix && row.dedupe_key === dedupeKey)
+      .map(projectRun)
+      .slice(0, 1);
+  }
+  if (query.includes("parent_run_id = ?")) {
+    const parentRunId = stringBinding(bindings[1]);
+    return state.runs
+      .filter(
+        (row) => row.prefix === prefix && row.parent_run_id === parentRunId
+      )
+      .sort((left: RunRow, right: RunRow) => left.created_at - right.created_at)
+      .map(projectRun);
+  }
+  throw new Error(`Unsupported in-memory run SQL query: ${query}`);
 }
 
 function selectEventMetaRows(
@@ -177,4 +229,8 @@ function projectThreadMessage(row: ThreadMessageRow, query: string): unknown {
     projected.message = row.message;
   }
   return projected;
+}
+
+function projectRun(row: RunRow): unknown {
+  return { record: row.record };
 }

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/state.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/state.ts
@@ -1,8 +1,8 @@
 export interface ThreadMetaRow {
   readonly message_count: number;
   readonly next_seq: number;
-  readonly session_key: string;
   readonly state_blob: string | null;
+  readonly thread_key: string;
   readonly version: number | string;
 }
 
@@ -10,7 +10,21 @@ export interface ThreadMessageRow {
   active: number;
   readonly message: string;
   readonly seq: number;
-  readonly session_key: string;
+  readonly thread_key: string;
+}
+
+export interface RunRow {
+  readonly checkpoint_version: number;
+  readonly created_at: number;
+  readonly dedupe_key: string | null;
+  readonly parent_run_id: string | null;
+  readonly prefix: string;
+  readonly record: string;
+  readonly root_run_id: string;
+  readonly run_id: string;
+  readonly status: string;
+  readonly thread_key: string;
+  readonly updated_at: number;
 }
 
 export interface EventMetaRow {
@@ -42,6 +56,7 @@ export interface InMemoryDurableObjectSqlState {
   checkpoints: CheckpointRow[];
   eventMeta: Map<string, EventMetaRow>;
   events: EventRow[];
+  runs: RunRow[];
   scheduledWork: ScheduledWorkRow[];
   threadMessages: ThreadMessageRow[];
   threadMeta: Map<string, ThreadMetaRow>;
@@ -52,6 +67,7 @@ export function createInMemoryDurableObjectSqlState(): InMemoryDurableObjectSqlS
     checkpoints: [],
     eventMeta: new Map(),
     events: [],
+    runs: [],
     scheduledWork: [],
     threadMessages: [],
     threadMeta: new Map(),
@@ -67,6 +83,7 @@ export function cloneInMemoryDurableObjectSqlState(
       [...state.eventMeta].map(([key, value]) => [key, structuredClone(value)])
     ),
     events: structuredClone(state.events),
+    runs: structuredClone(state.runs),
     scheduledWork: structuredClone(state.scheduledWork),
     threadMessages: structuredClone(state.threadMessages),
     threadMeta: new Map(

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/storage.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/storage.ts
@@ -43,7 +43,11 @@ function normalizeSql(query: string): string {
 }
 
 function isSchemaStatement(query: string): boolean {
-  return query.startsWith("create table ") || query.startsWith("create index ");
+  return (
+    query.startsWith("create table ") ||
+    query.startsWith("create index ") ||
+    query.startsWith("create unique index ")
+  );
 }
 
 function isTransactionStatement(query: string): boolean {

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
@@ -3,6 +3,7 @@ import {
   numberBinding,
   stringBinding,
 } from "./bindings";
+import { writeRunStatement } from "./run-write";
 import type { InMemoryDurableObjectSqlState, ThreadMetaRow } from "./state";
 
 export function writeSqlStatement(
@@ -10,8 +11,11 @@ export function writeSqlStatement(
   query: string,
   bindings: readonly unknown[]
 ): void {
-  if (query.includes("pss_session_")) {
+  if (query.includes("pss_thread_") || query.includes("pss_session_")) {
     writeThreadStatement(state, query, bindings);
+    return;
+  }
+  if (writeRunStatement(state, query, bindings)) {
     return;
   }
   if (query.startsWith("insert into pss_event_meta")) {
@@ -44,23 +48,38 @@ function writeThreadStatement(
   query: string,
   bindings: readonly unknown[]
 ): void {
-  if (query.startsWith("delete from pss_session_message")) {
+  if (
+    query.startsWith("delete from pss_thread_message") ||
+    query.startsWith("delete from pss_session_message")
+  ) {
     deleteThreadMessages(state, bindings);
     return;
   }
-  if (query.startsWith("delete from pss_session_meta")) {
+  if (
+    query.startsWith("delete from pss_thread_meta") ||
+    query.startsWith("delete from pss_session_meta")
+  ) {
     state.threadMeta.delete(stringBinding(bindings[0]));
     return;
   }
-  if (query.startsWith("update pss_session_message set active = 0")) {
+  if (
+    query.startsWith("update pss_thread_message set active = 0") ||
+    query.startsWith("update pss_session_message set active = 0")
+  ) {
     deactivateThreadMessages(state, query, bindings);
     return;
   }
-  if (query.startsWith("insert into pss_session_message")) {
+  if (
+    query.startsWith("insert into pss_thread_message") ||
+    query.startsWith("insert into pss_session_message")
+  ) {
     insertThreadMessage(state, query, bindings);
     return;
   }
-  if (query.startsWith("insert into pss_session_meta")) {
+  if (
+    query.startsWith("insert into pss_thread_meta") ||
+    query.startsWith("insert into pss_session_meta")
+  ) {
     insertThreadMeta(state, bindings);
     return;
   }
@@ -73,7 +92,7 @@ function deleteThreadMessages(
 ): void {
   const key = stringBinding(bindings[0]);
   state.threadMessages = state.threadMessages.filter(
-    (row) => row.session_key !== key
+    (row) => row.thread_key !== key
   );
 }
 
@@ -87,7 +106,7 @@ function deactivateThreadMessages(
     ? numberBinding(bindings[1])
     : Number.NEGATIVE_INFINITY;
   for (const row of state.threadMessages) {
-    if (row.session_key === key && row.active === 1 && row.seq >= minSeq) {
+    if (row.thread_key === key && row.active === 1 && row.seq >= minSeq) {
       row.active = 0;
     }
   }
@@ -103,7 +122,7 @@ function insertThreadMessage(
     active: 1,
     message: stringBinding(hasImplicitSeq ? bindings[1] : bindings[2]),
     seq: hasImplicitSeq ? 0 : numberBinding(bindings[1]),
-    session_key: stringBinding(bindings[0]),
+    thread_key: stringBinding(bindings[0]),
   });
 }
 
@@ -123,16 +142,16 @@ function createThreadMetaRow(
     return {
       message_count: numberBinding(bindings[2]),
       next_seq: numberBinding(bindings[3]),
-      session_key: key,
       state_blob: nullableStringBinding(bindings[4]),
+      thread_key: key,
       version: stringBinding(bindings[1]),
     };
   }
   return {
     message_count: 1,
     next_seq: 1,
-    session_key: key,
     state_blob: null,
+    thread_key: key,
     version: 1,
   };
 }

--- a/packages/runtime/src/cloudflare/storage/execution/records.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/records.ts
@@ -1,4 +1,4 @@
-import type { NotificationRecord, RunRecord } from "../../../execution";
+import type { NotificationRecord } from "../../../execution";
 import type {
   CloudflareDurableObjectStorage,
   CloudflareDurableObjectTransactionStorage,
@@ -16,49 +16,6 @@ export async function withTransaction<T>(
   return storage.transaction
     ? await storage.transaction(fn)
     : await fn(storage);
-}
-
-export async function getRun(
-  storage: CloudflareDurableObjectTransactionStorage,
-  prefix: string,
-  runId: string
-): Promise<RunRecord | null> {
-  return (await storage.get<RunRecord>(storeKey(prefix, "run", runId))) ?? null;
-}
-
-export async function putRun(
-  storage: CloudflareDurableObjectTransactionStorage,
-  prefix: string,
-  record: RunRecord,
-  options: StoragePayloadBudgetOptions = {}
-): Promise<void> {
-  assertJsonPayloadWithinBudget(
-    "run-record",
-    record,
-    resolveStoragePayloadMaxBytes(options)
-  );
-  await storage.put(storeKey(prefix, "run", record.runId), record);
-}
-
-export async function indexRun(
-  storage: CloudflareDurableObjectTransactionStorage,
-  prefix: string,
-  record: RunRecord
-): Promise<void> {
-  if (record.dedupeKey) {
-    await storage.put(
-      storeKey(prefix, "run-dedupe", record.dedupeKey),
-      record.runId
-    );
-  }
-  if (record.parentRunId) {
-    const parentKey = storeKey(prefix, "run-parent", record.parentRunId);
-    const runIds = await readList<string>(storage, parentKey);
-    if (!runIds.includes(record.runId)) {
-      runIds.push(record.runId);
-      await storage.put(parentKey, runIds);
-    }
-  }
 }
 
 export async function getNotification(

--- a/packages/runtime/src/cloudflare/storage/execution/run-records.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/run-records.ts
@@ -1,0 +1,205 @@
+import type { RunRecord } from "../../../execution";
+import type { SqlStorage } from "../../sql/ports/storage-port";
+import type { CloudflareDurableObjectTransactionStorage } from "../durable-object/durable-object-storage";
+import {
+  assertJsonPayloadWithinBudget,
+  resolveStoragePayloadMaxBytes,
+  type StoragePayloadBudgetOptions,
+} from "../payload-guard";
+import { readList, storeKey } from "./records";
+
+interface RunRow {
+  readonly record: string;
+}
+
+export async function getRun(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  runId: string
+): Promise<RunRecord | null> {
+  const sql = sqlStorage(storage);
+  if (sql) {
+    const row = selectRunRow(sql, prefix, runId);
+    if (row) {
+      return parseRunRecord(row);
+    }
+  }
+
+  const legacy =
+    (await storage.get<RunRecord>(storeKey(prefix, "run", runId))) ?? null;
+  if (legacy && sql) {
+    await putRun(storage, prefix, legacy);
+    await storage.delete(storeKey(prefix, "run", runId));
+  }
+  return legacy;
+}
+
+export async function getRunByDedupeKey(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  dedupeKey: string
+): Promise<RunRecord | null> {
+  const sql = sqlStorage(storage);
+  if (sql) {
+    ensureRunSchema(sql);
+    const row = sql
+      .exec<RunRow>(
+        "SELECT record FROM pss_run WHERE prefix = ? AND dedupe_key = ? LIMIT 1",
+        prefix,
+        dedupeKey
+      )
+      .toArray()[0];
+    return row ? parseRunRecord(row) : null;
+  }
+  const runId = await storage.get<string>(
+    storeKey(prefix, "run-dedupe", dedupeKey)
+  );
+  return runId ? await getRun(storage, prefix, runId) : null;
+}
+
+export async function listRunsByParentRunId(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  parentRunId: string
+): Promise<readonly RunRecord[]> {
+  const sql = sqlStorage(storage);
+  if (sql) {
+    ensureRunSchema(sql);
+    return sql
+      .exec<RunRow>(
+        "SELECT record FROM pss_run WHERE prefix = ? AND parent_run_id = ? ORDER BY created_at, rowid",
+        prefix,
+        parentRunId
+      )
+      .toArray()
+      .map(parseRunRecord);
+  }
+  const runIds = await readList<string>(
+    storage,
+    storeKey(prefix, "run-parent", parentRunId)
+  );
+  const runs = await Promise.all(
+    runIds.map((runId) => getRun(storage, prefix, runId))
+  );
+  return runs.filter(isRunRecord);
+}
+
+export async function putRun(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  record: RunRecord,
+  options: StoragePayloadBudgetOptions = {}
+): Promise<void> {
+  assertJsonPayloadWithinBudget(
+    "run-record",
+    record,
+    resolveStoragePayloadMaxBytes(options)
+  );
+  const sql = sqlStorage(storage);
+  if (sql) {
+    putSqlRun(sql, prefix, record);
+    await storage.delete(storeKey(prefix, "run", record.runId));
+    return;
+  }
+  await storage.put(storeKey(prefix, "run", record.runId), record);
+}
+
+export async function indexRun(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  record: RunRecord
+): Promise<void> {
+  if (hasSqlStorage(storage)) {
+    return;
+  }
+  if (record.dedupeKey) {
+    await storage.put(
+      storeKey(prefix, "run-dedupe", record.dedupeKey),
+      record.runId
+    );
+  }
+  if (record.parentRunId) {
+    const parentKey = storeKey(prefix, "run-parent", record.parentRunId);
+    const runIds = await readList<string>(storage, parentKey);
+    if (!runIds.includes(record.runId)) {
+      runIds.push(record.runId);
+      await storage.put(parentKey, runIds);
+    }
+  }
+}
+
+function hasSqlStorage(
+  storage: CloudflareDurableObjectTransactionStorage
+): boolean {
+  return sqlStorage(storage) !== undefined;
+}
+
+function selectRunRow(
+  sql: SqlStorage,
+  prefix: string,
+  runId: string
+): RunRow | undefined {
+  ensureRunSchema(sql);
+  return sql
+    .exec<RunRow>(
+      "SELECT record FROM pss_run WHERE prefix = ? AND run_id = ?",
+      prefix,
+      runId
+    )
+    .toArray()[0];
+}
+
+function parseRunRecord(row: RunRow): RunRecord {
+  return JSON.parse(row.record) as RunRecord;
+}
+
+function isRunRecord(record: RunRecord | null): record is RunRecord {
+  return record !== null;
+}
+
+function sqlStorage(
+  storage: CloudflareDurableObjectTransactionStorage
+): SqlStorage | undefined {
+  const sql = storage.sql;
+  return isSqlStorage(sql) ? sql : undefined;
+}
+
+function isSqlStorage(value: unknown): value is SqlStorage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "exec" in value &&
+    typeof value.exec === "function"
+  );
+}
+
+function ensureRunSchema(sql: SqlStorage): void {
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS pss_run (prefix TEXT NOT NULL, run_id TEXT NOT NULL, record TEXT NOT NULL, dedupe_key TEXT, parent_run_id TEXT, root_run_id TEXT NOT NULL, thread_key TEXT NOT NULL, status TEXT NOT NULL, checkpoint_version INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, PRIMARY KEY (prefix, run_id))"
+  );
+  sql.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS pss_run_dedupe_unique ON pss_run (prefix, dedupe_key) WHERE dedupe_key IS NOT NULL"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_run_parent ON pss_run (prefix, parent_run_id, created_at)"
+  );
+}
+
+function putSqlRun(sql: SqlStorage, prefix: string, record: RunRecord): void {
+  ensureRunSchema(sql);
+  const nowMs = Date.now();
+  sql.exec(
+    "INSERT INTO pss_run (prefix, run_id, record, dedupe_key, parent_run_id, root_run_id, thread_key, status, checkpoint_version, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(prefix, run_id) DO UPDATE SET record = excluded.record, dedupe_key = excluded.dedupe_key, parent_run_id = excluded.parent_run_id, root_run_id = excluded.root_run_id, thread_key = excluded.thread_key, status = excluded.status, checkpoint_version = excluded.checkpoint_version, updated_at = excluded.updated_at",
+    prefix,
+    record.runId,
+    JSON.stringify(record),
+    record.dedupeKey ?? null,
+    record.parentRunId ?? null,
+    record.rootRunId,
+    record.threadKey,
+    record.status,
+    record.checkpointVersion,
+    nowMs,
+    nowMs
+  );
+}

--- a/packages/runtime/src/cloudflare/storage/execution/run-store.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/run-store.ts
@@ -10,14 +10,14 @@ import {
   resolveStoragePayloadMaxBytes,
   type StoragePayloadBudgetOptions,
 } from "../payload-guard";
+import { withTransaction } from "./records";
 import {
   getRun,
+  getRunByDedupeKey,
   indexRun,
+  listRunsByParentRunId,
   putRun,
-  readList,
-  storeKey,
-  withTransaction,
-} from "./records";
+} from "./run-records";
 
 const claimableStatuses = new Set<RunStatus>([
   "leased",
@@ -85,19 +85,15 @@ export class DurableObjectRunStore implements RunStore {
   }
 
   async getByDedupeKey(dedupeKey: string): Promise<RunRecord | null> {
-    const runId = await this.#storage.get<string>(
-      storeKey(this.#prefix, "run-dedupe", dedupeKey)
-    );
-    return runId ? await this.get(runId) : null;
+    return await getRunByDedupeKey(this.#storage, this.#prefix, dedupeKey);
   }
 
   async listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]> {
-    const runIds = await readList<string>(
+    return await listRunsByParentRunId(
       this.#storage,
-      storeKey(this.#prefix, "run-parent", parentRunId)
+      this.#prefix,
+      parentRunId
     );
-    const runs = await Promise.all(runIds.map((runId) => this.get(runId)));
-    return runs.filter(isRunRecord);
   }
 
   async update(record: RunRecord): Promise<RunRecord> {
@@ -109,8 +105,4 @@ export class DurableObjectRunStore implements RunStore {
       return structuredClone(record);
     });
   }
-}
-
-function isRunRecord(record: RunRecord | null): record is RunRecord {
-  return record !== null;
 }

--- a/packages/runtime/src/cloudflare/storage/execution/store-contract.test.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/store-contract.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { describeExecutionStoreContract } from "../../../contracts/execution-store/contract";
 import type { RunRecord } from "../../../execution";
+import { InMemorySqlStorage } from "../../sql/node-test/node-sqlite-storage";
 import { InMemoryCloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
+import { storeKey } from "./records";
 import { DurableObjectExecutionStore } from "./store";
 
 describeExecutionStoreContract({
@@ -67,6 +69,40 @@ describe("DurableObjectExecutionStore payload guards", () => {
     await expect(store.runs.get("run-update")).resolves.toEqual(
       runRecord("run-update")
     );
+  });
+
+  it("stores run records in SQLite rows instead of Durable Object KV values", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage({
+      sql: new InMemorySqlStorage(),
+    });
+    const store = new DurableObjectExecutionStore({
+      prefix: "run-sql-test",
+      storage,
+    });
+    const record = runRecord("run-sql", {
+      dedupeKey: "dedupe-1",
+      parentRunId: "parent-1",
+    });
+
+    await store.runs.create(record);
+
+    const rows = (storage.sql as InMemorySqlStorage)
+      .exec<{ readonly record: string }>(
+        "SELECT record FROM pss_run WHERE prefix = ? AND run_id = ?",
+        "run-sql-test",
+        "run-sql"
+      )
+      .toArray();
+    expect(rows.map((row) => JSON.parse(row.record))).toEqual([record]);
+    await expect(
+      storage.get(storeKey("run-sql-test", "run", "run-sql"))
+    ).resolves.toBeUndefined();
+    await expect(store.runs.getByDedupeKey("dedupe-1")).resolves.toEqual(
+      record
+    );
+    await expect(store.runs.listByParentRunId("parent-1")).resolves.toEqual([
+      record,
+    ]);
   });
 });
 

--- a/packages/runtime/src/cloudflare/storage/sqlite/checkpoint-store.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/checkpoint-store.ts
@@ -5,12 +5,8 @@ import type {
 } from "../../../execution";
 import type { SqlStorage } from "../../sql/ports/storage-port";
 import type { CloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
-import {
-  getRun,
-  putRun,
-  storeKey,
-  withTransaction,
-} from "../execution/records";
+import { storeKey, withTransaction } from "../execution/records";
+import { getRun, putRun } from "../execution/run-records";
 import {
   resolveStoragePayloadMaxBytes,
   type StoragePayloadBudgetOptions,

--- a/packages/runtime/src/cloudflare/storage/sqlite/session-store-compat.test.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/session-store-compat.test.ts
@@ -6,10 +6,11 @@ import { DurableObjectSqliteThreadStore } from "./thread-store";
 import { PREFIX, snapshot } from "./thread-store.test-support";
 
 describe("DurableObjectSqliteThreadStore compatibility", () => {
-  it("normalizes a numeric meta version for the optimistic compare", async () => {
+  it("migrates legacy session rows into thread rows", async () => {
     const sql = new InMemorySqlStorage();
     const storage = new InMemoryCloudflareDurableObjectStorage({ sql });
-    const key = storeKey(PREFIX, "session", "num");
+    const legacyKey = storeKey(PREFIX, "session", "num");
+    const threadKey = storeKey(PREFIX, "thread", "num");
     sql.exec(
       "CREATE TABLE pss_session_meta (session_key TEXT PRIMARY KEY, version INTEGER NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
     );
@@ -18,12 +19,12 @@ describe("DurableObjectSqliteThreadStore compatibility", () => {
     );
     sql.exec(
       "INSERT INTO pss_session_message (session_key, seq, active, message) VALUES (?, 0, 1, ?)",
-      key,
+      legacyKey,
       JSON.stringify({ i: 0 })
     );
     sql.exec(
       "INSERT INTO pss_session_meta (session_key, version, message_count, next_seq, state_blob) VALUES (?, 1, 1, 1, NULL)",
-      key
+      legacyKey
     );
 
     const store = new DurableObjectSqliteThreadStore(storage, PREFIX);
@@ -36,5 +37,21 @@ describe("DurableObjectSqliteThreadStore compatibility", () => {
         expectedVersion: "1",
       })
     ).resolves.toEqual({ ok: true, version: "2" });
+    expect(
+      sql
+        .exec(
+          "SELECT thread_key FROM pss_thread_meta WHERE thread_key = ?",
+          threadKey
+        )
+        .toArray()
+    ).toEqual([{ thread_key: threadKey }]);
+    expect(
+      sql
+        .exec(
+          "SELECT session_key FROM pss_session_meta WHERE session_key = ?",
+          legacyKey
+        )
+        .toArray()
+    ).toEqual([]);
   });
 });

--- a/packages/runtime/src/cloudflare/storage/sqlite/thread-store-sql.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/thread-store-sql.ts
@@ -1,0 +1,239 @@
+import type { SqlStorage } from "../../sql/ports/storage-port";
+import { storeKey } from "../execution/records";
+import { stringifyJsonPayloadWithinBudget } from "../payload-guard";
+
+export interface ThreadMetaRow {
+  readonly message_count: number;
+  readonly next_seq: number;
+  readonly state_blob: string | null;
+  readonly version: string;
+}
+
+export interface ThreadMessageRow {
+  readonly message: string;
+  readonly seq: number;
+}
+
+interface LegacyThreadMessageRow extends ThreadMessageRow {
+  readonly active: number;
+}
+
+interface TableNameRow {
+  readonly name: string;
+}
+
+interface WriteHistoryRowsOptions {
+  readonly history: readonly unknown[];
+  readonly key: string;
+  readonly maxPayloadBytes: number;
+  readonly nextSeqStart: number;
+  readonly sql: SqlStorage;
+}
+
+const legacyThreadMessageTable = "pss_session_message";
+const legacyThreadMetaTable = "pss_session_meta";
+
+export function threadRowKey(prefix: string, threadKey: string): string {
+  return storeKey(prefix, "thread", threadKey);
+}
+
+export function legacyThreadRowKey(prefix: string, threadKey: string): string {
+  return storeKey(prefix, "session", threadKey);
+}
+
+export function ensureThreadSchema(sql: SqlStorage): void {
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS pss_thread_message (thread_key TEXT NOT NULL, seq INTEGER NOT NULL, active INTEGER NOT NULL DEFAULT 1, message TEXT NOT NULL, PRIMARY KEY (thread_key, seq))"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_thread_message_active ON pss_thread_message (thread_key, active, seq)"
+  );
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS pss_thread_meta (thread_key TEXT PRIMARY KEY, version TEXT NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
+  );
+}
+
+export function migrateLegacyThreadRows(
+  sql: SqlStorage,
+  prefix: string,
+  threadKey: string
+): void {
+  const key = threadRowKey(prefix, threadKey);
+  if (readThreadMeta(sql, key) || !legacyTablesExist(sql)) {
+    return;
+  }
+
+  const legacyKey = legacyThreadRowKey(prefix, threadKey);
+  const legacyMeta = readLegacyThreadMeta(sql, legacyKey);
+  if (!legacyMeta) {
+    return;
+  }
+
+  for (const row of readLegacyThreadMessages(sql, legacyKey)) {
+    sql.exec(
+      "INSERT INTO pss_thread_message (thread_key, seq, active, message) VALUES (?, ?, ?, ?)",
+      key,
+      row.seq,
+      row.active,
+      row.message
+    );
+  }
+  writeThreadMeta(sql, key, legacyMeta);
+  deleteLegacyThreadRows(sql, legacyKey);
+}
+
+export function readThreadMeta(
+  sql: SqlStorage,
+  key: string
+): ThreadMetaRow | null {
+  const row = sql
+    .exec<{
+      message_count: number;
+      next_seq: number;
+      state_blob: string | null;
+      version: number | string;
+    }>(
+      "SELECT version, message_count, next_seq, state_blob FROM pss_thread_meta WHERE thread_key = ?",
+      key
+    )
+    .toArray()[0];
+  return row ? { ...row, version: String(row.version) } : null;
+}
+
+export function readActiveThreadMessages(
+  sql: SqlStorage,
+  key: string
+): ThreadMessageRow[] {
+  return sql
+    .exec<ThreadMessageRow>(
+      "SELECT seq, message FROM pss_thread_message WHERE thread_key = ? AND active = 1 ORDER BY seq",
+      key
+    )
+    .toArray();
+}
+
+export function writeThreadHistoryRows(
+  options: WriteHistoryRowsOptions
+): number {
+  const { history, key, maxPayloadBytes, nextSeqStart, sql } = options;
+  const existing = readActiveThreadMessages(sql, key);
+  let prefix = 0;
+  while (
+    prefix < existing.length &&
+    prefix < history.length &&
+    existing[prefix].message === JSON.stringify(history[prefix])
+  ) {
+    prefix += 1;
+  }
+  const messages = history
+    .slice(prefix)
+    .map((message) =>
+      stringifyJsonPayloadWithinBudget(
+        "thread-message",
+        message,
+        maxPayloadBytes
+      )
+    );
+  if (prefix < existing.length) {
+    sql.exec(
+      "UPDATE pss_thread_message SET active = 0 WHERE thread_key = ? AND active = 1 AND seq >= ?",
+      key,
+      existing[prefix].seq
+    );
+  }
+  let seq = nextSeqStart;
+  for (const message of messages) {
+    sql.exec(
+      "INSERT INTO pss_thread_message (thread_key, seq, active, message) VALUES (?, ?, 1, ?)",
+      key,
+      seq,
+      message
+    );
+    seq += 1;
+  }
+  return seq;
+}
+
+export function softDeleteActiveThreadRows(sql: SqlStorage, key: string): void {
+  sql.exec(
+    "UPDATE pss_thread_message SET active = 0 WHERE thread_key = ? AND active = 1",
+    key
+  );
+}
+
+export function writeThreadMeta(
+  sql: SqlStorage,
+  key: string,
+  meta: ThreadMetaRow
+): void {
+  sql.exec(
+    "INSERT INTO pss_thread_meta (thread_key, version, message_count, next_seq, state_blob) VALUES (?, ?, ?, ?, ?) ON CONFLICT(thread_key) DO UPDATE SET version = excluded.version, message_count = excluded.message_count, next_seq = excluded.next_seq, state_blob = excluded.state_blob",
+    key,
+    meta.version,
+    meta.message_count,
+    meta.next_seq,
+    meta.state_blob
+  );
+}
+
+export function deleteThreadRows(
+  sql: SqlStorage,
+  key: string,
+  legacyKey: string
+): void {
+  sql.exec("DELETE FROM pss_thread_message WHERE thread_key = ?", key);
+  sql.exec("DELETE FROM pss_thread_meta WHERE thread_key = ?", key);
+  deleteLegacyThreadRows(sql, legacyKey);
+}
+
+function legacyTablesExist(sql: SqlStorage): boolean {
+  const rows = sql
+    .exec<TableNameRow>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?)",
+      legacyThreadMetaTable,
+      legacyThreadMessageTable
+    )
+    .toArray();
+  const names = new Set(rows.map((row) => row.name));
+  return (
+    names.has(legacyThreadMetaTable) && names.has(legacyThreadMessageTable)
+  );
+}
+
+function readLegacyThreadMeta(
+  sql: SqlStorage,
+  key: string
+): ThreadMetaRow | null {
+  const row = sql
+    .exec<{
+      message_count: number;
+      next_seq: number;
+      state_blob: string | null;
+      version: number | string;
+    }>(
+      "SELECT version, message_count, next_seq, state_blob FROM pss_session_meta WHERE session_key = ?",
+      key
+    )
+    .toArray()[0];
+  return row ? { ...row, version: String(row.version) } : null;
+}
+
+function readLegacyThreadMessages(
+  sql: SqlStorage,
+  key: string
+): LegacyThreadMessageRow[] {
+  return sql
+    .exec<LegacyThreadMessageRow>(
+      "SELECT seq, active, message FROM pss_session_message WHERE session_key = ? ORDER BY seq",
+      key
+    )
+    .toArray();
+}
+
+function deleteLegacyThreadRows(sql: SqlStorage, key: string): void {
+  if (!legacyTablesExist(sql)) {
+    return;
+  }
+  sql.exec("DELETE FROM pss_session_message WHERE session_key = ?", key);
+  sql.exec("DELETE FROM pss_session_meta WHERE session_key = ?", key);
+}

--- a/packages/runtime/src/cloudflare/storage/sqlite/thread-store.test-support.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/thread-store.test-support.ts
@@ -40,8 +40,8 @@ export function readRows(
 ): MessageRowProbe[] {
   return (storage.sql as InMemorySqlStorage)
     .exec<MessageRowProbe>(
-      "SELECT seq, active, message FROM pss_session_message WHERE session_key = ? ORDER BY seq",
-      storeKey(PREFIX, "session", threadKey)
+      "SELECT seq, active, message FROM pss_thread_message WHERE thread_key = ? ORDER BY seq",
+      storeKey(PREFIX, "thread", threadKey)
     )
     .toArray();
 }

--- a/packages/runtime/src/cloudflare/storage/sqlite/thread-store.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/thread-store.ts
@@ -7,24 +7,23 @@ import type {
 } from "../../../index";
 import type { SqlStorage } from "../../sql/ports/storage-port";
 import type { CloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
-import { storeKey } from "../execution/records";
 import {
   resolveStoragePayloadMaxBytes,
   type StoragePayloadBudgetOptions,
   stringifyJsonPayloadWithinBudget,
 } from "../payload-guard";
-
-interface MetaRow {
-  readonly message_count: number;
-  readonly next_seq: number;
-  readonly state_blob: string | null;
-  readonly version: string;
-}
-
-interface MessageRow {
-  readonly message: string;
-  readonly seq: number;
-}
+import {
+  deleteThreadRows,
+  ensureThreadSchema,
+  legacyThreadRowKey,
+  migrateLegacyThreadRows,
+  readActiveThreadMessages,
+  readThreadMeta,
+  softDeleteActiveThreadRows,
+  threadRowKey,
+  writeThreadHistoryRows,
+  writeThreadMeta,
+} from "./thread-store-sql";
 
 interface ThreadSnapshotV1 {
   readonly history: unknown[];
@@ -73,9 +72,10 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
     try {
       this.#ensureSchema();
       const key = this.#rowKey(threadKey);
+      migrateLegacyThreadRows(this.#sql, this.#prefix, threadKey);
 
       // --- begin synchronous read-modify-write critical section (no await) ---
-      const meta = this.#readMeta(key);
+      const meta = readThreadMeta(this.#sql, key);
       const currentVersion = meta ? meta.version : null;
       if (options.expectedVersion !== currentVersion) {
         return Promise.resolve({ ok: false, reason: "conflict" });
@@ -85,12 +85,14 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
       const nextSeqStart = meta?.next_seq ?? 0;
 
       if (isSnapshotV1(next.state)) {
-        const nextSeq = this.#writeHistoryRows(
+        const nextSeq = writeThreadHistoryRows({
+          history: next.state.history,
           key,
-          next.state.history,
-          nextSeqStart
-        );
-        this.#writeMeta(key, {
+          maxPayloadBytes: this.#maxPayloadBytes,
+          nextSeqStart,
+          sql: this.#sql,
+        });
+        writeThreadMeta(this.#sql, key, {
           message_count: next.state.history.length,
           next_seq: nextSeq,
           state_blob: null,
@@ -102,8 +104,8 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
           next.state ?? null,
           this.#maxPayloadBytes
         );
-        this.#softDeleteActiveRows(key);
-        this.#writeMeta(key, {
+        softDeleteActiveThreadRows(this.#sql, key);
+        writeThreadMeta(this.#sql, key, {
           message_count: 0,
           next_seq: nextSeqStart,
           state_blob: stateBlob,
@@ -120,20 +122,19 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
 
   delete(threadKey: string): Promise<void> {
     this.#ensureSchema();
+    migrateLegacyThreadRows(this.#sql, this.#prefix, threadKey);
     const key = this.#rowKey(threadKey);
-    this.#sql.exec(
-      "DELETE FROM pss_session_message WHERE session_key = ?",
-      key
-    );
-    this.#sql.exec("DELETE FROM pss_session_meta WHERE session_key = ?", key);
+    const legacyKey = this.#legacyRowKey(threadKey);
+    deleteThreadRows(this.#sql, key, legacyKey);
     return Promise.resolve();
   }
 
   load(threadKey: string): Promise<StoredThread | null> {
     this.#ensureSchema();
     const key = this.#rowKey(threadKey);
+    migrateLegacyThreadRows(this.#sql, this.#prefix, threadKey);
 
-    const meta = this.#readMeta(key);
+    const meta = readThreadMeta(this.#sql, key);
     if (!meta) {
       return Promise.resolve(null);
     }
@@ -142,120 +143,26 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
       const state: unknown = JSON.parse(meta.state_blob);
       return Promise.resolve({ state, version });
     }
-    const history: unknown[] = this.#readActiveMessages(key).map((row) =>
-      JSON.parse(row.message)
+    const history: unknown[] = readActiveThreadMessages(this.#sql, key).map(
+      (row) => JSON.parse(row.message)
     );
     return Promise.resolve({ state: { history, schemaVersion: 1 }, version });
   }
 
   #rowKey(threadKey: string): string {
-    return storeKey(this.#prefix, "session", threadKey);
+    return threadRowKey(this.#prefix, threadKey);
+  }
+
+  #legacyRowKey(threadKey: string): string {
+    return legacyThreadRowKey(this.#prefix, threadKey);
   }
 
   #ensureSchema(): void {
     if (this.#schemaReady) {
       return;
     }
-    this.#sql.exec(
-      "CREATE TABLE IF NOT EXISTS pss_session_message (session_key TEXT NOT NULL, seq INTEGER NOT NULL, active INTEGER NOT NULL DEFAULT 1, message TEXT NOT NULL, PRIMARY KEY (session_key, seq))"
-    );
-    this.#sql.exec(
-      "CREATE INDEX IF NOT EXISTS pss_session_message_active ON pss_session_message (session_key, active, seq)"
-    );
-    this.#sql.exec(
-      "CREATE TABLE IF NOT EXISTS pss_session_meta (session_key TEXT PRIMARY KEY, version TEXT NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
-    );
+    ensureThreadSchema(this.#sql);
     this.#schemaReady = true;
-  }
-
-  #readMeta(key: string): MetaRow | null {
-    const rows = this.#sql
-      .exec<{
-        message_count: number;
-        next_seq: number;
-        state_blob: string | null;
-        version: number | string;
-      }>(
-        "SELECT version, message_count, next_seq, state_blob FROM pss_session_meta WHERE session_key = ?",
-        key
-      )
-      .toArray();
-    const row = rows[0];
-    if (!row) {
-      return null;
-    }
-    return { ...row, version: String(row.version) };
-  }
-
-  #readActiveMessages(key: string): MessageRow[] {
-    return this.#sql
-      .exec<MessageRow>(
-        "SELECT seq, message FROM pss_session_message WHERE session_key = ? AND active = 1 ORDER BY seq",
-        key
-      )
-      .toArray();
-  }
-
-  #writeHistoryRows(
-    key: string,
-    history: readonly unknown[],
-    nextSeqStart: number
-  ): number {
-    const existing = this.#readActiveMessages(key);
-    let prefix = 0;
-    while (
-      prefix < existing.length &&
-      prefix < history.length &&
-      existing[prefix].message === JSON.stringify(history[prefix])
-    ) {
-      prefix += 1;
-    }
-    const messages = history
-      .slice(prefix)
-      .map((message) =>
-        stringifyJsonPayloadWithinBudget(
-          "thread-message",
-          message,
-          this.#maxPayloadBytes
-        )
-      );
-    if (prefix < existing.length) {
-      // History diverged or shrank (rollback): soft-delete the divergent tail.
-      this.#sql.exec(
-        "UPDATE pss_session_message SET active = 0 WHERE session_key = ? AND active = 1 AND seq >= ?",
-        key,
-        existing[prefix].seq
-      );
-    }
-    let seq = nextSeqStart;
-    for (const message of messages) {
-      this.#sql.exec(
-        "INSERT INTO pss_session_message (session_key, seq, active, message) VALUES (?, ?, 1, ?)",
-        key,
-        seq,
-        message
-      );
-      seq += 1;
-    }
-    return seq;
-  }
-
-  #softDeleteActiveRows(key: string): void {
-    this.#sql.exec(
-      "UPDATE pss_session_message SET active = 0 WHERE session_key = ? AND active = 1",
-      key
-    );
-  }
-
-  #writeMeta(key: string, meta: MetaRow): void {
-    this.#sql.exec(
-      "INSERT INTO pss_session_meta (session_key, version, message_count, next_seq, state_blob) VALUES (?, ?, ?, ?, ?) ON CONFLICT(session_key) DO UPDATE SET version = excluded.version, message_count = excluded.message_count, next_seq = excluded.next_seq, state_blob = excluded.state_blob",
-      key,
-      meta.version,
-      meta.message_count,
-      meta.next_seq,
-      meta.state_blob
-    );
   }
 }
 

--- a/scripts/cloudflare-example.test.mjs
+++ b/scripts/cloudflare-example.test.mjs
@@ -22,6 +22,9 @@ describe("cloudflare durable object adapter", () => {
     const threadStoreSource = readText(
       "packages/runtime/src/cloudflare/storage/sqlite/thread-store.ts"
     );
+    const threadStoreSqlSource = readText(
+      "packages/runtime/src/cloudflare/storage/sqlite/thread-store-sql.ts"
+    );
 
     expect(hostSource).not.toContain("createFakeCloudflareDurableObjectHost");
     expect(hostSource).toContain("createCloudflareDurableObjectHost");
@@ -32,7 +35,8 @@ describe("cloudflare durable object adapter", () => {
     expect(alarmWorkSource).toContain("agent.resume(");
     expect(alarmWorkSource).toContain("ackScheduledCloudflareRun");
     expect(alarmDrainerSource).toContain("rescheduleCloudflareAlarm");
-    expect(threadStoreSource).toContain("pss_session_meta");
+    expect(threadStoreSource).toContain("DurableObjectSqliteThreadStore");
+    expect(threadStoreSqlSource).toContain("pss_thread_meta");
   });
 
   it("drives Cloudflare scheduled runs and thread prompts through stored alarms", async () => {


### PR DESCRIPTION
## Summary

- rename the Cloudflare SQLite thread history tables to `pss_thread_meta` and `pss_thread_message`
- migrate legacy `pss_session_*` rows into the new thread tables on first access
- store `RunRecord` data in a `pss_run` SQLite table instead of Durable Object KV records and KV arrays
- keep legacy KV run migration for existing records

## Validation

- `pnpm lint`
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm build`
- `pnpm verify:release`

## Release

Includes a patch changeset for `@minpeter/pss-runtime` on the `v0.1` next release lane.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores runtime thread history and run records in SQLite for better indexing and simpler storage. Introduces `pss_thread_*` and `pss_run` tables with automatic migration from legacy `pss_session_*` and KV data.

- **New Features**
  - Threads: `pss_thread_meta` and `pss_thread_message` with soft-deletes on divergent history.
  - Runs: `pss_run` table with unique `(prefix, dedupe_key)` and parent-run indices; fetch by runId, dedupeKey, and parentRunId.
  - SQL path writes and reads runs directly from SQLite; KV indexing is skipped. In-memory SQL harness and tests updated.

- **Migration**
  - Legacy `pss_session_*` rows migrate to `pss_thread_*` on first access; old rows are removed.
  - Legacy KV run records migrate into `pss_run` on read/write; KV copies are cleaned up automatically.

<sup>Written for commit df8e53e6afbec82100eaac490bdf85152985562c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

