### PR TITLE
Store Cloudflare notifications in SQLite rows

### DIFF
--- a/.changeset/runtime-sqlite-notifications.md
+++ b/.changeset/runtime-sqlite-notifications.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Store Cloudflare Durable Object notification records in SQLite rows with legacy KV read-through, and make runtime checkpoint ids include run, version, and phase metadata.

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/notification-write.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/notification-write.ts
@@ -1,0 +1,48 @@
+import {
+  nullableStringBinding,
+  numberBinding,
+  stringBinding,
+} from "./bindings";
+import type { InMemoryDurableObjectSqlState, NotificationRow } from "./state";
+
+export function writeNotificationStatement(
+  state: InMemoryDurableObjectSqlState,
+  query: string,
+  bindings: readonly unknown[]
+): boolean {
+  if (query.startsWith("insert into pss_notification")) {
+    upsertNotification(state, bindings);
+    return true;
+  }
+  return false;
+}
+
+function upsertNotification(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const row = createNotificationRow(bindings);
+  state.notifications = state.notifications.filter(
+    (existing) =>
+      !(
+        existing.prefix === row.prefix &&
+        existing.idempotency_key === row.idempotency_key
+      )
+  );
+  state.notifications.push(row);
+}
+
+function createNotificationRow(bindings: readonly unknown[]): NotificationRow {
+  return {
+    created_at: numberBinding(bindings[8]),
+    idempotency_key: stringBinding(bindings[1]),
+    notification_id: stringBinding(bindings[3]),
+    owner_namespace: nullableStringBinding(bindings[6]),
+    prefix: stringBinding(bindings[0]),
+    record: stringBinding(bindings[2]),
+    run_id: stringBinding(bindings[4]),
+    status: stringBinding(bindings[7]),
+    thread_key: stringBinding(bindings[5]),
+    updated_at: numberBinding(bindings[9]),
+  };
+}

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/select.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/select.ts
@@ -3,6 +3,7 @@ import type {
   CheckpointRow,
   EventRow,
   InMemoryDurableObjectSqlState,
+  NotificationRow,
   RunRow,
   ScheduledWorkRow,
   ThreadMessageRow,
@@ -31,6 +32,9 @@ export function selectSqlRows(
   }
   if (query.includes("from pss_run")) {
     return selectRunRows(state, query, bindings);
+  }
+  if (query.includes("from pss_notification")) {
+    return selectNotificationRows(state, query, bindings);
   }
   if (query.includes("from pss_event_meta")) {
     return selectEventMetaRows(state, bindings);
@@ -121,6 +125,24 @@ function selectRunRows(
       .map(projectRun);
   }
   throw new Error(`Unsupported in-memory run SQL query: ${query}`);
+}
+
+function selectNotificationRows(
+  state: InMemoryDurableObjectSqlState,
+  query: string,
+  bindings: readonly unknown[]
+): unknown[] {
+  const prefix = stringBinding(bindings[0]);
+  if (query.includes("idempotency_key = ?")) {
+    const idempotencyKey = stringBinding(bindings[1]);
+    return state.notifications
+      .filter(
+        (row) => row.prefix === prefix && row.idempotency_key === idempotencyKey
+      )
+      .map(projectNotification)
+      .slice(0, 1);
+  }
+  throw new Error(`Unsupported in-memory notification SQL query: ${query}`);
 }
 
 function selectEventMetaRows(
@@ -232,5 +254,9 @@ function projectThreadMessage(row: ThreadMessageRow, query: string): unknown {
 }
 
 function projectRun(row: RunRow): unknown {
+  return { record: row.record };
+}
+
+function projectNotification(row: NotificationRow): unknown {
   return { record: row.record };
 }

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/state.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/state.ts
@@ -27,6 +27,19 @@ export interface RunRow {
   readonly updated_at: number;
 }
 
+export interface NotificationRow {
+  readonly created_at: number;
+  readonly idempotency_key: string;
+  readonly notification_id: string;
+  readonly owner_namespace: string | null;
+  readonly prefix: string;
+  readonly record: string;
+  readonly run_id: string;
+  readonly status: string;
+  readonly thread_key: string;
+  readonly updated_at: number;
+}
+
 export interface EventMetaRow {
   readonly next_seq: number;
   readonly run_key: string;
@@ -56,6 +69,7 @@ export interface InMemoryDurableObjectSqlState {
   checkpoints: CheckpointRow[];
   eventMeta: Map<string, EventMetaRow>;
   events: EventRow[];
+  notifications: NotificationRow[];
   runs: RunRow[];
   scheduledWork: ScheduledWorkRow[];
   threadMessages: ThreadMessageRow[];
@@ -67,6 +81,7 @@ export function createInMemoryDurableObjectSqlState(): InMemoryDurableObjectSqlS
     checkpoints: [],
     eventMeta: new Map(),
     events: [],
+    notifications: [],
     runs: [],
     scheduledWork: [],
     threadMessages: [],
@@ -83,6 +98,7 @@ export function cloneInMemoryDurableObjectSqlState(
       [...state.eventMeta].map(([key, value]) => [key, structuredClone(value)])
     ),
     events: structuredClone(state.events),
+    notifications: structuredClone(state.notifications),
     runs: structuredClone(state.runs),
     scheduledWork: structuredClone(state.scheduledWork),
     threadMessages: structuredClone(state.threadMessages),

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
@@ -3,6 +3,7 @@ import {
   numberBinding,
   stringBinding,
 } from "./bindings";
+import { writeNotificationStatement } from "./notification-write";
 import { writeRunStatement } from "./run-write";
 import type { InMemoryDurableObjectSqlState, ThreadMetaRow } from "./state";
 
@@ -16,6 +17,9 @@ export function writeSqlStatement(
     return;
   }
   if (writeRunStatement(state, query, bindings)) {
+    return;
+  }
+  if (writeNotificationStatement(state, query, bindings)) {
     return;
   }
   if (query.startsWith("insert into pss_event_meta")) {

--- a/packages/runtime/src/cloudflare/storage/execution/notification-records.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/notification-records.ts
@@ -1,0 +1,123 @@
+import type { NotificationRecord } from "../../../execution";
+import type { SqlStorage } from "../../sql/ports/storage-port";
+import type { CloudflareDurableObjectTransactionStorage } from "../durable-object/durable-object-storage";
+import {
+  assertJsonPayloadWithinBudget,
+  resolveStoragePayloadMaxBytes,
+  type StoragePayloadBudgetOptions,
+} from "../payload-guard";
+import { storeKey } from "./records";
+
+interface NotificationRow {
+  readonly record: string;
+}
+
+export async function getNotification(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  idempotencyKey: string
+): Promise<NotificationRecord | null> {
+  const sql = sqlStorage(storage);
+  if (sql) {
+    const row = selectNotificationRow(sql, prefix, idempotencyKey);
+    if (row) {
+      return parseNotificationRecord(row);
+    }
+  }
+
+  const legacy =
+    (await storage.get<NotificationRecord>(
+      storeKey(prefix, "notification", idempotencyKey)
+    )) ?? null;
+  if (legacy && sql) {
+    await putNotification(storage, prefix, legacy);
+  }
+  return legacy;
+}
+
+export async function putNotification(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  record: NotificationRecord,
+  options: StoragePayloadBudgetOptions = {}
+): Promise<void> {
+  assertJsonPayloadWithinBudget(
+    "notification-record",
+    record,
+    resolveStoragePayloadMaxBytes(options)
+  );
+  const sql = sqlStorage(storage);
+  const key = storeKey(prefix, "notification", record.idempotencyKey);
+  if (sql) {
+    putSqlNotification(sql, prefix, record);
+    await storage.delete(key);
+    return;
+  }
+  await storage.put(key, record);
+}
+
+function selectNotificationRow(
+  sql: SqlStorage,
+  prefix: string,
+  idempotencyKey: string
+): NotificationRow | undefined {
+  ensureNotificationSchema(sql);
+  return sql
+    .exec<NotificationRow>(
+      "SELECT record FROM pss_notification WHERE prefix = ? AND idempotency_key = ? LIMIT 1",
+      prefix,
+      idempotencyKey
+    )
+    .toArray()[0];
+}
+
+function parseNotificationRecord(row: NotificationRow): NotificationRecord {
+  return JSON.parse(row.record) as NotificationRecord;
+}
+
+function sqlStorage(
+  storage: CloudflareDurableObjectTransactionStorage
+): SqlStorage | undefined {
+  const sql = storage.sql;
+  return isSqlStorage(sql) ? sql : undefined;
+}
+
+function isSqlStorage(value: unknown): value is SqlStorage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "exec" in value &&
+    typeof value.exec === "function"
+  );
+}
+
+function ensureNotificationSchema(sql: SqlStorage): void {
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS pss_notification (prefix TEXT NOT NULL, idempotency_key TEXT NOT NULL, record TEXT NOT NULL, notification_id TEXT NOT NULL, run_id TEXT NOT NULL, thread_key TEXT NOT NULL, owner_namespace TEXT, status TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, PRIMARY KEY (prefix, idempotency_key))"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_notification_status ON pss_notification (prefix, status, created_at)"
+  );
+}
+
+function putSqlNotification(
+  sql: SqlStorage,
+  prefix: string,
+  record: NotificationRecord
+): void {
+  ensureNotificationSchema(sql);
+  const nowMs = Date.now();
+  sql.exec(
+    "INSERT INTO pss_notification (prefix, idempotency_key, record, notification_id, run_id, thread_key, owner_namespace, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(prefix, idempotency_key) DO UPDATE SET record = excluded.record, notification_id = excluded.notification_id, run_id = excluded.run_id, thread_key = excluded.thread_key, owner_namespace = excluded.owner_namespace, status = excluded.status, updated_at = excluded.updated_at",
+    prefix,
+    record.idempotencyKey,
+    JSON.stringify(record),
+    record.notificationId,
+    record.runId,
+    record.threadKey,
+    record.ownerNamespace ?? null,
+    record.status,
+    nowMs,
+    nowMs
+  );
+}

--- a/packages/runtime/src/cloudflare/storage/execution/notification-store.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/notification-store.ts
@@ -9,7 +9,8 @@ import {
   resolveStoragePayloadMaxBytes,
   type StoragePayloadBudgetOptions,
 } from "../payload-guard";
-import { getNotification, putNotification, withTransaction } from "./records";
+import { getNotification, putNotification } from "./notification-records";
+import { withTransaction } from "./records";
 
 export class DurableObjectNotificationInbox implements NotificationInbox {
   readonly #maxPayloadBytes: number;

--- a/packages/runtime/src/cloudflare/storage/execution/records.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/records.ts
@@ -1,13 +1,7 @@
-import type { NotificationRecord } from "../../../execution";
 import type {
   CloudflareDurableObjectStorage,
   CloudflareDurableObjectTransactionStorage,
 } from "../durable-object/durable-object-storage";
-import {
-  assertJsonPayloadWithinBudget,
-  resolveStoragePayloadMaxBytes,
-  type StoragePayloadBudgetOptions,
-} from "../payload-guard";
 
 export async function withTransaction<T>(
   storage: CloudflareDurableObjectStorage,
@@ -16,35 +10,6 @@ export async function withTransaction<T>(
   return storage.transaction
     ? await storage.transaction(fn)
     : await fn(storage);
-}
-
-export async function getNotification(
-  storage: CloudflareDurableObjectTransactionStorage,
-  prefix: string,
-  idempotencyKey: string
-): Promise<NotificationRecord | null> {
-  return (
-    (await storage.get<NotificationRecord>(
-      storeKey(prefix, "notification", idempotencyKey)
-    )) ?? null
-  );
-}
-
-export async function putNotification(
-  storage: CloudflareDurableObjectTransactionStorage,
-  prefix: string,
-  record: NotificationRecord,
-  options: StoragePayloadBudgetOptions = {}
-): Promise<void> {
-  assertJsonPayloadWithinBudget(
-    "notification-record",
-    record,
-    resolveStoragePayloadMaxBytes(options)
-  );
-  await storage.put(
-    storeKey(prefix, "notification", record.idempotencyKey),
-    record
-  );
 }
 
 export async function readList<T>(

--- a/packages/runtime/src/cloudflare/storage/execution/store-contract.test.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/store-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { describeExecutionStoreContract } from "../../../contracts/execution-store/contract";
-import type { RunRecord } from "../../../execution";
+import type { NotificationRecord, RunRecord } from "../../../execution";
 import { InMemorySqlStorage } from "../../sql/node-test/node-sqlite-storage";
 import { InMemoryCloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
 import { storeKey } from "./records";
@@ -104,6 +104,73 @@ describe("DurableObjectExecutionStore payload guards", () => {
       record,
     ]);
   });
+
+  it("stores notification records in SQLite rows instead of Durable Object KV values", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage({
+      sql: new InMemorySqlStorage(),
+    });
+    const store = new DurableObjectExecutionStore({
+      prefix: "notification-sql-test",
+      storage,
+    });
+    const record = notificationRecord("notify-sql");
+
+    await expect(store.notifications.enqueue(record)).resolves.toEqual({
+      ok: true,
+    });
+
+    const rows = (storage.sql as InMemorySqlStorage)
+      .exec<{ readonly record: string }>(
+        "SELECT record FROM pss_notification WHERE prefix = ? AND idempotency_key = ?",
+        "notification-sql-test",
+        "notify-sql"
+      )
+      .toArray();
+    expect(rows.map((row) => JSON.parse(row.record))).toEqual([record]);
+    await expect(
+      storage.get(
+        storeKey("notification-sql-test", "notification", "notify-sql")
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("migrates legacy notification KV records to SQLite rows when claimed by idempotency key", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage({
+      sql: new InMemorySqlStorage(),
+    });
+    const store = new DurableObjectExecutionStore({
+      prefix: "notification-migration-test",
+      storage,
+    });
+    const legacy = notificationRecord("notify-legacy");
+    await storage.put(
+      storeKey("notification-migration-test", "notification", "notify-legacy"),
+      legacy
+    );
+
+    await expect(
+      store.notifications.claimByIdempotencyKey("notify-legacy")
+    ).resolves.toEqual({
+      ok: true,
+      record: { ...legacy, status: "acked" },
+    });
+
+    const rows = (storage.sql as InMemorySqlStorage)
+      .exec<{ readonly record: string }>(
+        "SELECT record FROM pss_notification WHERE prefix = ? AND idempotency_key = ?",
+        "notification-migration-test",
+        "notify-legacy"
+      )
+      .toArray();
+    expect(rows.map((row) => JSON.parse(row.record))).toEqual([
+      { ...legacy, status: "acked" },
+    ]);
+    await expect(
+      storage.get(
+        storeKey("notification-migration-test", "notification", "notify-legacy")
+      )
+    ).resolves.toBeUndefined();
+  });
 });
 
 function createBudgetedStore(
@@ -127,6 +194,21 @@ function runRecord(
     runId,
     threadKey: "thread-1",
     status: "queued",
+    ...overrides,
+  };
+}
+
+function notificationRecord(
+  idempotencyKey: string,
+  overrides: Partial<NotificationRecord> = {}
+): NotificationRecord {
+  return {
+    idempotencyKey,
+    input: { text: "wake up", type: "user-text" },
+    notificationId: "notification-1",
+    runId: "run-1",
+    threadKey: "thread-1",
+    status: "pending",
     ...overrides,
   };
 }

--- a/packages/runtime/src/execution/host/checkpoint-ids.test.ts
+++ b/packages/runtime/src/execution/host/checkpoint-ids.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { createRunCheckpointId } from "./checkpoint-ids";
+
+const checkpointIdPattern =
+  /^run-checkpoint:turn%3Aagent%2Fthread%3Aabc:3:before-tool:/;
+
+describe("createRunCheckpointId", () => {
+  it("includes the run id, version, and checkpoint phase", () => {
+    const checkpointId = createRunCheckpointId({
+      phase: "before-tool",
+      runId: "turn:agent/thread:abc",
+      version: 3,
+    });
+
+    expect(checkpointId).toMatch(checkpointIdPattern);
+  });
+});

--- a/packages/runtime/src/execution/host/checkpoint-ids.ts
+++ b/packages/runtime/src/execution/host/checkpoint-ids.ts
@@ -1,0 +1,17 @@
+import type { CheckpointPhase } from "./types";
+
+export function createRunCheckpointId({
+  phase,
+  runId,
+  version,
+}: {
+  readonly phase: CheckpointPhase;
+  readonly runId: string;
+  readonly version: number;
+}): string {
+  return `run-checkpoint:${encodeCheckpointIdPart(runId)}:${version}:${phase}:${crypto.randomUUID()}`;
+}
+
+function encodeCheckpointIdPart(value: string): string {
+  return encodeURIComponent(value);
+}

--- a/packages/runtime/src/execution/resume/checkpoints.ts
+++ b/packages/runtime/src/execution/resume/checkpoints.ts
@@ -1,5 +1,6 @@
 import type { RuntimeToolExecutionCheckpointMetadata } from "../../llm/llm";
 import { ToolExecutionNeedsRecoveryError } from "../../llm/tool-execution";
+import { createRunCheckpointId } from "../host/checkpoint-ids";
 import type {
   CheckpointPhase,
   ExecutionHost,
@@ -107,7 +108,7 @@ export async function appendCheckpoint({
     const version = run.checkpointVersion + 1;
     const result = await host.store.checkpoints.append(
       {
-        checkpointId: crypto.randomUUID(),
+        checkpointId: createRunCheckpointId({ phase, runId, version }),
         ...(pendingToolCall === undefined ? {} : { pendingToolCall }),
         phase,
         runId,

--- a/packages/runtime/src/thread/runtime/execution-checkpoints.ts
+++ b/packages/runtime/src/thread/runtime/execution-checkpoints.ts
@@ -1,0 +1,113 @@
+import { createRunCheckpointId } from "../../execution/host/checkpoint-ids";
+import type {
+  CheckpointPhase,
+  ExecutionHost,
+} from "../../execution/host/types";
+import type {
+  RuntimeToolExecutionCheckpoint,
+  RuntimeToolExecutionContext,
+} from "../../llm/llm";
+import { persistedToolExecutionCheckpoint } from "../../llm/tool-execution";
+import type { ThreadState } from "../state/thread-state";
+
+const maxCheckpointWriteAttempts = 5;
+
+export class ThreadExecutionCheckpointError extends Error {
+  constructor(runId: string, expectedVersion: number, currentVersion: number) {
+    super(
+      `Thread execution run ${runId} checkpoint conflict: expected ${expectedVersion}, got ${currentVersion}`
+    );
+    this.name = "ThreadExecutionCheckpointError";
+  }
+}
+
+export function createThreadToolExecutionContext({
+  executionHost,
+  runId,
+  state,
+}: {
+  readonly executionHost: ExecutionHost;
+  readonly runId: string;
+  readonly state: ThreadState;
+}): RuntimeToolExecutionContext {
+  return {
+    attempt: 1,
+    afterTool: (checkpoint) =>
+      appendThreadToolExecutionCheckpoint({
+        executionHost,
+        phase: "after-tool",
+        runId,
+        state,
+        toolCall: checkpoint,
+      }),
+    beforeTool: async (checkpoint) => {
+      await appendThreadToolExecutionCheckpoint({
+        executionHost,
+        phase: "before-tool",
+        runId,
+        state,
+        toolCall: checkpoint,
+      });
+      return;
+    },
+    runId,
+  };
+}
+
+async function appendThreadToolExecutionCheckpoint({
+  executionHost,
+  phase,
+  runId,
+  state,
+  toolCall,
+}: {
+  readonly executionHost: ExecutionHost;
+  readonly phase: Extract<CheckpointPhase, "after-tool" | "before-tool">;
+  readonly runId: string;
+  readonly state: ThreadState;
+  readonly toolCall: RuntimeToolExecutionCheckpoint & {
+    readonly output?: unknown;
+  };
+}): Promise<void> {
+  let lastConflict:
+    | { readonly current: number; readonly expected: number }
+    | undefined;
+  for (let attempt = 0; attempt < maxCheckpointWriteAttempts; attempt += 1) {
+    const run = await executionHost.store.runs.get(runId);
+    if (!run) {
+      throw new Error(`Thread execution run ${runId} is missing.`);
+    }
+
+    const version = run.checkpointVersion + 1;
+    const result = await executionHost.store.checkpoints.append(
+      {
+        checkpointId: createRunCheckpointId({ phase, runId, version }),
+        pendingToolCall: persistedToolExecutionCheckpoint(toolCall),
+        phase,
+        runId,
+        runtimeState: {
+          toolCallId: toolCall.toolCallId,
+          toolName: toolCall.toolName,
+        },
+        threadSnapshot: state.threadCheckpointReference(),
+        version,
+      },
+      { expectedVersion: run.checkpointVersion }
+    );
+
+    if (result.ok) {
+      return;
+    }
+
+    lastConflict = {
+      current: result.currentVersion,
+      expected: run.checkpointVersion,
+    };
+  }
+
+  throw new ThreadExecutionCheckpointError(
+    runId,
+    lastConflict?.expected ?? 0,
+    lastConflict?.current ?? 0
+  );
+}

--- a/packages/runtime/src/thread/runtime/execution.ts
+++ b/packages/runtime/src/thread/runtime/execution.ts
@@ -1,17 +1,11 @@
 import type {
-  CheckpointPhase,
   ExecutionHost,
   RunRecord,
   RunStatus,
 } from "../../execution/host/types";
-import type {
-  RuntimeToolExecutionCheckpoint,
-  RuntimeToolExecutionContext,
-} from "../../llm/llm";
-import { persistedToolExecutionCheckpoint } from "../../llm/tool-execution";
+import type { RuntimeToolExecutionContext } from "../../llm/llm";
 import type { ThreadState } from "../state/thread-state";
-
-const maxCheckpointWriteAttempts = 5;
+import { createThreadToolExecutionContext } from "./execution-checkpoints";
 
 export interface ThreadExecutionOptions {
   readonly executionHost?: ExecutionHost;
@@ -27,15 +21,6 @@ export type ThreadExecutionTerminalStatus = Extract<
   RunStatus,
   "cancelled" | "completed" | "error" | "needs-recovery"
 >;
-
-export class ThreadExecutionCheckpointError extends Error {
-  constructor(runId: string, expectedVersion: number, currentVersion: number) {
-    super(
-      `Thread execution run ${runId} checkpoint conflict: expected ${expectedVersion}, got ${currentVersion}`
-    );
-    this.name = "ThreadExecutionCheckpointError";
-  }
-}
 
 export async function startThreadExecutionRun({
   executionHost,
@@ -68,86 +53,12 @@ export async function startThreadExecutionRun({
     complete: (status) =>
       completeThreadExecutionRun({ executionHost, runId, status }),
     runId,
-    toolExecution: {
-      attempt: 1,
-      afterTool: (checkpoint) =>
-        appendToolExecutionCheckpoint({
-          executionHost,
-          phase: "after-tool",
-          runId,
-          state,
-          toolCall: checkpoint,
-        }),
-      beforeTool: async (checkpoint) => {
-        await appendToolExecutionCheckpoint({
-          executionHost,
-          phase: "before-tool",
-          runId,
-          state,
-          toolCall: checkpoint,
-        });
-        return;
-      },
+    toolExecution: createThreadToolExecutionContext({
+      executionHost,
       runId,
-    },
+      state,
+    }),
   };
-}
-
-async function appendToolExecutionCheckpoint({
-  executionHost,
-  phase,
-  runId,
-  state,
-  toolCall,
-}: {
-  readonly executionHost: ExecutionHost;
-  readonly phase: Extract<CheckpointPhase, "after-tool" | "before-tool">;
-  readonly runId: string;
-  readonly state: ThreadState;
-  readonly toolCall: RuntimeToolExecutionCheckpoint & {
-    readonly output?: unknown;
-  };
-}): Promise<void> {
-  let lastConflict:
-    | { readonly current: number; readonly expected: number }
-    | undefined;
-  for (let attempt = 0; attempt < maxCheckpointWriteAttempts; attempt += 1) {
-    const run = await executionHost.store.runs.get(runId);
-    if (!run) {
-      throw new Error(`Thread execution run ${runId} is missing.`);
-    }
-
-    const result = await executionHost.store.checkpoints.append(
-      {
-        checkpointId: crypto.randomUUID(),
-        pendingToolCall: persistedToolExecutionCheckpoint(toolCall),
-        phase,
-        runId,
-        runtimeState: {
-          toolCallId: toolCall.toolCallId,
-          toolName: toolCall.toolName,
-        },
-        threadSnapshot: state.threadCheckpointReference(),
-        version: run.checkpointVersion + 1,
-      },
-      { expectedVersion: run.checkpointVersion }
-    );
-
-    if (result.ok) {
-      return;
-    }
-
-    lastConflict = {
-      current: result.currentVersion,
-      expected: run.checkpointVersion,
-    };
-  }
-
-  throw new ThreadExecutionCheckpointError(
-    runId,
-    lastConflict?.expected ?? 0,
-    lastConflict?.current ?? 0
-  );
 }
 
 async function completeThreadExecutionRun({


### PR DESCRIPTION
## Summary\n- Store Cloudflare Durable Object notification records in SQLite rows with legacy KV read-through migration\n- Remove old notification KV helper path from execution records\n- Add checkpoint id metadata and split thread tool checkpoint writing into a dedicated module\n\n## Verification\n- pnpm --filter @minpeter/pss-runtime lint\n- pnpm --filter @minpeter/pss-runtime typecheck\n- pnpm --filter @minpeter/pss-runtime test -- src/cloudflare/storage/execution/store-contract.test.ts src/execution/host/checkpoint-ids.test.ts src/agent/loop/resume-checkpoint.test.ts src/testing/tool-checkpointing-agent.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Durable Object notification storage to SQLite rows with automatic read-through migration from legacy KV. Also adds richer checkpoint IDs (run, version, phase) and extracts thread checkpoint writing into a dedicated module.

- **New Features**
  - Store notifications in SQLite table `pss_notification` (keyed by `prefix` + `idempotency_key`) with automatic migration from legacy KV on first claim.
  - Generate checkpoint IDs via `createRunCheckpointId` to include run, version, and phase for better traceability.

- **Refactors**
  - Moved thread tool checkpoint write logic to `thread/runtime/execution-checkpoints.ts` and removed the old KV helper path.

<sup>Written for commit ae58a13cd90c5eedbd4a6fbd5daa9536be2c2f73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

