### PR TITLE
Harden runtime storage integrity

### DIFF
--- a/.changeset/runtime-storage-integrity.md
+++ b/.changeset/runtime-storage-integrity.md
@@ -1,0 +1,16 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Harden Cloudflare Durable Object storage for production agent threads.
+
+- Make `RunStore.create()` insert-only and return typed duplicate results so
+  notification idempotency races do not overwrite canonical runs.
+- Stop retrying scheduled non-notification runs forever when the runtime cannot
+  resume them.
+- Store lower-level resume checkpoints as bounded thread references instead of
+  full history snapshots.
+- Normalize scheduled work rows with `thread_key` and `run_id` indexes for
+  exact cleanup.
+- Add append-delta writes and chunked oversized thread-message payloads for the
+  SQLite thread store.

--- a/packages/runtime/src/agent/loop/resume-checkpoint.test.ts
+++ b/packages/runtime/src/agent/loop/resume-checkpoint.test.ts
@@ -124,4 +124,37 @@ describe("resumeRun checkpoint recovery", () => {
     ).rejects.toBeInstanceOf(ToolExecutionNeedsRecoveryError);
     expect(model.model.doGenerateCalls).toHaveLength(0);
   });
+
+  it("stores bounded checkpoint metadata instead of full resume history", async () => {
+    const { checkpoints, host } = createCheckpointSpyHost();
+    const history: ModelMessage[] = [
+      userTextToModelMessage(userText("queued")),
+    ];
+    const model = createScriptedModelOptions([[assistantMessage("done")]]);
+
+    await host.store.runs.create(createQueuedUserTurnRun());
+
+    await expect(
+      resumeRun({
+        budget: { maxSteps: 1 },
+        host,
+        loadState: () => Promise.resolve({ history }),
+        model,
+        runId: "run-1",
+        saveState: (state) => {
+          history.length = 0;
+          history.push(...state.history);
+          return Promise.resolve();
+        },
+      })
+    ).resolves.toEqual({ status: "completed", steps: 1 });
+
+    expect(history).toHaveLength(2);
+    expect(
+      checkpoints.map((checkpoint) => checkpoint.threadSnapshot)
+    ).toEqual([
+      { kind: "resume-state-ref", messageCount: 1 },
+      { kind: "resume-state-ref", messageCount: 2 },
+    ]);
+  });
 });

--- a/packages/runtime/src/cloudflare/alarm/drainer.test.ts
+++ b/packages/runtime/src/cloudflare/alarm/drainer.test.ts
@@ -178,6 +178,26 @@ describe("Cloudflare alarm drain budgets", () => {
       "run-unclaimable",
     ]);
   });
+
+  it("acks scheduled non-notification runs when resume returns null", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage({
+      sql: new InMemorySqlStorage(),
+    });
+    const host = createCloudflareDurableObjectHost({ storage });
+
+    await enqueueStoredRun(host, "run-user-turn", "user-turn");
+
+    const summary = await drainCloudflareAlarm({
+      agent: { resume: () => Promise.resolve(null) },
+      prefix: "pss-runtime",
+      storage,
+    });
+
+    expect(summary.failedRuns).toEqual([]);
+    expect(summary.remainingRuns).toBe(0);
+    expect(summary.continuationScheduled).toBe(false);
+    await expect(listScheduledCloudflareRuns(storage)).resolves.toEqual([]);
+  });
 });
 
 function agentWithEvents(events: readonly AgentEvent[]): CloudflareAlarmAgent {
@@ -188,11 +208,12 @@ function agentWithEvents(events: readonly AgentEvent[]): CloudflareAlarmAgent {
 
 async function enqueueStoredRun(
   host: ReturnType<typeof createCloudflareDurableObjectHost>,
-  runId: string
+  runId: string,
+  kind: "notification" | "user-turn" = "notification"
 ): Promise<void> {
   await host.store.runs.create({
     checkpointVersion: 0,
-    kind: "notification",
+    kind,
     rootRunId: runId,
     runId,
     threadKey: "thread:test",

--- a/packages/runtime/src/cloudflare/alarm/scheduled-work-context.ts
+++ b/packages/runtime/src/cloudflare/alarm/scheduled-work-context.ts
@@ -50,7 +50,7 @@ export async function shouldRetryScheduledRun(
     prefix,
     storage,
   }).store.runs.get(runId);
-  return run ? isRetryableRunStatus(run.status) : false;
+  return run?.kind === "notification" && isRetryableRunStatus(run.status);
 }
 
 export async function shouldRetryScheduledThreadPrompt(

--- a/packages/runtime/src/cloudflare/host/durable-object-host.test.ts
+++ b/packages/runtime/src/cloudflare/host/durable-object-host.test.ts
@@ -27,6 +27,8 @@ const unclaimableAgent = {
 interface ScheduledWorkProbeRow {
   readonly kind: string;
   readonly payload: string;
+  readonly run_id: string | null;
+  readonly thread_key: string | null;
   readonly work_id: string;
 }
 
@@ -65,6 +67,22 @@ describe("Cloudflare Durable Object host adapter", () => {
     });
 
     expect(readScheduledWorkRows(storage)).toHaveLength(2);
+    expect(readScheduledWorkRows(storage)).toEqual([
+      {
+        kind: "run",
+        payload: JSON.stringify(runId),
+        run_id: runId,
+        thread_key: null,
+        work_id: runId,
+      },
+      {
+        kind: "thread-prompt",
+        payload: JSON.stringify(prompt),
+        run_id: notificationRunId,
+        thread_key: "example",
+        work_id: ["example", idempotencyKey, notificationRunId].join("\u0000"),
+      },
+    ]);
     await expect(listScheduledCloudflareRuns(storage)).resolves.toEqual([
       runId,
     ]);
@@ -305,7 +323,7 @@ function readScheduledWorkRows(
 ): ScheduledWorkProbeRow[] {
   return (storage.sql as InMemorySqlStorage)
     .exec<ScheduledWorkProbeRow>(
-      "SELECT kind, work_id, payload FROM pss_scheduled_work WHERE prefix = ? ORDER BY kind, created_at, work_id",
+      "SELECT kind, work_id, payload, thread_key, run_id FROM pss_scheduled_work WHERE prefix = ? ORDER BY kind, created_at, work_id",
       "pss-runtime"
     )
     .toArray();

--- a/packages/runtime/src/cloudflare/host/scheduled-work-queue.ts
+++ b/packages/runtime/src/cloudflare/host/scheduled-work-queue.ts
@@ -21,7 +21,14 @@ type ScheduledWorkKind = "run" | "thread-prompt";
 
 interface ScheduledWorkRow {
   readonly payload: string;
+  readonly run_id?: string | null;
+  readonly thread_key?: string | null;
   readonly work_id: string;
+}
+
+interface ScheduledWorkIndexes {
+  readonly runId?: string;
+  readonly threadKey?: string;
 }
 
 export async function appendScheduledRun(
@@ -31,7 +38,9 @@ export async function appendScheduledRun(
 ): Promise<void> {
   await withTransaction(storage, (tx) => {
     const sql = requiredScheduledWorkSql(tx);
-    insertScheduledWork(sql, prefix, "run", runScheduledWorkId(runId), runId);
+    insertScheduledWork(sql, prefix, "run", runScheduledWorkId(runId), runId, {
+      runId,
+    });
     return Promise.resolve();
   });
 }
@@ -48,7 +57,11 @@ export async function appendScheduledThreadPrompt(
       prefix,
       "thread-prompt",
       threadPromptScheduledWorkId(prompt),
-      prompt
+      prompt,
+      {
+        runId: prompt.runId,
+        threadKey: prompt.threadKey,
+      }
     );
     return Promise.resolve();
   });
@@ -116,7 +129,8 @@ function insertScheduledWork(
   prefix: string,
   kind: ScheduledWorkKind,
   workId: string,
-  payload: unknown
+  payload: unknown,
+  indexes: ScheduledWorkIndexes
 ): void {
   ensureScheduledWorkSchema(sql);
   const existing = sql
@@ -131,11 +145,13 @@ function insertScheduledWork(
     return;
   }
   sql.exec(
-    "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, created_at) VALUES (?, ?, ?, ?, ?)",
+    "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
     prefix,
     kind,
     workId,
     JSON.stringify(payload),
+    indexes.threadKey ?? null,
+    indexes.runId ?? null,
     Date.now()
   );
 }
@@ -183,10 +199,35 @@ function deleteScheduledWork(
 
 function ensureScheduledWorkSchema(sql: SqlStorage): void {
   sql.exec(
-    "CREATE TABLE IF NOT EXISTS pss_scheduled_work (prefix TEXT NOT NULL, kind TEXT NOT NULL, work_id TEXT NOT NULL, payload TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY (prefix, kind, work_id))"
+    "CREATE TABLE IF NOT EXISTS pss_scheduled_work (prefix TEXT NOT NULL, kind TEXT NOT NULL, work_id TEXT NOT NULL, payload TEXT NOT NULL, thread_key TEXT, run_id TEXT, created_at INTEGER NOT NULL, PRIMARY KEY (prefix, kind, work_id))"
   );
+  ensureScheduledWorkColumn(sql, "thread_key");
+  ensureScheduledWorkColumn(sql, "run_id");
   sql.exec(
     "CREATE INDEX IF NOT EXISTS pss_scheduled_work_due ON pss_scheduled_work (prefix, kind, created_at, work_id)"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_thread ON pss_scheduled_work (prefix, thread_key)"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_run ON pss_scheduled_work (prefix, run_id)"
+  );
+}
+
+function ensureScheduledWorkColumn(sql: SqlStorage, column: string): void {
+  try {
+    sql.exec(`ALTER TABLE pss_scheduled_work ADD COLUMN ${column} TEXT`);
+  } catch (error) {
+    if (!isDuplicateColumnError(error)) {
+      throw error;
+    }
+  }
+}
+
+function isDuplicateColumnError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.toLowerCase().includes("duplicate column")
   );
 }
 

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/select.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/select.ts
@@ -209,7 +209,12 @@ function selectScheduledWorkRows(
     if (query.startsWith("select work_id from")) {
       return { work_id: row.work_id };
     }
-    return { payload: row.payload, work_id: row.work_id };
+    return {
+      payload: row.payload,
+      run_id: row.run_id,
+      thread_key: row.thread_key,
+      work_id: row.work_id,
+    };
   });
 }
 

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/state.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/state.ts
@@ -62,6 +62,8 @@ export interface ScheduledWorkRow {
   readonly kind: string;
   readonly payload: string;
   readonly prefix: string;
+  readonly run_id: string | null;
+  readonly thread_key: string | null;
   readonly work_id: string;
 }
 

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/storage.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/storage.ts
@@ -45,6 +45,7 @@ function normalizeSql(query: string): string {
 function isSchemaStatement(query: string): boolean {
   return (
     query.startsWith("create table ") ||
+    query.startsWith("alter table ") ||
     query.startsWith("create index ") ||
     query.startsWith("create unique index ")
   );

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
@@ -195,10 +195,12 @@ function writeScheduledWork(
       !(row.prefix === prefix && row.kind === kind && row.work_id === workId)
   );
   state.scheduledWork.push({
-    created_at: numberBinding(bindings[4]),
+    created_at: numberBinding(bindings[6]),
     kind,
     payload: stringBinding(bindings[3]),
     prefix,
+    run_id: nullableStringBinding(bindings[5]),
+    thread_key: nullableStringBinding(bindings[4]),
     work_id: workId,
   });
 }

--- a/packages/runtime/src/cloudflare/storage/execution/run-records.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/run-records.ts
@@ -71,6 +71,21 @@ export function putRun(
   return Promise.resolve();
 }
 
+export function insertRun(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  record: RunRecord,
+  options: StoragePayloadBudgetOptions = {}
+): Promise<void> {
+  assertJsonPayloadWithinBudget(
+    "run-record",
+    record,
+    resolveStoragePayloadMaxBytes(options)
+  );
+  insertSqlRun(requiredSqlStorage(storage), prefix, record);
+  return Promise.resolve();
+}
+
 function selectRunRow(
   sql: SqlStorage,
   prefix: string,
@@ -126,6 +141,25 @@ function putSqlRun(sql: SqlStorage, prefix: string, record: RunRecord): void {
   const nowMs = Date.now();
   sql.exec(
     "INSERT INTO pss_run (prefix, run_id, record, dedupe_key, parent_run_id, root_run_id, thread_key, status, checkpoint_version, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(prefix, run_id) DO UPDATE SET record = excluded.record, dedupe_key = excluded.dedupe_key, parent_run_id = excluded.parent_run_id, root_run_id = excluded.root_run_id, thread_key = excluded.thread_key, status = excluded.status, checkpoint_version = excluded.checkpoint_version, updated_at = excluded.updated_at",
+    prefix,
+    record.runId,
+    JSON.stringify(record),
+    record.dedupeKey ?? null,
+    record.parentRunId ?? null,
+    record.rootRunId,
+    record.threadKey,
+    record.status,
+    record.checkpointVersion,
+    nowMs,
+    nowMs
+  );
+}
+
+function insertSqlRun(sql: SqlStorage, prefix: string, record: RunRecord): void {
+  ensureRunSchema(sql);
+  const nowMs = Date.now();
+  sql.exec(
+    "INSERT INTO pss_run (prefix, run_id, record, dedupe_key, parent_run_id, root_run_id, thread_key, status, checkpoint_version, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     prefix,
     record.runId,
     JSON.stringify(record),

--- a/packages/runtime/src/cloudflare/storage/execution/run-store.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/run-store.ts
@@ -1,6 +1,7 @@
 import type {
   ClaimRunOptions,
   ClaimRunResult,
+  CreateRunResult,
   RunRecord,
   RunStatus,
   RunStore,
@@ -14,6 +15,7 @@ import { withTransaction } from "./records";
 import {
   getRun,
   getRunByDedupeKey,
+  insertRun,
   listRunsByParentRunId,
   putRun,
 } from "./run-records";
@@ -69,12 +71,25 @@ export class DurableObjectRunStore implements RunStore {
     });
   }
 
-  async create(record: RunRecord): Promise<RunRecord> {
+  async create(record: RunRecord): Promise<CreateRunResult> {
     return await withTransaction(this.#storage, async (storage) => {
-      await putRun(storage, this.#prefix, record, {
+      const existing =
+        (await getRun(storage, this.#prefix, record.runId)) ??
+        (record.dedupeKey
+          ? await getRunByDedupeKey(storage, this.#prefix, record.dedupeKey)
+          : null);
+      if (existing) {
+        return {
+          ok: false,
+          reason: "duplicate",
+          record: structuredClone(existing),
+        };
+      }
+
+      await insertRun(storage, this.#prefix, record, {
         maxPayloadBytes: this.#maxPayloadBytes,
       });
-      return structuredClone(record);
+      return { ok: true, record: structuredClone(record) };
     });
   }
 

--- a/packages/runtime/src/cloudflare/storage/sqlite/thread-store-sql.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/thread-store-sql.ts
@@ -1,6 +1,9 @@
 import type { SqlStorage } from "../../sql/ports/storage-port";
 import { storeKey } from "../execution/records";
-import { stringifyJsonPayloadWithinBudget } from "../payload-guard";
+import {
+  serializedJsonByteLength,
+  stringifyJsonPayloadWithinBudget,
+} from "../payload-guard";
 
 export interface ThreadMetaRow {
   readonly message_count: number;
@@ -18,6 +21,7 @@ interface WriteHistoryRowsOptions {
   readonly history: readonly unknown[];
   readonly key: string;
   readonly maxPayloadBytes: number;
+  readonly meta: ThreadMetaRow | null;
   readonly nextSeqStart: number;
   readonly sql: SqlStorage;
 }
@@ -35,6 +39,9 @@ export function ensureThreadSchema(sql: SqlStorage): void {
   );
   sql.exec(
     "CREATE TABLE IF NOT EXISTS pss_thread_meta (thread_key TEXT PRIMARY KEY, version TEXT NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
+  );
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS pss_thread_message_chunk (thread_key TEXT NOT NULL, seq INTEGER NOT NULL, chunk_index INTEGER NOT NULL, chunk TEXT NOT NULL, PRIMARY KEY (thread_key, seq, chunk_index))"
   );
 }
 
@@ -65,13 +72,28 @@ export function readActiveThreadMessages(
       "SELECT seq, message FROM pss_thread_message WHERE thread_key = ? AND active = 1 ORDER BY seq",
       key
     )
-    .toArray();
+    .toArray()
+    .map((row) => ({ ...row, message: hydrateThreadMessage(sql, key, row) }));
 }
 
 export function writeThreadHistoryRows(
   options: WriteHistoryRowsOptions
 ): number {
-  const { history, key, maxPayloadBytes, nextSeqStart, sql } = options;
+  const { history, key, maxPayloadBytes, meta, nextSeqStart, sql } = options;
+  if (
+    meta?.state_blob === null &&
+    history.length > meta.message_count &&
+    meta.next_seq === nextSeqStart
+  ) {
+    return insertThreadMessages({
+      history: history.slice(meta.message_count),
+      key,
+      maxPayloadBytes,
+      seq: nextSeqStart,
+      sql,
+    });
+  }
+
   const existing = readActiveThreadMessages(sql, key);
   let prefix = 0;
   while (
@@ -81,15 +103,6 @@ export function writeThreadHistoryRows(
   ) {
     prefix += 1;
   }
-  const messages = history
-    .slice(prefix)
-    .map((message) =>
-      stringifyJsonPayloadWithinBudget(
-        "thread-message",
-        message,
-        maxPayloadBytes
-      )
-    );
   if (prefix < existing.length) {
     sql.exec(
       "UPDATE pss_thread_message SET active = 0 WHERE thread_key = ? AND active = 1 AND seq >= ?",
@@ -97,17 +110,13 @@ export function writeThreadHistoryRows(
       existing[prefix].seq
     );
   }
-  let seq = nextSeqStart;
-  for (const message of messages) {
-    sql.exec(
-      "INSERT INTO pss_thread_message (thread_key, seq, active, message) VALUES (?, ?, 1, ?)",
-      key,
-      seq,
-      message
-    );
-    seq += 1;
-  }
-  return seq;
+  return insertThreadMessages({
+    history: history.slice(prefix),
+    key,
+    maxPayloadBytes,
+    seq: nextSeqStart,
+    sql,
+  });
 }
 
 export function softDeleteActiveThreadRows(sql: SqlStorage, key: string): void {
@@ -133,6 +142,139 @@ export function writeThreadMeta(
 }
 
 export function deleteThreadRows(sql: SqlStorage, key: string): void {
+  sql.exec("DELETE FROM pss_thread_message_chunk WHERE thread_key = ?", key);
   sql.exec("DELETE FROM pss_thread_message WHERE thread_key = ?", key);
   sql.exec("DELETE FROM pss_thread_meta WHERE thread_key = ?", key);
+}
+
+function insertThreadMessages({
+  history,
+  key,
+  maxPayloadBytes,
+  seq,
+  sql,
+}: {
+  readonly history: readonly unknown[];
+  readonly key: string;
+  readonly maxPayloadBytes: number;
+  readonly seq: number;
+  readonly sql: SqlStorage;
+}): number {
+  let nextSeq = seq;
+  for (const value of history) {
+    const message = stringifyThreadMessagePayload(
+      sql,
+      key,
+      nextSeq,
+      value,
+      maxPayloadBytes
+    );
+    sql.exec(
+      "INSERT INTO pss_thread_message (thread_key, seq, active, message) VALUES (?, ?, 1, ?)",
+      key,
+      nextSeq,
+      message
+    );
+    nextSeq += 1;
+  }
+  return nextSeq;
+}
+
+function stringifyThreadMessagePayload(
+  sql: SqlStorage,
+  key: string,
+  seq: number,
+  value: unknown,
+  maxPayloadBytes: number
+): string {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    return stringifyJsonPayloadWithinBudget(
+      "thread-message",
+      value,
+      maxPayloadBytes
+    );
+  }
+  if (serializedJsonByteLength(serialized) <= maxPayloadBytes) {
+    return serialized;
+  }
+
+  const chunks = chunkSerializedPayload(serialized, maxPayloadBytes);
+  for (const [index, chunk] of chunks.entries()) {
+    sql.exec(
+      "INSERT INTO pss_thread_message_chunk (thread_key, seq, chunk_index, chunk) VALUES (?, ?, ?, ?)",
+      key,
+      seq,
+      index,
+      chunk
+    );
+  }
+  return JSON.stringify({ $pss: "chunk", n: chunks.length });
+}
+
+function chunkSerializedPayload(
+  serialized: string,
+  maxPayloadBytes: number
+): string[] {
+  const chunkMaxBytes = Math.max(1, maxPayloadBytes);
+  const chunks: string[] = [];
+  let current = "";
+  for (const char of serialized) {
+    const next = current + char;
+    if (current && serializedJsonByteLength(next) > chunkMaxBytes) {
+      chunks.push(current);
+      current = char;
+    } else {
+      current = next;
+    }
+  }
+  if (current) {
+    chunks.push(current);
+  }
+  return chunks;
+}
+
+function hydrateThreadMessage(
+  sql: SqlStorage,
+  key: string,
+  row: ThreadMessageRow
+): string {
+  const marker = parseThreadMessageChunkMarker(row.message);
+  if (!marker) {
+    return row.message;
+  }
+  const chunks = sql
+    .exec<{ chunk: string }>(
+      "SELECT chunk FROM pss_thread_message_chunk WHERE thread_key = ? AND seq = ? ORDER BY chunk_index",
+      key,
+      row.seq
+    )
+    .toArray();
+  if (chunks.length !== marker.n) {
+    throw new Error(
+      `Missing chunked thread message payload for ${key} seq ${row.seq}`
+    );
+  }
+  return chunks.map((chunk) => chunk.chunk).join("");
+}
+
+function parseThreadMessageChunkMarker(
+  message: string
+): { readonly n: number } | null {
+  try {
+    const parsed = JSON.parse(message) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "$pss" in parsed &&
+      (parsed as { $pss?: unknown }).$pss === "chunk" &&
+      "n" in parsed &&
+      typeof (parsed as { n?: unknown }).n === "number"
+    ) {
+      return { n: (parsed as { n: number }).n };
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }

--- a/packages/runtime/src/cloudflare/storage/sqlite/thread-store.test-support.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/thread-store.test-support.ts
@@ -12,6 +12,12 @@ interface MessageRowProbe {
   readonly seq: number;
 }
 
+interface MessageChunkRowProbe {
+  readonly chunk: string;
+  readonly chunk_index: number;
+  readonly seq: number;
+}
+
 export function createStore(
   options: { readonly maxPayloadBytes?: number } = {}
 ): {
@@ -41,6 +47,18 @@ export function readRows(
   return (storage.sql as InMemorySqlStorage)
     .exec<MessageRowProbe>(
       "SELECT seq, active, message FROM pss_thread_message WHERE thread_key = ? ORDER BY seq",
+      storeKey(PREFIX, "thread", threadKey)
+    )
+    .toArray();
+}
+
+export function readChunkRows(
+  storage: InMemoryCloudflareDurableObjectStorage,
+  threadKey: string
+): MessageChunkRowProbe[] {
+  return (storage.sql as InMemorySqlStorage)
+    .exec<MessageChunkRowProbe>(
+      "SELECT seq, chunk_index, chunk FROM pss_thread_message_chunk WHERE thread_key = ? ORDER BY seq, chunk_index",
       storeKey(PREFIX, "thread", threadKey)
     )
     .toArray();

--- a/packages/runtime/src/cloudflare/storage/sqlite/thread-store.test.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/thread-store.test.ts
@@ -5,6 +5,7 @@ import { DurableObjectSqliteThreadStore } from "./thread-store";
 import {
   createStore,
   PREFIX,
+  readChunkRows,
   REQUIRES_SQLITE,
   readRows,
   snapshot,
@@ -155,21 +156,21 @@ describe("DurableObjectSqliteThreadStore", () => {
     ).resolves.toEqual({ ok: false, reason: "conflict" });
   });
 
-  it("rejects snapshot message rows that exceed the serialized payload budget", async () => {
+  it("chunks snapshot message rows that exceed the serialized payload budget", async () => {
     const { storage, store } = createStore({ maxPayloadBytes: 80 });
+    const bigMessage = { content: "x".repeat(120), role: "user" };
 
     await expect(
-      store.commit(
-        "key",
-        snapshot([{ content: "x".repeat(120), role: "user" }]),
-        { expectedVersion: null }
-      )
-    ).rejects.toMatchObject({
-      maxBytes: 80,
-      payloadKind: "thread-message",
+      store.commit("key", snapshot([bigMessage]), { expectedVersion: null })
+    ).resolves.toEqual({ ok: true, version: "1" });
+
+    const [row] = readRows(storage, "key");
+    expect(row?.message).toBe(JSON.stringify({ $pss: "chunk", n: 2 }));
+    expect(readChunkRows(storage, "key")).toHaveLength(2);
+    await expect(store.load("key")).resolves.toEqual({
+      state: { history: [bigMessage], schemaVersion: 1 },
+      version: "1",
     });
-    expect(readRows(storage, "key")).toEqual([]);
-    await expect(store.load("key")).resolves.toBeNull();
   });
 
   it("rejects opaque thread state blobs that exceed the serialized payload budget", async () => {

--- a/packages/runtime/src/cloudflare/storage/sqlite/thread-store.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/thread-store.ts
@@ -86,6 +86,7 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
           history: next.state.history,
           key,
           maxPayloadBytes: this.#maxPayloadBytes,
+          meta,
           nextSeqStart,
           sql: this.#sql,
         });

--- a/packages/runtime/src/contracts/execution-store/contract.ts
+++ b/packages/runtime/src/contracts/execution-store/contract.ts
@@ -157,6 +157,26 @@ export function describeExecutionStoreContract({
       ).resolves.toEqual({ ok: false, reason: "leased" });
     });
 
+    it("keeps the existing run unchanged when create sees a duplicate run id", async () => {
+      const store = createStore();
+      const original = createQueuedRun("run-duplicate");
+
+      const created = await store.runs.create(original);
+      const duplicate = await store.runs.create({
+        ...original,
+        checkpointVersion: 7,
+        status: "completed",
+      });
+
+      expect(created).toEqual({ ok: true, record: original });
+      expect(duplicate).toEqual({
+        ok: false,
+        reason: "duplicate",
+        record: original,
+      });
+      await expect(store.runs.get("run-duplicate")).resolves.toEqual(original);
+    });
+
     it("rejects stale checkpoint writes", async () => {
       const store = createStore();
       await store.runs.create(createQueuedRun());

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { agentNamespace } from "../../agent/identity/namespace";
+import type { ExecutionHost, RunRecord, RunStore } from "../host/types";
 import { createInMemoryExecutionHost } from "../memory";
 import { dispatchAgentNotification } from "./notification-dispatch";
 
@@ -85,4 +86,63 @@ describe("dispatchAgentNotification", () => {
       threadKey: "room:1:user:2",
     });
   });
+
+  it("returns the existing notification when run dedupe wins a create race", async () => {
+    const baseHost = createInMemoryExecutionHost();
+    const first = await dispatchAgentNotification({
+      host: baseHost,
+      idempotencyKey: "reminder:race",
+      input: { text: "first", type: "user-text" },
+      namespace: "agent-a",
+      threadKey: "room:1:user:2",
+    });
+    const racingHost = hostWithDuplicateRunCreate(baseHost);
+
+    const duplicate = await dispatchAgentNotification({
+      host: racingHost,
+      idempotencyKey: "reminder:race",
+      input: { text: "duplicate", type: "user-text" },
+      namespace: "agent-a",
+      threadKey: "room:1:user:2",
+    });
+
+    expect(duplicate).toEqual({ ...first, deduplicated: true });
+  });
 });
+
+function hostWithDuplicateRunCreate(host: ExecutionHost): ExecutionHost {
+  const runs = {
+    claim: (runId, options) => host.store.runs.claim(runId, options),
+    create: async (record: RunRecord) => {
+      const existing = record.dedupeKey
+        ? await host.store.runs.getByDedupeKey(record.dedupeKey)
+        : await host.store.runs.get(record.runId);
+      if (!existing) {
+        throw new Error("Expected pre-existing run for duplicate create race.");
+      }
+      return { ok: false, reason: "duplicate", record: existing } as const;
+    },
+    get: (runId) => host.store.runs.get(runId),
+    getByDedupeKey: (dedupeKey) =>
+      host.store.runs.getByDedupeKey(dedupeKey),
+    listByParentRunId: (parentRunId) =>
+      host.store.runs.listByParentRunId(parentRunId),
+    update: (record) => host.store.runs.update(record),
+  } satisfies RunStore;
+
+  return {
+    ...host,
+    store: {
+      ...host.store,
+      runs,
+      transaction: (callback) =>
+        callback({
+          checkpoints: host.store.checkpoints,
+          events: host.store.events,
+          notifications: host.store.notifications,
+          runs,
+          threads: host.store.threads,
+        }),
+    },
+  };
+}

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.ts
@@ -80,7 +80,10 @@ export async function dispatchAgentNotification(
 
   try {
     await input.host.store.transaction(async (tx) => {
-      await tx.runs.create(runRecord);
+      const runCreate = await tx.runs.create(runRecord);
+      if (!runCreate.ok) {
+        throw new DuplicateNotificationError();
+      }
       const writeResult = await tx.notifications.enqueue(notificationRecord);
       if (!writeResult.ok) {
         throw new DuplicateNotificationError();

--- a/packages/runtime/src/execution/host/types.ts
+++ b/packages/runtime/src/execution/host/types.ts
@@ -72,6 +72,14 @@ export type ClaimRunResult =
       readonly reason: "leased" | "not-claimable" | "not-found";
     };
 
+export type CreateRunResult =
+  | { readonly ok: true; readonly record: RunRecord }
+  | {
+      readonly ok: false;
+      readonly reason: "duplicate";
+      readonly record: RunRecord;
+    };
+
 export interface ClaimRunOptions {
   readonly attempt: number;
   readonly leaseId: string;
@@ -150,7 +158,7 @@ export type NotificationClaimResult =
 
 export interface RunStore {
   claim(runId: string, options: ClaimRunOptions): Promise<ClaimRunResult>;
-  create(record: RunRecord): Promise<RunRecord>;
+  create(record: RunRecord): Promise<CreateRunResult>;
   get(runId: string): Promise<RunRecord | null>;
   getByDedupeKey(dedupeKey: string): Promise<RunRecord | null>;
   listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]>;

--- a/packages/runtime/src/execution/index.ts
+++ b/packages/runtime/src/execution/index.ts
@@ -24,6 +24,7 @@ export type {
   CheckpointWriteResult,
   ClaimRunOptions,
   ClaimRunResult,
+  CreateRunResult,
   EventCursor,
   EventStore,
   ExecutionHost,

--- a/packages/runtime/src/execution/memory/runs.ts
+++ b/packages/runtime/src/execution/memory/runs.ts
@@ -1,0 +1,109 @@
+import type {
+  ClaimRunOptions,
+  ClaimRunResult,
+  CreateRunResult,
+  RunRecord,
+  RunStatus,
+  RunStore,
+} from "../host/types";
+import type { ExecutionState } from "./state";
+
+const claimableStatuses = new Set<RunStatus>([
+  "leased",
+  "queued",
+  "running",
+  "suspended",
+]);
+
+export class InMemoryRunStore implements RunStore {
+  readonly #state: () => ExecutionState;
+
+  constructor(state: () => ExecutionState) {
+    this.#state = state;
+  }
+
+  create(record: RunRecord): Promise<CreateRunResult> {
+    const state = this.#state();
+    const existing =
+      state.runs.get(record.runId) ?? existingDedupeRun(state, record);
+    if (existing) {
+      return Promise.resolve({
+        ok: false,
+        reason: "duplicate",
+        record: structuredClone(existing),
+      });
+    }
+
+    const stored = structuredClone(record);
+    state.runs.set(record.runId, stored);
+    return Promise.resolve({ ok: true, record: structuredClone(stored) });
+  }
+
+  get(runId: string): Promise<RunRecord | null> {
+    const record = this.#state().runs.get(runId);
+    return Promise.resolve(record ? structuredClone(record) : null);
+  }
+
+  getByDedupeKey(dedupeKey: string): Promise<RunRecord | null> {
+    const record = [...this.#state().runs.values()].find(
+      (candidate) => candidate.dedupeKey === dedupeKey
+    );
+    return Promise.resolve(record ? structuredClone(record) : null);
+  }
+
+  listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]> {
+    const records = [...this.#state().runs.values()].filter(
+      (candidate) => candidate.parentRunId === parentRunId
+    );
+    return Promise.resolve(records.map((record) => structuredClone(record)));
+  }
+
+  update(record: RunRecord): Promise<RunRecord> {
+    const stored = structuredClone(record);
+    this.#state().runs.set(record.runId, stored);
+    return Promise.resolve(structuredClone(stored));
+  }
+
+  claim(runId: string, options: ClaimRunOptions): Promise<ClaimRunResult> {
+    const record = this.#state().runs.get(runId);
+    if (!record) {
+      return Promise.resolve({ ok: false, reason: "not-found" });
+    }
+
+    if (!claimableStatuses.has(record.status)) {
+      return Promise.resolve({ ok: false, reason: "not-claimable" });
+    }
+
+    if (record.lease && record.lease.leaseUntilMs > options.nowMs) {
+      return Promise.resolve({ ok: false, reason: "leased" });
+    }
+
+    const lease = {
+      attempt: options.attempt,
+      leaseId: options.leaseId,
+      leaseUntilMs: options.nowMs + options.leaseMs,
+    };
+    const claimed: RunRecord = {
+      ...record,
+      lease,
+      status: "leased",
+    };
+    this.#state().runs.set(runId, claimed);
+    return Promise.resolve({
+      lease,
+      ok: true,
+      record: structuredClone(claimed),
+    });
+  }
+}
+
+function existingDedupeRun(
+  state: ExecutionState,
+  record: RunRecord
+): RunRecord | undefined {
+  return record.dedupeKey
+    ? [...state.runs.values()].find(
+        (candidate) => candidate.dedupeKey === record.dedupeKey
+      )
+    : undefined;
+}

--- a/packages/runtime/src/execution/memory/store.ts
+++ b/packages/runtime/src/execution/memory/store.ts
@@ -9,29 +9,19 @@ import type {
 import type {
   CheckpointStore,
   CheckpointWriteResult,
-  ClaimRunOptions,
-  ClaimRunResult,
   EventCursor,
   EventStore,
   ExecutionStore,
   ExecutionStoreTransaction,
   NotificationInbox,
   RunCheckpoint,
-  RunRecord,
-  RunStatus,
   RunStore,
   StoredAgentEvent,
 } from "../host/types";
 import { InMemoryNotificationInbox } from "./notifications";
+import { InMemoryRunStore } from "./runs";
 import type { ExecutionState } from "./state";
 import { cloneState, createEmptyState } from "./state";
-
-const claimableStatuses = new Set<RunStatus>([
-  "leased",
-  "queued",
-  "running",
-  "suspended",
-]);
 
 export class InMemoryExecutionStore implements ExecutionStore {
   #state = createEmptyState();
@@ -131,77 +121,6 @@ class InMemoryExecutionThreadStore implements ThreadStore {
   load(key: string): Promise<StoredThread | null> {
     const stored = this.#state().threads.get(key);
     return Promise.resolve(stored ? structuredClone(stored) : null);
-  }
-}
-
-class InMemoryRunStore implements RunStore {
-  readonly #state: () => ExecutionState;
-
-  constructor(state: () => ExecutionState) {
-    this.#state = state;
-  }
-
-  create(record: RunRecord): Promise<RunRecord> {
-    const stored = structuredClone(record);
-    this.#state().runs.set(record.runId, stored);
-    return Promise.resolve(structuredClone(stored));
-  }
-
-  get(runId: string): Promise<RunRecord | null> {
-    const record = this.#state().runs.get(runId);
-    return Promise.resolve(record ? structuredClone(record) : null);
-  }
-
-  getByDedupeKey(dedupeKey: string): Promise<RunRecord | null> {
-    const record = [...this.#state().runs.values()].find(
-      (candidate) => candidate.dedupeKey === dedupeKey
-    );
-    return Promise.resolve(record ? structuredClone(record) : null);
-  }
-
-  listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]> {
-    const records = [...this.#state().runs.values()].filter(
-      (candidate) => candidate.parentRunId === parentRunId
-    );
-    return Promise.resolve(records.map((record) => structuredClone(record)));
-  }
-
-  update(record: RunRecord): Promise<RunRecord> {
-    const stored = structuredClone(record);
-    this.#state().runs.set(record.runId, stored);
-    return Promise.resolve(structuredClone(stored));
-  }
-
-  claim(runId: string, options: ClaimRunOptions): Promise<ClaimRunResult> {
-    const record = this.#state().runs.get(runId);
-    if (!record) {
-      return Promise.resolve({ ok: false, reason: "not-found" });
-    }
-
-    if (!claimableStatuses.has(record.status)) {
-      return Promise.resolve({ ok: false, reason: "not-claimable" });
-    }
-
-    if (record.lease && record.lease.leaseUntilMs > options.nowMs) {
-      return Promise.resolve({ ok: false, reason: "leased" });
-    }
-
-    const lease = {
-      attempt: options.attempt,
-      leaseId: options.leaseId,
-      leaseUntilMs: options.nowMs + options.leaseMs,
-    };
-    const claimed: RunRecord = {
-      ...record,
-      lease,
-      status: "leased",
-    };
-    this.#state().runs.set(runId, claimed);
-    return Promise.resolve({
-      lease,
-      ok: true,
-      record: structuredClone(claimed),
-    });
   }
 }
 

--- a/packages/runtime/src/execution/resume/checkpoints.ts
+++ b/packages/runtime/src/execution/resume/checkpoints.ts
@@ -10,6 +10,11 @@ import type { ResumeRunState } from "./types";
 
 const maxCheckpointWriteAttempts = 5;
 
+interface ResumeStateCheckpointReference {
+  readonly kind: "resume-state-ref";
+  readonly messageCount: number;
+}
+
 type ResumeStepStart = "new-step" | "resume-before-model";
 
 interface ResumeStep {
@@ -94,7 +99,7 @@ export async function appendCheckpoint({
   readonly phase: CheckpointPhase;
   readonly runId: string;
   readonly runtimeState: unknown;
-  readonly threadSnapshot: ResumeRunState;
+  readonly threadSnapshot: ResumeStateCheckpointReference;
 }): Promise<void> {
   let lastConflict:
     | { readonly current: number; readonly expected: number }
@@ -134,6 +139,15 @@ export async function appendCheckpoint({
     lastConflict?.expected ?? 0,
     lastConflict?.current ?? 0
   );
+}
+
+export function resumeStateCheckpointReference(
+  state: ResumeRunState
+): ResumeStateCheckpointReference {
+  return {
+    kind: "resume-state-ref",
+    messageCount: state.history.length,
+  };
 }
 
 function runtimeToolCheckpoint(

--- a/packages/runtime/src/execution/resume/llm.ts
+++ b/packages/runtime/src/execution/resume/llm.ts
@@ -8,7 +8,10 @@ import {
 import { persistedToolExecutionCheckpoint } from "../../llm/tool-execution";
 import { modelMessageToAgentEvents } from "../../thread/protocol/mapping";
 import type { ExecutionHost } from "../host/types";
-import { appendCheckpoint } from "./checkpoints";
+import {
+  appendCheckpoint,
+  resumeStateCheckpointReference,
+} from "./checkpoints";
 import type { ResumeRunState } from "./types";
 
 export async function readModelOutput({
@@ -63,7 +66,7 @@ export async function createResumeToolExecution({
           toolCallId: checkpoint.toolCallId,
           toolName: checkpoint.toolName,
         },
-        threadSnapshot,
+        threadSnapshot: resumeStateCheckpointReference(threadSnapshot),
       }),
     beforeTool: async (checkpoint) => {
       await appendCheckpoint({
@@ -76,7 +79,7 @@ export async function createResumeToolExecution({
           toolCallId: checkpoint.toolCallId,
           toolName: checkpoint.toolName,
         },
-        threadSnapshot,
+        threadSnapshot: resumeStateCheckpointReference(threadSnapshot),
       });
     },
     runId,

--- a/packages/runtime/src/execution/resume/resume.ts
+++ b/packages/runtime/src/execution/resume/resume.ts
@@ -1,6 +1,7 @@
 import {
   appendCheckpoint,
   resumeStepFromCheckpoint,
+  resumeStateCheckpointReference,
   throwIfManualToolRecoveryRequired,
 } from "./checkpoints";
 import {
@@ -49,7 +50,7 @@ export async function resumeRun(
         phase: "before-model",
         runId: options.runId,
         runtimeState: { step: nextStep.stepNumber },
-        threadSnapshot: state,
+        threadSnapshot: resumeStateCheckpointReference(state),
       });
     }
 
@@ -77,7 +78,7 @@ export async function resumeRun(
       phase: "after-model",
       runId: options.runId,
       runtimeState: { step: nextStep.stepNumber },
-      threadSnapshot: stateAfterModel,
+      threadSnapshot: resumeStateCheckpointReference(stateAfterModel),
     });
 
     const shouldContinue = await emitModelOutputEvents({
@@ -100,7 +101,7 @@ export async function resumeRun(
         phase: "suspended",
         runId: options.runId,
         runtimeState: { step: nextStep.stepNumber },
-        threadSnapshot: stateAfterModel,
+        threadSnapshot: resumeStateCheckpointReference(stateAfterModel),
       });
       return { status: "suspended", steps };
     }


### PR DESCRIPTION
## Summary
- make run creation insert-only and handle notification idempotency races without overwriting canonical runs
- avoid scheduled non-notification resume retry loops and normalize scheduled work rows with thread/run indexes
- store bounded resume checkpoint references and chunk oversized SQLite thread-message rows

## Verification
- pnpm --filter @minpeter/pss-runtime exec vitest run src/cloudflare/storage/execution/store-stress.test.ts src/cloudflare/storage/sqlite/thread-store.test.ts src/cloudflare/host/durable-object-host.test.ts src/cloudflare/alarm/drainer.test.ts src/agent/loop/resume-checkpoint.test.ts src/execution/dispatch/notification-dispatch.test.ts src/cloudflare/storage/execution/store-contract.test.ts
- pnpm --filter @minpeter/pss-runtime typecheck
- pnpm --filter @minpeter/pss-runtime build
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Cloudflare Durable Object storage in `@minpeter/pss-runtime` to prevent data races, reduce retry loops, and make large thread histories reliable in production. This makes run creation safe, checkpoints smaller, and thread message storage resilient.

- **New Features**
  - `RunStore.create()` is insert-only and returns typed duplicate results; notification dispatch uses this to dedupe safely.
  - Resume checkpoints store lightweight refs `{ kind: "resume-state-ref", messageCount }` instead of full history.
  - SQLite thread store writes append-only deltas and chunks oversized messages into `pss_thread_message_chunk` with transparent hydration on read.
  - Scheduled work rows now include `thread_key` and `run_id`, with new indexes for precise cleanup and faster queries.

- **Bug Fixes**
  - Stop retrying scheduled non-notification runs; ack when `resume()` returns null and do not reschedule.
  - Large thread messages now load correctly from chunked storage.
  - Schema migrations handle repeated runs safely by idempotently adding missing columns.

<sup>Written for commit f0922f82d1d805ac29840ba488c519bf7634e231. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

