### PR TITLE
Refactor runtime turns and checkpoints

### DIFF
--- a/.changeset/runtime-turn-step-naming.md
+++ b/.changeset/runtime-turn-step-naming.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Replace legacy session/run public aliases with Thread, Turn, and Checkpoint runtime naming.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -11,24 +11,24 @@ const agent = new Agent({
   model: createCodingLanguageModel(),
 });
 
-const run = await agent.send("Hello from pss");
-for await (const event of run.events()) {
+const turn = await agent.send("Hello from pss");
+for await (const event of turn.events()) {
   console.dir(event, { depth: null });
 }
 ```
 
-`run.events()` is synchronized and drives the run. The runtime waits at
+`turn.events()` is synchronized and drives the turn. The runtime waits at
 `turn-start`, `step-start`, and `step-end` until the events consumer continues,
-so consume the events to let the run progress. Use `thread.send(input)` for a
-new user turn and `thread.steer(input)` to steer the active run. If no run is
-active, `thread.steer(input)` starts a normal run.
+so consume the events to let the turn progress. Use `thread.send(input)` for a
+new user turn and `thread.steer(input)` to steer the active turn. If no turn is
+active, `thread.steer(input)` starts a normal turn.
 
 ```ts
 const thread = agent.thread("default");
-const run = await thread.send("Explain the latest result.");
+const turn = await thread.send("Explain the latest result.");
 let askedForExample = false;
 
-for await (const event of run.events()) {
+for await (const event of turn.events()) {
   if (event.type === "step-end" && !askedForExample) {
     askedForExample = true;
     await thread.steer("Add one concrete example.");
@@ -44,7 +44,7 @@ the turn running indefinitely.
 Runtime additions emit `runtime-input`: runtime/API-originated input mapped
 internally to the model's user role, separate from human `user-text` and
 `user-message` events. `thread.send(input)` starts or enqueues a new turn;
-`thread.steer(input)` steers the active run or starts a normal run when idle.
+`thread.steer(input)` steers the active turn or starts a normal turn when idle.
 
 ## CLI
 
@@ -71,7 +71,7 @@ await startTui({ tools });
 
 When the TUI is idle, submitting text starts a normal `thread.send()` turn. When
 a run is active, submitting text calls `thread.steer(trimmed)` so the text lands
-in the current run and renders as dim `runtime: ...` input instead of a new human
+in the current turn and renders as dim `runtime: ...` input instead of a new human
 turn.
 
 ## Env

--- a/apps/coding-agent/src/tui-runner.ts
+++ b/apps/coding-agent/src/tui-runner.ts
@@ -1,6 +1,6 @@
 import type {
   AgentEvent,
-  AgentRun,
+  AgentTurn,
   ThreadHandle,
   UserInput,
   UserMessage,
@@ -22,9 +22,9 @@ export interface TuiRunnerOptions {
 }
 
 export interface TuiRunner {
-  readonly activeRun: AgentRun | undefined;
-  clearActiveRun(run?: AgentRun): void;
-  consumeRun(run: AgentRun): Promise<void>;
+  readonly activeRun: AgentTurn | undefined;
+  clearActiveRun(run?: AgentTurn): void;
+  consumeRun(run: AgentTurn): Promise<void>;
   submit(text: string): void;
 }
 
@@ -71,15 +71,15 @@ export function createTuiRunner({
   requestRender,
   thread,
 }: TuiRunnerOptions): TuiRunner {
-  let activeRun: AgentRun | undefined;
+  let activeRun: AgentTurn | undefined;
 
-  const clearActiveRun = (run?: AgentRun): void => {
+  const clearActiveRun = (run?: AgentTurn): void => {
     if (run === undefined || activeRun === run) {
       activeRun = undefined;
     }
   };
 
-  const consumeRun = async (run: AgentRun): Promise<void> => {
+  const consumeRun = async (run: AgentTurn): Promise<void> => {
     activeRun = run;
 
     try {

--- a/apps/worker-agent/src/agent.test.ts
+++ b/apps/worker-agent/src/agent.test.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, AgentRun } from "@minpeter/pss-runtime";
+import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
 import { describe, expect, it } from "vitest";
 
 import { collectAssistantText, WORKER_AGENT_INSTRUCTIONS } from "./agent";
@@ -84,7 +84,7 @@ describe("collectAssistantText", () => {
   });
 });
 
-function runWithEvents(events: readonly AgentEvent[]): AgentRun {
+function runWithEvents(events: readonly AgentEvent[]): AgentTurn {
   return {
     events: () => eventStream(events),
   };

--- a/apps/worker-agent/src/agent.ts
+++ b/apps/worker-agent/src/agent.ts
@@ -3,9 +3,9 @@ import {
   Agent,
   type AgentEvent,
   type AgentHost,
-  type AgentRun,
+  type AgentTurn,
 } from "@minpeter/pss-runtime";
-import { drainAgentRun } from "@minpeter/pss-runtime/cloudflare";
+import { drainAgentTurn } from "@minpeter/pss-runtime/cloudflare";
 
 import type { Env } from "./env";
 
@@ -74,8 +74,8 @@ export function createConfiguredAgent(env: Env, host: AgentHost): Agent {
   });
 }
 
-export async function collectAssistantText(run: AgentRun): Promise<string> {
-  const events = await drainAgentRun(run);
+export async function collectAssistantText(run: AgentTurn): Promise<string> {
+  const events = await drainAgentTurn(run);
   const turnError = events.find(
     (event): event is Extract<AgentEvent, { type: "turn-error" }> =>
       event.type === "turn-error"

--- a/examples/background-subagent/src/app-agent.ts
+++ b/examples/background-subagent/src/app-agent.ts
@@ -1,8 +1,8 @@
-import type { Agent, AgentRun } from "@minpeter/pss-runtime";
+import type { Agent, AgentTurn } from "@minpeter/pss-runtime";
 import type {
   ExecutionHost,
   NotificationRecord,
-  RunRecord,
+  TurnRecord,
 } from "@minpeter/pss-runtime/execution";
 import { readDurableBackgroundDelegationState } from "./background-delegation";
 import { readerChildName } from "./delegate-tool";
@@ -16,7 +16,7 @@ export function createAppAgent(options: {
 }): Agent {
   return {
     resume: async (runId: string) => {
-      const run = await options.host.store.runs.get(runId);
+      const run = await options.host.store.turns.get(runId);
       if (run?.runId.startsWith("background:")) {
         return await resumeBackgroundDelegation({
           host: options.host,
@@ -54,8 +54,8 @@ async function resumeBackgroundDelegation({
   readonly ownerNamespace: string;
   readonly parentThreadKey: string;
   readonly reader: Agent;
-  readonly run: RunRecord;
-}): Promise<AgentRun | null> {
+  readonly run: TurnRecord;
+}): Promise<AgentTurn | null> {
   if (run.status === "completed") {
     return null;
   }
@@ -67,7 +67,7 @@ async function resumeBackgroundDelegation({
   }
   assertOwnedBackgroundRun({ ownerNamespace, parentThreadKey, run, state });
 
-  await host.store.runs.update({ ...run, status: "running" });
+  await host.store.turns.update({ ...run, status: "running" });
   const childRun = await reader.thread(run.threadKey).send(state.prompt);
   const events = await collectRunEvents(childRun);
   const output = {
@@ -75,7 +75,7 @@ async function resumeBackgroundDelegation({
     subagent: readerChildName,
     text: collectAssistantText(events),
   };
-  await host.store.runs.update({
+  await host.store.turns.update({
     ...run,
     checkpointVersion: run.checkpointVersion,
     output,
@@ -90,8 +90,8 @@ async function resumeBackgroundDelegation({
   return replayRun(events);
 }
 
-async function collectRunEvents(run: AgentRun) {
-  const events: Awaited<ReturnType<AgentRun["events"]>> extends AsyncIterable<
+async function collectRunEvents(run: AgentTurn) {
+  const events: Awaited<ReturnType<AgentTurn["events"]>> extends AsyncIterable<
     infer Event
   >
     ? Event[]
@@ -117,7 +117,7 @@ async function enqueueCompletionNotification({
   state,
 }: {
   readonly host: ExecutionHost;
-  readonly run: RunRecord;
+  readonly run: TurnRecord;
   readonly state: NonNullable<
     ReturnType<typeof readDurableBackgroundDelegationState>
   >;
@@ -146,7 +146,7 @@ async function enqueueCompletionNotification({
     return;
   }
 
-  await host.store.runs.create({
+  await host.store.turns.create({
     checkpointVersion: 0,
     dedupeKey: idempotencyKey,
     kind: "notification",
@@ -176,8 +176,8 @@ async function resumeCompletionNotification({
   readonly host: ExecutionHost;
   readonly ownerNamespace: string;
   readonly parentThreadKey: string;
-  readonly run: RunRecord;
-}): Promise<AgentRun | null> {
+  readonly run: TurnRecord;
+}): Promise<AgentTurn | null> {
   if (
     run.ownerNamespace !== ownerNamespace ||
     run.threadKey !== parentThreadKey
@@ -198,7 +198,7 @@ async function resumeCompletionNotification({
   const notificationRun = await coordinator
     .thread(notification.threadKey)
     .send(notification.input);
-  await host.store.runs.update({ ...run, status: "completed" });
+  await host.store.turns.update({ ...run, status: "completed" });
   return notificationRun;
 }
 
@@ -254,7 +254,7 @@ function assertOwnedBackgroundRun({
 }: {
   readonly ownerNamespace: string;
   readonly parentThreadKey: string;
-  readonly run: RunRecord;
+  readonly run: TurnRecord;
   readonly state: NonNullable<
     ReturnType<typeof readDurableBackgroundDelegationState>
   >;
@@ -265,7 +265,7 @@ function assertOwnedBackgroundRun({
 
   if (state.parentThreadKey !== parentThreadKey) {
     throw new Error(
-      `Background task ${run.runId} is not linked to this session.`
+      `Background task ${run.runId} is not linked to this thread.`
     );
   }
 
@@ -276,7 +276,7 @@ function assertOwnedBackgroundRun({
 
 function replayRun(
   events: Awaited<ReturnType<typeof collectRunEvents>>
-): AgentRun {
+): AgentTurn {
   return {
     events: () => eventStream(events),
   };

--- a/examples/background-subagent/src/app-owned-background.test.ts
+++ b/examples/background-subagent/src/app-owned-background.test.ts
@@ -1,4 +1,4 @@
-import type { Agent, AgentInput, AgentRun } from "@minpeter/pss-runtime";
+import type { Agent, AgentInput, AgentTurn } from "@minpeter/pss-runtime";
 import {
   createInMemoryExecutionHost,
   type ExecutionHost,
@@ -35,11 +35,11 @@ describe("app-owned background delegation", () => {
     const job = await launchTask(host, {
       ownerNamespace: "app:other:default",
     });
-    const run = await host.store.runs.get(`background:${job.id}`);
+    const run = await host.store.turns.get(`background:${job.id}`);
     if (!run) {
       throw new Error("expected background run to exist");
     }
-    await host.store.runs.update({
+    await host.store.turns.update({
       ...run,
       output: { text: "SECRET" },
       status: "completed",
@@ -81,7 +81,7 @@ describe("app-owned background delegation", () => {
     await appAgent.resume(`background:${job.id}`);
 
     await expect(
-      host.store.runs.get(`notification:${job.id}`)
+      host.store.turns.get(`notification:${job.id}`)
     ).resolves.toBeNull();
     expect(resumeCalls).toEqual([]);
   });
@@ -102,7 +102,7 @@ describe("app-owned background delegation", () => {
       "coordinator saw notification"
     );
     await expect(
-      host.store.runs.get(`notification:${job.id}`)
+      host.store.turns.get(`notification:${job.id}`)
     ).resolves.toEqual(expect.objectContaining({ status: "completed" }));
   });
 });
@@ -141,7 +141,7 @@ function createTestAppAgent(host: ExecutionHost): Agent {
   });
 }
 
-async function collectAssistantText(run: AgentRun) {
+async function collectAssistantText(run: AgentTurn) {
   let text = "";
   for await (const event of run.events()) {
     if (event.type === "assistant-text") {
@@ -162,7 +162,7 @@ function createReaderAgent(): Agent {
   } as unknown as Agent;
 }
 
-function runWithText(text: string): AgentRun {
+function runWithText(text: string): AgentTurn {
   return {
     events: () => eventStream([{ text, type: "assistant-text" }]),
   };

--- a/examples/background-subagent/src/background-delegation.ts
+++ b/examples/background-subagent/src/background-delegation.ts
@@ -1,5 +1,8 @@
 import type { AgentInput } from "@minpeter/pss-runtime";
-import type { ExecutionHost, RunRecord } from "@minpeter/pss-runtime/execution";
+import type {
+  ExecutionHost,
+  TurnRecord,
+} from "@minpeter/pss-runtime/execution";
 
 const backgroundDelegationStateKind = "background-delegation" as const;
 
@@ -94,27 +97,27 @@ async function createDurableBackgroundTaskId({
 
 async function getBackgroundChildRun(
   input: BackgroundChildRunInput
-): Promise<RunRecord | undefined> {
+): Promise<TurnRecord | undefined> {
   const dedupeKey = backgroundSubagentDedupeKey(input);
   return (
-    (await input.executionHost.store.runs.getByDedupeKey(dedupeKey)) ??
+    (await input.executionHost.store.turns.getByDedupeKey(dedupeKey)) ??
     undefined
   );
 }
 
 async function getOrCreateBackgroundChildRun(
   input: BackgroundChildRunInput & { readonly publicTaskId: string }
-): Promise<RunRecord | undefined> {
+): Promise<TurnRecord | undefined> {
   const dedupeKey = backgroundSubagentDedupeKey(input);
   return await input.executionHost.store.transaction(async (tx) => {
-    const existing = await tx.runs.getByDedupeKey(dedupeKey);
+    const existing = await tx.turns.getByDedupeKey(dedupeKey);
     if (existing) {
       return existing;
     }
 
     const parentRunId = input.parentThreadKey ?? input.threadKey;
     const runtimeState = durableBackgroundChildRunState(input);
-    const run: RunRecord = {
+    const run: TurnRecord = {
       checkpointVersion: 0,
       dedupeKey,
       kind: "user-turn",
@@ -126,7 +129,7 @@ async function getOrCreateBackgroundChildRun(
       threadKey: `${input.threadKey}:task:${input.publicTaskId}`,
       status: "queued",
     };
-    await tx.runs.create(run);
+    await tx.turns.create(run);
     await tx.checkpoints.append(
       {
         checkpointId: crypto.randomUUID(),
@@ -150,7 +153,7 @@ async function getOrCreateBackgroundChildRun(
       },
       { expectedVersion: 1 }
     );
-    return (await tx.runs.get(run.runId)) ?? run;
+    return (await tx.turns.get(run.runId)) ?? run;
   });
 }
 

--- a/examples/background-subagent/src/background-output-tool.ts
+++ b/examples/background-subagent/src/background-output-tool.ts
@@ -1,4 +1,7 @@
-import type { ExecutionHost, RunStatus } from "@minpeter/pss-runtime/execution";
+import type {
+  ExecutionHost,
+  TurnStatus,
+} from "@minpeter/pss-runtime/execution";
 import { jsonSchema, tool } from "ai";
 import { readDurableBackgroundDelegationState } from "./background-delegation";
 import { readerChildName } from "./delegate-tool";
@@ -19,7 +22,7 @@ export function createBackgroundOutputTool({
   return tool<BackgroundOutputInput, unknown, Record<string, unknown>>({
     description: "백그라운드 reader 작업의 결과를 가져온다.",
     execute: async ({ task_id }) => {
-      const record = await executionHost.store.runs.get(
+      const record = await executionHost.store.turns.get(
         `background:${task_id}`
       );
       if (!record || record.publicTaskId !== task_id) {
@@ -55,7 +58,7 @@ export function createBackgroundOutputTool({
   });
 }
 
-function normalizeStatus(status: RunStatus): string {
+function normalizeStatus(status: TurnStatus): string {
   if (status === "completed" || status === "cancelled" || status === "error") {
     return status;
   }

--- a/examples/background-subagent/src/local-host.ts
+++ b/examples/background-subagent/src/local-host.ts
@@ -1,4 +1,4 @@
-import type { Agent, AgentRun } from "@minpeter/pss-runtime";
+import type { Agent, AgentTurn } from "@minpeter/pss-runtime";
 import {
   createInMemoryExecutionHost,
   type ExecutionHost,
@@ -24,7 +24,7 @@ interface ThreadPromptWaiter {
 }
 
 export interface LocalHost extends ExecutionHost {
-  resumeThread(options?: { readonly timeoutMs?: number }): Promise<AgentRun>;
+  resumeThread(options?: { readonly timeoutMs?: number }): Promise<AgentTurn>;
 }
 
 class LocalHostError extends Error {

--- a/examples/background-subagent/src/print-run.ts
+++ b/examples/background-subagent/src/print-run.ts
@@ -1,6 +1,6 @@
-import type { AgentEvent, AgentRun } from "@minpeter/pss-runtime";
+import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
 
-export async function drainRunForCli(run: AgentRun) {
+export async function drainRunForCli(run: AgentTurn) {
   for await (const event of run.events()) {
     printCliEvent(event);
   }

--- a/examples/basic/src/drain.ts
+++ b/examples/basic/src/drain.ts
@@ -1,6 +1,6 @@
-import type { AgentRun } from "@minpeter/pss-runtime";
+import type { AgentTurn } from "@minpeter/pss-runtime";
 
-export async function drain(run: AgentRun) {
+export async function drain(run: AgentTurn) {
   for await (const event of run.events()) {
     switch (event.type) {
       case "assistant-text":

--- a/examples/local-file-agent/src/drain.ts
+++ b/examples/local-file-agent/src/drain.ts
@@ -1,6 +1,6 @@
-import type { AgentRun } from "@minpeter/pss-runtime";
+import type { AgentTurn } from "@minpeter/pss-runtime";
 
-export async function drain(run: AgentRun): Promise<void> {
+export async function drain(run: AgentTurn): Promise<void> {
   for await (const event of run.events()) {
     switch (event.type) {
       case "assistant-text":

--- a/examples/sync-subagent/src/delegate-tool.ts
+++ b/examples/sync-subagent/src/delegate-tool.ts
@@ -1,7 +1,7 @@
 import {
   type Agent,
   type AgentInput,
-  type AgentRun,
+  type AgentTurn,
   delegateUserInput,
 } from "@minpeter/pss-runtime";
 import { defaultChildThreadKey } from "@minpeter/pss-runtime/namespace";
@@ -90,7 +90,7 @@ async function runBlockingDelegation({
   }
 }
 
-async function collectAssistantText(run: AgentRun) {
+async function collectAssistantText(run: AgentTurn) {
   let text = "";
   for await (const event of run.events()) {
     if (event.type === "assistant-text") {

--- a/examples/sync-subagent/src/print-run.ts
+++ b/examples/sync-subagent/src/print-run.ts
@@ -1,6 +1,6 @@
-import type { AgentEvent, AgentRun } from "@minpeter/pss-runtime";
+import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
 
-export async function drainRunForCli(run: AgentRun) {
+export async function drainRunForCli(run: AgentTurn) {
   for await (const event of run.events()) {
     printCliEvent(event);
   }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -4,8 +4,8 @@
 
 # @minpeter/pss-runtime
 
-Minimal, platform-agnostic agent runtime with keyed sessions, synchronized
-`run.events()`, and opaque persistence contracts.
+Minimal, platform-agnostic agent runtime with keyed threads, synchronized
+`turn.events()`, and opaque persistence contracts.
 
 ## Core DX
 
@@ -37,15 +37,15 @@ const agent = new Agent({
   model: provider(env.AI_MODEL),
 });
 
-const run = await agent.send("Hello");
-for await (const event of run.events()) {
+const turn = await agent.send("Hello");
+for await (const event of turn.events()) {
   console.log(event);
 }
 ```
 
-`run.events()` is the run driver. The runtime stops at synchronized lifecycle
+`turn.events()` is the turn driver. The runtime stops at synchronized lifecycle
 boundaries until the events consumer asks for the next event, so callers must
-consume the events for the run to progress. This is what lets code react to
+consume the events for the turn to progress. This is what lets code react to
 `turn-start`, `step-start`, and `step-end` before the next model snapshot is
 created.
 
@@ -69,8 +69,8 @@ Per-key conversations use `thread(key)`:
 
 ```ts
 const roomThread = agent.thread("room:123:user:456");
-const run = await roomThread.send(["Context: user prefers short answers", "Hi"]);
-for await (const event of run.events()) {
+const turn = await roomThread.send(["Context: user prefers short answers", "Hi"]);
+for await (const event of turn.events()) {
   // events for this single turn
 }
 ```
@@ -82,7 +82,7 @@ parts through the same API. String input and `readonly string[]` remain supporte
 shortcuts for text-only turns.
 
 ```ts
-const run = await agent.send([
+const turn = await agent.send([
   { type: "text", text: "Describe this UI screenshot." },
   {
     type: "image",
@@ -107,12 +107,12 @@ await agent.send([
 ]);
 ```
 
-The runtime normalizes and persists these content parts as session continuation
+The runtime normalizes and persists these content parts as thread continuation
 state; it does not fetch remote media, decode files, or guarantee provider support
 for every media type.
 
-The public transcript protocol is `AgentEvent`: live runs emit runtime-defined
-events through `run.events()`. Provider/model message history is internal
+The public transcript protocol is `AgentEvent`: live turns emit runtime-defined
+events through `turn.events()`. Provider/model message history is internal
 continuation state, not a public history API.
 
 ## Delegation
@@ -136,9 +136,9 @@ const coordinator = new Agent({
     delegate_to_reader: tool({
       description: "Ask the reader agent to inspect the knowledge base.",
       execute: async ({ prompt }) => {
-        const run = await reader.thread("kb").send(prompt);
+        const turn = await reader.thread("kb").send(prompt);
         const text: string[] = [];
-        for await (const event of run.events()) {
+        for await (const event of turn.events()) {
           if (event.type === "assistant-text") {
             text.push(event.text);
           }
@@ -153,7 +153,7 @@ const coordinator = new Agent({
 
 For background delegation, let your host own task ids, scheduling, output
 storage, and notification resume. The runtime provides generic execution stores,
-notifications, `Agent.resume(...)`, and `run.events()`; it does not generate
+notifications, `Agent.resume(...)`, and `turn.events()`; it does not generate
 delegation tools or own child-agent lifecycle semantics. See
 the sync and background example packages for app-owned blocking and background
 delegation patterns.
@@ -212,10 +212,10 @@ on `event.meta?.source`:
 |----------|----------|
 | `send` | `thread.send()` / `agent.send()` |
 | `steer` | `thread.steer()` and drained steering queue |
-| `notify` | `session.notify()` runtime input |
+| `notify` | host notification runtime input |
 | `delegate` | parent `delegate_to_*` child `thread.send()` |
 
-`meta` appears on `run.events()` for input events but is stripped before session
+`meta` appears on `turn.events()` for input events but is stripped before thread
 history persistence and model mapping. It never reaches the LLM prompt.
 
 ### Delegate prompt wrapping
@@ -259,14 +259,14 @@ plugin.
 
 ## Send, Host Resume, and Steer
 
-Use `thread.send(input)` for a new user turn. If a run is already active, the
-turn is queued until the active run finishes. Use `thread.steer(input)` when
-the input should steer the active run; if no run is active, it starts a normal
-run.
+Use `thread.send(input)` for a new user turn. If a turn is already active, the
+turn is queued until the active turn finishes. Use `thread.steer(input)` when
+the input should steer the active turn; if no turn is active, it starts a normal
+turn.
 
 Durable hosts resume completed background work by writing a notification record
 and calling `agent.resume(notificationRunId)`. The resume call claims the
-notification idempotently through its durable run id and returns one `AgentRun`,
+notification idempotently through its durable run id and returns one `AgentTurn`,
 or `null` when a duplicate queue/alarm delivery already claimed it.
 
 `agent.resume(runId)` also returns `null` when the host does not support durable
@@ -278,8 +278,8 @@ Runtime-originated input is delivered through the host notification inbox and
 internal plugin paths. App code should use `thread.send()`, `thread.steer()`,
 or `agent.resume(runId)` for host-scheduled durable work.
 
-Each accepted call returns one `AgentRun`. Drain that run's `events()` stream to
-observe the turn; each `AgentRun.events()` stream is single-consumer.
+Each accepted call returns one `AgentTurn`. Drain that turn's `events()` stream to
+observe the turn; each `AgentTurn.events()` stream is single-consumer.
 
 Input APIs accept the same input shapes: strings, arrays of strings,
 `{ type: "user-text", text }`, and multipart `{ type: "user-message", content }`
@@ -299,10 +299,10 @@ on every `step-end` can keep the turn running indefinitely.
 
 ```ts
 const thread = agent.thread("room:123:user:456");
-const run = await thread.send("Draft a short answer.");
+const turn = await thread.send("Draft a short answer.");
 let addedSteer = false;
 
-for await (const event of run.events()) {
+for await (const event of turn.events()) {
   if (event.type === "assistant-text") {
     process.stdout.write(event.text);
   }
@@ -314,8 +314,8 @@ for await (const event of run.events()) {
 }
 ```
 
-`thread.steer()` resolves when the input is accepted into the active run's
-pending steering path or, when idle, when a new run is scheduled. It does not wait
+`thread.steer()` resolves when the input is accepted into the active turn's
+pending steering path or, when idle, when a new turn is scheduled. It does not wait
 for a later model snapshot.
 
 ## Thread Storage and Portability

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -21,16 +21,6 @@
       "types": "./dist/thread/store/file.d.ts",
       "import": "./dist/thread/store/file.js"
     },
-    "./session-store/memory": {
-      "@minpeter/pss-source": "./src/thread/store/memory.ts",
-      "types": "./dist/thread/store/memory.d.ts",
-      "import": "./dist/thread/store/memory.js"
-    },
-    "./session-store/file": {
-      "@minpeter/pss-source": "./src/thread/store/file.ts",
-      "types": "./dist/thread/store/file.d.ts",
-      "import": "./dist/thread/store/file.js"
-    },
     "./cloudflare": {
       "@minpeter/pss-source": "./src/platform/cloudflare/index.ts",
       "types": "./dist/platform/cloudflare/index.d.ts",

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -3,10 +3,10 @@ import type { AgentHost, NotificationRecord } from "../../execution/host/types";
 import { createInMemoryExecutionHost } from "../../execution/memory";
 import { type AgentInput, AgentThread } from "../../thread/handle/thread";
 import type { AgentPlugin } from "../../thread/plugins/pipeline";
-import type { AgentRun } from "../../thread/protocol/run";
+import type { AgentTurn } from "../../thread/protocol/turn";
 import type { ThreadStore } from "../../thread/store/types";
 import { stableAgentNamespace } from "../identity/namespace";
-import { resumeAgentRun } from "../resume/resume";
+import { resumeAgentTurn } from "../resume/resume";
 import { threadStoreForHost } from "./host-thread-store";
 import {
   type AgentModelOptions,
@@ -68,25 +68,25 @@ export class Agent {
     return executionHost(this.#host) !== undefined;
   }
 
-  send(input: AgentInput): Promise<AgentRun> {
+  send(input: AgentInput): Promise<AgentTurn> {
     return this.thread("default").send(input);
   }
 
   /**
-   * Resume a durable run by id. Returns the resumed `AgentRun`, or `null` when
+   * Resume a durable run by id. Returns the resumed `AgentTurn`, or `null` when
    * the host does not support durable resume (`supportsResume === false`), the
    * run id is unknown to this namespace, or a duplicate queue/alarm delivery
    * already claimed it. This never throws for a missing host; check
    * `supportsResume` first when you need to distinguish unsupported from
    * not-found.
    */
-  async resume(runId: string): Promise<AgentRun | null> {
+  async resume(runId: string): Promise<AgentTurn | null> {
     const host = executionHost(this.#host);
     if (!host) {
       return null;
     }
 
-    return await resumeAgentRun({
+    return await resumeAgentTurn({
       host,
       ownerNamespace: this.#ownerNamespace,
       resumeNotification: (notification) =>
@@ -141,7 +141,7 @@ export class Agent {
     this.#threads.delete(key);
   }
 
-  #resumeNotification(notification: NotificationRecord): Promise<AgentRun> {
+  #resumeNotification(notification: NotificationRecord): Promise<AgentTurn> {
     return this.#threadEntry(notification.threadKey).notify(
       notification.input,
       { observerEvents: notification.observerEvents }

--- a/packages/runtime/src/agent/core/host-api.test.ts
+++ b/packages/runtime/src/agent/core/host-api.test.ts
@@ -4,7 +4,6 @@ import {
   type DurableBackgroundHost,
   type ExecutionHost,
   type ExecutionScheduler,
-  type SessionHost,
   type ThreadHost,
 } from "../../execution";
 import {
@@ -35,32 +34,14 @@ const acceptsThreadHost = {
   kind: "thread",
   threadStore: new SpyStore(),
 } satisfies ThreadHost;
-const acceptsLegacySessionHost = {
-  kind: "session",
-  threadStore: new SpyStore(),
-} satisfies SessionHost;
-const acceptsSessionStoreOnlyLegacySessionHost = {
-  kind: "session",
-  sessionStore: new SpyStore(),
-} satisfies SessionHost;
 const acceptsDurableBackgroundHost = {
   backgroundScheduler: aggregateHost.scheduler,
   checkpointStore: aggregateHost.store.checkpoints,
   eventStore: aggregateHost.store.events,
   kind: "durable-background",
   notificationInbox: aggregateHost.store.notifications,
-  runStore: aggregateHost.store.runs,
+  turnStore: aggregateHost.store.turns,
   threadStore: aggregateHost.store.threads,
-  transaction: aggregateHost.store.transaction.bind(aggregateHost.store),
-} satisfies DurableBackgroundHost;
-const acceptsSessionStoreOnlyDurableBackgroundHost = {
-  backgroundScheduler: aggregateHost.scheduler,
-  checkpointStore: aggregateHost.store.checkpoints,
-  eventStore: aggregateHost.store.events,
-  kind: "durable-background",
-  notificationInbox: aggregateHost.store.notifications,
-  runStore: aggregateHost.store.runs,
-  sessionStore: aggregateHost.store.threads,
   transaction: aggregateHost.store.transaction.bind(aggregateHost.store),
 } satisfies DurableBackgroundHost;
 
@@ -91,21 +72,30 @@ type AcceptsThreadHostAsAgentHost = IsAssignable<
   typeof acceptsThreadHost,
   AgentHost
 >;
-type AcceptsLegacySessionHostAsAgentHost = IsAssignable<
-  typeof acceptsLegacySessionHost,
-  AgentHost
->;
-type AcceptsSessionStoreOnlyLegacySessionHostAsAgentHost = IsAssignable<
-  typeof acceptsSessionStoreOnlyLegacySessionHost,
-  AgentHost
->;
 type AcceptsExecutionHostAsAgentHost = IsAssignable<
   typeof aggregateHost,
   AgentHost
 >;
-type AcceptsSessionStoreOnlyDurableBackgroundHostAsAgentHost = IsAssignable<
-  typeof acceptsSessionStoreOnlyDurableBackgroundHost,
-  AgentHost
+type RejectsLegacyKindAsAgentHost = AssertFalse<
+  IsAssignable<
+    { readonly kind: "legacy"; readonly threadStore: SpyStore },
+    AgentHost
+  >
+>;
+type RejectsLegacyStoreOnlyDurableBackgroundHost = AssertFalse<
+  IsAssignable<
+    {
+      readonly backgroundScheduler: typeof aggregateHost.scheduler;
+      readonly eventStore: typeof aggregateHost.store.events;
+      readonly kind: "durable-background";
+      readonly notificationInbox: typeof aggregateHost.store.notifications;
+      readonly legacyStore: SpyStore;
+      readonly checkpointStore: typeof aggregateHost.store.checkpoints;
+      readonly transaction: typeof aggregateHost.store.transaction;
+      readonly turnStore: typeof aggregateHost.store.turns;
+    },
+    AgentHost
+  >
 >;
 type DurableSchedulerMatchesExecutionScheduler = IsAssignable<
   DurableBackgroundHost["backgroundScheduler"],
@@ -115,9 +105,6 @@ type DurableSchedulerMatchesExecutionScheduler = IsAssignable<
 const typeFixtures = [
   acceptsDurableBackgroundHost,
   acceptsHostOptions,
-  acceptsLegacySessionHost,
-  acceptsSessionStoreOnlyDurableBackgroundHost,
-  acceptsSessionStoreOnlyLegacySessionHost,
   acceptsThreadHost,
 ];
 const acceptsHostOptionAssertion: AcceptsHostOption = true;
@@ -129,15 +116,14 @@ const hostThreadStoreAssertion: RejectsBareThreadStoreAsHost = false;
 const executionThreadStoreAssertion: RejectsExecutionHostThreadStoreKey = false;
 const hostKindAssertion: RequiresHostKindKey = true;
 const acceptsThreadHostAssertion: AcceptsThreadHostAsAgentHost = true;
-const acceptsLegacySessionHostAssertion: AcceptsLegacySessionHostAsAgentHost = true;
-const acceptsSessionStoreOnlyLegacySessionHostAssertion: AcceptsSessionStoreOnlyLegacySessionHostAsAgentHost = true;
 const acceptsExecutionHostAssertion: AcceptsExecutionHostAsAgentHost = true;
-const acceptsSessionStoreOnlyDurableBackgroundHostAssertion: AcceptsSessionStoreOnlyDurableBackgroundHostAsAgentHost = true;
+const rejectsLegacyKindAssertion: RejectsLegacyKindAsAgentHost = false;
+const rejectsLegacyStoreOnlyDurableBackgroundHostAssertion: RejectsLegacyStoreOnlyDurableBackgroundHost = false;
 const durableSchedulerAssertion: DurableSchedulerMatchesExecutionScheduler = true;
 
 describe("Agent host public API", () => {
   it("accepts host option and keeps unsupported option keys out of AgentOptions", () => {
-    expect(typeFixtures).toHaveLength(6);
+    expect(typeFixtures).toHaveLength(3);
     expect(acceptsHostOptionAssertion).toBe(true);
     expect(rejectsRuntimeModelOptionAssertion).toBe(false);
     expect(llmOptionAssertion).toBe(false);
@@ -147,10 +133,9 @@ describe("Agent host public API", () => {
     expect(executionThreadStoreAssertion).toBe(false);
     expect(hostKindAssertion).toBe(true);
     expect(acceptsThreadHostAssertion).toBe(true);
-    expect(acceptsLegacySessionHostAssertion).toBe(true);
-    expect(acceptsSessionStoreOnlyLegacySessionHostAssertion).toBe(true);
     expect(acceptsExecutionHostAssertion).toBe(true);
-    expect(acceptsSessionStoreOnlyDurableBackgroundHostAssertion).toBe(true);
+    expect(rejectsLegacyKindAssertion).toBe(false);
+    expect(rejectsLegacyStoreOnlyDurableBackgroundHostAssertion).toBe(false);
     expect(durableSchedulerAssertion).toBe(true);
     expect(new Agent({ host: inProcessHost, model: fakeModel })).toBeInstanceOf(
       Agent
@@ -203,20 +188,6 @@ describe("Agent host public API", () => {
     await collect(await agent.thread("host-owned").send("hello"));
 
     expect(threadStore.commits.at(-1)?.key).toBe("host-owned");
-  });
-
-  it("uses deprecated session host store for thread snapshots", async () => {
-    const sessionStore = new SpyStore();
-    const agent = new Agent({
-      host: { kind: "session", sessionStore },
-      model: createCallbackModel(() =>
-        Promise.resolve([assistantMessage("DONE")])
-      ),
-    });
-
-    await collect(await agent.thread("legacy-host-owned").send("hello"));
-
-    expect(sessionStore.commits.at(-1)?.key).toBe("legacy-host-owned");
   });
 
   it("includes scoped thread addresses in the stored thread key", async () => {

--- a/packages/runtime/src/agent/core/thread-entry.ts
+++ b/packages/runtime/src/agent/core/thread-entry.ts
@@ -1,5 +1,5 @@
 import type { AgentInput, NotifyOptions } from "../../thread/handle/thread";
-import type { AgentRun } from "../../thread/protocol/run";
+import type { AgentTurn } from "../../thread/protocol/turn";
 import { namespacePart } from "../identity/namespace";
 
 export interface ThreadMetadata {
@@ -18,12 +18,12 @@ export interface ThreadHandle {
   delete(): Promise<void>;
   dispose(): Promise<void>;
   interrupt(): void;
-  send(input: AgentInput): Promise<AgentRun>;
-  steer(input: AgentInput): Promise<AgentRun>;
+  send(input: AgentInput): Promise<AgentTurn>;
+  steer(input: AgentInput): Promise<AgentTurn>;
 }
 
 export interface AgentThreadEntry {
-  notify(input: AgentInput, options?: NotifyOptions): Promise<AgentRun>;
+  notify(input: AgentInput, options?: NotifyOptions): Promise<AgentTurn>;
   readonly publicHandle: ThreadHandle;
 }
 

--- a/packages/runtime/src/agent/loop/resume-checkpoint.test.ts
+++ b/packages/runtime/src/agent/loop/resume-checkpoint.test.ts
@@ -26,7 +26,7 @@ describe("resumeRun checkpoint recovery", () => {
     const history: ModelMessage[] = [
       userTextToModelMessage(userText("queued")),
     ];
-    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.turns.create(createQueuedUserTurnRun());
 
     const model = createMockLanguageModelV4([
       mockLanguageModelV4ToolCall({
@@ -98,7 +98,7 @@ describe("resumeRun checkpoint recovery", () => {
     const model = createScriptedModelOptions([
       [assistantMessage("SHOULD NOT RUN")],
     ]);
-    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.turns.create(createQueuedUserTurnRun());
     await host.store.checkpoints.append(
       {
         checkpointId: "pending-tool",
@@ -132,7 +132,7 @@ describe("resumeRun checkpoint recovery", () => {
     ];
     const model = createScriptedModelOptions([[assistantMessage("done")]]);
 
-    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.turns.create(createQueuedUserTurnRun());
 
     await expect(
       resumeRun({

--- a/packages/runtime/src/agent/loop/resume.test.ts
+++ b/packages/runtime/src/agent/loop/resume.test.ts
@@ -35,7 +35,7 @@ describe("resumeRun", () => {
   it("suspends without calling the model when maxSteps is zero", async () => {
     const host = createInMemoryExecutionHost();
     const model = createScriptedModelOptions([[assistantMessage("DONE")]]);
-    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.turns.create(createQueuedUserTurnRun());
 
     await expect(
       resumeRun({
@@ -57,7 +57,7 @@ describe("resumeRun", () => {
     const controller = new AbortController();
     controller.abort();
     const model = createScriptedModelOptions([[assistantMessage("DONE")]]);
-    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.turns.create(createQueuedUserTurnRun());
 
     await expect(
       resumeRun({
@@ -90,7 +90,7 @@ describe("resumeRun", () => {
       ],
       [assistantMessage("DONE")],
     ]);
-    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.turns.create(createQueuedUserTurnRun());
 
     const first = await resumeRun({
       budget: { maxSteps: 1 },
@@ -149,7 +149,7 @@ describe("resumeRun", () => {
       modelCalls += 1;
       return Promise.resolve(mockLanguageModelV4Text(`attempt ${modelCalls}`));
     });
-    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.turns.create(createQueuedUserTurnRun());
 
     await expect(
       resumeRun({

--- a/packages/runtime/src/agent/resume/notification-resume.test-support.ts
+++ b/packages/runtime/src/agent/resume/notification-resume.test-support.ts
@@ -1,11 +1,11 @@
 import { expect } from "vitest";
-import type { ExecutionHost, RunRecord } from "../../execution/host/types";
+import type { ExecutionHost, TurnRecord } from "../../execution/host/types";
 import { createInMemoryExecutionHost } from "../../execution/memory";
-import type { AgentRun } from "../../thread/protocol/run";
+import type { AgentTurn } from "../../thread/protocol/turn";
 import { agentNamespace } from "../identity/namespace";
 
 interface ResumableAgent {
-  resume(runId: string): Promise<AgentRun | null>;
+  resume(runId: string): Promise<AgentTurn | null>;
 }
 
 export function expectResumeSurface(
@@ -40,7 +40,7 @@ export function notificationRunRecord({
   readonly idempotencyKey: string;
   readonly ownerNamespace?: string;
   readonly runId: string;
-}): RunRecord {
+}): TurnRecord {
   return {
     checkpointVersion: 0,
     dedupeKey: idempotencyKey,

--- a/packages/runtime/src/agent/resume/notification-resume.test.ts
+++ b/packages/runtime/src/agent/resume/notification-resume.test.ts
@@ -46,7 +46,7 @@ describe("host notification resume", () => {
       status: "pending",
     } as const;
     await host.store.notifications.enqueue(notification);
-    await host.store.runs.create(
+    await host.store.turns.create(
       notificationRunRecord({
         idempotencyKey: notification.idempotencyKey,
         runId: notification.runId,
@@ -104,7 +104,7 @@ describe("host notification resume", () => {
       status: "pending",
     } as const;
     await host.store.notifications.enqueue(notification);
-    await host.store.runs.create(
+    await host.store.turns.create(
       notificationRunRecord({
         idempotencyKey: notification.idempotencyKey,
         ownerNamespace: agentNamespace("owner"),
@@ -139,7 +139,7 @@ describe("host notification resume", () => {
       status: "pending",
     } as const;
     await host.store.notifications.enqueue(notification);
-    await host.store.runs.create(
+    await host.store.turns.create(
       notificationRunRecord({
         idempotencyKey: notification.idempotencyKey,
         runId: notification.runId,
@@ -176,7 +176,7 @@ describe("host notification resume", () => {
       threadKey: "default",
       status: "acked",
     });
-    await host.store.runs.create(
+    await host.store.turns.create(
       notificationRunRecord({ idempotencyKey, runId })
     );
 
@@ -190,7 +190,7 @@ describe("host notification resume", () => {
     await expect(
       host.store.notifications.getByIdempotencyKey(idempotencyKey)
     ).resolves.toEqual(expect.objectContaining({ status: "acked" }));
-    await expect(host.store.runs.get(runId)).resolves.toEqual(
+    await expect(host.store.turns.get(runId)).resolves.toEqual(
       expect.objectContaining({ status: "completed" })
     );
     expect(calls).toBe(1);
@@ -207,12 +207,12 @@ describe("host notification resume", () => {
     });
     const idempotencyKey = "background-complete:bg_missing";
     const runId = "notification-run-missing";
-    await host.store.runs.create(
+    await host.store.turns.create(
       notificationRunRecord({ idempotencyKey, runId })
     );
 
     await expect(agent.resume(runId)).resolves.toBeNull();
-    await expect(host.store.runs.get(runId)).resolves.toEqual(
+    await expect(host.store.turns.get(runId)).resolves.toEqual(
       expect.objectContaining({ status: "leased" })
     );
   });

--- a/packages/runtime/src/agent/resume/resume.ts
+++ b/packages/runtime/src/agent/resume/resume.ts
@@ -1,25 +1,25 @@
 import type {
   ExecutionHost,
   NotificationRecord,
-  RunRecord,
+  TurnRecord,
 } from "../../execution/host/types";
-import type { AgentRun } from "../../thread/protocol/run";
+import type { AgentTurn } from "../../thread/protocol/turn";
 import { ownsAgentNamespace } from "../identity/namespace";
 
-interface ResumeAgentRunInput {
+interface ResumeAgentTurnInput {
   readonly host: ExecutionHost;
   readonly ownerNamespace: string;
-  resumeNotification(notification: NotificationRecord): Promise<AgentRun>;
+  resumeNotification(notification: NotificationRecord): Promise<AgentTurn>;
   readonly runId: string;
 }
 
-export async function resumeAgentRun({
+export async function resumeAgentTurn({
   host,
   ownerNamespace,
   resumeNotification,
   runId,
-}: ResumeAgentRunInput): Promise<AgentRun | null> {
-  const run = await host.store.runs.get(runId);
+}: ResumeAgentTurnInput): Promise<AgentTurn | null> {
+  const run = await host.store.turns.get(runId);
   if (!run) {
     return null;
   }
@@ -91,7 +91,7 @@ async function claimNotificationForRun({
   return null;
 }
 
-function canAccessRun(run: RunRecord, ownerNamespace: string): boolean {
+function canAccessRun(run: TurnRecord, ownerNamespace: string): boolean {
   if (run.ownerNamespace) {
     return ownsAgentNamespace(run.ownerNamespace, ownerNamespace);
   }
@@ -106,19 +106,19 @@ export async function completeNotificationRun(
   host: ExecutionHost,
   runId: string
 ): Promise<void> {
-  const run = await host.store.runs.get(runId);
+  const run = await host.store.turns.get(runId);
   if (run?.kind !== "notification" || run.status === "completed") {
     return;
   }
 
-  await host.store.runs.update({ ...run, status: "completed" });
+  await host.store.turns.update({ ...run, status: "completed" });
 }
 
 async function claimRun(
   host: ExecutionHost,
-  run: RunRecord
-): Promise<RunRecord | null> {
-  const claim = await host.store.runs.claim(run.runId, {
+  run: TurnRecord
+): Promise<TurnRecord | null> {
+  const claim = await host.store.turns.claim(run.runId, {
     attempt: (run.lease?.attempt ?? 0) + 1,
     leaseId: crypto.randomUUID(),
     leaseMs: 300_000,

--- a/packages/runtime/src/contracts/execution-store/contract.ts
+++ b/packages/runtime/src/contracts/execution-store/contract.ts
@@ -21,7 +21,7 @@ export function describeExecutionStoreContract({
       const store = createStore();
 
       await store.transaction(async (tx) => {
-        await tx.runs.create(createQueuedRun());
+        await tx.turns.create(createQueuedRun());
         const checkpointResult = await tx.checkpoints.append(
           {
             checkpointId: "checkpoint-1",
@@ -51,7 +51,7 @@ export function describeExecutionStoreContract({
         expect(checkpointResult).toEqual({ ok: true, version: 1 });
       });
 
-      await expect(store.runs.get("run-1")).resolves.toMatchObject({
+      await expect(store.turns.get("run-1")).resolves.toMatchObject({
         runId: "run-1",
         status: "queued",
       });
@@ -76,12 +76,12 @@ export function describeExecutionStoreContract({
 
       await expect(
         store.transaction(async (tx) => {
-          await tx.runs.create(createQueuedRun());
+          await tx.turns.create(createQueuedRun());
           throw new Error("transaction failed");
         })
       ).rejects.toThrow("transaction failed");
 
-      await expect(store.runs.get("run-1")).resolves.toBeNull();
+      await expect(store.turns.get("run-1")).resolves.toBeNull();
     });
 
     it("rolls back transaction thread writes when the transaction fails", async () => {
@@ -108,18 +108,18 @@ export function describeExecutionStoreContract({
       let secondSettled = false;
 
       const first = store.transaction(async (tx) => {
-        await tx.runs.create(createQueuedRun("run-serial"));
+        await tx.turns.create(createQueuedRun("run-serial"));
         firstStarted.resolve();
         await firstCanFinish.promise;
       });
       await firstStarted.promise;
       const second = store
         .transaction(async (tx) => {
-          const run = await tx.runs.get("run-serial");
+          const run = await tx.turns.get("run-serial");
           if (!run) {
             throw new Error("Expected first transaction to commit first.");
           }
-          await tx.runs.update({ ...run, status: "cancelled" });
+          await tx.turns.update({ ...run, status: "cancelled" });
         })
         .then(() => {
           secondSettled = true;
@@ -130,17 +130,17 @@ export function describeExecutionStoreContract({
       firstCanFinish.resolve();
       await Promise.all([first, second]);
 
-      await expect(store.runs.get("run-serial")).resolves.toMatchObject({
+      await expect(store.turns.get("run-serial")).resolves.toMatchObject({
         status: "cancelled",
       });
     });
 
     it("rejects duplicate active run claims", async () => {
       const store = createStore();
-      await store.runs.create(createQueuedRun());
+      await store.turns.create(createQueuedRun());
 
       await expect(
-        store.runs.claim("run-1", {
+        store.turns.claim("run-1", {
           attempt: 1,
           leaseId: "lease-1",
           leaseMs: 100,
@@ -148,7 +148,7 @@ export function describeExecutionStoreContract({
         })
       ).resolves.toMatchObject({ ok: true });
       await expect(
-        store.runs.claim("run-1", {
+        store.turns.claim("run-1", {
           attempt: 2,
           leaseId: "lease-2",
           leaseMs: 100,
@@ -161,8 +161,8 @@ export function describeExecutionStoreContract({
       const store = createStore();
       const original = createQueuedRun("run-duplicate");
 
-      const created = await store.runs.create(original);
-      const duplicate = await store.runs.create({
+      const created = await store.turns.create(original);
+      const duplicate = await store.turns.create({
         ...original,
         checkpointVersion: 7,
         status: "completed",
@@ -174,12 +174,12 @@ export function describeExecutionStoreContract({
         reason: "duplicate",
         record: original,
       });
-      await expect(store.runs.get("run-duplicate")).resolves.toEqual(original);
+      await expect(store.turns.get("run-duplicate")).resolves.toEqual(original);
     });
 
     it("rejects stale checkpoint writes", async () => {
       const store = createStore();
-      await store.runs.create(createQueuedRun());
+      await store.turns.create(createQueuedRun());
 
       const first = await appendCheckpoint(store, 0);
       const stale = await appendCheckpoint(store, 0);
@@ -194,7 +194,7 @@ export function describeExecutionStoreContract({
 
     it("replays events from a cursor without duplicates", async () => {
       const store = createStore();
-      await store.runs.create(createQueuedRun());
+      await store.turns.create(createQueuedRun());
 
       const firstCursor = await store.events.append("run-1", {
         type: "turn-start",

--- a/packages/runtime/src/contracts/execution-store/fixtures.ts
+++ b/packages/runtime/src/contracts/execution-store/fixtures.ts
@@ -1,11 +1,11 @@
 import type {
   CheckpointWriteResult,
   ExecutionStore,
-  RunRecord,
   StoredAgentEvent,
+  TurnRecord,
 } from "../../execution";
 
-export function createQueuedRun(runId = "run-1"): RunRecord {
+export function createQueuedRun(runId = "run-1"): TurnRecord {
   return {
     checkpointVersion: 0,
     kind: "user-turn",

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -11,27 +11,16 @@ import type {
   ExecutionStoreTransaction,
   NotificationInbox,
   NotificationRecord,
-  RunRecord,
-  RunStore,
-  SessionHost,
   ThreadHost,
+  TurnRecord,
+  TurnStore,
 } from "../execution";
 import type {
   AgentEvent,
   AgentHost,
   ControlAgentEvent,
-  ExpectedSessionVersion,
-  ExpectedThreadVersion,
   LifecycleAgentEvent,
-  SessionInput,
-  SessionStore,
-  SessionStoreCommit,
-  StoredSession,
-  StoredThread,
   TelemetryAgentEvent,
-  ThreadInput,
-  ThreadStore,
-  ThreadStoreCommit,
   VisibleAgentEvent,
 } from "../index";
 import {
@@ -156,7 +145,7 @@ describe("runtime public exports", () => {
       ExecutionStore["notifications"]
     >().toEqualTypeOf<NotificationInbox>();
     expectTypeOf<ExecutionHost["kind"]>().toEqualTypeOf<"execution">();
-    expectTypeOf<ExecutionStore["runs"]>().toEqualTypeOf<RunStore>();
+    expectTypeOf<ExecutionStore["turns"]>().toEqualTypeOf<TurnStore>();
     expectTypeOf<
       ExecutionStore["checkpoints"]
     >().toEqualTypeOf<CheckpointStore>();
@@ -165,9 +154,11 @@ describe("runtime public exports", () => {
       Parameters<NotificationInbox["enqueue"]>[0]
     >().toEqualTypeOf<NotificationRecord>();
     expectTypeOf<
-      Awaited<ReturnType<RunStore["get"]>>
-    >().toEqualTypeOf<RunRecord | null>();
-    expectTypeOf<ExecutionStoreTransaction["runs"]>().toEqualTypeOf<RunStore>();
+      Awaited<ReturnType<TurnStore["get"]>>
+    >().toEqualTypeOf<TurnRecord | null>();
+    expectTypeOf<
+      ExecutionStoreTransaction["turns"]
+    >().toEqualTypeOf<TurnStore>();
     expectTypeOf<
       ExecutionStoreTransaction["notifications"]
     >().toEqualTypeOf<NotificationInbox>();
@@ -175,19 +166,10 @@ describe("runtime public exports", () => {
       kind: "thread",
       threadStore: {} as ThreadHost["threadStore"],
     } satisfies ThreadHost;
-    const legacySessionHost = {
-      kind: "session",
-      threadStore: {} as ThreadHost["threadStore"],
-    } satisfies SessionHost;
-    const legacySessionStoreHost = {
-      kind: "session",
-      sessionStore: {} as ThreadHost["threadStore"],
-    } satisfies SessionHost;
     const agentHost = threadHost satisfies AgentHost;
-    const legacyAgentHost = legacySessionHost satisfies AgentHost;
-    const legacySessionStoreAgentHost =
-      legacySessionStoreHost satisfies AgentHost;
-    expectTypeOf<DurableBackgroundHost["runStore"]>().toEqualTypeOf<RunStore>();
+    expectTypeOf<
+      DurableBackgroundHost["turnStore"]
+    >().toEqualTypeOf<TurnStore>();
     expectTypeOf<
       DurableBackgroundHost["checkpointStore"]
     >().toEqualTypeOf<CheckpointStore>();
@@ -204,19 +186,9 @@ describe("runtime public exports", () => {
       ExecutionStore["transaction"]
     >();
     expect(agentHost.kind).toBe("thread");
-    expect(legacyAgentHost.kind).toBe("session");
-    expect(legacySessionStoreAgentHost.kind).toBe("session");
   });
 
-  it("types legacy session aliases from the package root", () => {
-    expectTypeOf<SessionInput>().toEqualTypeOf<ThreadInput>();
-    expectTypeOf<SessionStore>().toEqualTypeOf<ThreadStore>();
-    expectTypeOf<SessionStoreCommit>().toEqualTypeOf<ThreadStoreCommit>();
-    expectTypeOf<StoredSession>().toEqualTypeOf<StoredThread>();
-    expectTypeOf<ExpectedSessionVersion>().toEqualTypeOf<ExpectedThreadVersion>();
-  });
-
-  it("declares thread store package subpaths with legacy adapters", async () => {
+  it("declares thread store package subpaths without session aliases", async () => {
     const packageJson = JSON.parse(
       await readFile(
         fileURLToPath(new URL("../../package.json", import.meta.url)),
@@ -232,12 +204,8 @@ describe("runtime public exports", () => {
     expect(packageJson.exports["./thread-store/file"]).toMatchObject({
       "@minpeter/pss-source": "./src/thread/store/file.ts",
     });
-    expect(packageJson.exports["./session-store/memory"]).toEqual(
-      packageJson.exports["./thread-store/memory"]
-    );
-    expect(packageJson.exports["./session-store/file"]).toEqual(
-      packageJson.exports["./thread-store/file"]
-    );
+    expect(packageJson.exports["./session-store/memory"]).toBeUndefined();
+    expect(packageJson.exports["./session-store/file"]).toBeUndefined();
   });
 
   it("declares the Cloudflare adapter as a platform implementation subpath", async () => {

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { agentNamespace } from "../../agent/identity/namespace";
-import type { ExecutionHost, RunRecord, RunStore } from "../host/types";
+import type { ExecutionHost, TurnRecord, TurnStore } from "../host/types";
 import { createInMemoryExecutionHost } from "../memory";
 import { dispatchAgentNotification } from "./notification-dispatch";
 
@@ -28,7 +28,7 @@ describe("dispatchAgentNotification", () => {
       idempotencyKey: "reminder:1",
     });
     expect(second).toEqual({ ...first, deduplicated: true });
-    const run = await host.store.runs.get(first.runId);
+    const run = await host.store.turns.get(first.runId);
     expect(run).toMatchObject({
       kind: "notification",
       ownerNamespace: agentNamespace("agent-a"),
@@ -77,11 +77,11 @@ describe("dispatchAgentNotification", () => {
     expect(second.deduplicated).toBe(false);
     expect(second.runId).not.toBe(first.runId);
     expect(duplicateFirst).toEqual({ ...first, deduplicated: true });
-    await expect(host.store.runs.get(first.runId)).resolves.toMatchObject({
+    await expect(host.store.turns.get(first.runId)).resolves.toMatchObject({
       ownerNamespace: agentNamespace("agent-a"),
       threadKey: "room:1:user:1",
     });
-    await expect(host.store.runs.get(second.runId)).resolves.toMatchObject({
+    await expect(host.store.turns.get(second.runId)).resolves.toMatchObject({
       ownerNamespace: agentNamespace("agent-b"),
       threadKey: "room:1:user:2",
     });
@@ -112,35 +112,35 @@ describe("dispatchAgentNotification", () => {
 
 function hostWithDuplicateRunCreate(host: ExecutionHost): ExecutionHost {
   const runs = {
-    claim: (runId, options) => host.store.runs.claim(runId, options),
-    create: async (record: RunRecord) => {
+    claim: (runId, options) => host.store.turns.claim(runId, options),
+    create: async (record: TurnRecord) => {
       const existing = record.dedupeKey
-        ? await host.store.runs.getByDedupeKey(record.dedupeKey)
-        : await host.store.runs.get(record.runId);
+        ? await host.store.turns.getByDedupeKey(record.dedupeKey)
+        : await host.store.turns.get(record.runId);
       if (!existing) {
         throw new Error("Expected pre-existing run for duplicate create race.");
       }
       return { ok: false, reason: "duplicate", record: existing } as const;
     },
-    get: (runId) => host.store.runs.get(runId),
-    getByDedupeKey: (dedupeKey) => host.store.runs.getByDedupeKey(dedupeKey),
+    get: (runId) => host.store.turns.get(runId),
+    getByDedupeKey: (dedupeKey) => host.store.turns.getByDedupeKey(dedupeKey),
     listByParentRunId: (parentRunId) =>
-      host.store.runs.listByParentRunId(parentRunId),
-    update: (record) => host.store.runs.update(record),
-  } satisfies RunStore;
+      host.store.turns.listByParentRunId(parentRunId),
+    update: (record) => host.store.turns.update(record),
+  } satisfies TurnStore;
 
   return {
     ...host,
     store: {
       ...host.store,
-      runs,
+      turns: runs,
       transaction: (callback) =>
         callback({
-          checkpoints: host.store.checkpoints,
           events: host.store.events,
           notifications: host.store.notifications,
-          runs,
+          checkpoints: host.store.checkpoints,
           threads: host.store.threads,
+          turns: runs,
         }),
     },
   };

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.ts
@@ -3,7 +3,7 @@ import type { AgentEvent, UserInput } from "../../thread/protocol/events";
 import type {
   ExecutionHost,
   NotificationRecord,
-  RunRecord,
+  TurnRecord,
 } from "../host/types";
 
 export interface DispatchAgentNotificationInput {
@@ -66,7 +66,7 @@ export async function dispatchAgentNotification(
     runId,
     threadKey: input.threadKey,
     status: "queued",
-  } satisfies RunRecord;
+  } satisfies TurnRecord;
   const notificationRecord = {
     idempotencyKey: storageIdempotencyKey,
     input: input.input,
@@ -80,7 +80,7 @@ export async function dispatchAgentNotification(
 
   try {
     await input.host.store.transaction(async (tx) => {
-      const runCreate = await tx.runs.create(runRecord);
+      const runCreate = await tx.turns.create(runRecord);
       if (!runCreate.ok) {
         throw new DuplicateNotificationError();
       }
@@ -131,7 +131,7 @@ async function queuedNotificationRun({
   readonly threadKey: string;
   readonly storageIdempotencyKey: string;
 }): Promise<SchedulableAgentNotification | null> {
-  const existingRun = await host.store.runs.getByDedupeKey(
+  const existingRun = await host.store.turns.getByDedupeKey(
     storageIdempotencyKey
   );
   if (

--- a/packages/runtime/src/execution/host/capabilities.ts
+++ b/packages/runtime/src/execution/host/capabilities.ts
@@ -5,7 +5,7 @@ import type {
   ExecutionScheduler,
   ExecutionStore,
   NotificationInbox,
-  RunStore,
+  TurnStore,
 } from "./types";
 
 export interface ThreadHost {
@@ -14,26 +14,11 @@ export interface ThreadHost {
 }
 
 interface ThreadStoreHost {
-  readonly sessionStore?: ThreadStore;
   readonly threadStore: ThreadStore;
 }
 
-interface LegacySessionStoreHost {
-  readonly sessionStore: ThreadStore;
-  readonly threadStore?: ThreadStore;
-}
-
-type ThreadStoreCompatibilityHost = LegacySessionStoreHost | ThreadStoreHost;
-
-export type LegacySessionHost = {
-  readonly kind: "session";
-} & ThreadStoreCompatibilityHost;
-
-/** @deprecated Use ThreadHost. */
-export type SessionHost = LegacySessionHost;
-
-interface RunHost {
-  readonly runStore: RunStore;
+interface TurnHost {
+  readonly turnStore: TurnStore;
 }
 
 interface CheckpointHost {
@@ -57,11 +42,10 @@ interface ExecutionTransactionHost {
 }
 
 export type DurableBackgroundHost = BackgroundSchedulerHost &
-  CheckpointHost &
   EventHost &
   ExecutionTransactionHost &
   NotificationHost &
-  RunHost &
-  ThreadStoreCompatibilityHost & {
+  CheckpointHost &
+  ThreadStoreHost & {
     readonly kind: "durable-background";
-  };
+  } & TurnHost;

--- a/packages/runtime/src/execution/host/checkpoint-ids.test.ts
+++ b/packages/runtime/src/execution/host/checkpoint-ids.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { createRunCheckpointId } from "./checkpoint-ids";
+import { createCheckpointId } from "./checkpoint-ids";
 
 const checkpointIdPattern =
-  /^run-checkpoint:turn%3Aagent%2Fthread%3Aabc:3:before-tool:/;
+  /^checkpoint:turn%3Aagent%2Fthread%3Aabc:3:before-tool:/;
 
-describe("createRunCheckpointId", () => {
+describe("createCheckpointId", () => {
   it("includes the run id, version, and checkpoint phase", () => {
-    const checkpointId = createRunCheckpointId({
+    const checkpointId = createCheckpointId({
       phase: "before-tool",
       runId: "turn:agent/thread:abc",
       version: 3,

--- a/packages/runtime/src/execution/host/checkpoint-ids.ts
+++ b/packages/runtime/src/execution/host/checkpoint-ids.ts
@@ -1,6 +1,6 @@
 import type { CheckpointPhase } from "./types";
 
-export function createRunCheckpointId({
+export function createCheckpointId({
   phase,
   runId,
   version,
@@ -9,7 +9,7 @@ export function createRunCheckpointId({
   readonly runId: string;
   readonly version: number;
 }): string {
-  return `run-checkpoint:${encodeCheckpointIdPart(runId)}:${version}:${phase}:${crypto.randomUUID()}`;
+  return `checkpoint:${encodeCheckpointIdPart(runId)}:${version}:${phase}:${crypto.randomUUID()}`;
 }
 
 function encodeCheckpointIdPart(value: string): string {

--- a/packages/runtime/src/execution/host/host.test.ts
+++ b/packages/runtime/src/execution/host/host.test.ts
@@ -12,7 +12,7 @@ describe("execution host capability normalizers", () => {
       eventStore: aggregateHost.store.events,
       kind: "durable-background",
       notificationInbox: aggregateHost.store.notifications,
-      runStore: aggregateHost.store.runs,
+      turnStore: aggregateHost.store.turns,
       threadStore: aggregateHost.store.threads,
       transaction: aggregateHost.store.transaction.bind(aggregateHost.store),
     } satisfies DurableBackgroundHost;
@@ -20,29 +20,24 @@ describe("execution host capability normalizers", () => {
     expect(durableBackgroundHost(splitHost)).toBe(splitHost);
   });
 
-  it("normalizes durable background hosts with only deprecated sessionStore", () => {
+  it("normalizes durable background hosts into execution hosts", () => {
     const aggregateHost = createInMemoryExecutionHost();
-    const legacySplitHost = {
+    const splitHost = {
       backgroundScheduler: aggregateHost.scheduler,
       checkpointStore: aggregateHost.store.checkpoints,
       eventStore: aggregateHost.store.events,
       kind: "durable-background",
       notificationInbox: aggregateHost.store.notifications,
-      runStore: aggregateHost.store.runs,
-      sessionStore: aggregateHost.store.threads,
+      turnStore: aggregateHost.store.turns,
+      threadStore: aggregateHost.store.threads,
       transaction: aggregateHost.store.transaction.bind(aggregateHost.store),
     } satisfies DurableBackgroundHost;
 
-    expect(durableBackgroundHost(legacySplitHost)).toBe(legacySplitHost);
-    expect(threadHost(legacySplitHost).threadStore).toBe(
-      aggregateHost.store.threads
-    );
-    const normalizedExecutionHost = executionHost(legacySplitHost);
+    expect(durableBackgroundHost(splitHost)).toBe(splitHost);
+    expect(threadHost(splitHost).threadStore).toBe(aggregateHost.store.threads);
+    const normalizedExecutionHost = executionHost(splitHost);
 
     expect(normalizedExecutionHost?.store.threads).toBe(
-      aggregateHost.store.threads
-    );
-    expect(normalizedExecutionHost?.store.sessions).toBe(
       aggregateHost.store.threads
     );
   });

--- a/packages/runtime/src/execution/host/host.ts
+++ b/packages/runtime/src/execution/host/host.ts
@@ -1,24 +1,14 @@
-import type {
-  DurableBackgroundHost,
-  SessionHost,
-  ThreadHost,
-} from "./capabilities";
+import type { DurableBackgroundHost, ThreadHost } from "./capabilities";
 import type { AgentHost, ExecutionHost, ExecutionStorePorts } from "./types";
 
 type Transaction = ExecutionHost["store"]["transaction"];
-interface CompatibleThreadStoreHost {
-  readonly sessionStore?: ThreadHost["threadStore"];
-  readonly threadStore?: ThreadHost["threadStore"];
-}
 
 export function threadHost(host: AgentHost): ThreadHost {
   switch (host.kind) {
     case "thread":
       return host;
-    case "session":
-      return { kind: "thread", threadStore: threadStoreFromHost(host) };
     case "durable-background":
-      return { kind: "thread", threadStore: threadStoreFromHost(host) };
+      return { kind: "thread", threadStore: host.threadStore };
     case "execution":
       return {
         kind: "thread",
@@ -27,12 +17,6 @@ export function threadHost(host: AgentHost): ThreadHost {
     default:
       return assertNeverHost(host);
   }
-}
-
-/** @deprecated Use threadHost. */
-export function sessionHost(host: AgentHost): SessionHost {
-  const threadStore = threadHost(host).threadStore;
-  return { kind: "session", sessionStore: threadStore, threadStore };
 }
 
 export function executionHost(host: AgentHost): ExecutionHost | undefined {
@@ -70,27 +54,25 @@ function durableBackgroundHostFromExecutionHost(
     eventStore: host.store.events,
     kind: "durable-background",
     notificationInbox: host.store.notifications,
-    runStore: host.store.runs,
-    sessionStore: threadStoreFromExecutionStore(host.store),
     threadStore: threadStoreFromExecutionStore(host.store),
     transaction: transactionForStore(host.store),
+    turnStore: host.store.turns,
   };
 }
 
 function executionHostFromDurableBackgroundHost(
   host: DurableBackgroundHost
 ): ExecutionHost {
-  const threadStore = threadStoreFromHost(host);
+  const threadStore = host.threadStore;
   return {
     kind: "execution",
     scheduler: host.backgroundScheduler,
     store: {
-      checkpoints: host.checkpointStore,
       events: host.eventStore,
       notifications: host.notificationInbox,
-      runs: host.runStore,
-      sessions: threadStore,
+      checkpoints: host.checkpointStore,
       threads: threadStore,
+      turns: host.turnStore,
       transaction: host.transaction,
     },
   };
@@ -103,13 +85,7 @@ function transactionForStore(store: ExecutionHost["store"]): Transaction {
 function threadStoreFromExecutionStore(
   store: ExecutionStorePorts
 ): ThreadHost["threadStore"] {
-  return store.threads ?? store.sessions ?? assertMissingThreadStore();
-}
-
-function threadStoreFromHost(
-  host: CompatibleThreadStoreHost
-): ThreadHost["threadStore"] {
-  return host.threadStore ?? host.sessionStore ?? assertMissingThreadStore();
+  return store.threads ?? assertMissingThreadStore();
 }
 
 function assertMissingThreadStore(): never {

--- a/packages/runtime/src/execution/host/types.ts
+++ b/packages/runtime/src/execution/host/types.ts
@@ -1,16 +1,8 @@
 import type { AgentEvent, UserInput } from "../../thread/protocol/events";
 import type { ThreadStore } from "../../thread/store/types";
-import type {
-  DurableBackgroundHost,
-  LegacySessionHost,
-  ThreadHost,
-} from "./capabilities";
+import type { DurableBackgroundHost, ThreadHost } from "./capabilities";
 
-export type AgentHost =
-  | DurableBackgroundHost
-  | ExecutionHost
-  | LegacySessionHost
-  | ThreadHost;
+export type AgentHost = DurableBackgroundHost | ExecutionHost | ThreadHost;
 
 export interface ExecutionHost {
   readonly kind: "execution";
@@ -32,9 +24,9 @@ export interface ResumeThreadOptions {
   readonly runId: string;
 }
 
-export type RunKind = "notification" | "tool-recovery" | "user-turn";
+export type TurnKind = "notification" | "tool-recovery" | "user-turn";
 
-export type RunStatus =
+export type TurnStatus =
   | "cancelled"
   | "completed"
   | "error"
@@ -44,43 +36,47 @@ export type RunStatus =
   | "running"
   | "suspended";
 
-export interface RunLease {
+export interface TurnLease {
   readonly attempt: number;
   readonly leaseId: string;
   readonly leaseUntilMs: number;
 }
 
-export interface RunRecord {
+export interface TurnRecord {
   readonly checkpointVersion: number;
   readonly dedupeKey?: string;
-  readonly kind: RunKind;
-  readonly lease?: RunLease;
+  readonly kind: TurnKind;
+  readonly lease?: TurnLease;
   readonly output?: unknown;
   readonly ownerNamespace?: string;
   readonly parentRunId?: string;
   readonly publicTaskId?: string;
   readonly rootRunId: string;
   readonly runId: string;
-  readonly status: RunStatus;
+  readonly status: TurnStatus;
   readonly threadKey: string;
 }
 
-export type ClaimRunResult =
-  | { readonly lease: RunLease; readonly ok: true; readonly record: RunRecord }
+export type ClaimTurnResult =
+  | {
+      readonly lease: TurnLease;
+      readonly ok: true;
+      readonly record: TurnRecord;
+    }
   | {
       readonly ok: false;
       readonly reason: "leased" | "not-claimable" | "not-found";
     };
 
-export type CreateRunResult =
-  | { readonly ok: true; readonly record: RunRecord }
+export type CreateTurnResult =
+  | { readonly ok: true; readonly record: TurnRecord }
   | {
       readonly ok: false;
       readonly reason: "duplicate";
-      readonly record: RunRecord;
+      readonly record: TurnRecord;
     };
 
-export interface ClaimRunOptions {
+export interface ClaimTurnOptions {
   readonly attempt: number;
   readonly leaseId: string;
   readonly leaseMs: number;
@@ -98,7 +94,7 @@ export type CheckpointPhase =
   | "child-linked"
   | "suspended";
 
-export interface RunCheckpoint {
+export interface Checkpoint {
   readonly checkpointId: string;
   readonly childRunId?: string;
   readonly pendingToolCall?: unknown;
@@ -156,21 +152,21 @@ export type NotificationClaimResult =
       readonly record?: NotificationRecord;
     };
 
-export interface RunStore {
-  claim(runId: string, options: ClaimRunOptions): Promise<ClaimRunResult>;
-  create(record: RunRecord): Promise<CreateRunResult>;
-  get(runId: string): Promise<RunRecord | null>;
-  getByDedupeKey(dedupeKey: string): Promise<RunRecord | null>;
-  listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]>;
-  update(record: RunRecord): Promise<RunRecord>;
+export interface TurnStore {
+  claim(runId: string, options: ClaimTurnOptions): Promise<ClaimTurnResult>;
+  create(record: TurnRecord): Promise<CreateTurnResult>;
+  get(runId: string): Promise<TurnRecord | null>;
+  getByDedupeKey(dedupeKey: string): Promise<TurnRecord | null>;
+  listByParentRunId(parentRunId: string): Promise<readonly TurnRecord[]>;
+  update(record: TurnRecord): Promise<TurnRecord>;
 }
 
 export interface CheckpointStore {
   append(
-    checkpoint: RunCheckpoint,
+    checkpoint: Checkpoint,
     options: { readonly expectedVersion: number }
   ): Promise<CheckpointWriteResult>;
-  latest(runId: string): Promise<RunCheckpoint | null>;
+  latest(runId: string): Promise<Checkpoint | null>;
 }
 
 export interface EventStore {
@@ -193,10 +189,8 @@ export interface ExecutionStorePorts {
   readonly checkpoints: CheckpointStore;
   readonly events: EventStore;
   readonly notifications: NotificationInbox;
-  readonly runs: RunStore;
-  /** @deprecated Use threads. */
-  readonly sessions?: ThreadStore;
   readonly threads: ThreadStore;
+  readonly turns: TurnStore;
 }
 
 export interface ExecutionStoreTransaction extends ExecutionStorePorts {}

--- a/packages/runtime/src/execution/index.ts
+++ b/packages/runtime/src/execution/index.ts
@@ -13,18 +13,17 @@ export type {
 export { dispatchAgentNotification } from "./dispatch/notification-dispatch";
 export type {
   DurableBackgroundHost,
-  LegacySessionHost,
-  SessionHost,
   ThreadHost,
 } from "./host/capabilities";
-export { executionHost, sessionHost, threadHost } from "./host/host";
+export { executionHost, threadHost } from "./host/host";
 export type {
+  Checkpoint,
   CheckpointPhase,
   CheckpointStore,
   CheckpointWriteResult,
-  ClaimRunOptions,
-  ClaimRunResult,
-  CreateRunResult,
+  ClaimTurnOptions,
+  ClaimTurnResult,
+  CreateTurnResult,
   EventCursor,
   EventStore,
   ExecutionHost,
@@ -37,12 +36,11 @@ export type {
   NotificationStatus,
   NotificationWriteResult,
   ResumeThreadOptions,
-  RunCheckpoint,
-  RunKind,
-  RunLease,
-  RunRecord,
-  RunStatus,
-  RunStore,
   StoredAgentEvent,
+  TurnKind,
+  TurnLease,
+  TurnRecord,
+  TurnStatus,
+  TurnStore,
 } from "./host/types";
 export { createInMemoryExecutionHost } from "./memory";

--- a/packages/runtime/src/execution/memory/runs.ts
+++ b/packages/runtime/src/execution/memory/runs.ts
@@ -1,31 +1,31 @@
 import type {
-  ClaimRunOptions,
-  ClaimRunResult,
-  CreateRunResult,
-  RunRecord,
-  RunStatus,
-  RunStore,
+  ClaimTurnOptions,
+  ClaimTurnResult,
+  CreateTurnResult,
+  TurnRecord,
+  TurnStatus,
+  TurnStore,
 } from "../host/types";
 import type { ExecutionState } from "./state";
 
-const claimableStatuses = new Set<RunStatus>([
+const claimableStatuses = new Set<TurnStatus>([
   "leased",
   "queued",
   "running",
   "suspended",
 ]);
 
-export class InMemoryRunStore implements RunStore {
+export class InMemoryRunStore implements TurnStore {
   readonly #state: () => ExecutionState;
 
   constructor(state: () => ExecutionState) {
     this.#state = state;
   }
 
-  create(record: RunRecord): Promise<CreateRunResult> {
+  create(record: TurnRecord): Promise<CreateTurnResult> {
     const state = this.#state();
     const existing =
-      state.runs.get(record.runId) ?? existingDedupeRun(state, record);
+      state.turns.get(record.runId) ?? existingDedupeRun(state, record);
     if (existing) {
       return Promise.resolve({
         ok: false,
@@ -35,37 +35,37 @@ export class InMemoryRunStore implements RunStore {
     }
 
     const stored = structuredClone(record);
-    state.runs.set(record.runId, stored);
+    state.turns.set(record.runId, stored);
     return Promise.resolve({ ok: true, record: structuredClone(stored) });
   }
 
-  get(runId: string): Promise<RunRecord | null> {
-    const record = this.#state().runs.get(runId);
+  get(runId: string): Promise<TurnRecord | null> {
+    const record = this.#state().turns.get(runId);
     return Promise.resolve(record ? structuredClone(record) : null);
   }
 
-  getByDedupeKey(dedupeKey: string): Promise<RunRecord | null> {
-    const record = [...this.#state().runs.values()].find(
+  getByDedupeKey(dedupeKey: string): Promise<TurnRecord | null> {
+    const record = [...this.#state().turns.values()].find(
       (candidate) => candidate.dedupeKey === dedupeKey
     );
     return Promise.resolve(record ? structuredClone(record) : null);
   }
 
-  listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]> {
-    const records = [...this.#state().runs.values()].filter(
+  listByParentRunId(parentRunId: string): Promise<readonly TurnRecord[]> {
+    const records = [...this.#state().turns.values()].filter(
       (candidate) => candidate.parentRunId === parentRunId
     );
     return Promise.resolve(records.map((record) => structuredClone(record)));
   }
 
-  update(record: RunRecord): Promise<RunRecord> {
+  update(record: TurnRecord): Promise<TurnRecord> {
     const stored = structuredClone(record);
-    this.#state().runs.set(record.runId, stored);
+    this.#state().turns.set(record.runId, stored);
     return Promise.resolve(structuredClone(stored));
   }
 
-  claim(runId: string, options: ClaimRunOptions): Promise<ClaimRunResult> {
-    const record = this.#state().runs.get(runId);
+  claim(runId: string, options: ClaimTurnOptions): Promise<ClaimTurnResult> {
+    const record = this.#state().turns.get(runId);
     if (!record) {
       return Promise.resolve({ ok: false, reason: "not-found" });
     }
@@ -83,12 +83,12 @@ export class InMemoryRunStore implements RunStore {
       leaseId: options.leaseId,
       leaseUntilMs: options.nowMs + options.leaseMs,
     };
-    const claimed: RunRecord = {
+    const claimed: TurnRecord = {
       ...record,
       lease,
       status: "leased",
     };
-    this.#state().runs.set(runId, claimed);
+    this.#state().turns.set(runId, claimed);
     return Promise.resolve({
       lease,
       ok: true,
@@ -99,10 +99,10 @@ export class InMemoryRunStore implements RunStore {
 
 function existingDedupeRun(
   state: ExecutionState,
-  record: RunRecord
-): RunRecord | undefined {
+  record: TurnRecord
+): TurnRecord | undefined {
   return record.dedupeKey
-    ? [...state.runs.values()].find(
+    ? [...state.turns.values()].find(
         (candidate) => candidate.dedupeKey === record.dedupeKey
       )
     : undefined;

--- a/packages/runtime/src/execution/memory/state.ts
+++ b/packages/runtime/src/execution/memory/state.ts
@@ -1,18 +1,18 @@
 import type { StoredThread } from "../../thread/store/types";
 import type {
+  Checkpoint,
   NotificationRecord,
-  RunCheckpoint,
-  RunRecord,
   StoredAgentEvent,
+  TurnRecord,
 } from "../host/types";
 
 export interface ExecutionState {
-  readonly checkpoints: Map<string, RunCheckpoint[]>;
+  readonly checkpoints: Map<string, Checkpoint[]>;
   readonly events: Map<string, StoredAgentEvent[]>;
   readonly notificationsByKey: Map<string, NotificationRecord>;
-  readonly runs: Map<string, RunRecord>;
   readonly threads: Map<string, StoredThread>;
   readonly threadVersions: Map<string, number>;
+  readonly turns: Map<string, TurnRecord>;
 }
 
 export function createEmptyState(): ExecutionState {
@@ -20,7 +20,7 @@ export function createEmptyState(): ExecutionState {
     checkpoints: new Map(),
     events: new Map(),
     notificationsByKey: new Map(),
-    runs: new Map(),
+    turns: new Map(),
     threadVersions: new Map(),
     threads: new Map(),
   };
@@ -31,15 +31,15 @@ export function cloneState(state: ExecutionState): ExecutionState {
     checkpoints: cloneCheckpointMap(state.checkpoints),
     events: cloneEventMap(state.events),
     notificationsByKey: cloneRecordMap(state.notificationsByKey),
-    runs: cloneRecordMap(state.runs),
+    turns: cloneRecordMap(state.turns),
     threadVersions: cloneRecordMap(state.threadVersions),
     threads: cloneRecordMap(state.threads),
   };
 }
 
 function cloneCheckpointMap(
-  map: ReadonlyMap<string, readonly RunCheckpoint[]>
-): Map<string, RunCheckpoint[]> {
+  map: ReadonlyMap<string, readonly Checkpoint[]>
+): Map<string, Checkpoint[]> {
   return new Map(
     [...map.entries()].map(([key, value]) => [
       key,

--- a/packages/runtime/src/execution/memory/store.ts
+++ b/packages/runtime/src/execution/memory/store.ts
@@ -7,6 +7,7 @@ import type {
   ThreadStoreCommit,
 } from "../../thread/store/types";
 import type {
+  Checkpoint,
   CheckpointStore,
   CheckpointWriteResult,
   EventCursor,
@@ -14,9 +15,8 @@ import type {
   ExecutionStore,
   ExecutionStoreTransaction,
   NotificationInbox,
-  RunCheckpoint,
-  RunStore,
   StoredAgentEvent,
+  TurnStore,
 } from "../host/types";
 import { InMemoryNotificationInbox } from "./notifications";
 import { InMemoryRunStore } from "./runs";
@@ -33,7 +33,7 @@ export class InMemoryExecutionStore implements ExecutionStore {
   readonly notifications: NotificationInbox = new InMemoryNotificationInbox(
     () => this.#state
   );
-  readonly runs: RunStore = new InMemoryRunStore(() => this.#state);
+  readonly turns: TurnStore = new InMemoryRunStore(() => this.#state);
   readonly threads: ThreadStore = new InMemoryExecutionThreadStore(
     () => this.#state
   );
@@ -66,7 +66,7 @@ class InMemoryTransactionStore implements ExecutionStoreTransaction {
   readonly checkpoints: CheckpointStore;
   readonly events: EventStore;
   readonly notifications: NotificationInbox;
-  readonly runs: RunStore;
+  readonly turns: TurnStore;
   readonly threads: ThreadStore;
   readonly #state: ExecutionState;
 
@@ -75,7 +75,7 @@ class InMemoryTransactionStore implements ExecutionStoreTransaction {
     this.checkpoints = new InMemoryCheckpointStore(() => this.#state);
     this.events = new InMemoryEventStore(() => this.#state);
     this.notifications = new InMemoryNotificationInbox(() => this.#state);
-    this.runs = new InMemoryRunStore(() => this.#state);
+    this.turns = new InMemoryRunStore(() => this.#state);
     this.threads = new InMemoryExecutionThreadStore(() => this.#state);
   }
 
@@ -132,10 +132,10 @@ class InMemoryCheckpointStore implements CheckpointStore {
   }
 
   append(
-    checkpoint: RunCheckpoint,
+    checkpoint: Checkpoint,
     options: { readonly expectedVersion: number }
   ): Promise<CheckpointWriteResult> {
-    const run = this.#state().runs.get(checkpoint.runId);
+    const run = this.#state().turns.get(checkpoint.runId);
     const currentVersion = run?.checkpointVersion ?? 0;
     if (currentVersion !== options.expectedVersion) {
       return Promise.resolve({
@@ -150,7 +150,7 @@ class InMemoryCheckpointStore implements CheckpointStore {
     checkpoints.push(stored);
     this.#state().checkpoints.set(checkpoint.runId, checkpoints);
     if (run) {
-      this.#state().runs.set(checkpoint.runId, {
+      this.#state().turns.set(checkpoint.runId, {
         ...run,
         checkpointVersion: checkpoint.version,
       });
@@ -159,7 +159,7 @@ class InMemoryCheckpointStore implements CheckpointStore {
     return Promise.resolve({ ok: true, version: checkpoint.version });
   }
 
-  latest(runId: string): Promise<RunCheckpoint | null> {
+  latest(runId: string): Promise<Checkpoint | null> {
     const checkpoints = this.#state().checkpoints.get(runId) ?? [];
     const checkpoint = checkpoints.at(-1);
     return Promise.resolve(checkpoint ? structuredClone(checkpoint) : null);

--- a/packages/runtime/src/execution/resume/checkpoints.ts
+++ b/packages/runtime/src/execution/resume/checkpoints.ts
@@ -1,11 +1,7 @@
 import type { RuntimeToolExecutionCheckpointMetadata } from "../../llm/llm";
 import { ToolExecutionNeedsRecoveryError } from "../../llm/tool-execution";
-import { createRunCheckpointId } from "../host/checkpoint-ids";
-import type {
-  CheckpointPhase,
-  ExecutionHost,
-  RunCheckpoint,
-} from "../host/types";
+import { createCheckpointId } from "../host/checkpoint-ids";
+import type { Checkpoint, CheckpointPhase, ExecutionHost } from "../host/types";
 import type { ResumeRunState } from "./types";
 
 const maxCheckpointWriteAttempts = 5;
@@ -49,7 +45,7 @@ class ResumeRunMissingRunError extends Error {
 }
 
 export function resumeStepFromCheckpoint(
-  checkpoint: RunCheckpoint | null
+  checkpoint: Checkpoint | null
 ): ResumeStep {
   if (
     checkpoint?.phase === "before-model" ||
@@ -69,7 +65,7 @@ export function resumeStepFromCheckpoint(
 }
 
 export function throwIfManualToolRecoveryRequired(
-  checkpoint: RunCheckpoint | null
+  checkpoint: Checkpoint | null
 ): void {
   if (
     checkpoint?.phase !== "before-tool" &&
@@ -105,7 +101,7 @@ export async function appendCheckpoint({
     | { readonly current: number; readonly expected: number }
     | undefined;
   for (let attempt = 0; attempt < maxCheckpointWriteAttempts; attempt += 1) {
-    const run = await host.store.runs.get(runId);
+    const run = await host.store.turns.get(runId);
     if (!run) {
       throw new ResumeRunMissingRunError(runId);
     }
@@ -113,7 +109,7 @@ export async function appendCheckpoint({
     const version = run.checkpointVersion + 1;
     const result = await host.store.checkpoints.append(
       {
-        checkpointId: createRunCheckpointId({ phase, runId, version }),
+        checkpointId: createCheckpointId({ phase, runId, version }),
         ...(pendingToolCall === undefined ? {} : { pendingToolCall }),
         phase,
         runId,
@@ -195,7 +191,7 @@ function runtimeToolCheckpoint(
   };
 }
 
-function checkpointStep(checkpoint: RunCheckpoint): number {
+function checkpointStep(checkpoint: Checkpoint): number {
   const state = checkpoint.runtimeState;
   if (
     typeof state === "object" &&

--- a/packages/runtime/src/execution/resume/llm.ts
+++ b/packages/runtime/src/execution/resume/llm.ts
@@ -52,7 +52,7 @@ export async function createResumeToolExecution({
   readonly threadSnapshot: ResumeRunState;
   readonly stepNumber: number;
 }): Promise<RuntimeToolExecutionContext> {
-  const run = await host.store.runs.get(runId);
+  const run = await host.store.turns.get(runId);
   return {
     attempt: run?.lease?.attempt ?? 1,
     afterTool: (checkpoint) =>

--- a/packages/runtime/src/execution/resume/resume.ts
+++ b/packages/runtime/src/execution/resume/resume.ts
@@ -17,7 +17,7 @@ export type {
   ResumeRunOptions,
   ResumeRunResult,
   ResumeRunState,
-  ResumeRunStatus,
+  ResumeTurnStatus,
 } from "./types";
 
 export async function resumeRun(

--- a/packages/runtime/src/execution/resume/types.ts
+++ b/packages/runtime/src/execution/resume/types.ts
@@ -10,10 +10,10 @@ export interface ResumeRunBudget {
   readonly maxSteps: number;
 }
 
-export type ResumeRunStatus = "aborted" | "completed" | "suspended";
+export type ResumeTurnStatus = "aborted" | "completed" | "suspended";
 
 export interface ResumeRunResult {
-  readonly status: ResumeRunStatus;
+  readonly status: ResumeTurnStatus;
   readonly steps: number;
 }
 

--- a/packages/runtime/src/execution/run/stored-agent-turn.test.ts
+++ b/packages/runtime/src/execution/run/stored-agent-turn.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { AgentEvent } from "../../thread/protocol/events";
 import { createInMemoryExecutionHost } from "../memory";
-import { StoredAgentRun } from "./stored-agent-run";
+import { StoredAgentTurn } from "./stored-agent-turn";
 
-async function collectRunEvents(run: StoredAgentRun): Promise<AgentEvent[]> {
+async function collectRunEvents(run: StoredAgentTurn): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
   for await (const event of run.events()) {
     events.push(event);
@@ -11,10 +11,10 @@ async function collectRunEvents(run: StoredAgentRun): Promise<AgentEvent[]> {
   return events;
 }
 
-describe("stored AgentRun events", () => {
+describe("stored AgentTurn events", () => {
   it("replays stored events from cursor without thread runs", async () => {
     const host = createInMemoryExecutionHost();
-    await host.store.runs.create({
+    await host.store.turns.create({
       checkpointVersion: 0,
       kind: "user-turn",
       rootRunId: "run-1",
@@ -27,7 +27,7 @@ describe("stored AgentRun events", () => {
     });
     await host.store.events.append("run-1", { type: "turn-end" });
 
-    const run = new StoredAgentRun({
+    const run = new StoredAgentTurn({
       cursor,
       eventStore: host.store.events,
       runId: "run-1",
@@ -40,7 +40,7 @@ describe("stored AgentRun events", () => {
 
   it("rejects concurrent event iteration for one run", () => {
     const host = createInMemoryExecutionHost();
-    const run = new StoredAgentRun({
+    const run = new StoredAgentTurn({
       eventStore: host.store.events,
       runId: "run-1",
     });
@@ -48,7 +48,7 @@ describe("stored AgentRun events", () => {
     run.events();
 
     expect(() => run.events()).toThrow(
-      "AgentRun.events() can only be consumed once"
+      "AgentTurn.events() can only be consumed once"
     );
   });
 });

--- a/packages/runtime/src/execution/run/stored-agent-turn.ts
+++ b/packages/runtime/src/execution/run/stored-agent-turn.ts
@@ -1,8 +1,8 @@
 import type { AgentEvent } from "../../thread/protocol/events";
-import type { AgentRun } from "../../thread/protocol/run";
+import type { AgentTurn } from "../../thread/protocol/turn";
 import type { EventCursor, EventStore, StoredAgentEvent } from "../host/types";
 
-export class StoredAgentRun implements AgentRun {
+export class StoredAgentTurn implements AgentTurn {
   readonly #cursor: EventCursor | undefined;
   readonly #eventStore: EventStore;
   readonly #runId: string;
@@ -24,7 +24,7 @@ export class StoredAgentRun implements AgentRun {
 
   events(): AsyncIterable<AgentEvent> {
     if (this.#eventsStarted) {
-      throw new Error("AgentRun.events() can only be consumed once");
+      throw new Error("AgentTurn.events() can only be consumed once");
     }
     this.#eventsStarted = true;
 
@@ -49,7 +49,7 @@ class StoredAgentEventIterator implements AsyncIterableIterator<AgentEvent> {
   async next(): Promise<IteratorResult<AgentEvent>> {
     if (this.#nextPending) {
       throw new Error(
-        "AgentRun.events() does not allow concurrent next() calls"
+        "AgentTurn.events() does not allow concurrent next() calls"
       );
     }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,11 +9,7 @@ export {
 export type { AgentHost } from "./execution/host/types";
 export type { AgentToolChoice } from "./llm/llm";
 export { delegateUserInput } from "./thread/input/delegate-input";
-export type {
-  AgentInput,
-  SessionInput,
-  ThreadInput,
-} from "./thread/input/input";
+export type { AgentInput, ThreadInput } from "./thread/input/input";
 export {
   attachInputMeta,
   stripInputMeta,
@@ -61,14 +57,10 @@ export {
   isToolAgentEvent,
   isVisibleAgentEvent,
 } from "./thread/protocol/events";
-export type { AgentRun } from "./thread/protocol/run";
+export type { AgentTurn } from "./thread/protocol/turn";
 export type {
   CommitResult,
-  ExpectedSessionVersion,
   ExpectedThreadVersion,
-  SessionStore,
-  SessionStoreCommit,
-  StoredSession,
   StoredThread,
   ThreadStore,
   ThreadStoreCommit,

--- a/packages/runtime/src/platform/cloudflare/alarm/drainer.test.ts
+++ b/packages/runtime/src/platform/cloudflare/alarm/drainer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AgentEvent, AgentRun } from "../../../index";
+import type { AgentEvent, AgentTurn } from "../../../index";
 import {
   type CloudflareAlarmAgent,
   CloudflareAlarmDrainFailureError,
@@ -211,7 +211,7 @@ async function enqueueStoredRun(
   runId: string,
   kind: "notification" | "user-turn" = "notification"
 ): Promise<void> {
-  await host.store.runs.create({
+  await host.store.turns.create({
     checkpointVersion: 0,
     kind,
     rootRunId: runId,
@@ -230,7 +230,7 @@ function agentWithStream(
   };
 }
 
-function runWithEvents(events: readonly AgentEvent[]): AgentRun {
+function runWithEvents(events: readonly AgentEvent[]): AgentTurn {
   return {
     events: () => eventStream(events),
   };

--- a/packages/runtime/src/platform/cloudflare/alarm/drainer.ts
+++ b/packages/runtime/src/platform/cloudflare/alarm/drainer.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, AgentRun } from "../../../index";
+import type { AgentEvent, AgentTurn } from "../../../index";
 import {
   type CloudflareDurableObjectStorage,
   listScheduledCloudflareRuns,
@@ -42,7 +42,7 @@ export interface CloudflareAlarmDrainSummary {
 }
 
 export interface CloudflareAlarmAgent {
-  resume(runId: string): Promise<AgentRun | null>;
+  resume(runId: string): Promise<AgentTurn | null>;
 }
 
 export type CloudflareAlarmRunSource = "scheduled-run" | "thread-prompt";

--- a/packages/runtime/src/platform/cloudflare/alarm/run-context.test.ts
+++ b/packages/runtime/src/platform/cloudflare/alarm/run-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AgentEvent, AgentRun } from "../../../index";
+import type { AgentEvent, AgentTurn } from "../../../index";
 import {
   type CloudflareAlarmAgent,
   createCloudflareDurableObjectHost,
@@ -18,7 +18,7 @@ describe("Cloudflare alarm run contexts", () => {
     const host = createCloudflareDurableObjectHost({ storage });
     const contexts: string[] = [];
 
-    await host.store.runs.create({
+    await host.store.turns.create({
       checkpointVersion: 0,
       kind: "notification",
       rootRunId: "run-context",
@@ -89,7 +89,7 @@ describe("Cloudflare alarm run contexts", () => {
     });
     const host = createCloudflareDurableObjectHost({ storage });
 
-    await host.store.runs.create(notificationRunRecord("run-turn-error"));
+    await host.store.turns.create(notificationRunRecord("run-turn-error"));
     await host.scheduler.enqueueRun("run-turn-error");
 
     const summary = await drainCloudflareAlarm({
@@ -181,7 +181,7 @@ function agentWithEvents(events: readonly AgentEvent[]): CloudflareAlarmAgent {
   };
 }
 
-function runWithEvents(events: readonly AgentEvent[]): AgentRun {
+function runWithEvents(events: readonly AgentEvent[]): AgentTurn {
   return {
     events: () => eventStream(events),
   };

--- a/packages/runtime/src/platform/cloudflare/alarm/run-drain.ts
+++ b/packages/runtime/src/platform/cloudflare/alarm/run-drain.ts
@@ -1,27 +1,27 @@
-import type { AgentEvent, AgentRun } from "../../../index";
+import type { AgentEvent, AgentTurn } from "../../../index";
 
-export type AgentRunDrainStopReason = "deadline" | "event-budget";
+export type AgentTurnDrainStopReason = "deadline" | "event-budget";
 
-export interface CloudflareAgentRunDrainOptions {
+export interface CloudflareAgentTurnDrainOptions {
   readonly deadlineMs?: number;
   readonly maxEvents?: number;
   readonly onEvent?: (event: AgentEvent) => Promise<void> | void;
   readonly startedAt?: number;
 }
 
-export interface AgentRunDrainResult {
+export interface AgentTurnDrainResult {
   readonly droppedEvents: number;
   readonly events: readonly AgentEvent[];
-  readonly stoppedReason?: AgentRunDrainStopReason;
+  readonly stoppedReason?: AgentTurnDrainStopReason;
 }
 
-export async function drainAgentRun(
-  run: AgentRun,
-  options: CloudflareAgentRunDrainOptions = {}
+export async function drainAgentTurn(
+  run: AgentTurn,
+  options: CloudflareAgentTurnDrainOptions = {}
 ): Promise<AgentEvent[]> {
   return [
     ...(
-      await drainAgentRunWithBudget(run, {
+      await drainAgentTurnWithBudget(run, {
         deadlineMs: options.deadlineMs,
         maxEvents: options.maxEvents,
         onEvent: options.onEvent,
@@ -31,10 +31,10 @@ export async function drainAgentRun(
   ];
 }
 
-export async function drainAgentRunWithBudget(
-  run: AgentRun,
-  options: CloudflareAgentRunDrainOptions = {}
-): Promise<AgentRunDrainResult> {
+export async function drainAgentTurnWithBudget(
+  run: AgentTurn,
+  options: CloudflareAgentTurnDrainOptions = {}
+): Promise<AgentTurnDrainResult> {
   const events: AgentEvent[] = [];
   let droppedEvents = 0;
   const deadlineAt =
@@ -42,7 +42,7 @@ export async function drainAgentRunWithBudget(
       ? undefined
       : (options.startedAt ?? Date.now()) + options.deadlineMs;
   const iterator = run.events()[Symbol.asyncIterator]();
-  let stoppedReason: AgentRunDrainStopReason | undefined;
+  let stoppedReason: AgentTurnDrainStopReason | undefined;
 
   try {
     while (true) {

--- a/packages/runtime/src/platform/cloudflare/alarm/scheduled-work-context.ts
+++ b/packages/runtime/src/platform/cloudflare/alarm/scheduled-work-context.ts
@@ -1,4 +1,4 @@
-import type { RunRecord, RunStatus } from "../../../execution";
+import type { TurnRecord, TurnStatus } from "../../../execution";
 import {
   type CloudflareDurableObjectStorage,
   type CloudflareScheduledThreadPrompt,
@@ -14,7 +14,7 @@ export async function scheduledRunContext(
   const run = await createCloudflareDurableObjectHost({
     prefix,
     storage,
-  }).store.runs.get(runId);
+  }).store.turns.get(runId);
   return {
     runId,
     threadKey: run?.threadKey ?? "",
@@ -49,7 +49,7 @@ export async function shouldRetryScheduledRun(
   const run = await createCloudflareDurableObjectHost({
     prefix,
     storage,
-  }).store.runs.get(runId);
+  }).store.turns.get(runId);
   return run?.kind === "notification" && isRetryableRunStatus(run.status);
 }
 
@@ -76,12 +76,12 @@ export async function prepareScheduledNotificationRetry(
   const host = createCloudflareDurableObjectHost({ prefix, storage });
   let prepared = false;
   await host.store.transaction(async (tx) => {
-    const run = await tx.runs.get(runId);
+    const run = await tx.turns.get(runId);
     if (run?.kind !== "notification" || !run.dedupeKey) {
       return;
     }
 
-    await tx.runs.update(retryableNotificationRun(run));
+    await tx.turns.update(retryableNotificationRun(run));
     await tx.notifications.releaseByIdempotencyKey(run.dedupeKey);
     prepared = true;
   });
@@ -107,7 +107,7 @@ async function scheduledThreadPromptRunId(
   return notification?.runId;
 }
 
-function isRetryableRunStatus(status: RunStatus | undefined): boolean {
+function isRetryableRunStatus(status: TurnStatus | undefined): boolean {
   return (
     status === "leased" ||
     status === "queued" ||
@@ -116,7 +116,7 @@ function isRetryableRunStatus(status: RunStatus | undefined): boolean {
   );
 }
 
-function retryableNotificationRun(run: RunRecord): RunRecord {
+function retryableNotificationRun(run: TurnRecord): TurnRecord {
   const { lease: _lease, ...runWithoutLease } = run;
   return { ...runWithoutLease, status: "queued" };
 }

--- a/packages/runtime/src/platform/cloudflare/alarm/scheduled-work.ts
+++ b/packages/runtime/src/platform/cloudflare/alarm/scheduled-work.ts
@@ -13,7 +13,10 @@ import type {
   CloudflareAlarmAgentForRun,
   CloudflareAlarmEventHandler,
 } from "./drainer";
-import { type AgentRunDrainResult, drainAgentRunWithBudget } from "./run-drain";
+import {
+  type AgentTurnDrainResult,
+  drainAgentTurnWithBudget,
+} from "./run-drain";
 import {
   prepareScheduledNotificationRetry,
   scheduledRunContext,
@@ -62,7 +65,7 @@ export async function resumeScheduledRun({
       return;
     }
     state.resumedRuns.push(runId);
-    const drainResult = await drainAgentRunWithBudget(run, {
+    const drainResult = await drainAgentTurnWithBudget(run, {
       deadlineMs: budget.deadlineMs,
       maxEvents: eventSlotsRemaining(state, budget),
       onEvent: onEvent ? (event) => onEvent(context, event) : undefined,
@@ -129,7 +132,7 @@ export async function resumeScheduledThreadPrompt({
       await ackScheduledCloudflareThreadPrompt(storage, prompt, { prefix });
       return;
     }
-    const drainResult = await drainAgentRunWithBudget(run, {
+    const drainResult = await drainAgentTurnWithBudget(run, {
       deadlineMs: budget.deadlineMs,
       maxEvents: eventSlotsRemaining(state, budget),
       onEvent: onEvent ? (event) => onEvent(context, event) : undefined,
@@ -183,7 +186,7 @@ function describeError(error: unknown): string {
 
 function appendRunDrainEvents(
   state: AlarmDrainState,
-  result: AgentRunDrainResult
+  result: AgentTurnDrainResult
 ): void {
   state.events.push(...result.events);
   state.droppedEvents += result.droppedEvents;
@@ -195,7 +198,7 @@ function appendRunDrainEvents(
 function appendTurnErrorFailure(
   failedWork: AlarmDrainState["failedRuns"],
   id: string,
-  result: AgentRunDrainResult
+  result: AgentTurnDrainResult
 ): boolean {
   const turnError = result.events.find((event) => event.type === "turn-error");
   if (!turnError) {

--- a/packages/runtime/src/platform/cloudflare/alarm/thread-prompt-retry.test.ts
+++ b/packages/runtime/src/platform/cloudflare/alarm/thread-prompt-retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AgentEvent, AgentRun } from "../../../index";
+import type { AgentEvent, AgentTurn } from "../../../index";
 import {
   createCloudflareDurableObjectHost,
   drainCloudflareAlarm,
@@ -31,10 +31,10 @@ describe("Cloudflare alarm thread prompt retries", () => {
       { error: "model unavailable", id: idempotencyKey },
     ]);
     expect(summary.continuationScheduled).toBe(true);
-    await expect(host.store.runs.get(runId)).resolves.toEqual(
+    await expect(host.store.turns.get(runId)).resolves.toEqual(
       expect.objectContaining({ status: "queued" })
     );
-    expect((await host.store.runs.get(runId))?.lease).toBeUndefined();
+    expect((await host.store.turns.get(runId))?.lease).toBeUndefined();
     await expect(
       host.store.notifications.getByIdempotencyKey(idempotencyKey)
     ).resolves.toEqual(expect.objectContaining({ status: "pending" }));
@@ -65,10 +65,10 @@ describe("Cloudflare alarm thread prompt retries", () => {
     expect(summary.events).toEqual([{ text: "first", type: "assistant-text" }]);
     expect(summary.continuationReasons).toContain("event-budget");
     expect(summary.continuationScheduled).toBe(true);
-    await expect(host.store.runs.get(runId)).resolves.toEqual(
+    await expect(host.store.turns.get(runId)).resolves.toEqual(
       expect.objectContaining({ status: "queued" })
     );
-    expect((await host.store.runs.get(runId))?.lease).toBeUndefined();
+    expect((await host.store.turns.get(runId))?.lease).toBeUndefined();
     await expect(
       host.store.notifications.getByIdempotencyKey(idempotencyKey)
     ).resolves.toEqual(expect.objectContaining({ status: "pending" }));
@@ -87,11 +87,11 @@ async function completeAndClaimNotification({
   readonly idempotencyKey: string;
   readonly runId: string;
 }): Promise<void> {
-  const run = await host.store.runs.get(runId);
+  const run = await host.store.turns.get(runId);
   if (!run) {
     throw new Error("expected stored notification run");
   }
-  await host.store.runs.update({
+  await host.store.turns.update({
     ...run,
     lease: {
       attempt: 1,
@@ -125,7 +125,7 @@ async function createScheduledNotification(idempotencyKey: string): Promise<{
     threadKey,
     status: "pending",
   });
-  await host.store.runs.create({
+  await host.store.turns.create({
     checkpointVersion: 0,
     dedupeKey: idempotencyKey,
     kind: "notification",
@@ -139,7 +139,7 @@ async function createScheduledNotification(idempotencyKey: string): Promise<{
   return { host, idempotencyKey, runId, threadKey, storage };
 }
 
-function runWithEvents(events: readonly AgentEvent[]): AgentRun {
+function runWithEvents(events: readonly AgentEvent[]): AgentTurn {
   return {
     events: () => eventStream(events),
   };

--- a/packages/runtime/src/platform/cloudflare/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/platform/cloudflare/dispatch/notification-dispatch.test.ts
@@ -20,13 +20,15 @@ describe("dispatchCloudflareAgentNotification", () => {
       threadKey: "room:1:user:2",
     });
 
-    await expect(host.store.runs.get(dispatched.runId)).resolves.toMatchObject({
-      kind: "notification",
-      runId: dispatched.runId,
-      threadKey: "room:1:user:2",
-      status: "queued",
-    });
-    const run = await host.store.runs.get(dispatched.runId);
+    await expect(host.store.turns.get(dispatched.runId)).resolves.toMatchObject(
+      {
+        kind: "notification",
+        runId: dispatched.runId,
+        threadKey: "room:1:user:2",
+        status: "queued",
+      }
+    );
+    const run = await host.store.turns.get(dispatched.runId);
     await expect(
       host.store.notifications.getByIdempotencyKey(run?.dedupeKey ?? "")
     ).resolves.toMatchObject({

--- a/packages/runtime/src/platform/cloudflare/host/agent-context.test.ts
+++ b/packages/runtime/src/platform/cloudflare/host/agent-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AgentEvent, AgentRun } from "../../../index";
+import type { AgentEvent, AgentTurn } from "../../../index";
 import {
   type CloudflareDurableObjectNamespace,
   createCloudflareAgentContext,
@@ -70,7 +70,7 @@ describe("Cloudflare Worker DX helpers", () => {
 
     await storage.put("prefix", "tenant-prefix");
     const host = context.host("tenant-prefix");
-    await host.store.runs.create({
+    await host.store.turns.create({
       checkpointVersion: 0,
       kind: "notification",
       rootRunId: "background:bg_context",
@@ -93,7 +93,7 @@ describe("Cloudflare Worker DX helpers", () => {
   });
 });
 
-function runWithText(text: string): AgentRun {
+function runWithText(text: string): AgentTurn {
   return {
     events: () => eventStream([{ text, type: "assistant-text" }]),
   };

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import type { AgentEvent, AgentRun } from "../../../index";
-import { SpyStore } from "../../../thread/handle/test-support";
+import type { AgentEvent, AgentTurn } from "../../../index";
 import {
   ackScheduledCloudflareRun,
   ackScheduledCloudflareThreadPrompt,
@@ -11,7 +10,7 @@ import {
   type CloudflareDurableObjectStorage,
   type CloudflareDurableObjectStub,
   createCloudflareDurableObjectHost,
-  drainAgentRun,
+  drainAgentTurn,
   drainCloudflareAlarm,
   InMemoryCloudflareDurableObjectStorage,
   listScheduledCloudflareRuns,
@@ -217,22 +216,6 @@ describe("Cloudflare Durable Object host adapter", () => {
     expect(readScheduledWorkRows(storage)).toEqual([]);
   });
 
-  it("accepts the deprecated sessionStore option as a custom thread store", async () => {
-    const storage = new InMemoryCloudflareDurableObjectStorage({
-      sql: new InMemorySqlStorage(),
-    });
-    const sessionStore = new SpyStore();
-    const host = createCloudflareDurableObjectHost({ storage, sessionStore });
-
-    expect(host.store.threads).toBe(sessionStore);
-    expect(host.store.sessions).toBe(sessionStore);
-    await host.store.transaction((tx) => {
-      expect(tx.threads).toBe(sessionStore);
-      expect(tx.sessions).toBe(sessionStore);
-      return Promise.resolve();
-    });
-  });
-
   it("keeps unclaimable scheduled runs pending and reschedules the alarm", async () => {
     const storage = new InMemoryCloudflareDurableObjectStorage({
       sql: new InMemorySqlStorage(),
@@ -240,7 +223,7 @@ describe("Cloudflare Durable Object host adapter", () => {
     const host = createCloudflareDurableObjectHost({ storage });
     const runId = "background:bg_retry";
 
-    await host.store.runs.create(notificationRunRecord(runId));
+    await host.store.turns.create(notificationRunRecord(runId));
     await host.scheduler.enqueueRun(runId);
 
     const summary = await drainCloudflareAlarm({
@@ -275,7 +258,7 @@ describe("Cloudflare Durable Object host adapter", () => {
       idempotencyKey,
       runId,
     });
-    await host.store.runs.create(notificationRunRecord(runId, idempotencyKey));
+    await host.store.turns.create(notificationRunRecord(runId, idempotencyKey));
 
     const summary = await drainCloudflareAlarm({
       agent: unclaimableAgent,
@@ -302,7 +285,7 @@ describe("Cloudflare Durable Object host adapter", () => {
     ] satisfies readonly AgentEvent[];
     const observedEvents: AgentEvent[] = [];
 
-    const drainedEvents = await drainAgentRun(runWithEvents(runEvents), {
+    const drainedEvents = await drainAgentTurn(runWithEvents(runEvents), {
       onEvent: (event) => {
         observedEvents.push(event);
       },
@@ -344,7 +327,7 @@ function notificationRunRecord(runId: string, idempotencyKey = runId) {
   } as const;
 }
 
-function runWithEvents(events: readonly AgentEvent[]): AgentRun {
+function runWithEvents(events: readonly AgentEvent[]): AgentTurn {
   return {
     events: () => eventStream(events),
   };

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.ts
@@ -44,7 +44,6 @@ export class InMemoryCloudflareDurableObjectStorage extends BaseInMemoryCloudfla
 export function createCloudflareDurableObjectHost({
   maxPayloadBytes,
   prefix = defaultPrefix,
-  sessionStore,
   threadStore,
   storage,
   scheduler = createCloudflareAlarmScheduler({ prefix, storage }),
@@ -52,8 +51,6 @@ export function createCloudflareDurableObjectHost({
   readonly maxPayloadBytes?: number;
   readonly prefix?: string;
   readonly scheduler?: ExecutionScheduler;
-  /** @deprecated Use threadStore. */
-  readonly sessionStore?: ThreadStore;
   readonly threadStore?: ThreadStore;
   readonly storage: CloudflareDurableObjectStorage;
 }): ExecutionHost {
@@ -62,13 +59,10 @@ export function createCloudflareDurableObjectHost({
     prefix,
     storage,
   });
-  const customThreadStore = threadStore ?? sessionStore;
   return {
     kind: "execution",
     scheduler,
-    store: customThreadStore
-      ? executionStoreWithThreads(store, customThreadStore)
-      : store,
+    store: threadStore ? executionStoreWithThreads(store, threadStore) : store,
   };
 }
 
@@ -145,21 +139,19 @@ function executionStoreWithThreads(
   threads: ThreadStore
 ): ExecutionHost["store"] {
   return {
-    checkpoints: store.checkpoints,
     events: store.events,
     notifications: store.notifications,
-    runs: store.runs,
-    sessions: threads,
+    checkpoints: store.checkpoints,
     threads,
+    turns: store.turns,
     transaction: (fn) =>
       store.transaction((tx) =>
         fn({
-          checkpoints: tx.checkpoints,
           events: tx.events,
           notifications: tx.notifications,
-          runs: tx.runs,
-          sessions: threads,
+          checkpoints: tx.checkpoints,
           threads,
+          turns: tx.turns,
         })
       ),
   };

--- a/packages/runtime/src/platform/cloudflare/index.ts
+++ b/packages/runtime/src/platform/cloudflare/index.ts
@@ -17,8 +17,12 @@ export {
   CloudflareAlarmDrainFailureError,
   drainCloudflareAlarm,
 } from "./alarm/drainer";
-export type { CloudflareAgentRunDrainOptions } from "./alarm/run-drain";
-export { drainAgentRun } from "./alarm/run-drain";
+export type {
+  AgentTurnDrainResult,
+  AgentTurnDrainStopReason,
+  CloudflareAgentTurnDrainOptions,
+} from "./alarm/run-drain";
+export { drainAgentTurn, drainAgentTurnWithBudget } from "./alarm/run-drain";
 export type {
   DispatchCloudflareAgentNotificationInput,
   SourceCloudflareAgentNotificationIdempotencyKeyInput,
@@ -84,8 +88,4 @@ export {
 } from "./storage/payload-guard";
 export { DurableObjectSqliteCheckpointStore } from "./storage/sqlite/checkpoint-store";
 export { DurableObjectSqliteEventStore } from "./storage/sqlite/event-store";
-export {
-  DurableObjectSqliteThreadStore,
-  /** @deprecated Use DurableObjectSqliteThreadStore. */
-  DurableObjectSqliteThreadStore as DurableObjectSqliteSessionStore,
-} from "./storage/sqlite/thread-store";
+export { DurableObjectSqliteThreadStore } from "./storage/sqlite/thread-store";

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/run-write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/run-write.ts
@@ -26,11 +26,11 @@ function upsertRun(
   bindings: readonly unknown[]
 ): void {
   const row = createRunRow(bindings);
-  state.runs = state.runs.filter(
+  state.turns = state.turns.filter(
     (existing) =>
       !(existing.prefix === row.prefix && existing.run_id === row.run_id)
   );
-  state.runs.push(row);
+  state.turns.push(row);
 }
 
 function deleteRun(
@@ -39,7 +39,7 @@ function deleteRun(
 ): void {
   const prefix = stringBinding(bindings[0]);
   const runId = stringBinding(bindings[1]);
-  state.runs = state.runs.filter(
+  state.turns = state.turns.filter(
     (row) => !(row.prefix === prefix && row.run_id === runId)
   );
 }

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
@@ -142,20 +142,20 @@ function selectRunRows(
   const prefix = stringBinding(bindings[0]);
   if (query.includes("run_id = ?")) {
     const runId = stringBinding(bindings[1]);
-    return state.runs
+    return state.turns
       .filter((row) => row.prefix === prefix && row.run_id === runId)
       .map(projectRun);
   }
   if (query.includes("dedupe_key = ?")) {
     const dedupeKey = stringBinding(bindings[1]);
-    return state.runs
+    return state.turns
       .filter((row) => row.prefix === prefix && row.dedupe_key === dedupeKey)
       .map(projectRun)
       .slice(0, 1);
   }
   if (query.includes("parent_run_id = ?")) {
     const parentRunId = stringBinding(bindings[1]);
-    return state.runs
+    return state.turns
       .filter(
         (row) => row.prefix === prefix && row.parent_run_id === parentRunId
       )

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
@@ -88,11 +88,11 @@ export interface InMemoryDurableObjectSqlState {
   events: EventRow[];
   notifications: NotificationRow[];
   payloadChunks: PayloadChunkRow[];
-  runs: RunRow[];
   scheduledWork: ScheduledWorkRow[];
   threadMessageChunks: ThreadMessageChunkRow[];
   threadMessages: ThreadMessageRow[];
   threadMeta: Map<string, ThreadMetaRow>;
+  turns: RunRow[];
 }
 
 export function createInMemoryDurableObjectSqlState(): InMemoryDurableObjectSqlState {
@@ -102,7 +102,7 @@ export function createInMemoryDurableObjectSqlState(): InMemoryDurableObjectSqlS
     events: [],
     notifications: [],
     payloadChunks: [],
-    runs: [],
+    turns: [],
     scheduledWork: [],
     threadMessageChunks: [],
     threadMessages: [],
@@ -121,7 +121,7 @@ export function cloneInMemoryDurableObjectSqlState(
     events: structuredClone(state.events),
     notifications: structuredClone(state.notifications),
     payloadChunks: structuredClone(state.payloadChunks),
-    runs: structuredClone(state.runs),
+    turns: structuredClone(state.turns),
     scheduledWork: structuredClone(state.scheduledWork),
     threadMessageChunks: structuredClone(state.threadMessageChunks),
     threadMessages: structuredClone(state.threadMessages),

--- a/packages/runtime/src/platform/cloudflare/storage/execution/run-records.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/run-records.ts
@@ -1,4 +1,4 @@
-import type { RunRecord } from "../../../../execution";
+import type { TurnRecord } from "../../../../execution";
 import type { SqlStorage } from "../../sql/ports/storage-port";
 import type { CloudflareDurableObjectTransactionStorage } from "../durable-object/durable-object-storage";
 import {
@@ -15,7 +15,7 @@ export function getRun(
   storage: CloudflareDurableObjectTransactionStorage,
   prefix: string,
   runId: string
-): Promise<RunRecord | null> {
+): Promise<TurnRecord | null> {
   const row = selectRunRow(requiredSqlStorage(storage), prefix, runId);
   return Promise.resolve(row ? parseRunRecord(row) : null);
 }
@@ -24,7 +24,7 @@ export function getRunByDedupeKey(
   storage: CloudflareDurableObjectTransactionStorage,
   prefix: string,
   dedupeKey: string
-): Promise<RunRecord | null> {
+): Promise<TurnRecord | null> {
   const sql = requiredSqlStorage(storage);
   ensureRunSchema(sql);
   const row = sql
@@ -41,7 +41,7 @@ export function listRunsByParentRunId(
   storage: CloudflareDurableObjectTransactionStorage,
   prefix: string,
   parentRunId: string
-): Promise<readonly RunRecord[]> {
+): Promise<readonly TurnRecord[]> {
   const sql = requiredSqlStorage(storage);
   ensureRunSchema(sql);
   return Promise.resolve(
@@ -59,7 +59,7 @@ export function listRunsByParentRunId(
 export function putRun(
   storage: CloudflareDurableObjectTransactionStorage,
   prefix: string,
-  record: RunRecord,
+  record: TurnRecord,
   options: StoragePayloadBudgetOptions = {}
 ): Promise<void> {
   assertJsonPayloadWithinBudget(
@@ -74,7 +74,7 @@ export function putRun(
 export function insertRun(
   storage: CloudflareDurableObjectTransactionStorage,
   prefix: string,
-  record: RunRecord,
+  record: TurnRecord,
   options: StoragePayloadBudgetOptions = {}
 ): Promise<void> {
   assertJsonPayloadWithinBudget(
@@ -101,8 +101,8 @@ function selectRunRow(
     .toArray()[0];
 }
 
-function parseRunRecord(row: RunRow): RunRecord {
-  return JSON.parse(row.record) as RunRecord;
+function parseRunRecord(row: RunRow): TurnRecord {
+  return JSON.parse(row.record) as TurnRecord;
 }
 
 function requiredSqlStorage(
@@ -136,7 +136,7 @@ function ensureRunSchema(sql: SqlStorage): void {
   );
 }
 
-function putSqlRun(sql: SqlStorage, prefix: string, record: RunRecord): void {
+function putSqlRun(sql: SqlStorage, prefix: string, record: TurnRecord): void {
   ensureRunSchema(sql);
   const nowMs = Date.now();
   sql.exec(
@@ -158,7 +158,7 @@ function putSqlRun(sql: SqlStorage, prefix: string, record: RunRecord): void {
 function insertSqlRun(
   sql: SqlStorage,
   prefix: string,
-  record: RunRecord
+  record: TurnRecord
 ): void {
   ensureRunSchema(sql);
   const nowMs = Date.now();

--- a/packages/runtime/src/platform/cloudflare/storage/execution/run-store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/run-store.ts
@@ -1,10 +1,10 @@
 import type {
-  ClaimRunOptions,
-  ClaimRunResult,
-  CreateRunResult,
-  RunRecord,
-  RunStatus,
-  RunStore,
+  ClaimTurnOptions,
+  ClaimTurnResult,
+  CreateTurnResult,
+  TurnRecord,
+  TurnStatus,
+  TurnStore,
 } from "../../../../execution";
 import type { CloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
 import {
@@ -20,14 +20,14 @@ import {
   putRun,
 } from "./run-records";
 
-const claimableStatuses = new Set<RunStatus>([
+const claimableStatuses = new Set<TurnStatus>([
   "leased",
   "queued",
   "running",
   "suspended",
 ]);
 
-export class DurableObjectRunStore implements RunStore {
+export class DurableObjectRunStore implements TurnStore {
   readonly #maxPayloadBytes: number;
   readonly #prefix: string;
   readonly #storage: CloudflareDurableObjectStorage;
@@ -44,8 +44,8 @@ export class DurableObjectRunStore implements RunStore {
 
   async claim(
     runId: string,
-    options: ClaimRunOptions
-  ): Promise<ClaimRunResult> {
+    options: ClaimTurnOptions
+  ): Promise<ClaimTurnResult> {
     return await withTransaction(this.#storage, async (storage) => {
       const run = await getRun(storage, this.#prefix, runId);
       if (!run) {
@@ -63,7 +63,7 @@ export class DurableObjectRunStore implements RunStore {
         leaseId: options.leaseId,
         leaseUntilMs: options.nowMs + options.leaseMs,
       };
-      const claimed: RunRecord = { ...run, lease, status: "leased" };
+      const claimed: TurnRecord = { ...run, lease, status: "leased" };
       await putRun(storage, this.#prefix, claimed, {
         maxPayloadBytes: this.#maxPayloadBytes,
       });
@@ -71,7 +71,7 @@ export class DurableObjectRunStore implements RunStore {
     });
   }
 
-  async create(record: RunRecord): Promise<CreateRunResult> {
+  async create(record: TurnRecord): Promise<CreateTurnResult> {
     return await withTransaction(this.#storage, async (storage) => {
       const existing =
         (await getRun(storage, this.#prefix, record.runId)) ??
@@ -93,15 +93,15 @@ export class DurableObjectRunStore implements RunStore {
     });
   }
 
-  async get(runId: string): Promise<RunRecord | null> {
+  async get(runId: string): Promise<TurnRecord | null> {
     return await getRun(this.#storage, this.#prefix, runId);
   }
 
-  async getByDedupeKey(dedupeKey: string): Promise<RunRecord | null> {
+  async getByDedupeKey(dedupeKey: string): Promise<TurnRecord | null> {
     return await getRunByDedupeKey(this.#storage, this.#prefix, dedupeKey);
   }
 
-  async listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]> {
+  async listByParentRunId(parentRunId: string): Promise<readonly TurnRecord[]> {
     return await listRunsByParentRunId(
       this.#storage,
       this.#prefix,
@@ -109,7 +109,7 @@ export class DurableObjectRunStore implements RunStore {
     );
   }
 
-  async update(record: RunRecord): Promise<RunRecord> {
+  async update(record: TurnRecord): Promise<TurnRecord> {
     return await withTransaction(this.#storage, async (storage) => {
       await putRun(storage, this.#prefix, record, {
         maxPayloadBytes: this.#maxPayloadBytes,

--- a/packages/runtime/src/platform/cloudflare/storage/execution/storage-metrics.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/storage-metrics.test.ts
@@ -29,7 +29,7 @@ describe("storage metrics", () => {
       },
       { expectedVersion: null }
     );
-    await host.store.runs.create({
+    await host.store.turns.create({
       checkpointVersion: 0,
       kind: "user-turn",
       rootRunId: runId,

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-contract.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { describeExecutionStoreContract } from "../../../../contracts/execution-store/contract";
-import type { NotificationRecord, RunRecord } from "../../../../execution";
+import type { NotificationRecord, TurnRecord } from "../../../../execution";
 import { InMemorySqlStorage } from "../../sql/node-test/node-sqlite-storage";
 import { InMemoryCloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
 import { DurableObjectExecutionStore } from "./store";
@@ -47,7 +47,7 @@ describe("DurableObjectExecutionStore payload guards", () => {
     const store = createBudgetedStore(180);
 
     await expect(
-      store.runs.create(
+      store.turns.create(
         runRecord("run-create", { output: { notes: "x".repeat(240) } })
       )
     ).rejects.toMatchObject({
@@ -55,15 +55,15 @@ describe("DurableObjectExecutionStore payload guards", () => {
       maxBytes: 180,
       payloadKind: "run-record",
     });
-    await expect(store.runs.get("run-create")).resolves.toBeNull();
+    await expect(store.turns.get("run-create")).resolves.toBeNull();
   });
 
   it("rejects run records on update when they exceed the serialized payload budget", async () => {
     const store = createBudgetedStore(180);
-    await store.runs.create(runRecord("run-update"));
+    await store.turns.create(runRecord("run-update"));
 
     await expect(
-      store.runs.update(
+      store.turns.update(
         runRecord("run-update", { output: { notes: "x".repeat(240) } })
       )
     ).rejects.toMatchObject({
@@ -71,7 +71,7 @@ describe("DurableObjectExecutionStore payload guards", () => {
       maxBytes: 180,
       payloadKind: "run-record",
     });
-    await expect(store.runs.get("run-update")).resolves.toEqual(
+    await expect(store.turns.get("run-update")).resolves.toEqual(
       runRecord("run-update")
     );
   });
@@ -89,7 +89,7 @@ describe("DurableObjectExecutionStore payload guards", () => {
       parentRunId: "parent-1",
     });
 
-    await store.runs.create(record);
+    await store.turns.create(record);
 
     const rows = (storage.sql as InMemorySqlStorage)
       .exec<{ readonly record: string }>(
@@ -99,10 +99,10 @@ describe("DurableObjectExecutionStore payload guards", () => {
       )
       .toArray();
     expect(rows.map((row) => JSON.parse(row.record))).toEqual([record]);
-    await expect(store.runs.getByDedupeKey("dedupe-1")).resolves.toEqual(
+    await expect(store.turns.getByDedupeKey("dedupe-1")).resolves.toEqual(
       record
     );
-    await expect(store.runs.listByParentRunId("parent-1")).resolves.toEqual([
+    await expect(store.turns.listByParentRunId("parent-1")).resolves.toEqual([
       record,
     ]);
   });
@@ -165,8 +165,8 @@ function createBudgetedStore(
 
 function runRecord(
   runId: string,
-  overrides: Partial<RunRecord> = {}
-): RunRecord {
+  overrides: Partial<TurnRecord> = {}
+): TurnRecord {
   return {
     checkpointVersion: 0,
     kind: "user-turn",

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-oversized-payload.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-oversized-payload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { RunRecord } from "../../../../execution";
+import type { TurnRecord } from "../../../../execution";
 import type { AgentEvent } from "../../../../index";
 import { createCloudflareDurableObjectHost } from "../../index";
 import { InMemorySqlStorage } from "../../sql/node-test/node-sqlite-storage";
@@ -45,7 +45,7 @@ describe("DurableObjectExecutionStore oversized payload stress", () => {
     expect(threadCommit).toEqual({ ok: true, version: "1" });
 
     const run = runRecord({ runId, threadKey });
-    await host.store.runs.create(run);
+    await host.store.turns.create(run);
     await host.store.events.append(runId, {
       text: oversizedEventText,
       type: "assistant-text",
@@ -67,7 +67,7 @@ describe("DurableObjectExecutionStore oversized payload stress", () => {
       },
       { expectedVersion: 0 }
     );
-    await host.store.runs.update({
+    await host.store.turns.update({
       ...run,
       checkpointVersion: 1,
       status: "completed",
@@ -144,7 +144,7 @@ describe("DurableObjectExecutionStore oversized payload stress", () => {
       runId: latencyRunId,
       threadKey: latencyThreadKey,
     });
-    await timed(timings, "run create", () => host.store.runs.create(run));
+    await timed(timings, "run create", () => host.store.turns.create(run));
     await timed(timings, "assistant event append", () =>
       host.store.events.append(latencyRunId, {
         text: hugeAssistantOutput,
@@ -173,7 +173,7 @@ describe("DurableObjectExecutionStore oversized payload stress", () => {
       )
     );
     await timed(timings, "run update", () =>
-      host.store.runs.update({
+      host.store.turns.update({
         ...run,
         checkpointVersion: 1,
         status: "completed",
@@ -223,7 +223,7 @@ describe("DurableObjectExecutionStore oversized payload stress", () => {
 function runRecord(input: {
   readonly runId: string;
   readonly threadKey: string;
-}): RunRecord {
+}): TurnRecord {
   return {
     checkpointVersion: 0,
     kind: "user-turn",

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-stress-helpers.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-stress-helpers.ts
@@ -1,4 +1,4 @@
-import type { RunRecord } from "../../../../execution";
+import type { TurnRecord } from "../../../../execution";
 import type { AgentEvent } from "../../../../index";
 import { createCloudflareDurableObjectHost } from "../../index";
 import type { InMemoryCloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
@@ -15,7 +15,7 @@ export async function hostLoadFinalThread(
 export function runRecord(input: {
   readonly runId: string;
   readonly threadKey: string;
-}): RunRecord {
+}): TurnRecord {
   return {
     checkpointVersion: 0,
     kind: "user-turn",

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-stress-scenario.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-stress-scenario.ts
@@ -1,4 +1,4 @@
-import type { RunRecord } from "../../../../execution";
+import type { TurnRecord } from "../../../../execution";
 import type { AgentEvent } from "../../../../index";
 import {
   type CloudflareDurableObjectStorage,
@@ -123,12 +123,12 @@ async function writeThreadTurns(input: WriteThreadTurnsInput): Promise<number> {
     }
 
     const run = runRecord({ runId, threadKey: input.threadKey });
-    const create = await input.host.store.runs.create(run);
+    const create = await input.host.store.turns.create(run);
     if (!create.ok) {
       throw new Error(`mock run create failed for ${runId}`);
     }
     if (turn === 0) {
-      const duplicate = await input.host.store.runs.create(run);
+      const duplicate = await input.host.store.turns.create(run);
       if (duplicate.ok) {
         throw new Error(`mock run duplicate was inserted for ${runId}`);
       }
@@ -156,7 +156,7 @@ async function writeThreadTurns(input: WriteThreadTurnsInput): Promise<number> {
       runId,
       eventRecord("step-end", input.eventPayloadBytes)
     );
-    await input.host.store.runs.update({
+    await input.host.store.turns.update({
       ...run,
       checkpointVersion: 1,
       status: "completed",
@@ -217,7 +217,7 @@ function assistantContent(turn: number, input: WriteThreadTurnsInput): string {
 function runRecord(input: {
   readonly runId: string;
   readonly threadKey: string;
-}): RunRecord {
+}): TurnRecord {
   return {
     checkpointVersion: 0,
     dedupeKey: `${input.runId}:dedupe`,

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-stress.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-stress.test.ts
@@ -122,7 +122,7 @@ describe("DurableObjectExecutionStore storage stress", () => {
         for (let runIndex = 0; runIndex < stressRunsPerThread; runIndex += 1) {
           const runId = `${threadKey}:run-${runIndex}`;
           const run = runRecord({ runId, threadKey });
-          await host.store.runs.create(run);
+          await host.store.turns.create(run);
           await host.store.events.append(runId, eventRecord("step-start"));
           await host.store.events.append(runId, eventRecord("step-end"));
           await host.store.checkpoints.append(
@@ -136,7 +136,7 @@ describe("DurableObjectExecutionStore storage stress", () => {
             },
             { expectedVersion: 0 }
           );
-          await host.store.runs.update({
+          await host.store.turns.update({
             ...run,
             checkpointVersion: 1,
             status: "completed",
@@ -163,7 +163,7 @@ describe("DurableObjectExecutionStore storage stress", () => {
         host.store.threads.load(`thread-${stressThreadCount - 1}`)
       ).resolves.toMatchObject({ version: String(stressTurnsPerThread) });
       await expect(
-        host.store.runs.listByParentRunId("missing-parent")
+        host.store.turns.listByParentRunId("missing-parent")
       ).resolves.toEqual([]);
       await expect(
         listScheduledCloudflareRuns(storage, {

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store.ts
@@ -4,7 +4,7 @@ import type {
   ExecutionStore,
   ExecutionStoreTransaction,
   NotificationInbox,
-  RunStore,
+  TurnStore,
 } from "../../../../execution";
 import type { ThreadStore } from "../../../../index";
 import {
@@ -25,7 +25,7 @@ export class DurableObjectExecutionStore implements ExecutionStore {
   readonly checkpoints: CheckpointStore;
   readonly events: EventStore;
   readonly notifications: NotificationInbox;
-  readonly runs: RunStore;
+  readonly turns: TurnStore;
   readonly threads: ThreadStore;
   readonly #maxPayloadBytes: number;
   readonly #prefix: string;
@@ -59,7 +59,7 @@ export class DurableObjectExecutionStore implements ExecutionStore {
       prefix,
       payloadBudget
     );
-    this.runs = new DurableObjectRunStore(storage, prefix, payloadBudget);
+    this.turns = new DurableObjectRunStore(storage, prefix, payloadBudget);
     this.threads = new DurableObjectSqliteThreadStore(
       storage,
       prefix,

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/bootstrap.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { RunRecord } from "../../../../execution";
+import type { TurnRecord } from "../../../../execution";
 import {
   createCloudflareDurableObjectHost,
   InMemoryCloudflareDurableObjectStorage,
@@ -11,7 +11,7 @@ import { storeKey } from "../execution/records";
 const PREFIX = "pss-runtime";
 const requiresSqlitePattern = /SQLite-backed/;
 
-const createRun = (runId = "run-1"): RunRecord => ({
+const createRun = (runId = "run-1"): TurnRecord => ({
   checkpointVersion: 0,
   kind: "user-turn",
   rootRunId: runId,
@@ -25,7 +25,7 @@ describe("createCloudflareDurableObjectHost store selection", () => {
     const storage = new InMemoryCloudflareDurableObjectStorage();
     const host = createCloudflareDurableObjectHost({ storage });
 
-    await host.store.runs.create(createRun());
+    await host.store.turns.create(createRun());
     await host.store.events.append("run-1", { type: "turn-start" });
 
     const events: unknown[] = [];
@@ -41,7 +41,7 @@ describe("createCloudflareDurableObjectHost store selection", () => {
     });
     const host = createCloudflareDurableObjectHost({ storage });
 
-    await host.store.runs.create(createRun());
+    await host.store.turns.create(createRun());
 
     const big = "x".repeat(120_000);
     // 20 events * ~120KB ~= ~2.4MB — past the Durable Object per-value limit
@@ -94,7 +94,7 @@ describe("createCloudflareDurableObjectHost store selection", () => {
 
     await expect(
       host.store.transaction(async (tx) => {
-        await tx.runs.create(createRun("run-rollback"));
+        await tx.turns.create(createRun("run-rollback"));
         await tx.events.append("run-rollback", { type: "turn-start" });
         await tx.checkpoints.append(
           {
@@ -124,7 +124,7 @@ describe("createCloudflareDurableObjectHost store selection", () => {
       })
     ).rejects.toThrow("transaction failed");
 
-    await expect(host.store.runs.get("run-rollback")).resolves.toBeNull();
+    await expect(host.store.turns.get("run-rollback")).resolves.toBeNull();
     await expect(
       host.store.threads.load("thread-rollback")
     ).resolves.toBeNull();

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/checkpoint-store.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/checkpoint-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { RunRecord } from "../../../../execution";
+import type { TurnRecord } from "../../../../execution";
 import { InMemorySqlStorage } from "../../sql/node-test/node-sqlite-storage";
 import {
   type CloudflareDurableObjectStorage,
@@ -40,7 +40,7 @@ function checkpoint(
   };
 }
 
-function createRun(runId = "run-1"): RunRecord {
+function createRun(runId = "run-1"): TurnRecord {
   return {
     checkpointVersion: 0,
     kind: "user-turn",

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/checkpoint-store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/checkpoint-store.ts
@@ -1,7 +1,7 @@
 import type {
+  Checkpoint,
   CheckpointStore,
   CheckpointWriteResult,
-  RunCheckpoint,
 } from "../../../../execution";
 import type { SqlStorage } from "../../sql/ports/storage-port";
 import type { CloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
@@ -30,8 +30,8 @@ interface CheckpointRow {
  * checkpoints can no longer reach the Durable Object ~2MB per-value limit
  * (`SQLITE_TOOBIG`) by accumulation.
  *
- * The optimistic version check reads the run record (`RunStore`) as the
- * version authority. The check, the row `INSERT`, and the `RunStore` bump run
+ * The optimistic version check reads the run record (`TurnStore`) as the
+ * version authority. The check, the row `INSERT`, and the `TurnStore` bump run
  * inside a single `storage.transaction`
  * so concurrent writes to the same run serialize — exactly one wins, the rest
  * get `stale-version`. (`ctx.storage.sql.exec` issued inside a Durable Object
@@ -63,7 +63,7 @@ export class DurableObjectSqliteCheckpointStore implements CheckpointStore {
   }
 
   async append(
-    checkpoint: RunCheckpoint,
+    checkpoint: Checkpoint,
     options: { readonly expectedVersion: number }
   ): Promise<CheckpointWriteResult> {
     this.#ensureSchema();
@@ -107,7 +107,7 @@ export class DurableObjectSqliteCheckpointStore implements CheckpointStore {
     });
   }
 
-  latest(runId: string): Promise<RunCheckpoint | null> {
+  latest(runId: string): Promise<Checkpoint | null> {
     this.#ensureSchema();
     const rows = this.#sql
       .exec<CheckpointRow>(
@@ -124,7 +124,7 @@ export class DurableObjectSqliteCheckpointStore implements CheckpointStore {
         )
       : null;
     return Promise.resolve(
-      checkpoint ? (JSON.parse(checkpoint) as RunCheckpoint) : null
+      checkpoint ? (JSON.parse(checkpoint) as Checkpoint) : null
     );
   }
 

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/session-store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/session-store.ts
@@ -1,6 +1,0 @@
-// biome-ignore-all lint/performance/noBarrelFile: Deprecated package subpath compatibility entrypoint required by package exports.
-export {
-  DurableObjectSqliteThreadStore,
-  /** @deprecated Use DurableObjectSqliteThreadStore. */
-  DurableObjectSqliteThreadStore as DurableObjectSqliteSessionStore,
-} from "./thread-store";

--- a/packages/runtime/src/platform/node/host/file-execution-host.test.ts
+++ b/packages/runtime/src/platform/node/host/file-execution-host.test.ts
@@ -89,7 +89,7 @@ describe("createNodeFileExecutionHost", () => {
         "turn-end",
       ]);
       await expect(
-        secondHost.store.runs.get(dispatched.runId)
+        secondHost.store.turns.get(dispatched.runId)
       ).resolves.toEqual(
         expect.objectContaining({
           ownerNamespace: agentNamespace("local-owner"),
@@ -186,7 +186,7 @@ describe("createNodeFileExecutionHost", () => {
         ),
         namespace: "local-owner",
       });
-      await host.store.runs.create({
+      await host.store.turns.create({
         checkpointVersion: 0,
         kind: "notification",
         lease: {

--- a/packages/runtime/src/platform/node/host/scheduled-work-drainer.ts
+++ b/packages/runtime/src/platform/node/host/scheduled-work-drainer.ts
@@ -1,6 +1,6 @@
 import type { Agent } from "../../../agent/core/agent";
 import { executionHost } from "../../../execution/host/host";
-import type { RunStatus } from "../../../execution/host/types";
+import type { TurnStatus } from "../../../execution/host/types";
 import type { AgentEvent } from "../../../thread/protocol/events";
 import { decrementLimit, normalizedListLimit } from "./scheduled-work-codec";
 import {
@@ -139,13 +139,13 @@ async function shouldAckNullResume(
   if (!host) {
     return false;
   }
-  const record = await host.store.runs.get(runId);
+  const record = await host.store.turns.get(runId);
   if (!record) {
     return true;
   }
   return isTerminalRunStatus(record.status);
 }
 
-function isTerminalRunStatus(status: RunStatus): boolean {
+function isTerminalRunStatus(status: TurnStatus): boolean {
   return status === "cancelled" || status === "completed" || status === "error";
 }

--- a/packages/runtime/src/platform/node/index.ts
+++ b/packages/runtime/src/platform/node/index.ts
@@ -33,7 +33,4 @@ export type {
   NodeScheduledWorkRunContext,
 } from "./host/scheduled-work-types";
 export { FileExecutionStore } from "./storage/file-execution-store";
-export {
-  FileSessionStore,
-  FileThreadStore,
-} from "./storage/file-thread-store";
+export { FileThreadStore } from "./storage/file-thread-store";

--- a/packages/runtime/src/platform/node/storage/file-execution-store-edge.test.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store-edge.test.ts
@@ -23,12 +23,12 @@ describe("FileExecutionStore edge cases", () => {
       dedupeKey: "dedupe:duplicate",
     });
 
-    await expect(store.runs.create(original)).resolves.toEqual({
+    await expect(store.turns.create(original)).resolves.toEqual({
       ok: true,
       record: original,
     });
     await expect(
-      store.runs.create({
+      store.turns.create({
         ...runRecord("run:duplicate"),
         checkpointVersion: 7,
         dedupeKey: "other-dedupe",
@@ -40,7 +40,7 @@ describe("FileExecutionStore edge cases", () => {
       record: original,
     });
     await expect(
-      store.runs.create({
+      store.turns.create({
         ...runRecord("run:other"),
         dedupeKey: "dedupe:duplicate",
       })
@@ -49,16 +49,16 @@ describe("FileExecutionStore edge cases", () => {
       reason: "duplicate",
       record: original,
     });
-    await expect(store.runs.get("run:duplicate")).resolves.toEqual(original);
-    await expect(store.runs.get("run:other")).resolves.toBeNull();
+    await expect(store.turns.get("run:duplicate")).resolves.toEqual(original);
+    await expect(store.turns.get("run:other")).resolves.toBeNull();
   });
 
   it("claims only claimable runs after active leases expire", async () => {
     const store = new FileExecutionStore(await tempDir());
-    await store.runs.create(runRecord("run:claim"));
+    await store.turns.create(runRecord("run:claim"));
 
     await expect(
-      store.runs.claim("run:claim", {
+      store.turns.claim("run:claim", {
         attempt: 1,
         leaseId: "lease-1",
         leaseMs: 100,
@@ -70,7 +70,7 @@ describe("FileExecutionStore edge cases", () => {
       record: { status: "leased" },
     });
     await expect(
-      store.runs.claim("run:claim", {
+      store.turns.claim("run:claim", {
         attempt: 2,
         leaseId: "lease-2",
         leaseMs: 100,
@@ -78,7 +78,7 @@ describe("FileExecutionStore edge cases", () => {
       })
     ).resolves.toEqual({ ok: false, reason: "leased" });
     await expect(
-      store.runs.claim("run:claim", {
+      store.turns.claim("run:claim", {
         attempt: 2,
         leaseId: "lease-2",
         leaseMs: 50,
@@ -89,9 +89,9 @@ describe("FileExecutionStore edge cases", () => {
       ok: true,
     });
 
-    await store.runs.create(runRecord("run:done", { status: "completed" }));
+    await store.turns.create(runRecord("run:done", { status: "completed" }));
     await expect(
-      store.runs.claim("run:done", {
+      store.turns.claim("run:done", {
         attempt: 1,
         leaseId: "lease-done",
         leaseMs: 100,
@@ -134,7 +134,7 @@ describe("FileExecutionStore edge cases", () => {
   it("throws deterministic errors for malformed persisted JSON files", async () => {
     const directory = await tempDir();
     const store = new FileExecutionStore(directory);
-    await expect(store.runs.get("run:missing")).resolves.toBeNull();
+    await expect(store.turns.get("run:missing")).resolves.toBeNull();
     const dataDirectory = await currentDataDirectory(directory);
 
     await mkdir(join(dataDirectory, "runs"), { recursive: true });
@@ -170,7 +170,7 @@ describe("FileExecutionStore edge cases", () => {
       "utf8"
     );
 
-    await expect(store.runs.get("run:bad")).rejects.toThrow(
+    await expect(store.turns.get("run:bad")).rejects.toThrow(
       malformedRunPattern
     );
     await expect(collectEvents(store.events.read("run:bad"))).rejects.toThrow(

--- a/packages/runtime/src/platform/node/storage/file-execution-store-test-support.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store-test-support.ts
@@ -3,10 +3,10 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
+  Checkpoint,
   NotificationRecord,
-  RunCheckpoint,
-  RunRecord,
   StoredAgentEvent,
+  TurnRecord,
 } from "../../../execution";
 
 export const base64Url = (value: string) =>
@@ -65,8 +65,8 @@ export function createDeferred(): {
 
 export function runRecord(
   runId: string,
-  overrides: Partial<RunRecord> = {}
-): RunRecord {
+  overrides: Partial<TurnRecord> = {}
+): TurnRecord {
   return {
     checkpointVersion: 0,
     kind: "user-turn",
@@ -78,10 +78,7 @@ export function runRecord(
   };
 }
 
-export function checkpointRecord(
-  runId: string,
-  version: number
-): RunCheckpoint {
+export function checkpointRecord(runId: string, version: number): Checkpoint {
   return {
     checkpointId: `${runId}:checkpoint-${version}`,
     phase: "before-model",

--- a/packages/runtime/src/platform/node/storage/file-execution-store.test.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store.test.ts
@@ -34,7 +34,7 @@ describe("FileExecutionStore", () => {
       runId: "run:persist",
     });
 
-    await expect(store.runs.create(run)).resolves.toEqual({
+    await expect(store.turns.create(run)).resolves.toEqual({
       ok: true,
       record: run,
     });
@@ -59,18 +59,18 @@ describe("FileExecutionStore", () => {
     ).resolves.toEqual({ ok: true, version: "1" });
 
     const reopened = new FileExecutionStore(directory);
-    await expect(reopened.runs.get("run:persist")).resolves.toEqual({
+    await expect(reopened.turns.get("run:persist")).resolves.toEqual({
       ...run,
       checkpointVersion: 1,
     });
     await expect(
-      reopened.runs.getByDedupeKey("dedupe:persist")
+      reopened.turns.getByDedupeKey("dedupe:persist")
     ).resolves.toEqual({
       ...run,
       checkpointVersion: 1,
     });
     await expect(
-      reopened.runs.listByParentRunId("parent:persist")
+      reopened.turns.listByParentRunId("parent:persist")
     ).resolves.toEqual([{ ...run, checkpointVersion: 1 }]);
     await expect(reopened.checkpoints.latest("run:persist")).resolves.toEqual(
       checkpoint
@@ -91,8 +91,6 @@ describe("FileExecutionStore", () => {
       state: { messages: ["persisted"] },
       version: "1",
     });
-    expect(reopened.sessions).toBe(reopened.threads);
-
     const dataDirectory = await currentDataDirectory(directory);
 
     await expect(readdir(join(dataDirectory, "threads"))).resolves.toContain(
@@ -117,7 +115,7 @@ describe("FileExecutionStore", () => {
 
     await expect(
       store.transaction(async (tx) => {
-        await tx.runs.create(runRecord("run:rollback"));
+        await tx.turns.create(runRecord("run:rollback"));
         await tx.events.append("run:rollback", { type: "turn-start" });
         await tx.checkpoints.append(checkpointRecord("run:rollback", 1), {
           expectedVersion: 0,
@@ -134,7 +132,7 @@ describe("FileExecutionStore", () => {
       })
     ).rejects.toThrow("rollback me");
 
-    await expect(store.runs.get("run:rollback")).resolves.toBeNull();
+    await expect(store.turns.get("run:rollback")).resolves.toBeNull();
     await expect(
       collectEvents(store.events.read("run:rollback"))
     ).resolves.toEqual([]);

--- a/packages/runtime/src/platform/node/storage/file-execution-store.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store.ts
@@ -7,7 +7,7 @@ import type {
   ExecutionStore,
   ExecutionStoreTransaction,
   NotificationInbox,
-  RunStore,
+  TurnStore,
 } from "../../../execution/host/types";
 import type { ThreadStore } from "../../../thread/store/types";
 import {
@@ -26,7 +26,7 @@ export class FileExecutionStore implements ExecutionStore {
   readonly checkpoints: CheckpointStore;
   readonly events: EventStore;
   readonly notifications: NotificationInbox;
-  readonly runs: RunStore;
+  readonly turns: TurnStore;
   readonly threads: ThreadStore;
 
   readonly #directory: string;
@@ -40,15 +40,11 @@ export class FileExecutionStore implements ExecutionStore {
       createFileExecutionLock(this.#lockDirectory, "auto")
     );
 
-    this.runs = ports.runs;
+    this.turns = ports.turns;
     this.events = ports.events;
     this.checkpoints = ports.checkpoints;
     this.notifications = ports.notifications;
     this.threads = ports.threads;
-  }
-
-  get sessions(): ThreadStore {
-    return this.threads;
   }
 
   async transaction<T>(

--- a/packages/runtime/src/platform/node/storage/file-execution-store/checkpoint-store.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store/checkpoint-store.ts
@@ -1,9 +1,9 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type {
+  Checkpoint,
   CheckpointStore,
   CheckpointWriteResult,
-  RunCheckpoint,
 } from "../../../../execution/host/types";
 import { readJsonFile, writeJsonFile } from "./json";
 import type { FileRunStore } from "./run-store";
@@ -14,20 +14,20 @@ import { encodeKey, isNodeError } from "./utils";
 export class FileCheckpointStore implements CheckpointStore {
   readonly #directory: DataDirectoryResolver;
   readonly #lock: <T>(fn: () => Promise<T>) => Promise<T>;
-  readonly #runs: FileRunStore;
+  readonly #turns: FileRunStore;
 
   constructor(
     directory: DataDirectoryResolver,
     lock: <T>(fn: () => Promise<T>) => Promise<T>,
-    runs: FileRunStore
+    turns: FileRunStore
   ) {
     this.#directory = directory;
     this.#lock = lock;
-    this.#runs = runs;
+    this.#turns = turns;
   }
 
   async append(
-    checkpoint: RunCheckpoint,
+    checkpoint: Checkpoint,
     options: { readonly expectedVersion: number }
   ): Promise<CheckpointWriteResult> {
     return await this.#lock(async () => {
@@ -45,7 +45,7 @@ export class FileCheckpointStore implements CheckpointStore {
         await this.#fileForCheckpoint(checkpoint.runId, checkpoint.version),
         checkpoint
       );
-      await this.#runs.updateCheckpointVersion(
+      await this.#turns.updateCheckpointVersion(
         checkpoint.runId,
         checkpoint.version
       );
@@ -53,11 +53,11 @@ export class FileCheckpointStore implements CheckpointStore {
     });
   }
 
-  async latest(runId: string): Promise<RunCheckpoint | null> {
+  async latest(runId: string): Promise<Checkpoint | null> {
     return await this.#lock(async () => await this.latestUnlocked(runId));
   }
 
-  async latestUnlocked(runId: string): Promise<RunCheckpoint | null> {
+  async latestUnlocked(runId: string): Promise<Checkpoint | null> {
     const directory = join(
       await this.#directory(),
       "checkpoints",

--- a/packages/runtime/src/platform/node/storage/file-execution-store/ports.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store/ports.ts
@@ -12,14 +12,16 @@ export function createFileExecutionStorePorts(
   lock: <T>(fn: () => Promise<T>) => Promise<T>
 ): ExecutionStoreTransaction {
   const runs = new FileRunStore(directory, lock);
+  const checkpoints = new FileCheckpointStore(directory, lock, runs);
+  const threads = new LockedThreadStore(
+    async () => join(await directory(), "threads"),
+    lock
+  );
   return {
-    checkpoints: new FileCheckpointStore(directory, lock, runs),
     events: new FileEventStore(directory, lock),
     notifications: new FileNotificationInbox(directory, lock),
-    runs,
-    threads: new LockedThreadStore(
-      async () => join(await directory(), "threads"),
-      lock
-    ),
+    checkpoints,
+    threads,
+    turns: runs,
   };
 }

--- a/packages/runtime/src/platform/node/storage/file-execution-store/run-store.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store/run-store.ts
@@ -1,19 +1,19 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type {
-  ClaimRunOptions,
-  ClaimRunResult,
-  CreateRunResult,
-  RunLease,
-  RunRecord,
-  RunStore,
+  ClaimTurnOptions,
+  ClaimTurnResult,
+  CreateTurnResult,
+  TurnLease,
+  TurnRecord,
+  TurnStore,
 } from "../../../../execution/host/types";
 import { readJsonFile, writeJsonFile } from "./json";
 import { isClaimable, parseRunRecord } from "./schemas";
 import type { DataDirectoryResolver } from "./types";
 import { encodeKey, isNodeError } from "./utils";
 
-export class FileRunStore implements RunStore {
+export class FileRunStore implements TurnStore {
   readonly #directory: DataDirectoryResolver;
   readonly #lock: <T>(fn: () => Promise<T>) => Promise<T>;
 
@@ -27,8 +27,8 @@ export class FileRunStore implements RunStore {
 
   async claim(
     runId: string,
-    options: ClaimRunOptions
-  ): Promise<ClaimRunResult> {
+    options: ClaimTurnOptions
+  ): Promise<ClaimTurnResult> {
     return await this.#lock(async () => {
       const record = await this.#getUnlocked(runId);
       if (!record) {
@@ -47,18 +47,18 @@ export class FileRunStore implements RunStore {
         return { ok: false, reason: "leased" };
       }
 
-      const lease: RunLease = {
+      const lease: TurnLease = {
         attempt: options.attempt,
         leaseId: options.leaseId,
         leaseUntilMs: options.nowMs + options.leaseMs,
       };
-      const claimed: RunRecord = { ...record, lease, status: "leased" };
+      const claimed: TurnRecord = { ...record, lease, status: "leased" };
       await this.#writeUnlocked(claimed);
       return { lease, ok: true, record: claimed };
     });
   }
 
-  async create(record: RunRecord): Promise<CreateRunResult> {
+  async create(record: TurnRecord): Promise<CreateTurnResult> {
     return await this.#lock(async () => {
       const existingById = await this.#getUnlocked(record.runId);
       if (existingById) {
@@ -83,24 +83,24 @@ export class FileRunStore implements RunStore {
     });
   }
 
-  async get(runId: string): Promise<RunRecord | null> {
+  async get(runId: string): Promise<TurnRecord | null> {
     return await this.#lock(async () => await this.#getUnlocked(runId));
   }
 
-  async getByDedupeKey(dedupeKey: string): Promise<RunRecord | null> {
+  async getByDedupeKey(dedupeKey: string): Promise<TurnRecord | null> {
     return await this.#lock(
       async () => await this.#getByDedupeKeyUnlocked(dedupeKey)
     );
   }
 
-  async listByParentRunId(parentRunId: string): Promise<readonly RunRecord[]> {
+  async listByParentRunId(parentRunId: string): Promise<readonly TurnRecord[]> {
     return await this.#lock(async () => {
       const records = await this.#listUnlocked();
       return records.filter((record) => record.parentRunId === parentRunId);
     });
   }
 
-  async update(record: RunRecord): Promise<RunRecord> {
+  async update(record: TurnRecord): Promise<TurnRecord> {
     return await this.#lock(async () => {
       await this.#writeUnlocked(record);
       return record;
@@ -118,12 +118,12 @@ export class FileRunStore implements RunStore {
     await this.#writeUnlocked({ ...record, checkpointVersion });
   }
 
-  async #getByDedupeKeyUnlocked(dedupeKey: string): Promise<RunRecord | null> {
+  async #getByDedupeKeyUnlocked(dedupeKey: string): Promise<TurnRecord | null> {
     const records = await this.#listUnlocked();
     return records.find((record) => record.dedupeKey === dedupeKey) ?? null;
   }
 
-  async #getUnlocked(runId: string): Promise<RunRecord | null> {
+  async #getUnlocked(runId: string): Promise<TurnRecord | null> {
     return await readJsonFile(
       await this.#fileForRun(runId),
       parseRunRecord,
@@ -131,7 +131,7 @@ export class FileRunStore implements RunStore {
     );
   }
 
-  async #listUnlocked(): Promise<readonly RunRecord[]> {
+  async #listUnlocked(): Promise<readonly TurnRecord[]> {
     const directory = join(await this.#directory(), "runs");
     let entries: readonly string[];
     try {
@@ -143,7 +143,7 @@ export class FileRunStore implements RunStore {
       throw error;
     }
 
-    const records: RunRecord[] = [];
+    const records: TurnRecord[] = [];
     for (const entry of entries) {
       if (!entry.endsWith(".json")) {
         continue;
@@ -160,7 +160,7 @@ export class FileRunStore implements RunStore {
     return records;
   }
 
-  async #writeUnlocked(record: RunRecord): Promise<void> {
+  async #writeUnlocked(record: TurnRecord): Promise<void> {
     await writeJsonFile(await this.#fileForRun(record.runId), record);
   }
 

--- a/packages/runtime/src/platform/node/storage/file-execution-store/schemas.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store/schemas.ts
@@ -1,16 +1,16 @@
 import type {
+  Checkpoint,
   NotificationRecord,
-  RunCheckpoint,
-  RunKind,
-  RunLease,
-  RunRecord,
-  RunStatus,
   StoredAgentEvent,
+  TurnKind,
+  TurnLease,
+  TurnRecord,
+  TurnStatus,
 } from "../../../../execution/host/types";
 import type { AgentEvent, UserInput } from "../../../../thread/protocol/events";
 import { isRecord } from "./utils";
 
-export function parseRunRecord(value: unknown, file: string): RunRecord {
+export function parseRunRecord(value: unknown, file: string): TurnRecord {
   if (!isRecord(value)) {
     throw invalidFile(file, "expected run object");
   }
@@ -49,10 +49,7 @@ export function parseRunRecord(value: unknown, file: string): RunRecord {
   };
 }
 
-export function parseRunCheckpoint(
-  value: unknown,
-  file: string
-): RunCheckpoint {
+export function parseRunCheckpoint(value: unknown, file: string): Checkpoint {
   if (!isRecord(value)) {
     throw invalidFile(file, "expected checkpoint object");
   }
@@ -157,7 +154,7 @@ export function parseEventLogLine(
   };
 }
 
-export function isClaimable(record: RunRecord): boolean {
+export function isClaimable(record: TurnRecord): boolean {
   return (
     record.status === "leased" ||
     record.status === "needs-recovery" ||
@@ -186,7 +183,7 @@ function isStringArray(value: unknown): value is readonly string[] {
   );
 }
 
-function isRunLease(value: unknown): value is RunLease {
+function isRunLease(value: unknown): value is TurnLease {
   return (
     isRecord(value) &&
     typeof value.attempt === "number" &&
@@ -195,7 +192,7 @@ function isRunLease(value: unknown): value is RunLease {
   );
 }
 
-function isRunKind(value: unknown): value is RunKind {
+function isRunKind(value: unknown): value is TurnKind {
   return (
     value === "notification" ||
     value === "tool-recovery" ||
@@ -203,7 +200,7 @@ function isRunKind(value: unknown): value is RunKind {
   );
 }
 
-function isRunStatus(value: unknown): value is RunStatus {
+function isRunStatus(value: unknown): value is TurnStatus {
   return (
     value === "cancelled" ||
     value === "completed" ||
@@ -216,7 +213,7 @@ function isRunStatus(value: unknown): value is RunStatus {
   );
 }
 
-function isCheckpointPhase(value: unknown): value is RunCheckpoint["phase"] {
+function isCheckpointPhase(value: unknown): value is Checkpoint["phase"] {
   return (
     value === "after-model" ||
     value === "after-notification" ||

--- a/packages/runtime/src/platform/node/storage/file-thread-store.ts
+++ b/packages/runtime/src/platform/node/storage/file-thread-store.ts
@@ -125,7 +125,6 @@ function parseStoredFileThread(value: unknown, file: string): StoredThread {
 }
 
 /** @deprecated Use FileThreadStore. */
-export { FileThreadStore as FileSessionStore };
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;

--- a/packages/runtime/src/testing/execution-checkpoint-test-support.ts
+++ b/packages/runtime/src/testing/execution-checkpoint-test-support.ts
@@ -1,9 +1,9 @@
 import type { Tool, ToolSet } from "ai";
 import { jsonSchema, tool } from "ai";
 import type {
+  Checkpoint,
   ExecutionHost,
-  RunCheckpoint,
-  RunRecord,
+  TurnRecord,
 } from "../execution/host/types";
 import { createInMemoryExecutionHost } from "../execution/memory";
 
@@ -11,7 +11,7 @@ export interface GenerateTextToolOptions {
   readonly tools?: ToolSet;
 }
 
-export const createQueuedUserTurnRun = (runId = "run-1"): RunRecord => ({
+export const createQueuedUserTurnRun = (runId = "run-1"): TurnRecord => ({
   checkpointVersion: 0,
   kind: "user-turn",
   rootRunId: runId,
@@ -47,11 +47,11 @@ export function toolOptions(toolCallId: string, signal: AbortSignal) {
 }
 
 export function createCheckpointSpyHost(): {
-  readonly checkpoints: RunCheckpoint[];
+  readonly checkpoints: Checkpoint[];
   readonly host: ExecutionHost;
 } {
   const baseHost = createInMemoryExecutionHost();
-  const checkpoints: RunCheckpoint[] = [];
+  const checkpoints: Checkpoint[] = [];
   return {
     checkpoints,
     host: {
@@ -67,7 +67,7 @@ export function createCheckpointSpyHost(): {
         },
         events: baseHost.store.events,
         notifications: baseHost.store.notifications,
-        runs: baseHost.store.runs,
+        turns: baseHost.store.turns,
         threads: baseHost.store.threads,
         transaction: (fn) => baseHost.store.transaction(fn),
       },

--- a/packages/runtime/src/testing/tool-checkpointing-agent.test.ts
+++ b/packages/runtime/src/testing/tool-checkpointing-agent.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ExecutionHost, RunCheckpoint } from "../execution";
+import type { Checkpoint, ExecutionHost } from "../execution";
 import { InMemorySqlStorage } from "../platform/cloudflare/sql/node-test/node-sqlite-storage";
 import { InMemoryCloudflareDurableObjectStorage } from "../platform/cloudflare/storage/durable-object/durable-object-storage";
 import { DurableObjectExecutionStore } from "../platform/cloudflare/storage/execution/store";
@@ -22,7 +22,7 @@ const generateTextMock = getGenerateTextMock();
 const textEncoder = new TextEncoder();
 
 function createCheckpointSpyCloudflareHost(maxPayloadBytes: number): {
-  readonly checkpoints: RunCheckpoint[];
+  readonly checkpoints: Checkpoint[];
   readonly host: ExecutionHost;
 } {
   const store = new DurableObjectExecutionStore({
@@ -31,7 +31,7 @@ function createCheckpointSpyCloudflareHost(maxPayloadBytes: number): {
       sql: new InMemorySqlStorage(),
     }),
   });
-  const checkpoints: RunCheckpoint[] = [];
+  const checkpoints: Checkpoint[] = [];
 
   return {
     checkpoints,
@@ -54,7 +54,7 @@ function createCheckpointSpyCloudflareHost(maxPayloadBytes: number): {
         },
         events: store.events,
         notifications: store.notifications,
-        runs: store.runs,
+        turns: store.turns,
         threads: store.threads,
         transaction: (fn) => store.transaction(fn),
       },
@@ -140,7 +140,7 @@ describe("tool checkpointing through Agent", () => {
     expect(beforeTool?.threadSnapshot).not.toHaveProperty("history");
     expect(afterTool?.threadSnapshot).toEqual(beforeTool?.threadSnapshot);
     await expect(
-      host.store.runs.get(beforeTool?.runId ?? "")
+      host.store.turns.get(beforeTool?.runId ?? "")
     ).resolves.toMatchObject({
       checkpointVersion: 2,
       kind: "user-turn",

--- a/packages/runtime/src/testing/tool-checkpointing.test.ts
+++ b/packages/runtime/src/testing/tool-checkpointing.test.ts
@@ -32,7 +32,7 @@ describe("tool checkpointing", () => {
     const host = createInMemoryExecutionHost();
     const order: string[] = [];
     const signal = new AbortController().signal;
-    await host.store.runs.create(createQueuedUserTurnRun());
+    await host.store.turns.create(createQueuedUserTurnRun());
 
     generateTextMock.mockImplementationOnce(
       async (options: GenerateTextToolOptions) => {
@@ -109,7 +109,7 @@ describe("tool checkpointing", () => {
     const host = createInMemoryExecutionHost();
     const signal = new AbortController().signal;
     let executions = 0;
-    await host.store.runs.create({
+    await host.store.turns.create({
       ...createQueuedUserTurnRun(),
       checkpointVersion: 1,
     });

--- a/packages/runtime/src/thread/handle/lifecycle.test.ts
+++ b/packages/runtime/src/thread/handle/lifecycle.test.ts
@@ -13,7 +13,7 @@ import { userTextToModelMessage } from "../protocol/mapping";
 import { collect } from "./test-support";
 
 describe("Agent thread lifecycle", () => {
-  it("idle thread.steer starts a new run after turn-end", async () => {
+  it("idle thread.steer starts a new turn after turn-end", async () => {
     let calls = 0;
     const agent = new Agent({
       model: createCallbackModel(() => {
@@ -30,7 +30,7 @@ describe("Agent thread lifecycle", () => {
     expect(calls).toBe(2);
   });
 
-  it("idle thread.steer starts a new run after model turn-error", async () => {
+  it("idle thread.steer starts a new turn after model turn-error", async () => {
     let calls = 0;
     const agent = new Agent({
       model: createCallbackModel(() => {
@@ -49,7 +49,7 @@ describe("Agent thread lifecycle", () => {
     expect(calls).toBe(2);
   });
 
-  it("idle thread.steer starts a new run after interrupt turn-abort", async () => {
+  it("idle thread.steer starts a new turn after interrupt turn-abort", async () => {
     const llmStarted = createDeferred();
     const llmGate = createDeferred();
     const thread = new Agent({

--- a/packages/runtime/src/thread/handle/notify.test.ts
+++ b/packages/runtime/src/thread/handle/notify.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../testing/test-fixtures";
 import type { AgentEvent } from "../protocol/events";
 import { userTextToModelMessage } from "../protocol/mapping";
-import type { AgentRun } from "../protocol/run";
+import type { AgentTurn } from "../protocol/turn";
 import { MemoryThreadStore } from "../store/memory";
 import { AgentThread } from "./thread";
 
@@ -22,7 +22,7 @@ describe("AgentThread.notify", () => {
       Promise.resolve([assistantMessage("SENT")])
     );
 
-    const events = await collectAgentRun(await thread.send("hello"));
+    const events = await collectAgentTurn(await thread.send("hello"));
 
     expect(eventTypes(events)).toEqual([
       "user-text",
@@ -43,7 +43,7 @@ describe("AgentThread.notify", () => {
       return Promise.resolve([assistantMessage("NOTIFIED")]);
     });
 
-    const events = await collectAgentRun(await thread.notify(notification));
+    const events = await collectAgentTurn(await thread.notify(notification));
 
     expect(eventTypes(events)).toEqual([
       "turn-start",
@@ -68,7 +68,7 @@ describe("AgentThread.notify", () => {
     );
 
     const directRun = await thread.notify("job done");
-    const events = await collectAgentRun(directRun);
+    const events = await collectAgentTurn(directRun);
 
     expect(eventTypes(events)).toContain("runtime-input");
   });
@@ -101,7 +101,7 @@ describe("AgentThread.notify", () => {
     firstCanFinish.resolve();
 
     await drainIterator(firstIterator);
-    const secondEvents = await collectAgentRun(secondRun);
+    const secondEvents = await collectAgentTurn(secondRun);
 
     expect(notifiedRun).toBe(secondRun);
     expect(eventTypes(secondEvents)).toEqual([
@@ -189,7 +189,7 @@ function getProperty(value: unknown, property: "notify"): unknown {
   return property in value ? value[property] : undefined;
 }
 
-async function collectAgentRun(run: AgentRun): Promise<AgentEvent[]> {
+async function collectAgentTurn(run: AgentTurn): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
   for await (const event of run.events()) {
     events.push(event);

--- a/packages/runtime/src/thread/handle/thread.ts
+++ b/packages/runtime/src/thread/handle/thread.ts
@@ -10,7 +10,7 @@ import {
   type RuntimeInputState,
 } from "../input/runtime-input";
 import type { AgentPlugin } from "../plugins/pipeline";
-import { type AgentRun, BufferedAgentRun } from "../protocol/run";
+import { type AgentTurn, BufferedAgentTurn } from "../protocol/turn";
 import { ThreadEventDispatcher } from "../runtime/events";
 import type { ThreadExecutionOptions } from "../runtime/execution";
 import { closeKilledRuntimeInputs } from "../runtime/kill";
@@ -27,7 +27,7 @@ import {
 } from "../state/thread-state";
 
 export type { AgentInput, ThreadInput, UserInput } from "../input/input";
-export type { AgentRun } from "../protocol/run";
+export type { AgentTurn } from "../protocol/turn";
 export type { NotifyOptions } from "../runtime/notification";
 
 export class AgentThread {
@@ -39,12 +39,12 @@ export class AgentThread {
   readonly #threadKey: string;
   readonly #state: ThreadState;
   #activeAbort?: AbortController;
-  #activeRun?: BufferedAgentRun;
+  #activeRun?: BufferedAgentTurn;
   #activeRuntimeInput?: RuntimeInputState;
   #deletePromise?: Promise<void>;
   #killed = false;
   #running = false;
-  #runToCloseOnKill?: BufferedAgentRun;
+  #runToCloseOnKill?: BufferedAgentTurn;
 
   constructor(
     model: ModelGenerationOptions,
@@ -63,7 +63,7 @@ export class AgentThread {
     });
   }
 
-  async send(input: AgentInput): Promise<AgentRun> {
+  async send(input: AgentInput): Promise<AgentTurn> {
     if (this.#killed || this.#deletePromise) {
       throw threadTerminalError(this.#killed);
     }
@@ -82,7 +82,7 @@ export class AgentThread {
       normalized.meta === undefined
         ? attachInputMeta(normalized, { source: "send" })
         : normalized;
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const emitted = await this.#events.emitRunEvent(run, acceptedInput);
     if (emitted === "handled") {
       run.close();
@@ -108,7 +108,7 @@ export class AgentThread {
   async notify(
     input: AgentInput,
     options: NotifyOptions = {}
-  ): Promise<AgentRun> {
+  ): Promise<AgentTurn> {
     if (this.#killed || this.#deletePromise) {
       throw threadTerminalError(this.#killed);
     }
@@ -130,7 +130,7 @@ export class AgentThread {
     });
   }
 
-  async steer(input: AgentInput): Promise<AgentRun> {
+  async steer(input: AgentInput): Promise<AgentTurn> {
     if (this.#killed || this.#deletePromise) {
       throw threadTerminalError(this.#killed);
     }

--- a/packages/runtime/src/thread/input/input.ts
+++ b/packages/runtime/src/thread/input/input.ts
@@ -55,4 +55,3 @@ export type AgentInput =
 export type ThreadInput = AgentInput;
 
 /** @deprecated Use ThreadInput or AgentInput. */
-export type SessionInput = AgentInput;

--- a/packages/runtime/src/thread/input/runtime-input-emit.ts
+++ b/packages/runtime/src/thread/input/runtime-input-emit.ts
@@ -1,5 +1,5 @@
 import type { AgentEvent, RuntimeInput } from "../protocol/events";
-import type { BufferedAgentRun } from "../protocol/run";
+import type { BufferedAgentTurn } from "../protocol/turn";
 import type { ThreadEventDispatcher } from "../runtime/events";
 import type { ThreadState } from "../state/thread-state";
 import type { UserInput } from "./input";
@@ -42,7 +42,7 @@ export async function commitPreUserRuntimeInputs(
 
 export function emitCommittedRuntimeInputs(
   events: ThreadEventDispatcher,
-  run: BufferedAgentRun,
+  run: BufferedAgentTurn,
   committed: readonly AgentEvent[]
 ): void {
   for (const event of committed) {
@@ -52,7 +52,7 @@ export function emitCommittedRuntimeInputs(
 
 export async function emitRuntimeInputEvent(
   events: ThreadEventDispatcher,
-  run: BufferedAgentRun,
+  run: BufferedAgentTurn,
   state: ThreadState,
   queued: QueuedRuntimeInput
 ): Promise<boolean> {

--- a/packages/runtime/src/thread/input/runtime-input.ts
+++ b/packages/runtime/src/thread/input/runtime-input.ts
@@ -1,5 +1,5 @@
 import type { AgentEvent, RuntimeInput } from "../protocol/events";
-import type { BufferedAgentRun } from "../protocol/run";
+import type { BufferedAgentTurn } from "../protocol/turn";
 import type { AgentInput, UserInput } from "./input";
 import { attachInputMeta } from "./input-meta";
 import { normalizeAgentInput } from "./input-normalization";
@@ -23,7 +23,7 @@ export interface QueuedInput {
   readonly initialEvents: AgentEvent[];
   readonly input?: UserInput;
   readonly preUserRuntimeInputs: QueuedRuntimeInput[];
-  readonly run: BufferedAgentRun;
+  readonly run: BufferedAgentTurn;
   readonly runtimeInput: RuntimeInputState;
 }
 

--- a/packages/runtime/src/thread/protocol/turn.test.ts
+++ b/packages/runtime/src/thread/protocol/turn.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentEvent } from "./events";
-import { BufferedAgentRun } from "./run";
+import { BufferedAgentTurn } from "./turn";
 
 const expectPending = async (promise: Promise<unknown>) => {
   const marker = Symbol("pending");
@@ -9,9 +9,9 @@ const expectPending = async (promise: Promise<unknown>) => {
   );
 };
 
-describe("AgentRun", () => {
+describe("AgentTurn", () => {
   it("delivers events emitted before events consumption", async () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     run.emit({ type: "user-text", text: "hello" });
     run.emit({ type: "turn-end" });
     run.close();
@@ -28,7 +28,7 @@ describe("AgentRun", () => {
   });
 
   it("delivers events emitted after events consumption starts", async () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const events: unknown[] = [];
     const collecting = (async () => {
       for await (const event of run.events()) {
@@ -45,7 +45,7 @@ describe("AgentRun", () => {
   });
 
   it("keeps boundary emit pending until the consumer asks for another event", async () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const iterator = run.events()[Symbol.asyncIterator]();
 
     const boundary = run.emitBoundary({ type: "step-end" });
@@ -66,15 +66,15 @@ describe("AgentRun", () => {
   });
 
   it("rejects duplicate events readers", () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     run.events();
     expect(() => run.events()).toThrow(
-      "AgentRun.events() can only be consumed once"
+      "AgentTurn.events() can only be consumed once"
     );
   });
 
   it("returns the same iterator for repeated async iterator access", () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const eventIterator = run.events();
 
     expect(eventIterator[Symbol.asyncIterator]()).toBe(
@@ -83,12 +83,12 @@ describe("AgentRun", () => {
   });
 
   it("rejects concurrent next calls so consumers cannot prefetch", async () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const iterator = run.events()[Symbol.asyncIterator]();
 
     const waitingNext = iterator.next();
     await expect(iterator.next()).rejects.toThrow(
-      "AgentRun.events() does not allow concurrent next() calls"
+      "AgentTurn.events() does not allow concurrent next() calls"
     );
 
     run.emit({ type: "turn-start" });
@@ -99,7 +99,7 @@ describe("AgentRun", () => {
   });
 
   it("rejects same-tick prefetch when a boundary event is already queued", async () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const iterator = run.events()[Symbol.asyncIterator]();
 
     const boundary = run.emitBoundary({ type: "step-end" });
@@ -107,7 +107,7 @@ describe("AgentRun", () => {
     const second = iterator.next();
 
     await expect(second).rejects.toThrow(
-      "AgentRun.events() does not allow concurrent next() calls"
+      "AgentTurn.events() does not allow concurrent next() calls"
     );
     await expectPending(boundary);
     await expect(first).resolves.toEqual({
@@ -127,7 +127,7 @@ describe("AgentRun", () => {
   });
 
   it("return() settles pending boundary ack and pending next waiter", async () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const iterator = run.events()[Symbol.asyncIterator]();
 
     const boundary = run.emitBoundary({ type: "step-start" });
@@ -149,7 +149,7 @@ describe("AgentRun", () => {
   });
 
   it("close() settles queued boundary acknowledgements", async () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const boundary = run.emitBoundary({ type: "step-start" });
     await expectPending(boundary);
 
@@ -159,7 +159,7 @@ describe("AgentRun", () => {
   });
 
   it("closes and discards queued events when the events iterator returns early", async () => {
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
     const iterator = run.events()[Symbol.asyncIterator]();
 
     run.emit({ type: "turn-start" });

--- a/packages/runtime/src/thread/protocol/turn.ts
+++ b/packages/runtime/src/thread/protocol/turn.ts
@@ -1,6 +1,6 @@
 import type { AgentEvent } from "./events";
 
-export interface AgentRun {
+export interface AgentTurn {
   events(): AsyncIterable<AgentEvent>;
 }
 
@@ -14,7 +14,7 @@ interface NextWaiter {
   readonly resolve: (value: IteratorResult<AgentEvent>) => void;
 }
 
-export class BufferedAgentRun implements AgentRun {
+export class BufferedAgentTurn implements AgentTurn {
   readonly #events: QueuedEvent[] = [];
   #closed = false;
   #error: unknown;
@@ -66,7 +66,7 @@ export class BufferedAgentRun implements AgentRun {
 
   events(): AsyncIterable<AgentEvent> {
     if (this.#eventsStarted) {
-      throw new Error("AgentRun.events() can only be consumed once");
+      throw new Error("AgentTurn.events() can only be consumed once");
     }
     this.#eventsStarted = true;
 
@@ -101,7 +101,7 @@ export class BufferedAgentRun implements AgentRun {
   #next(): Promise<IteratorResult<AgentEvent>> {
     if (this.#resultPending || this.#waiter) {
       return Promise.reject(
-        new Error("AgentRun.events() does not allow concurrent next() calls")
+        new Error("AgentTurn.events() does not allow concurrent next() calls")
       );
     }
 

--- a/packages/runtime/src/thread/runtime/drain.ts
+++ b/packages/runtime/src/thread/runtime/drain.ts
@@ -4,7 +4,7 @@ import {
   shiftRuntimeInput,
 } from "../input/runtime-input";
 import { emitRuntimeInputEvent } from "../input/runtime-input-emit";
-import type { BufferedAgentRun } from "../protocol/run";
+import type { BufferedAgentTurn } from "../protocol/turn";
 import type { ThreadState } from "../state/thread-state";
 import type { ThreadEventDispatcher } from "./events";
 
@@ -17,7 +17,7 @@ export async function drainRuntimeInput({
 }: {
   readonly events: ThreadEventDispatcher;
   readonly placement: RuntimeInputPlacement;
-  readonly run: BufferedAgentRun;
+  readonly run: BufferedAgentTurn;
   readonly runtimeInput: RuntimeInputState;
   readonly state: ThreadState;
 }): Promise<boolean> {

--- a/packages/runtime/src/thread/runtime/events.test.ts
+++ b/packages/runtime/src/thread/runtime/events.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentPlugin } from "../plugins/pipeline";
-import { BufferedAgentRun } from "../protocol/run";
+import { BufferedAgentTurn } from "../protocol/turn";
 import { ThreadEventDispatcher } from "./events";
 
 function createDispatcher(
@@ -27,7 +27,7 @@ describe("ThreadEventDispatcher.emitRunEvent", () => {
       },
     };
     const dispatcher = createDispatcher([transformPlugin]);
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
 
     const emitted = await dispatcher.emitRunEvent(run, {
       type: "user-text",
@@ -48,7 +48,7 @@ describe("ThreadEventDispatcher.emitRunEvent", () => {
       on: () => ({ action: "handled" }),
     };
     const dispatcher = createDispatcher([handledPlugin]);
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
 
     const emitted = await dispatcher.emitRunEvent(run, {
       type: "user-text",
@@ -72,7 +72,7 @@ describe("ThreadEventDispatcher.emitObserverEvent", () => {
         },
       },
     ]);
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
 
     await dispatcher.emitObserverEvent(run, {
       text: "observer reasoning",
@@ -90,7 +90,7 @@ describe("ThreadEventDispatcher.emitObserverEvent", () => {
 
   it("buffers observer events during capture", async () => {
     const dispatcher = createDispatcher([]);
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
 
     const captured = await dispatcher.captureObserverEvents(run, async () => {
       await dispatcher.emitObserverEvent(run, {
@@ -117,7 +117,7 @@ describe("ThreadEventDispatcher.emitRunBoundaryEvent", () => {
       }),
     };
     const dispatcher = createDispatcher([transformPlugin]);
-    const run = new BufferedAgentRun();
+    const run = new BufferedAgentTurn();
 
     const iterator = run.events()[Symbol.asyncIterator]();
     const boundary = dispatcher.emitRunBoundaryEvent(run, {

--- a/packages/runtime/src/thread/runtime/events.ts
+++ b/packages/runtime/src/thread/runtime/events.ts
@@ -5,7 +5,7 @@ import {
   runPluginsForEvent,
 } from "../plugins/pipeline";
 import type { AgentEvent } from "../protocol/events";
-import type { BufferedAgentRun } from "../protocol/run";
+import type { BufferedAgentTurn } from "../protocol/turn";
 
 interface ThreadEventDispatcherOptions {
   readonly history: () => readonly ModelMessage[];
@@ -26,7 +26,7 @@ export class ThreadEventDispatcher {
   }
 
   async captureObserverEvents<T>(
-    run: BufferedAgentRun,
+    run: BufferedAgentTurn,
     callback: () => Promise<T>
   ): Promise<{
     readonly events: AgentEvent[];
@@ -57,7 +57,7 @@ export class ThreadEventDispatcher {
   }
 
   emitObserverEvent(
-    activeRun: BufferedAgentRun | undefined,
+    activeRun: BufferedAgentTurn | undefined,
     event: AgentEvent
   ): Promise<void> {
     const observerEventBuffer = this.#observerEventBuffer;
@@ -74,7 +74,7 @@ export class ThreadEventDispatcher {
   }
 
   async emitRunBoundaryEvent(
-    run: BufferedAgentRun,
+    run: BufferedAgentTurn,
     event: AgentEvent
   ): Promise<void> {
     await runPluginsForEvent(
@@ -90,7 +90,7 @@ export class ThreadEventDispatcher {
   }
 
   async emitRunEvent(
-    run: BufferedAgentRun,
+    run: BufferedAgentTurn,
     event: AgentEvent
   ): Promise<AgentEvent | "handled"> {
     const processed = await this.interceptEvent(event);
@@ -111,7 +111,7 @@ export class ThreadEventDispatcher {
     return pipeline.event;
   }
 
-  emitProcessedEvent(run: BufferedAgentRun, event: AgentEvent): void {
+  emitProcessedEvent(run: BufferedAgentTurn, event: AgentEvent): void {
     run.emit(event);
   }
 

--- a/packages/runtime/src/thread/runtime/execution-checkpoints.ts
+++ b/packages/runtime/src/thread/runtime/execution-checkpoints.ts
@@ -1,4 +1,4 @@
-import { createRunCheckpointId } from "../../execution/host/checkpoint-ids";
+import { createCheckpointId } from "../../execution/host/checkpoint-ids";
 import type {
   CheckpointPhase,
   ExecutionHost,
@@ -73,7 +73,7 @@ async function appendThreadToolExecutionCheckpoint({
     | { readonly current: number; readonly expected: number }
     | undefined;
   for (let attempt = 0; attempt < maxCheckpointWriteAttempts; attempt += 1) {
-    const run = await executionHost.store.runs.get(runId);
+    const run = await executionHost.store.turns.get(runId);
     if (!run) {
       throw new Error(`Thread execution run ${runId} is missing.`);
     }
@@ -81,7 +81,7 @@ async function appendThreadToolExecutionCheckpoint({
     const version = run.checkpointVersion + 1;
     const result = await executionHost.store.checkpoints.append(
       {
-        checkpointId: createRunCheckpointId({ phase, runId, version }),
+        checkpointId: createCheckpointId({ phase, runId, version }),
         pendingToolCall: persistedToolExecutionCheckpoint(toolCall),
         phase,
         runId,

--- a/packages/runtime/src/thread/runtime/execution.ts
+++ b/packages/runtime/src/thread/runtime/execution.ts
@@ -1,7 +1,7 @@
 import type {
   ExecutionHost,
-  RunRecord,
-  RunStatus,
+  TurnRecord,
+  TurnStatus,
 } from "../../execution/host/types";
 import type { RuntimeToolExecutionContext } from "../../llm/llm";
 import type { ThreadState } from "../state/thread-state";
@@ -18,7 +18,7 @@ export interface ThreadExecutionRun {
 }
 
 export type ThreadExecutionTerminalStatus = Extract<
-  RunStatus,
+  TurnStatus,
   "cancelled" | "completed" | "error" | "needs-recovery"
 >;
 
@@ -38,7 +38,7 @@ export async function startThreadExecutionRun({
   }
 
   const runId = `turn:${threadKey}:${turnId}`;
-  const run: RunRecord = {
+  const run: TurnRecord = {
     checkpointVersion: 0,
     dedupeKey: runId,
     kind: "user-turn",
@@ -47,7 +47,7 @@ export async function startThreadExecutionRun({
     threadKey,
     status: "running",
   };
-  await executionHost.store.runs.create(run);
+  await executionHost.store.turns.create(run);
 
   return {
     complete: (status) =>
@@ -70,10 +70,10 @@ async function completeThreadExecutionRun({
   readonly runId: string;
   readonly status: ThreadExecutionTerminalStatus;
 }): Promise<void> {
-  const run = await executionHost.store.runs.get(runId);
+  const run = await executionHost.store.turns.get(runId);
   if (!run) {
     return;
   }
 
-  await executionHost.store.runs.update({ ...run, status });
+  await executionHost.store.turns.update({ ...run, status });
 }

--- a/packages/runtime/src/thread/runtime/kill.ts
+++ b/packages/runtime/src/thread/runtime/kill.ts
@@ -3,13 +3,13 @@ import {
   type QueuedInput,
   type RuntimeInputState,
 } from "../input/runtime-input";
-import type { BufferedAgentRun } from "../protocol/run";
+import type { BufferedAgentTurn } from "../protocol/turn";
 
 interface CloseKilledRuntimeInputsOptions {
   readonly activeRuntimeInput: RuntimeInputState | undefined;
   readonly inputQueue: QueuedInput[];
   readonly message: string;
-  readonly runToClose: BufferedAgentRun | undefined;
+  readonly runToClose: BufferedAgentTurn | undefined;
 }
 
 export function closeKilledRuntimeInputs({

--- a/packages/runtime/src/thread/runtime/notification.ts
+++ b/packages/runtime/src/thread/runtime/notification.ts
@@ -9,7 +9,7 @@ import {
   type RuntimeInputState,
 } from "../input/runtime-input";
 import type { AgentEvent } from "../protocol/events";
-import { type AgentRun, BufferedAgentRun } from "../protocol/run";
+import { type AgentTurn, BufferedAgentTurn } from "../protocol/turn";
 import { errorMessage } from "../state/thread-errors";
 
 export interface NotifyOptions {
@@ -18,11 +18,11 @@ export interface NotifyOptions {
 }
 
 interface QueueThreadNotificationOptions {
-  readonly activeRun: BufferedAgentRun | undefined;
+  readonly activeRun: BufferedAgentTurn | undefined;
   readonly activeRuntimeInput: RuntimeInputState | undefined;
   readonly drain: () => Promise<void>;
   emitObserverEvent(
-    run: BufferedAgentRun | undefined,
+    run: BufferedAgentTurn | undefined,
     event: AgentEvent
   ): Promise<void>;
   readonly inputQueue: QueuedInput[];
@@ -33,7 +33,7 @@ export async function queueThreadNotification(
   input: AgentInput,
   options: NotifyOptions,
   state: QueueThreadNotificationOptions
-): Promise<AgentRun> {
+): Promise<AgentTurn> {
   const queuedRuntimeInput: QueuedRuntimeInput = {
     input: attachInputMeta(normalizeAgentInput(input), { source: "notify" }),
     placement: "turn-start",
@@ -61,12 +61,12 @@ export async function queueThreadNotification(
 
   if (options.deferWhenUnobserved === true) {
     state.pendingRuntimeInputs.push(queuedRuntimeInput);
-    const deferredRun = new BufferedAgentRun();
+    const deferredRun = new BufferedAgentTurn();
     deferredRun.close();
     return deferredRun;
   }
 
-  const run = new BufferedAgentRun();
+  const run = new BufferedAgentTurn();
   state.inputQueue.push({
     initialEvents: observerEvents,
     preUserRuntimeInputs: [],
@@ -78,7 +78,7 @@ export async function queueThreadNotification(
 }
 
 export function startThreadQueueDrain(
-  run: BufferedAgentRun,
+  run: BufferedAgentTurn,
   drain: () => Promise<void>
 ): void {
   drain().catch((error: unknown) => {

--- a/packages/runtime/src/thread/runtime/plugins.test.ts
+++ b/packages/runtime/src/thread/runtime/plugins.test.ts
@@ -12,7 +12,7 @@ import { collect } from "../handle/test-support";
 import { userTextToModelMessage } from "../protocol/mapping";
 
 describe("Agent thread runtime input plugins", () => {
-  it("drains event-plugin steering at turn-start, step-start, and step-end but starts a new run after turn-end", async () => {
+  it("drains event-plugin steering at turn-start, step-start, and step-end but starts a new turn after turn-end", async () => {
     const seenHistory: ModelMessage[][] = [];
     let turnEndRun:
       | Promise<Awaited<ReturnType<typeof thread.steer>>>
@@ -85,7 +85,7 @@ describe("Agent thread runtime input plugins", () => {
       ],
     ]);
     if (!turnEndRun) {
-      throw new Error("expected turn-end steer to start a new run");
+      throw new Error("expected turn-end steer to start a new turn");
     }
     const turnEndEvents = await collect(await turnEndRun);
     expect(turnEndEvents[0]).toEqual(sentUserText("turn end steer"));

--- a/packages/runtime/src/thread/runtime/turn-error.ts
+++ b/packages/runtime/src/thread/runtime/turn-error.ts
@@ -3,7 +3,7 @@ import {
   closeRuntimeInput,
   type RuntimeInputState,
 } from "../input/runtime-input";
-import type { BufferedAgentRun } from "../protocol/run";
+import type { BufferedAgentTurn } from "../protocol/turn";
 import { errorMessage } from "../state/thread-errors";
 import {
   ThreadCommitConflictError,
@@ -19,7 +19,7 @@ export async function emitTurnErrorAfterRecovery({
 }: {
   readonly error: unknown;
   readonly historySnapshot: ModelMessage[];
-  readonly run: BufferedAgentRun;
+  readonly run: BufferedAgentTurn;
   readonly runtimeInput: RuntimeInputState;
   readonly state: ThreadState;
 }): Promise<void> {

--- a/packages/runtime/src/thread/runtime/turn-processor.ts
+++ b/packages/runtime/src/thread/runtime/turn-processor.ts
@@ -12,7 +12,7 @@ import {
   emitCommittedRuntimeInputs,
 } from "../input/runtime-input-emit";
 import type { AgentEvent } from "../protocol/events";
-import type { BufferedAgentRun } from "../protocol/run";
+import type { BufferedAgentTurn } from "../protocol/turn";
 import { errorMessage } from "../state/thread-errors";
 import type { ThreadState } from "../state/thread-state";
 import { drainRuntimeInput } from "./drain";
@@ -27,7 +27,7 @@ import { emitTurnErrorAfterRecovery } from "./turn-error";
 
 interface ActiveTurn {
   readonly abort: AbortController;
-  readonly run: BufferedAgentRun;
+  readonly run: BufferedAgentTurn;
   readonly runtimeInput: RuntimeInputState;
   readonly turnId: string;
 }
@@ -164,7 +164,7 @@ async function closeSuccessfulTurn({
   readonly deactivateRun: () => void;
   readonly events: ThreadEventDispatcher;
   readonly result: "aborted" | "completed";
-  readonly run: BufferedAgentRun;
+  readonly run: BufferedAgentTurn;
   readonly runtimeInput: RuntimeInputState;
 }): Promise<void> {
   const terminalEvent = result === "aborted" ? "turn-abort" : "turn-end";
@@ -187,7 +187,7 @@ async function emitTurnEvent({
 }: {
   readonly event: AgentEvent;
   readonly events: ThreadEventDispatcher;
-  readonly run: BufferedAgentRun;
+  readonly run: BufferedAgentTurn;
   readonly runtimeInput: RuntimeInputState;
   readonly state: ThreadState;
 }): Promise<{ readonly runtimeInputAdded: boolean } | undefined> {

--- a/packages/runtime/src/thread/store/file.ts
+++ b/packages/runtime/src/thread/store/file.ts
@@ -1,7 +1,3 @@
-// biome-ignore-all lint/performance/noBarrelFile: Legacy package subpath compatibility entrypoint.
+// biome-ignore-all lint/performance/noBarrelFile: Public package subpath entrypoint required by package exports.
 
-export {
-  /** @deprecated Use FileThreadStore. */
-  FileSessionStore,
-  FileThreadStore,
-} from "../../platform/node/storage/file-thread-store";
+export { FileThreadStore } from "../../platform/node/storage/file-thread-store";

--- a/packages/runtime/src/thread/store/memory.ts
+++ b/packages/runtime/src/thread/store/memory.ts
@@ -39,6 +39,3 @@ export class MemoryThreadStore implements ThreadStore {
     return Promise.resolve({ ok: true, version });
   }
 }
-
-/** @deprecated Use MemoryThreadStore. */
-export { MemoryThreadStore as MemorySessionStore };

--- a/packages/runtime/src/thread/store/types.ts
+++ b/packages/runtime/src/thread/store/types.ts
@@ -22,15 +22,3 @@ export interface ThreadStore {
   delete(key: string): Promise<void>;
   load(key: string): Promise<StoredThread | null>;
 }
-
-/** @deprecated Use StoredThread. */
-export type StoredSession = StoredThread;
-
-/** @deprecated Use ThreadStoreCommit. */
-export type SessionStoreCommit = ThreadStoreCommit;
-
-/** @deprecated Use ExpectedThreadVersion. */
-export type ExpectedSessionVersion = ExpectedThreadVersion;
-
-/** @deprecated Use ThreadStore. */
-export type SessionStore = ThreadStore;

--- a/scripts/runtime-docs.test.mjs
+++ b/scripts/runtime-docs.test.mjs
@@ -10,20 +10,20 @@ function readRepoFile(path) {
 }
 
 describe("runtime docs", () => {
-  it("keeps raw run.events as the public control loop", () => {
+  it("keeps raw turn.events as the public control loop", () => {
     const readme = readRepoFile("packages/runtime/README.md");
     const changeset = readRepoFile(".changeset/runtime-plugin-sessions.md");
-    const runSource = readRepoFile(
-      "packages/runtime/src/thread/protocol/run.ts"
+    const turnSource = readRepoFile(
+      "packages/runtime/src/thread/protocol/turn.ts"
     );
 
-    expect(readme).toContain("for await (const event of run.events())");
+    expect(readme).toContain("for await (const event of turn.events())");
     expect(readme).toContain("thread.steer");
     expect(readme).not.toContain("consumeRunEvents");
     expect(changeset).toContain('"@minpeter/pss-runtime": patch');
     expect(changeset).not.toContain("consumeRunEvents");
-    expect(runSource).not.toContain("consumeRunEvents");
-    expect(runSource).not.toContain("AgentRunEventListener");
+    expect(turnSource).not.toContain("consumeRunEvents");
+    expect(turnSource).not.toContain("AgentRunEventListener");
   });
 
   it("keeps the durable background host snippet assignable", () => {

--- a/scripts/verify-release-artifacts-node.test.mjs
+++ b/scripts/verify-release-artifacts-node.test.mjs
@@ -37,7 +37,6 @@ describe("verifyReleaseArtifacts node declaration checks", () => {
 
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
       "packages/runtime/dist/platform/node/index.d.ts: missing explicit node runtime export FileExecutionStore",
-      "packages/runtime/dist/platform/node/index.d.ts: missing explicit node runtime export FileSessionStore",
       "packages/runtime/dist/platform/node/index.d.ts: missing explicit node runtime export FileThreadStore",
       "packages/runtime/dist/platform/node/index.d.ts: missing explicit node runtime export NodeFileAgentContext",
       "packages/runtime/dist/platform/node/index.d.ts: missing explicit node runtime export NodeFileAgentContextFactoryOptions",

--- a/scripts/verify-release-artifacts-runtime.test.mjs
+++ b/scripts/verify-release-artifacts-runtime.test.mjs
@@ -53,7 +53,7 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      `export type { AgentMessage, ${forbiddenModelName}, AgentRun, AgentTool, AgentTools, CreateLlmOptions, Llm, LlmContext, LlmOutput, LlmOutputPart, ${removedRuntimeModelNames.join(", ")}, RuntimeInput } from "./llm";\nexport type { AgentHost } from "./execution/types";\n`
+      `export type { AgentMessage, ${forbiddenModelName}, AgentRun, AgentTool, AgentTools, CreateLlmOptions, Llm, LlmContext, LlmOutput, LlmOutputPart, ${removedRuntimeModelNames.join(", ")}, RuntimeInput } from "./llm";\nexport type { AgentHost } from "./execution/types";\nexport type { AgentTurn } from "./thread";\n`
     );
 
     expect(
@@ -61,6 +61,7 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
     ).toEqual([
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name AgentMessage",
       `packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name ${forbiddenModelName}`,
+      "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name AgentRun",
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name AgentTool",
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name AgentTools",
       "packages/runtime/dist/index.d.ts: root declaration exposes internal runtime name CreateLlmOptions",
@@ -178,7 +179,7 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
     );
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
       "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentHost",
-      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentRun",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentTurn",
       "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeInput",
     ]);
   });
@@ -213,7 +214,9 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export CloudflareAgentContextFactoryOptions",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export CloudflareAgentContextOptions",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export CloudflareAgentContextPrefixOptions",
-      "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export CloudflareAgentRunDrainOptions",
+      "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export AgentTurnDrainResult",
+      "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export AgentTurnDrainStopReason",
+      "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export CloudflareAgentTurnDrainOptions",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export CloudflareAlarmAgent",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export CloudflareAlarmDrainSummary",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export CloudflareDurableObjectFetchOptions",
@@ -230,7 +233,8 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export createCloudflareAlarmScheduler",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export createCloudflareAgentContext",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export createCloudflareDurableObjectHost",
-      "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export drainAgentRun",
+      "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export drainAgentTurn",
+      "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export drainAgentTurnWithBudget",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export drainCloudflareAlarm",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export fetchCloudflareDurableObject",
       "packages/runtime/dist/platform/cloudflare/index.d.ts: missing explicit cloudflare runtime export getCloudflareDurableObjectStub",
@@ -258,8 +262,9 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
       "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export ExecutionStoreTransaction",
       "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export NotificationInbox",
       "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export NotificationRecord",
-      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RunRecord",
-      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RunStore",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export TurnRecord",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export TurnStore",
+      "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export TurnStatus",
       "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RuntimeToolExecutionCheckpoint",
       "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RuntimeToolExecutionContext",
       "packages/runtime/dist/execution/index.d.ts: missing explicit execution runtime export RuntimeToolExecutionDecision",

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -7,24 +7,24 @@ export const cliBinReadFailurePattern =
 export const forbiddenModelName = ["Agent", "Model"].join("");
 export const runtimeRootDeclaration = [
   'export type { AgentHost } from "./execution/types";',
-  'export type { AgentRun, RuntimeInput } from "./session/events";',
+  'export type { AgentTurn, RuntimeInput } from "./thread";',
   "",
 ].join("\n");
 export const runtimeExecutionDeclaration = [
   'export { createInMemoryExecutionHost } from "./memory";',
-  'export type { DurableBackgroundHost, SessionHost } from "./capabilities";',
-  'export type { CheckpointStore, EventStore, ExecutionHost, ExecutionScheduler, ExecutionStore, ExecutionStoreTransaction, NotificationInbox, NotificationRecord, RunRecord, RunStore } from "./types";',
+  'export type { DurableBackgroundHost } from "./capabilities";',
+  'export type { CheckpointStore, EventStore, ExecutionHost, ExecutionScheduler, ExecutionStore, ExecutionStoreTransaction, NotificationInbox, NotificationRecord, TurnRecord, TurnStatus, TurnStore } from "./types";',
   'export type { RuntimeToolExecutionCheckpoint, RuntimeToolExecutionContext, RuntimeToolExecutionDecision, RuntimeToolRetryPolicy } from "../llm-tool-execution";',
   'export { ToolExecutionNeedsRecoveryError } from "../llm-tool-execution";',
   "",
 ].join("\n");
 export const runtimeCloudflareDeclaration = [
-  'export { ackScheduledCloudflareRun, ackScheduledCloudflareThreadPrompt, createCloudflareAlarmScheduler, createCloudflareAgentContext, createCloudflareDurableObjectHost, drainAgentRun, drainCloudflareAlarm, fetchCloudflareDurableObject, getCloudflareDurableObjectStub, InMemoryCloudflareDurableObjectStorage, listScheduledCloudflareRuns, listScheduledCloudflareThreadPrompts, rescheduleCloudflareAlarm } from "./index";',
-  'export type { CloudflareAgentContext, CloudflareAgentContextFactoryOptions, CloudflareAgentContextOptions, CloudflareAgentContextPrefixOptions, CloudflareAgentRunDrainOptions, CloudflareAlarmAgent, CloudflareAlarmDrainSummary, CloudflareDurableObjectFetchOptions, CloudflareDurableObjectId, CloudflareDurableObjectNamespace, CloudflareDurableObjectState, CloudflareDurableObjectStorage, CloudflareDurableObjectStub, CloudflareDurableObjectStubOptions, CloudflareScheduledThreadPrompt } from "./index";',
+  'export { ackScheduledCloudflareRun, ackScheduledCloudflareThreadPrompt, createCloudflareAlarmScheduler, createCloudflareAgentContext, createCloudflareDurableObjectHost, drainAgentTurn, drainAgentTurnWithBudget, drainCloudflareAlarm, fetchCloudflareDurableObject, getCloudflareDurableObjectStub, InMemoryCloudflareDurableObjectStorage, listScheduledCloudflareRuns, listScheduledCloudflareThreadPrompts, rescheduleCloudflareAlarm } from "./index";',
+  'export type { AgentTurnDrainResult, AgentTurnDrainStopReason, CloudflareAgentContext, CloudflareAgentContextFactoryOptions, CloudflareAgentContextOptions, CloudflareAgentContextPrefixOptions, CloudflareAgentTurnDrainOptions, CloudflareAlarmAgent, CloudflareAlarmDrainSummary, CloudflareDurableObjectFetchOptions, CloudflareDurableObjectId, CloudflareDurableObjectNamespace, CloudflareDurableObjectState, CloudflareDurableObjectStorage, CloudflareDurableObjectStub, CloudflareDurableObjectStubOptions, CloudflareScheduledThreadPrompt } from "./index";',
   "",
 ].join("\n");
 export const runtimeNodeDeclaration = [
-  'export { ackScheduledNodeRun, ackScheduledNodeThreadPrompt, appendScheduledNodeRun, appendScheduledNodeThreadPrompt, createNodeFileAgentContext, createNodeFileExecutionHost, createNodeFileScheduler, createNodeFileThreadHost, drainScheduledNodeWork, FileExecutionStore, FileSessionStore, FileThreadStore, listScheduledNodeRuns, listScheduledNodeThreadPrompts } from "./index";',
+  'export { ackScheduledNodeRun, ackScheduledNodeThreadPrompt, appendScheduledNodeRun, appendScheduledNodeThreadPrompt, createNodeFileAgentContext, createNodeFileExecutionHost, createNodeFileScheduler, createNodeFileThreadHost, drainScheduledNodeWork, FileExecutionStore, FileThreadStore, listScheduledNodeRuns, listScheduledNodeThreadPrompts } from "./index";',
   'export type { NodeFileAgentContext, NodeFileAgentContextFactoryOptions, NodeFileAgentContextOptions, NodeFileExecutionHostOptions, NodeFileThreadHostOptions, NodeScheduledThreadPrompt, NodeScheduledWorkAppendOptions, NodeScheduledWorkDrainOptions, NodeScheduledWorkDrainResult, NodeScheduledWorkListOptions, NodeScheduledWorkRunContext } from "./index";',
   "",
 ].join("\n");

--- a/scripts/verify-release-artifacts/runtime-checks.mjs
+++ b/scripts/verify-release-artifacts/runtime-checks.mjs
@@ -2,7 +2,11 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { listFiles, packageDistPath, relativeToCwd } from "./shared.mjs";
 
-const REQUIRED_RUNTIME_ROOT_EXPORTS = ["AgentHost", "AgentRun", "RuntimeInput"];
+const REQUIRED_RUNTIME_ROOT_EXPORTS = [
+  "AgentHost",
+  "AgentTurn",
+  "RuntimeInput",
+];
 const REQUIRED_RUNTIME_EXECUTION_EXPORTS = [
   "CheckpointStore",
   "createInMemoryExecutionHost",
@@ -14,8 +18,9 @@ const REQUIRED_RUNTIME_EXECUTION_EXPORTS = [
   "ExecutionStoreTransaction",
   "NotificationInbox",
   "NotificationRecord",
-  "RunRecord",
-  "RunStore",
+  "TurnRecord",
+  "TurnStore",
+  "TurnStatus",
   "RuntimeToolExecutionCheckpoint",
   "RuntimeToolExecutionContext",
   "RuntimeToolExecutionDecision",
@@ -27,7 +32,9 @@ const REQUIRED_RUNTIME_CLOUDFLARE_EXPORTS = [
   "CloudflareAgentContextFactoryOptions",
   "CloudflareAgentContextOptions",
   "CloudflareAgentContextPrefixOptions",
-  "CloudflareAgentRunDrainOptions",
+  "AgentTurnDrainResult",
+  "AgentTurnDrainStopReason",
+  "CloudflareAgentTurnDrainOptions",
   "CloudflareAlarmAgent",
   "CloudflareAlarmDrainSummary",
   "CloudflareDurableObjectFetchOptions",
@@ -44,7 +51,8 @@ const REQUIRED_RUNTIME_CLOUDFLARE_EXPORTS = [
   "createCloudflareAlarmScheduler",
   "createCloudflareAgentContext",
   "createCloudflareDurableObjectHost",
-  "drainAgentRun",
+  "drainAgentTurn",
+  "drainAgentTurnWithBudget",
   "drainCloudflareAlarm",
   "fetchCloudflareDurableObject",
   "getCloudflareDurableObjectStub",
@@ -53,21 +61,21 @@ const REQUIRED_RUNTIME_CLOUDFLARE_EXPORTS = [
   "rescheduleCloudflareAlarm",
 ];
 const REQUIRED_RUNTIME_NODE_EXPORTS =
-  "FileExecutionStore FileSessionStore FileThreadStore NodeFileAgentContext NodeFileAgentContextFactoryOptions NodeFileAgentContextOptions NodeFileExecutionHostOptions NodeFileThreadHostOptions NodeScheduledThreadPrompt NodeScheduledWorkAppendOptions NodeScheduledWorkDrainOptions NodeScheduledWorkDrainResult NodeScheduledWorkListOptions NodeScheduledWorkRunContext ackScheduledNodeRun ackScheduledNodeThreadPrompt appendScheduledNodeRun appendScheduledNodeThreadPrompt createNodeFileAgentContext createNodeFileExecutionHost createNodeFileScheduler createNodeFileThreadHost drainScheduledNodeWork listScheduledNodeRuns listScheduledNodeThreadPrompts".split(
+  "FileExecutionStore FileThreadStore NodeFileAgentContext NodeFileAgentContextFactoryOptions NodeFileAgentContextOptions NodeFileExecutionHostOptions NodeFileThreadHostOptions NodeScheduledThreadPrompt NodeScheduledWorkAppendOptions NodeScheduledWorkDrainOptions NodeScheduledWorkDrainResult NodeScheduledWorkListOptions NodeScheduledWorkRunContext ackScheduledNodeRun ackScheduledNodeThreadPrompt appendScheduledNodeRun appendScheduledNodeThreadPrompt createNodeFileAgentContext createNodeFileExecutionHost createNodeFileScheduler createNodeFileThreadHost drainScheduledNodeWork listScheduledNodeRuns listScheduledNodeThreadPrompts".split(
     " "
   );
 const FORBIDDEN_RUNTIME_ROOT_NAMES = [
   ...[
-    "AgentMessage AgentModel AgentLoopResult AgentRunInput AgentTool AgentTools",
+    "AgentMessage AgentModel AgentLoopResult AgentRun AgentRunInput AgentTool AgentTools",
     "BackgroundScheduler BackgroundSchedulerHost CheckpointHost CheckpointStore",
     "CloudflareAgentContext CloudflareAgentContextFactoryOptions CloudflareAgentContextOptions",
-    "CloudflareAgentContextPrefixOptions CloudflareAgentRunDrainOptions CloudflareAlarmAgent",
+    "AgentTurnDrainResult AgentTurnDrainStopReason CloudflareAgentContextPrefixOptions CloudflareAgentTurnDrainOptions CloudflareAlarmAgent",
     "CloudflareAlarmDrainSummary CloudflareDurableObjectFetchOptions CloudflareDurableObjectId",
     "CloudflareDurableObjectNamespace CloudflareDurableObjectState CloudflareDurableObjectStorage",
     "CloudflareDurableObjectStub CloudflareDurableObjectStubOptions CloudflareScheduledThreadPrompt",
     "createInMemoryExecutionHost createCloudflareAlarmScheduler createCloudflareAgentContext",
     "createCloudflareDurableObjectHost CreateLlmOptions DurableBackgroundHost DurableNotificationResumeHost",
-    "drainCloudflareAlarm EventHost EventStore ExecutionHost ExecutionScheduler ExecutionStore",
+    "drainAgentTurn drainAgentTurnWithBudget drainCloudflareAlarm EventHost EventStore ExecutionHost ExecutionScheduler ExecutionStore",
     "ExecutionStoreTransaction ExecutionTransactionHost Llm LlmContext LlmOutput LlmOutputPart",
     "NotificationHost NotificationInbox NotificationRecord fetchCloudflareDurableObject",
     "getCloudflareDurableObjectStub InMemoryCloudflareDurableObjectStorage RunHost RunRecord",


### PR DESCRIPTION
## Summary
- replace the public runtime run/session compatibility surface with Thread, Turn, and Checkpoint names
- update Cloudflare/Node host exports, execution store naming, examples, and release artifact guards
- keep durable internals behind the execution store while public APIs expose AgentTurn and TurnStore names

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm verify:release
- pnpm boundaries

Changeset expects @minpeter/pss-runtime 0.1.0-next.18.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor the public runtime API to use Thread, Turn, and Checkpoint naming instead of legacy session/run terms. Updates Cloudflare/Node hosts, execution stores, docs, and examples to match; no behavior change intended.

- **Refactors**
  - Types and methods: `AgentRun` → `AgentTurn`, `run.events()` → `turn.events()`.
  - Execution store: `runs` → `turns`; `RunRecord/RunStatus/RunLease/RunKind` → `TurnRecord/TurnStatus/TurnLease/TurnKind`.
  - Cloudflare alarm drain: `drainAgentRun` → `drainAgentTurn` with `CloudflareAgentTurnDrainOptions` and `AgentTurnDrainResult`.
  - Checkpoints: `RunCheckpoint` → `Checkpoint`; `createRunCheckpointId` → `createCheckpointId` (prefix now `checkpoint:`).
  - Hosts: remove deprecated `SessionHost` and session store compatibility; durable background host now exposes `turnStore`.
  - Exports cleanup: removed session-store subpaths and legacy aliases (e.g., `FileSessionStore`, `DurableObjectSqliteSessionStore`); use thread store exports instead.
  - Docs/examples/tests updated to new names across the repo.

- **Migration**
  - Replace imports and usages:
    - `AgentRun` → `AgentTurn`; `.events()` usage unchanged beyond the rename.
    - `host.store.runs.*` → `host.store.turns.*` (and related `Run*` types to `Turn*`).
    - Cloudflare drain: `drainAgentRun` → `drainAgentTurn` (+ renamed option/result types).
    - Checkpoints: `RunCheckpoint` → `Checkpoint`; `createRunCheckpointId` → `createCheckpointId`.
  - Stop using session-based hosts and exports; use thread hosts/stores (`ThreadHost`, `FileThreadStore`, `DurableObjectSqliteThreadStore`).

<sup>Written for commit 8c3e69679daba929f61e32d8a0b2877cb162302b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

