### PR TITLE
Version Packages (next)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -19,6 +19,7 @@
     "runtime-plugin-constructor",
     "runtime-plugin-sessions",
     "runtime-sqlite-notifications",
+    "runtime-storage-integrity",
     "runtime-subagents",
     "runtime-thread-key-surface",
     "sqlite-event-checkpoint-stores",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @minpeter/pss-runtime
 
+## 0.1.0-next.14
+
+### Patch Changes
+
+- f3c4461: Harden Cloudflare Durable Object storage for production agent threads.
+
+  - Make `RunStore.create()` insert-only and return typed duplicate results so
+    notification idempotency races do not overwrite canonical runs.
+  - Stop retrying scheduled non-notification runs forever when the runtime cannot
+    resume them.
+  - Store lower-level resume checkpoints as bounded thread references instead of
+    full history snapshots.
+  - Normalize scheduled work rows with `thread_key` and `run_id` indexes for
+    exact cleanup.
+  - Add append-delta writes and chunked oversized thread-message payloads for the
+    SQLite thread store.
+
 ## 0.1.0-next.13
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minpeter/pss-runtime",
-  "version": "0.1.0-next.13",
+  "version": "0.1.0-next.14",
   "description": "Generic agent runtime for threads, model loops, and synchronized run events.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump @minpeter/pss-runtime to 0.1.0-next.14
- consume the runtime storage integrity changeset

## Verification
- pnpm version-packages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@minpeter/pss-runtime` to 0.1.0-next.14 with storage integrity hardening for production agent threads. Improves idempotency, cleanup accuracy, and resume behavior in Cloudflare Durable Objects and the SQLite thread store.

- Bug Fixes
  - Make `RunStore.create()` insert-only with typed duplicate results to protect canonical runs.
  - Stop endless retries for scheduled non-notification runs when resume fails.
  - Use bounded thread refs for resume checkpoints and index scheduled work by `thread_key`/`run_id` for exact cleanup.
  - Add append-delta writes and chunk large thread-message payloads in the SQLite store.

<sup>Written for commit f668bfff1bb3210fd52ea3942da1647286d264b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

