### PR TITLE
Fix runtime README thread store export

### DIFF
--- a/.changeset/runtime-readme-thread-store-export.md
+++ b/.changeset/runtime-readme-thread-store-export.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Fix the runtime README to document the exported `thread-store/file` subpath without referencing the removed `session-store/file` path.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -430,9 +430,9 @@ const agent = new Agent({
 });
 ```
 
-The legacy `@minpeter/pss-runtime/thread-store/file` and
-`@minpeter/pss-runtime/session-store/file` subpaths still resolve for existing
-callers, but new Node/local code should import from the `node` platform subpath.
+The legacy `@minpeter/pss-runtime/thread-store/file` subpath still resolves for
+existing callers, but new Node/local code should import from the `node` platform
+subpath.
 App-owned background work still needs its own durable task/output storage if it
 must survive process restarts.
 


### PR DESCRIPTION
## Summary
- remove stale `@minpeter/pss-runtime/session-store/file` documentation
- keep README aligned with exported `thread-store/file` and `node` platform subpaths

## Verification
- `pnpm lint`
- `pnpm verify:release`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the `@minpeter/pss-runtime` README to document the exported `thread-store/file` subpath and remove stale `session-store/file` references. Clarifies that new Node/local imports should use the `node` platform subpath.

<sup>Written for commit 515b089c6b3cc441158e43b81689462ae661fe16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

