### PR TITLE
Support scheduled work index deletes in test SQL

### DIFF
--- a/.changeset/runtime-scheduled-work-test-adapter.md
+++ b/.changeset/runtime-scheduled-work-test-adapter.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Support secondary-index scheduled work deletes in the local Durable Object SQL test adapter.

--- a/packages/runtime/src/cloudflare/host/durable-object-host.test.ts
+++ b/packages/runtime/src/cloudflare/host/durable-object-host.test.ts
@@ -119,6 +119,38 @@ describe("Cloudflare Durable Object host adapter", () => {
     expect(readScheduledWorkRows(storage)).toHaveLength(3);
   });
 
+  it("supports deleting SQLite scheduled work by normalized indexes in local tests", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage({
+      sql: new InMemorySqlStorage(),
+    });
+    const host = createCloudflareDurableObjectHost({ storage });
+
+    await host.scheduler.enqueueRun("run-a");
+    await host.scheduler.resumeThread("thread-a", { runId: "run-a" });
+    await host.scheduler.resumeThread("thread-b", { runId: "run-b" });
+
+    storage.sql.exec(
+      "DELETE FROM pss_scheduled_work WHERE prefix = ? AND thread_key = ?",
+      "pss-runtime",
+      "thread-a"
+    );
+    storage.sql.exec(
+      "DELETE FROM pss_scheduled_work WHERE prefix = ? AND run_id = ?",
+      "pss-runtime",
+      "run-a"
+    );
+
+    expect(readScheduledWorkRows(storage)).toEqual([
+      {
+        kind: "thread-prompt",
+        payload: JSON.stringify({ runId: "run-b", threadKey: "thread-b" }),
+        run_id: "run-b",
+        thread_key: "thread-b",
+        work_id: expect.any(String),
+      },
+    ]);
+  });
+
   it("uses the SQLite scheduled queue with default in-memory Durable Object storage", async () => {
     const storage = new InMemoryCloudflareDurableObjectStorage();
     const host = createCloudflareDurableObjectHost({ storage });

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
@@ -52,7 +52,7 @@ export function writeSqlStatement(
     return;
   }
   if (query.startsWith("delete from pss_scheduled_work")) {
-    deleteScheduledWork(state, bindings);
+    deleteScheduledWork(state, query, bindings);
     return;
   }
   throw new Error(
@@ -299,9 +299,24 @@ function writeScheduledWork(
 
 function deleteScheduledWork(
   state: InMemoryDurableObjectSqlState,
+  query: string,
   bindings: readonly unknown[]
 ): void {
   const prefix = stringBinding(bindings[0]);
+  if (query.includes("thread_key = ?")) {
+    const threadKey = stringBinding(bindings[1]);
+    state.scheduledWork = state.scheduledWork.filter(
+      (row) => !(row.prefix === prefix && row.thread_key === threadKey)
+    );
+    return;
+  }
+  if (query.includes("run_id = ?")) {
+    const runId = stringBinding(bindings[1]);
+    state.scheduledWork = state.scheduledWork.filter(
+      (row) => !(row.prefix === prefix && row.run_id === runId)
+    );
+    return;
+  }
   const kind = stringBinding(bindings[1]);
   const workId = stringBinding(bindings[2]);
   state.scheduledWork = state.scheduledWork.filter(


### PR DESCRIPTION
## Summary
- support local Durable Object SQL test adapter deletes by scheduled work thread_key and run_id
- add a regression test matching Bori reset cleanup SQL

## Verification
- pnpm --filter @minpeter/pss-runtime exec vitest run src/cloudflare/host/durable-object-host.test.ts --reporter=verbose --no-cache
- pnpm --filter @minpeter/pss-runtime test
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm verify:release
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support secondary-index deletes of scheduled work (`thread_key`, `run_id`) in the local Durable Object SQL test adapter for `@minpeter/pss-runtime`. This aligns test behavior with SQLite and fixes reset/cleanup flows that rely on these queries.

- **Bug Fixes**
  - Handle deletes by `thread_key` or `run_id` in `deleteScheduledWork` (alongside `kind` + `work_id`).
  - Add a regression test mirroring the Bori reset cleanup SQL.

<sup>Written for commit 64f3f3566b4fb2dc3c708cbba928498bc190577a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

