### PR TITLE
Fix runtime storage lint

### DIFF
--- a/packages/runtime/src/agent/loop/resume-checkpoint.test.ts
+++ b/packages/runtime/src/agent/loop/resume-checkpoint.test.ts
@@ -150,9 +150,7 @@ describe("resumeRun checkpoint recovery", () => {
     ).resolves.toEqual({ status: "completed", steps: 1 });
 
     expect(history).toHaveLength(2);
-    expect(
-      checkpoints.map((checkpoint) => checkpoint.threadSnapshot)
-    ).toEqual([
+    expect(checkpoints.map((checkpoint) => checkpoint.threadSnapshot)).toEqual([
       { kind: "resume-state-ref", messageCount: 1 },
       { kind: "resume-state-ref", messageCount: 2 },
     ]);

--- a/packages/runtime/src/cloudflare/storage/execution/run-records.ts
+++ b/packages/runtime/src/cloudflare/storage/execution/run-records.ts
@@ -155,7 +155,11 @@ function putSqlRun(sql: SqlStorage, prefix: string, record: RunRecord): void {
   );
 }
 
-function insertSqlRun(sql: SqlStorage, prefix: string, record: RunRecord): void {
+function insertSqlRun(
+  sql: SqlStorage,
+  prefix: string,
+  record: RunRecord
+): void {
   ensureRunSchema(sql);
   const nowMs = Date.now();
   sql.exec(

--- a/packages/runtime/src/cloudflare/storage/sqlite/thread-store.test.ts
+++ b/packages/runtime/src/cloudflare/storage/sqlite/thread-store.test.ts
@@ -5,8 +5,8 @@ import { DurableObjectSqliteThreadStore } from "./thread-store";
 import {
   createStore,
   PREFIX,
-  readChunkRows,
   REQUIRES_SQLITE,
+  readChunkRows,
   readRows,
   snapshot,
 } from "./thread-store.test-support";

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -123,8 +123,7 @@ function hostWithDuplicateRunCreate(host: ExecutionHost): ExecutionHost {
       return { ok: false, reason: "duplicate", record: existing } as const;
     },
     get: (runId) => host.store.runs.get(runId),
-    getByDedupeKey: (dedupeKey) =>
-      host.store.runs.getByDedupeKey(dedupeKey),
+    getByDedupeKey: (dedupeKey) => host.store.runs.getByDedupeKey(dedupeKey),
     listByParentRunId: (parentRunId) =>
       host.store.runs.listByParentRunId(parentRunId),
     update: (record) => host.store.runs.update(record),

--- a/packages/runtime/src/execution/resume/resume.ts
+++ b/packages/runtime/src/execution/resume/resume.ts
@@ -1,7 +1,7 @@
 import {
   appendCheckpoint,
-  resumeStepFromCheckpoint,
   resumeStateCheckpointReference,
+  resumeStepFromCheckpoint,
   throwIfManualToolRecoveryRequired,
 } from "./checkpoints";
 import {


### PR DESCRIPTION
## Summary
- apply repository lint formatting for runtime storage integrity changes

## Verification
- pnpm lint
- pnpm --filter @minpeter/pss-runtime typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied repository lint rules to runtime storage, resume, and related tests. Formatting-only changes (import order, line breaks, inline callbacks); no behavior changes.

<sup>Written for commit c8106bc00af34cdfb84fcedbb8c3585404423022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

