### PR TITLE
Support scheduled work payload deletes in tests

### DIFF
--- a/.changeset/runtime-scheduled-work-like-delete.md
+++ b/.changeset/runtime-scheduled-work-like-delete.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Support scheduled work payload LIKE deletes in the local Durable Object SQL test adapter.

--- a/packages/runtime/src/cloudflare/host/durable-object-host.test.ts
+++ b/packages/runtime/src/cloudflare/host/durable-object-host.test.ts
@@ -149,6 +149,14 @@ describe("Cloudflare Durable Object host adapter", () => {
         work_id: expect.any(String),
       },
     ]);
+
+    storage.sql.exec(
+      "DELETE FROM pss_scheduled_work WHERE prefix = ? AND payload LIKE ? ESCAPE '\\'",
+      "pss-runtime",
+      '%"threadKey":"thread-b"%'
+    );
+
+    expect(readScheduledWorkRows(storage)).toEqual([]);
   });
 
   it("uses the SQLite scheduled queue with default in-memory Durable Object storage", async () => {

--- a/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/cloudflare/sql/durable-object-test/write.ts
@@ -303,6 +303,14 @@ function deleteScheduledWork(
   bindings: readonly unknown[]
 ): void {
   const prefix = stringBinding(bindings[0]);
+  if (query.includes("payload like ?")) {
+    const pattern = stringBinding(bindings[1]);
+    state.scheduledWork = state.scheduledWork.filter(
+      (row) =>
+        !(row.prefix === prefix && sqliteLikeMatches(row.payload, pattern))
+    );
+    return;
+  }
   if (query.includes("thread_key = ?")) {
     const threadKey = stringBinding(bindings[1]);
     state.scheduledWork = state.scheduledWork.filter(
@@ -323,4 +331,37 @@ function deleteScheduledWork(
     (row) =>
       !(row.prefix === prefix && row.kind === kind && row.work_id === workId)
   );
+}
+
+function sqliteLikeMatches(value: string, pattern: string): boolean {
+  let source = "^";
+  let escaping = false;
+  for (const char of pattern) {
+    if (escaping) {
+      source += escapeRegExp(char);
+      escaping = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaping = true;
+      continue;
+    }
+    if (char === "%") {
+      source += ".*";
+      continue;
+    }
+    if (char === "_") {
+      source += ".";
+      continue;
+    }
+    source += escapeRegExp(char);
+  }
+  if (escaping) {
+    source += "\\\\";
+  }
+  return new RegExp(`${source}$`, "s").test(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }


### PR DESCRIPTION
## Summary
- support SQLite scheduled work deletes by payload LIKE in the local DO SQL test adapter
- cover the Bori legacy scheduled-work cleanup query shape with a regression test
- add a patch changeset for @minpeter/pss-runtime

## Verification
- pnpm --filter @minpeter/pss-runtime exec vitest run src/cloudflare/host/durable-object-host.test.ts --reporter=verbose --no-cache
- pnpm --filter @minpeter/pss-runtime test
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm verify:release
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for deleting scheduled work by payload LIKE in the local Durable Object SQL test adapter to match production cleanup queries. Includes a regression test for the legacy Bori query and a patch changeset for `@minpeter/pss-runtime`.

<sup>Written for commit d4d6c6de6b03a2b7206b4f98f4e116b28f2aeb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

