### PR TITLE
Add runtime auto compaction

### DIFF
--- a/.changeset/runtime-auto-compaction.md
+++ b/.changeset/runtime-auto-compaction.md
@@ -1,0 +1,12 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add opt-in automatic Thread compaction for long-running agents.
+
+- Add `AgentOptions.autoCompaction` with validated `minMessages` and
+  `retainMessages` thresholds.
+- Persist compaction summaries as `pss_thread_compaction` rows while keeping the
+  full durable Thread log intact.
+- Schedule compaction after successful user-input turns without blocking turn
+  completion.

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -9,9 +9,11 @@ import { stableAgentNamespace } from "../identity/namespace";
 import { resumeAgentTurn } from "../resume/resume";
 import { threadStoreForHost } from "./host-thread-store";
 import {
+  type AgentAutoCompactionOptions,
   type AgentModelOptions,
   type AgentOptions,
   assertAgentOptions,
+  normalizeAgentAutoCompactionOptions,
 } from "./options";
 import {
   type AgentThreadEntry,
@@ -21,7 +23,8 @@ import {
 } from "./thread-entry";
 
 export type { AgentHost } from "../../execution/host/types";
-export type { AgentOptions } from "./options";
+export type { ThreadCompactionInput } from "../../thread/handle/thread";
+export type { AgentAutoCompactionOptions, AgentOptions } from "./options";
 export type {
   ThreadAddress,
   ThreadHandle,
@@ -36,6 +39,7 @@ export class Agent {
   readonly #store: ThreadStore;
   readonly #host: AgentHost;
   readonly #plugins: readonly AgentPlugin[];
+  readonly #autoCompaction?: AgentAutoCompactionOptions;
   readonly host: AgentHost;
   readonly namespace?: string;
   constructor(options: AgentOptions) {
@@ -49,6 +53,9 @@ export class Agent {
     this.host = this.#host;
     this.#store = threadStoreForHost(this.#host);
     this.#plugins = options.plugins ?? [];
+    this.#autoCompaction = normalizeAgentAutoCompactionOptions(
+      options.autoCompaction
+    );
     this.#modelOptions = {
       instructions: options.instructions,
       model: options.model,
@@ -111,10 +118,12 @@ export class Agent {
       { key, store: this.#store },
       this.#plugins,
       {
+        autoCompaction: this.#autoCompaction,
         executionHost: executionHost(this.#host),
       }
     );
     const publicHandle: ThreadHandle = {
+      compact: (input) => thread.compact(input),
       delete: async () => {
         thread.kill();
         this.#evictThreadHandle(key);

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -3,7 +3,13 @@ import type { AgentHost } from "../../execution/host/types";
 import type { AgentToolChoice } from "../../llm/llm";
 import type { AgentPlugin } from "../../thread/plugins/pipeline";
 
+export interface AgentAutoCompactionOptions {
+  readonly minMessages: number;
+  readonly retainMessages: number;
+}
+
 export interface AgentOptions {
+  readonly autoCompaction?: AgentAutoCompactionOptions | false;
   readonly host?: AgentHost;
   readonly instructions?: string;
   readonly model: LanguageModel;
@@ -34,4 +40,48 @@ export function assertAgentOptions(
   if (typeof options.model !== "object" || options.model === null) {
     throw new TypeError("Agent: invalid options.model.");
   }
+
+  const candidate = options as {
+    readonly autoCompaction?: AgentOptions["autoCompaction"];
+  };
+  normalizeAgentAutoCompactionOptions(candidate.autoCompaction);
+}
+
+export function normalizeAgentAutoCompactionOptions(
+  value: AgentOptions["autoCompaction"]
+): AgentAutoCompactionOptions | undefined {
+  if (value === undefined || value === false) {
+    return;
+  }
+
+  if (value === null || typeof value !== "object") {
+    throw new TypeError("Agent: invalid options.autoCompaction.");
+  }
+
+  if (!isPositiveInteger(value.minMessages)) {
+    throw new TypeError(
+      "Agent: options.autoCompaction.minMessages must be a positive integer."
+    );
+  }
+
+  if (!isPositiveInteger(value.retainMessages)) {
+    throw new TypeError(
+      "Agent: options.autoCompaction.retainMessages must be a positive integer."
+    );
+  }
+
+  if (value.retainMessages >= value.minMessages) {
+    throw new TypeError(
+      "Agent: options.autoCompaction.retainMessages must be smaller than minMessages."
+    );
+  }
+
+  return {
+    minMessages: value.minMessages,
+    retainMessages: value.retainMessages,
+  };
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
 }

--- a/packages/runtime/src/agent/core/thread-entry.ts
+++ b/packages/runtime/src/agent/core/thread-entry.ts
@@ -1,4 +1,8 @@
-import type { AgentInput, NotifyOptions } from "../../thread/handle/thread";
+import type {
+  AgentInput,
+  NotifyOptions,
+  ThreadCompactionInput,
+} from "../../thread/handle/thread";
 import type { AgentTurn } from "../../thread/protocol/turn";
 import { namespacePart } from "../identity/namespace";
 
@@ -15,6 +19,7 @@ export interface ThreadAddress {
 export type ThreadKey = string | ThreadAddress;
 
 export interface ThreadHandle {
+  compact(input: ThreadCompactionInput): Promise<void>;
   delete(): Promise<void>;
   dispose(): Promise<void>;
   interrupt(): void;

--- a/packages/runtime/src/agent/loop/loop.ts
+++ b/packages/runtime/src/agent/loop/loop.ts
@@ -10,6 +10,7 @@ import { modelMessageToAgentEvents } from "../../thread/protocol/mapping";
 
 interface ModelHistory {
   appendModelMessage(message: ModelMessage): void;
+  modelContextSnapshot(): ModelMessage[];
   modelSnapshot(): ModelMessage[];
 }
 
@@ -177,7 +178,7 @@ async function readModelOutput({
 }): Promise<ModelStepOutput | "aborted"> {
   try {
     return await generateModelStep({
-      history: history.modelSnapshot(),
+      history: history.modelContextSnapshot(),
       ...model,
       signal,
       toolExecution,

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -16,11 +16,15 @@ import type {
   TurnStore,
 } from "../execution";
 import type {
+  AgentAutoCompactionOptions,
   AgentEvent,
   AgentHost,
+  AgentOptions,
   ControlAgentEvent,
   LifecycleAgentEvent,
   TelemetryAgentEvent,
+  ThreadCompactionInput,
+  ThreadHandle,
   VisibleAgentEvent,
 } from "../index";
 import {
@@ -134,6 +138,34 @@ describe("runtime public exports", () => {
       "assistant-reasoning",
       "turn-start",
     ]);
+  });
+
+  it("types public thread compaction options from the package root", () => {
+    const autoCompaction = {
+      minMessages: 12,
+      retainMessages: 4,
+    } satisfies AgentAutoCompactionOptions;
+    const model = {} as AgentOptions["model"];
+    const enabledOptions = {
+      autoCompaction,
+      model,
+    } satisfies AgentOptions;
+    const disabledOptions = {
+      autoCompaction: false,
+      model,
+    } satisfies AgentOptions;
+    const compaction = {
+      endSeqExclusive: 8,
+      startSeq: 0,
+      summary: "Earlier turns established the durable context.",
+    } satisfies ThreadCompactionInput;
+
+    expectTypeOf<
+      Parameters<ThreadHandle["compact"]>[0]
+    >().toEqualTypeOf<ThreadCompactionInput>();
+    expect(enabledOptions.autoCompaction).toEqual(autoCompaction);
+    expect(disabledOptions.autoCompaction).toBe(false);
+    expect(compaction.startSeq).toBe(0);
   });
 
   it("types advanced host contracts", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,7 +1,9 @@
 export {
   Agent,
+  type AgentAutoCompactionOptions,
   type AgentOptions,
   type ThreadAddress,
+  type ThreadCompactionInput,
   type ThreadHandle,
   type ThreadKey,
   type ThreadMetadata,

--- a/packages/runtime/src/llm/llm.test.ts
+++ b/packages/runtime/src/llm/llm.test.ts
@@ -55,6 +55,35 @@ describe("generateModelStep", () => {
     );
   });
 
+  it("hoists system history into instructions for provider-compatible prompts", async () => {
+    const runModelStep = await loadModelStepRunner();
+    const signal = new AbortController().signal;
+    const messages = [{ role: "user" as const, content: "tail" }];
+
+    await expect(
+      runModelStep(
+        {
+          instructions: "base",
+          model: fakeModel,
+        },
+        {
+          history: [
+            { role: "system", content: "compacted context" },
+            ...messages,
+          ],
+          signal,
+        }
+      )
+    ).resolves.toEqual([assistantMessage("DONE")]);
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: "base\n\ncompacted context",
+        messages,
+      })
+    );
+  });
+
   it("passes configured toolChoice to generateText", async () => {
     const runModelStep = await loadModelStepRunner();
     const signal = new AbortController().signal;

--- a/packages/runtime/src/llm/llm.ts
+++ b/packages/runtime/src/llm/llm.ts
@@ -44,10 +44,11 @@ export async function generateModelStep({
   tools,
 }: ModelStepOptions): Promise<ModelStepOutput> {
   const toolCallIds = new Map<string, string>();
+  const prompt = promptForModel({ history, instructions });
   const { responseMessages } = await generateText({
     abortSignal: signal,
-    instructions,
-    messages: [...history],
+    instructions: prompt.instructions,
+    messages: prompt.messages,
     model,
     toolChoice,
     tools: normalizeToolCallIds(tools, toolCallIds, toolExecution),
@@ -56,4 +57,39 @@ export async function generateModelStep({
   return responseMessages.map((message) =>
     rewriteMessageToolCallIds(message, toolCallIds)
   );
+}
+
+function promptForModel({
+  history,
+  instructions,
+}: {
+  readonly history: readonly ModelMessage[];
+  readonly instructions?: string;
+}): {
+  readonly instructions?: string;
+  readonly messages: ModelMessage[];
+} {
+  const messages: ModelMessage[] = [];
+  const systemContents: string[] = instructions ? [instructions] : [];
+  for (const message of history) {
+    if (message.role === "system") {
+      systemContents.push(systemContentText(message.content));
+      continue;
+    }
+    messages.push(message);
+  }
+
+  return {
+    ...(systemContents.length === 0
+      ? {}
+      : { instructions: systemContents.join("\n\n") }),
+    messages,
+  };
+}
+
+function systemContentText(content: ModelMessage["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  return JSON.stringify(content);
 }

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
@@ -7,6 +7,7 @@ import type {
   PayloadChunkRow,
   RunRow,
   ScheduledWorkRow,
+  ThreadCompactionRow,
   ThreadMessageChunkRow,
   ThreadMessageRow,
   ThreadMetaRow,
@@ -22,6 +23,9 @@ export function selectSqlRows(
   }
   if (query.includes("from pss_thread_meta")) {
     return selectThreadMetaRows(state, query, bindings);
+  }
+  if (query.includes("from pss_thread_compaction")) {
+    return selectThreadCompactionRows(state, query, bindings);
   }
   if (query.includes("from pss_thread_message_chunk")) {
     return selectThreadMessageChunkRows(state, bindings);
@@ -96,6 +100,21 @@ function selectThreadMetaRows(
   throw new Error(`Unsupported in-memory thread meta SQL query: ${query}`);
 }
 
+function selectThreadCompactionRows(
+  state: InMemoryDurableObjectSqlState,
+  query: string,
+  bindings: readonly unknown[]
+): unknown[] {
+  const key = stringBinding(bindings[0]);
+  return state.threadCompactions
+    .filter((row) => row.thread_key === key)
+    .sort(
+      (left: ThreadCompactionRow, right: ThreadCompactionRow) =>
+        left.ordinal - right.ordinal
+    )
+    .map((row) => projectThreadCompaction(row, query));
+}
+
 function selectThreadMessageRows(
   state: InMemoryDurableObjectSqlState,
   query: string,
@@ -132,6 +151,25 @@ function selectThreadMessageChunkRows(
       chunk_index: row.chunk_index,
       seq: row.seq,
     }));
+}
+
+function projectThreadCompaction(
+  row: ThreadCompactionRow,
+  query: string
+): unknown {
+  if (query.includes("ordinal")) {
+    return {
+      end_seq_exclusive: row.end_seq_exclusive,
+      ordinal: row.ordinal,
+      start_seq: row.start_seq,
+      summary: row.summary,
+    };
+  }
+  return {
+    end_seq_exclusive: row.end_seq_exclusive,
+    start_seq: row.start_seq,
+    summary: row.summary,
+  };
 }
 
 function selectRunRows(

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
@@ -20,6 +20,14 @@ export interface ThreadMessageChunkRow {
   readonly thread_key: string;
 }
 
+export interface ThreadCompactionRow {
+  readonly end_seq_exclusive: number;
+  readonly ordinal: number;
+  readonly start_seq: number;
+  readonly summary: string;
+  readonly thread_key: string;
+}
+
 export interface RunRow {
   readonly checkpoint_version: number;
   readonly created_at: number;
@@ -89,6 +97,7 @@ export interface InMemoryDurableObjectSqlState {
   notifications: NotificationRow[];
   payloadChunks: PayloadChunkRow[];
   scheduledWork: ScheduledWorkRow[];
+  threadCompactions: ThreadCompactionRow[];
   threadMessageChunks: ThreadMessageChunkRow[];
   threadMessages: ThreadMessageRow[];
   threadMeta: Map<string, ThreadMetaRow>;
@@ -104,6 +113,7 @@ export function createInMemoryDurableObjectSqlState(): InMemoryDurableObjectSqlS
     payloadChunks: [],
     turns: [],
     scheduledWork: [],
+    threadCompactions: [],
     threadMessageChunks: [],
     threadMessages: [],
     threadMeta: new Map(),
@@ -123,6 +133,7 @@ export function cloneInMemoryDurableObjectSqlState(
     payloadChunks: structuredClone(state.payloadChunks),
     turns: structuredClone(state.turns),
     scheduledWork: structuredClone(state.scheduledWork),
+    threadCompactions: structuredClone(state.threadCompactions),
     threadMessageChunks: structuredClone(state.threadMessageChunks),
     threadMessages: structuredClone(state.threadMessages),
     threadMeta: new Map(

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/storage.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/storage.ts
@@ -36,6 +36,16 @@ export class InMemoryDurableObjectSqlStorage implements SqlStorage {
       throw error;
     }
   }
+
+  transactionSync<T>(fn: () => T): T {
+    const previous = cloneInMemoryDurableObjectSqlState(this.#state);
+    try {
+      return fn();
+    } catch (error) {
+      this.#state = previous;
+      throw error;
+    }
+  }
 }
 
 function normalizeSql(query: string): string {

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/write.ts
@@ -8,6 +8,7 @@ import { writeRunStatement } from "./run-write";
 import type {
   InMemoryDurableObjectSqlState,
   PayloadChunkRow,
+  ThreadCompactionRow,
   ThreadMessageChunkRow,
   ThreadMetaRow,
 } from "./state";
@@ -105,6 +106,14 @@ function writeThreadStatement(
   query: string,
   bindings: readonly unknown[]
 ): void {
+  if (query.startsWith("delete from pss_thread_compaction")) {
+    deleteThreadCompactions(state, bindings);
+    return;
+  }
+  if (query.startsWith("insert into pss_thread_compaction")) {
+    insertThreadCompaction(state, bindings);
+    return;
+  }
   if (query.startsWith("delete from pss_thread_message_chunk")) {
     deleteThreadMessageChunks(state, bindings);
     return;
@@ -134,6 +143,37 @@ function writeThreadStatement(
     return;
   }
   throw new Error(`Unsupported in-memory thread SQL statement: ${query}`);
+}
+
+function deleteThreadCompactions(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const key = stringBinding(bindings[0]);
+  state.threadCompactions = state.threadCompactions.filter(
+    (row) => row.thread_key !== key
+  );
+}
+
+function insertThreadCompaction(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const row: ThreadCompactionRow = {
+    end_seq_exclusive: numberBinding(bindings[3]),
+    ordinal: numberBinding(bindings[1]),
+    start_seq: numberBinding(bindings[2]),
+    summary: stringBinding(bindings[4]),
+    thread_key: stringBinding(bindings[0]),
+  };
+  state.threadCompactions = state.threadCompactions.filter(
+    (existing) =>
+      !(
+        existing.thread_key === row.thread_key &&
+        existing.ordinal === row.ordinal
+      )
+  );
+  state.threadCompactions.push(row);
 }
 
 function deleteThreadMessages(

--- a/packages/runtime/src/platform/cloudflare/sql/ports/storage-port.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/ports/storage-port.ts
@@ -14,4 +14,6 @@ export interface SqlStorage {
     query: string,
     ...bindings: unknown[]
   ): SqlStorageCursorLike<T>;
+  transaction?<T>(fn: () => Promise<T>): Promise<T>;
+  transactionSync?<T>(fn: () => T): T;
 }

--- a/packages/runtime/src/platform/cloudflare/storage/durable-object/durable-object-storage.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/durable-object/durable-object-storage.ts
@@ -15,6 +15,7 @@ export interface CloudflareDurableObjectStorage
   transaction?<T>(
     fn: (storage: CloudflareDurableObjectTransactionStorage) => Promise<T>
   ): Promise<T>;
+  transactionSync?<T>(fn: () => T): T;
 }
 
 export function withSqlStorage(
@@ -26,6 +27,8 @@ export function withSqlStorage(
     get: (key) => storage.get(key),
     put: (key, value) => storage.put(key, value),
     sql,
+    transaction: (fn) => fn(withSql),
+    transactionSync: (fn) => fn(),
   };
   if (storage.setAlarm) {
     withSql.setAlarm = (time) => storage.setAlarm?.(time) ?? Promise.resolve();
@@ -101,6 +104,32 @@ export class InMemoryCloudflareDurableObjectStorage
       releaseTransaction();
     }
   }
+
+  transactionSync<T>(fn: () => T): T {
+    const previousValues = cloneMap(this.#values);
+    const previousAlarmTime = this.#alarmTime;
+    const sql = this.sql;
+
+    if (isTransactionalSyncSqlStorage(sql)) {
+      return sql.transactionSync(() => {
+        try {
+          return fn();
+        } catch (error) {
+          this.#values = previousValues;
+          this.#alarmTime = previousAlarmTime;
+          throw error;
+        }
+      });
+    }
+
+    try {
+      return fn();
+    } catch (error) {
+      this.#values = previousValues;
+      this.#alarmTime = previousAlarmTime;
+      throw error;
+    }
+  }
 }
 
 class TransactionalCloudflareStorage
@@ -156,6 +185,10 @@ interface TransactionalSqlStorage extends SqlStorage {
   transaction<T>(fn: () => Promise<T>): Promise<T>;
 }
 
+interface TransactionalSyncSqlStorage extends SqlStorage {
+  transactionSync<T>(fn: () => T): T;
+}
+
 async function runSqlTransaction<T>(
   sql: unknown,
   fn: () => Promise<T>
@@ -164,19 +197,7 @@ async function runSqlTransaction<T>(
     return await sql.transaction(fn);
   }
 
-  if (!isSqlStorage(sql)) {
-    return await fn();
-  }
-
-  sql.exec("BEGIN");
-  try {
-    const result = await fn();
-    sql.exec("COMMIT");
-    return result;
-  } catch (error) {
-    sql.exec("ROLLBACK");
-    throw error;
-  }
+  return await fn();
 }
 
 function isTransactionalSqlStorage(
@@ -186,6 +207,16 @@ function isTransactionalSqlStorage(
     isSqlStorage(value) &&
     "transaction" in value &&
     typeof value.transaction === "function"
+  );
+}
+
+function isTransactionalSyncSqlStorage(
+  value: unknown
+): value is TransactionalSyncSqlStorage {
+  return (
+    isSqlStorage(value) &&
+    "transactionSync" in value &&
+    typeof value.transactionSync === "function"
   );
 }
 

--- a/packages/runtime/src/platform/cloudflare/storage/payload-guard.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/payload-guard.ts
@@ -8,6 +8,7 @@ export type StoragePayloadKind =
   | "event"
   | "notification-record"
   | "run-record"
+  | "thread-compaction"
   | "thread-message"
   | "thread-state";
 

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql.ts
@@ -1,3 +1,4 @@
+import type { ThreadCompactionRecord } from "../../../../thread/state/snapshot";
 import type { SqlStorage } from "../../sql/ports/storage-port";
 import { storeKey } from "../execution/records";
 import {
@@ -21,6 +22,13 @@ export interface ThreadMessageRow {
   readonly seq: number;
 }
 
+export interface StoredThreadCompactionRecord {
+  readonly endSeqExclusive: number;
+  readonly schemaVersion: 1;
+  readonly startSeq: number;
+  readonly summary: unknown;
+}
+
 interface RawThreadMessageRow {
   readonly message: string;
   readonly seq: number;
@@ -35,6 +43,13 @@ interface ThreadMessageChunkRow {
 interface ThreadMessageChunkMarker {
   readonly kind: "legacy-json" | "raw-prefix";
   readonly n: number;
+}
+
+export interface SerializedThreadCompactionRow {
+  readonly endSeqExclusive: number;
+  readonly ordinal: number;
+  readonly startSeq: number;
+  readonly summary: string;
 }
 
 interface WriteHistoryRowsOptions {
@@ -62,6 +77,12 @@ export function ensureThreadSchema(sql: SqlStorage): void {
   );
   sql.exec(
     "CREATE TABLE IF NOT EXISTS pss_thread_message_chunk (thread_key TEXT NOT NULL, seq INTEGER NOT NULL, chunk_index INTEGER NOT NULL, chunk TEXT NOT NULL, PRIMARY KEY (thread_key, seq, chunk_index))"
+  );
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS pss_thread_compaction (thread_key TEXT NOT NULL, ordinal INTEGER NOT NULL, start_seq INTEGER NOT NULL, end_seq_exclusive INTEGER NOT NULL, summary TEXT NOT NULL, PRIMARY KEY (thread_key, ordinal))"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_thread_compaction_range ON pss_thread_compaction (thread_key, start_seq, end_seq_exclusive)"
   );
 }
 
@@ -187,6 +208,70 @@ export function softDeleteActiveThreadRows(sql: SqlStorage, key: string): void {
   );
 }
 
+export function readThreadCompactions(
+  sql: SqlStorage,
+  key: string
+): StoredThreadCompactionRecord[] {
+  const rows = sql
+    .exec<{
+      end_seq_exclusive: number;
+      start_seq: number;
+      summary: string;
+    }>(
+      "SELECT start_seq, end_seq_exclusive, summary FROM pss_thread_compaction WHERE thread_key = ? ORDER BY ordinal",
+      key
+    )
+    .toArray();
+
+  return rows.map((row) => {
+    const summary: unknown = JSON.parse(row.summary);
+    return {
+      endSeqExclusive: row.end_seq_exclusive,
+      schemaVersion: 1,
+      startSeq: row.start_seq,
+      summary,
+    };
+  });
+}
+
+export function serializeThreadCompactions(
+  compactions: readonly ThreadCompactionRecord[],
+  maxPayloadBytes: number
+): SerializedThreadCompactionRow[] {
+  return compactions.map((record, ordinal) => ({
+    endSeqExclusive: record.endSeqExclusive,
+    ordinal,
+    startSeq: record.startSeq,
+    summary: stringifyJsonPayloadWithinBudget(
+      "thread-compaction",
+      record.summary,
+      maxPayloadBytes
+    ),
+  }));
+}
+
+export function writeThreadCompactions(
+  sql: SqlStorage,
+  key: string,
+  rows: readonly SerializedThreadCompactionRow[]
+): void {
+  deleteThreadCompactions(sql, key);
+  for (const row of rows) {
+    sql.exec(
+      "INSERT INTO pss_thread_compaction (thread_key, ordinal, start_seq, end_seq_exclusive, summary) VALUES (?, ?, ?, ?, ?)",
+      key,
+      row.ordinal,
+      row.startSeq,
+      row.endSeqExclusive,
+      row.summary
+    );
+  }
+}
+
+export function deleteThreadCompactions(sql: SqlStorage, key: string): void {
+  sql.exec("DELETE FROM pss_thread_compaction WHERE thread_key = ?", key);
+}
+
 export function writeThreadMeta(
   sql: SqlStorage,
   key: string,
@@ -203,6 +288,7 @@ export function writeThreadMeta(
 }
 
 export function deleteThreadRows(sql: SqlStorage, key: string): void {
+  deleteThreadCompactions(sql, key);
   sql.exec("DELETE FROM pss_thread_message_chunk WHERE thread_key = ?", key);
   sql.exec("DELETE FROM pss_thread_message WHERE thread_key = ?", key);
   sql.exec("DELETE FROM pss_thread_meta WHERE thread_key = ?", key);

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.test-support.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.test-support.ts
@@ -18,6 +18,13 @@ interface MessageChunkRowProbe {
   readonly seq: number;
 }
 
+interface CompactionRowProbe {
+  readonly end_seq_exclusive: number;
+  readonly ordinal: number;
+  readonly start_seq: number;
+  readonly summary: string;
+}
+
 export function createStore(
   options: { readonly maxPayloadBytes?: number } = {}
 ): {
@@ -59,6 +66,18 @@ export function readChunkRows(
   return (storage.sql as InMemorySqlStorage)
     .exec<MessageChunkRowProbe>(
       "SELECT seq, chunk_index, chunk FROM pss_thread_message_chunk WHERE thread_key = ? ORDER BY seq, chunk_index",
+      storeKey(PREFIX, "thread", threadKey)
+    )
+    .toArray();
+}
+
+export function readCompactionRows(
+  storage: InMemoryCloudflareDurableObjectStorage,
+  threadKey: string
+): CompactionRowProbe[] {
+  return (storage.sql as InMemorySqlStorage)
+    .exec<CompactionRowProbe>(
+      "SELECT ordinal, start_seq, end_seq_exclusive, summary FROM pss_thread_compaction WHERE thread_key = ? ORDER BY ordinal",
       storeKey(PREFIX, "thread", threadKey)
     )
     .toArray();

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.test.ts
@@ -9,6 +9,7 @@ import {
   PREFIX,
   REQUIRES_SQLITE,
   readChunkRows,
+  readCompactionRows,
   readRows,
   snapshot,
 } from "./thread-store.test-support";
@@ -53,6 +54,120 @@ describe("DurableObjectSqliteThreadStore", () => {
       { expectedVersion: "1" }
     );
     expect(second).toEqual({ ok: true, version: "2" });
+  });
+
+  it("stores v2 compactions in rows while preserving full message rows", async () => {
+    const { storage, store } = createStore();
+    const fullHistory = [
+      { content: "old", role: "user" },
+      { content: "answer", role: "assistant" },
+      { content: "tail", role: "user" },
+    ];
+
+    await expect(
+      store.commit(
+        "compact",
+        {
+          state: {
+            compactions: [
+              {
+                endSeqExclusive: 2,
+                schemaVersion: 1,
+                startSeq: 0,
+                summary: { content: "old summary", role: "system" },
+              },
+            ],
+            history: fullHistory,
+            schemaVersion: 2,
+          },
+        },
+        { expectedVersion: null }
+      )
+    ).resolves.toEqual({ ok: true, version: "1" });
+
+    expect(readRows(storage, "compact")).toHaveLength(3);
+    expect(readCompactionRows(storage, "compact")).toEqual([
+      {
+        end_seq_exclusive: 2,
+        ordinal: 0,
+        start_seq: 0,
+        summary: JSON.stringify({ content: "old summary", role: "system" }),
+      },
+    ]);
+    await expect(store.load("compact")).resolves.toEqual({
+      state: {
+        compactions: [
+          {
+            endSeqExclusive: 2,
+            schemaVersion: 1,
+            startSeq: 0,
+            summary: { content: "old summary", role: "system" },
+          },
+        ],
+        history: fullHistory,
+        schemaVersion: 2,
+      },
+      version: "1",
+    });
+  });
+
+  it("keeps the previous durable rows when compaction payload validation rejects", async () => {
+    const { storage, store } = createStore({ maxPayloadBytes: 120 });
+    const initialHistory = [
+      { content: "old", role: "user" },
+      { content: "answer", role: "assistant" },
+    ];
+
+    await expect(
+      store.commit("compact-too-large", snapshot(initialHistory), {
+        expectedVersion: null,
+      })
+    ).resolves.toEqual({ ok: true, version: "1" });
+
+    await expect(
+      store.commit(
+        "compact-too-large",
+        {
+          state: {
+            compactions: [
+              {
+                endSeqExclusive: 2,
+                schemaVersion: 1,
+                startSeq: 0,
+                summary: {
+                  content: "x".repeat(180),
+                  role: "system",
+                },
+              },
+            ],
+            history: [...initialHistory, { content: "tail", role: "user" }],
+            schemaVersion: 2,
+          },
+        },
+        { expectedVersion: "1" }
+      )
+    ).rejects.toMatchObject({
+      maxBytes: 120,
+      payloadKind: "thread-compaction",
+    });
+
+    expect(readRows(storage, "compact-too-large")).toEqual([
+      {
+        active: 1,
+        message: JSON.stringify(initialHistory[0]),
+        seq: 0,
+      },
+      {
+        active: 1,
+        message: JSON.stringify(initialHistory[1]),
+        seq: 1,
+      },
+    ]);
+    expect(readCompactionRows(storage, "compact-too-large")).toEqual([]);
+    await expect(store.load("compact-too-large")).resolves.toEqual({
+      state: { history: initialHistory, schemaVersion: 1 },
+      version: "1",
+    });
   });
 
   it("appends only the new messages (delta-append, unchanged prefix kept)", async () => {

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.ts
@@ -5,6 +5,7 @@ import type {
   ThreadStore,
   ThreadStoreCommit,
 } from "../../../../index";
+import { isAgentThreadSnapshot } from "../../../../thread/state/snapshot";
 import type { SqlStorage } from "../../sql/ports/storage-port";
 import type { CloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
 import {
@@ -13,20 +14,19 @@ import {
   stringifyJsonPayloadWithinBudget,
 } from "../payload-guard";
 import {
+  deleteThreadCompactions,
   deleteThreadRows,
   ensureThreadSchema,
   readActiveThreadMessages,
+  readThreadCompactions,
   readThreadMeta,
+  serializeThreadCompactions,
   softDeleteActiveThreadRows,
   threadRowKey,
+  writeThreadCompactions,
   writeThreadHistoryRows,
   writeThreadMeta,
 } from "./thread-store-sql";
-
-interface ThreadSnapshotV1 {
-  readonly history: unknown[];
-  readonly schemaVersion: 1;
-}
 
 /**
  * Append-only thread store for SQLite-backed Durable Objects.
@@ -44,7 +44,9 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
   readonly #maxPayloadBytes: number;
   readonly #prefix: string;
   readonly #sql: SqlStorage;
+  readonly #transaction: <T>(operation: () => T) => Promise<T>;
   #schemaReady = false;
+  #writeQueue: Promise<void> = Promise.resolve();
 
   constructor(
     storage: CloudflareDurableObjectStorage,
@@ -60,9 +62,10 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
     this.#maxPayloadBytes = resolveStoragePayloadMaxBytes(options);
     this.#prefix = prefix;
     this.#sql = sql;
+    this.#transaction = createStorageTransaction(storage, sql);
   }
 
-  commit(
+  async commit(
     threadKey: string,
     next: ThreadStoreCommit,
     options: { readonly expectedVersion: ExpectedThreadVersion }
@@ -71,58 +74,80 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
       this.#ensureSchema();
       const key = this.#rowKey(threadKey);
 
-      // --- begin synchronous read-modify-write critical section (no await) ---
-      const meta = readThreadMeta(this.#sql, key);
-      const currentVersion = meta ? meta.version : null;
-      if (options.expectedVersion !== currentVersion) {
-        return Promise.resolve({ ok: false, reason: "conflict" });
-      }
+      const prepared = isAgentThreadSnapshot(next.state)
+        ? {
+            kind: "snapshot" as const,
+            compactions: serializeThreadCompactions(
+              next.state.schemaVersion === 2 ? next.state.compactions : [],
+              this.#maxPayloadBytes
+            ),
+            state: next.state,
+          }
+        : {
+            kind: "opaque" as const,
+            stateBlob: stringifyJsonPayloadWithinBudget(
+              "thread-state",
+              next.state ?? null,
+              this.#maxPayloadBytes
+            ),
+          };
 
-      const version = String(versionCounter(meta?.version) + 1);
-      const nextSeqStart = meta?.next_seq ?? 0;
+      return await this.#enqueueWrite(() =>
+        this.#transaction(() => {
+          // --- begin synchronous read-modify-write critical section (no await) ---
+          const meta = readThreadMeta(this.#sql, key);
+          const currentVersion = meta ? meta.version : null;
+          if (options.expectedVersion !== currentVersion) {
+            return { ok: false, reason: "conflict" };
+          }
 
-      if (isSnapshotV1(next.state)) {
-        const nextSeq = writeThreadHistoryRows({
-          history: next.state.history,
-          key,
-          maxPayloadBytes: this.#maxPayloadBytes,
-          meta,
-          nextSeqStart,
-          sql: this.#sql,
-        });
-        writeThreadMeta(this.#sql, key, {
-          message_count: next.state.history.length,
-          next_seq: nextSeq,
-          state_blob: null,
-          version,
-        });
-      } else {
-        const stateBlob = stringifyJsonPayloadWithinBudget(
-          "thread-state",
-          next.state ?? null,
-          this.#maxPayloadBytes
-        );
-        softDeleteActiveThreadRows(this.#sql, key);
-        writeThreadMeta(this.#sql, key, {
-          message_count: 0,
-          next_seq: nextSeqStart,
-          state_blob: stateBlob,
-          version,
-        });
-      }
-      // --- end critical section ---
+          const version = String(versionCounter(meta?.version) + 1);
+          const nextSeqStart = meta?.next_seq ?? 0;
 
-      return Promise.resolve({ ok: true, version });
+          if (prepared.kind === "snapshot") {
+            const nextSeq = writeThreadHistoryRows({
+              history: prepared.state.history,
+              key,
+              maxPayloadBytes: this.#maxPayloadBytes,
+              meta,
+              nextSeqStart,
+              sql: this.#sql,
+            });
+            writeThreadCompactions(this.#sql, key, prepared.compactions);
+            writeThreadMeta(this.#sql, key, {
+              message_count: prepared.state.history.length,
+              next_seq: nextSeq,
+              state_blob: null,
+              version,
+            });
+          } else {
+            softDeleteActiveThreadRows(this.#sql, key);
+            deleteThreadCompactions(this.#sql, key);
+            writeThreadMeta(this.#sql, key, {
+              message_count: 0,
+              next_seq: nextSeqStart,
+              state_blob: prepared.stateBlob,
+              version,
+            });
+          }
+          // --- end critical section ---
+
+          return { ok: true, version };
+        })
+      );
     } catch (error) {
       return Promise.reject(error);
     }
   }
 
-  delete(threadKey: string): Promise<void> {
+  async delete(threadKey: string): Promise<void> {
     this.#ensureSchema();
     const key = this.#rowKey(threadKey);
-    deleteThreadRows(this.#sql, key);
-    return Promise.resolve();
+    await this.#enqueueWrite(() =>
+      this.#transaction(() => {
+        deleteThreadRows(this.#sql, key);
+      })
+    );
   }
 
   load(threadKey: string): Promise<StoredThread | null> {
@@ -141,6 +166,13 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
     const history: unknown[] = readActiveThreadMessages(this.#sql, key).map(
       (row) => JSON.parse(row.message)
     );
+    const compactions = readThreadCompactions(this.#sql, key);
+    if (compactions.length > 0) {
+      return Promise.resolve({
+        state: { compactions, history, schemaVersion: 2 },
+        version,
+      });
+    }
     return Promise.resolve({ state: { history, schemaVersion: 1 }, version });
   }
 
@@ -155,6 +187,15 @@ export class DurableObjectSqliteThreadStore implements ThreadStore {
     ensureThreadSchema(this.#sql);
     this.#schemaReady = true;
   }
+
+  #enqueueWrite<T>(operation: () => Promise<T>): Promise<T> {
+    const next = this.#writeQueue.then(operation, operation);
+    this.#writeQueue = next.then(
+      () => undefined,
+      () => undefined
+    );
+    return next;
+  }
 }
 
 function versionCounter(version: string | undefined): number {
@@ -162,13 +203,27 @@ function versionCounter(version: string | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function isSnapshotV1(value: unknown): value is ThreadSnapshotV1 {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "schemaVersion" in value &&
-    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
-    "history" in value &&
-    Array.isArray((value as { history?: unknown }).history)
+function createStorageTransaction(
+  storage: CloudflareDurableObjectStorage,
+  sql: SqlStorage
+): <T>(operation: () => T) => Promise<T> {
+  const transactionSync = storage.transactionSync?.bind(storage);
+  if (transactionSync) {
+    return <T>(operation: () => T) =>
+      Promise.resolve(transactionSync(operation));
+  }
+
+  const transaction = storage.transaction?.bind(storage);
+  if (transaction) {
+    return <T>(operation: () => T) => transaction(async () => operation());
+  }
+
+  const sqlTransaction = sql.transaction?.bind(sql);
+  if (sqlTransaction) {
+    return <T>(operation: () => T) => sqlTransaction(async () => operation());
+  }
+
+  throw new Error(
+    "DurableObjectSqliteThreadStore requires Cloudflare Durable Object storage transaction support."
   );
 }

--- a/packages/runtime/src/thread/handle/automatic-compaction-policy.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction-policy.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "../../agent/core/agent";
+import {
+  assistantMessage,
+  createCallbackModel,
+  createDeferred,
+  userText,
+} from "../../testing/test-fixtures";
+import { userTextToModelMessage } from "../protocol/mapping";
+import {
+  agentWithAutoCompaction,
+  nextMacrotask,
+  storedAssistantText,
+} from "./automatic-compaction.test-support";
+import { collect, SpyStore } from "./test-support";
+import { AgentThread } from "./thread";
+
+const minMessagesError = /autoCompaction\.minMessages/;
+const retainMessagesError = /autoCompaction\.retainMessages/;
+
+describe("Agent thread automatic compaction policy", () => {
+  it("is disabled by default", async () => {
+    const store = new SpyStore();
+    let calls = 0;
+    const agent = new Agent({
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(() => {
+        calls += 1;
+        return [assistantMessage(`DONE ${calls}`)];
+      }),
+    });
+    const thread = agent.thread("default-disabled");
+
+    await collect(await thread.send("old"));
+    await collect(await thread.send("next"));
+
+    expect(calls).toBe(2);
+    expect(store.threads.get("default-disabled")?.state).toEqual({
+      history: [
+        userTextToModelMessage(userText("old")),
+        storedAssistantText("DONE 1"),
+        userTextToModelMessage(userText("next")),
+        storedAssistantText("DONE 2"),
+      ],
+      schemaVersion: 1,
+    });
+  });
+
+  it("skips automatic compaction while history is below the threshold", async () => {
+    const store = new SpyStore();
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 8, retainMessages: 1 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(() => {
+        calls += 1;
+        return [assistantMessage("DONE")];
+      }),
+    });
+
+    await collect(await agent.thread("below-threshold").send("small"));
+
+    expect(calls).toBe(1);
+    expect(store.threads.get("below-threshold")?.state).toEqual({
+      history: [
+        userTextToModelMessage(userText("small")),
+        storedAssistantText("DONE"),
+      ],
+      schemaVersion: 1,
+    });
+  });
+
+  it("rejects malformed automatic compaction thresholds during AgentOptions validation", () => {
+    const model = createCallbackModel(() => [assistantMessage("unused")]);
+
+    for (const minMessages of [
+      0,
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      expect(() =>
+        agentWithAutoCompaction({
+          autoCompaction: { minMessages, retainMessages: 1 },
+          model,
+        })
+      ).toThrow(minMessagesError);
+    }
+
+    expect(() =>
+      agentWithAutoCompaction({
+        autoCompaction: { minMessages: 2, retainMessages: 2 },
+        model,
+      })
+    ).toThrow(retainMessagesError);
+  });
+
+  it("does not schedule automatic compaction for notify-only turns", async () => {
+    const store = new SpyStore();
+    const summaryStarted = createDeferred();
+    let calls = 0;
+    const thread = new AgentThread(
+      {
+        model: createCallbackModel(() => {
+          calls += 1;
+          if (calls === 1) {
+            return [assistantMessage("first notification done")];
+          }
+          if (calls === 2) {
+            return [assistantMessage("second notification done")];
+          }
+          summaryStarted.resolve();
+          return [assistantMessage("unexpected notify summary")];
+        }),
+      },
+      { key: "notify-only-auto-skip", store },
+      [],
+      { autoCompaction: { minMessages: 4, retainMessages: 2 } }
+    );
+
+    await collect(await thread.notify("first notification"));
+    await collect(await thread.notify("second notification"));
+
+    const result = await Promise.race([
+      summaryStarted.promise.then(() => "summary-started" as const),
+      nextMacrotask().then(() => "idle" as const),
+    ]);
+
+    expect(result).toBe("idle");
+    expect(calls).toBe(2);
+    expect(store.threads.get("notify-only-auto-skip")?.state).toEqual({
+      history: [
+        userTextToModelMessage(userText("first notification")),
+        storedAssistantText("first notification done"),
+        userTextToModelMessage(userText("second notification")),
+        storedAssistantText("second notification done"),
+      ],
+      schemaVersion: 1,
+    });
+  });
+});

--- a/packages/runtime/src/thread/handle/automatic-compaction-resilience.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction-resilience.test.ts
@@ -1,0 +1,259 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  assistantMessage,
+  createCallbackModel,
+  createDeferred,
+  createScriptedModelOptions,
+  eventTypes,
+  toolCallPart,
+  toolResultFor,
+  userText,
+} from "../../testing/test-fixtures";
+import { userTextToModelMessage } from "../protocol/mapping";
+import {
+  agentWithAutoCompaction,
+  storedAssistantText,
+  waitForModelCalls,
+} from "./automatic-compaction.test-support";
+import {
+  ConflictOnCommitStore,
+  collect,
+  RejectOnCompactionCommitStore,
+  SpyStore,
+} from "./test-support";
+
+describe("Agent thread automatic compaction resilience", () => {
+  it("preserves latest tail and tool-call/tool-result adjacency when choosing the compacted range", async () => {
+    const store = new SpyStore();
+    const toolCall = toolCallPart("call-1", "lookup", { query: "old" });
+    const model = createScriptedModelOptions([
+      [assistantMessage([toolCall]), toolResultFor(toolCall)],
+      [assistantMessage("tool turn complete")],
+      [assistantMessage("follow-up complete")],
+      [assistantMessage("tool turn summarized")],
+      [assistantMessage("after summary complete")],
+    ]);
+    const agent = agentWithAutoCompaction({
+      ...model,
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      host: { kind: "thread", threadStore: store },
+    });
+    const thread = agent.thread("tool-tail");
+
+    await collect(await thread.send("start"));
+    await waitForModelCalls(() => model.model.doGenerateCalls.length, 2);
+    expect(store.threads.get("tool-tail")?.state).not.toHaveProperty(
+      "compactions"
+    );
+
+    await collect(await thread.send("follow-up"));
+    await waitForModelCalls(() => model.model.doGenerateCalls.length, 4);
+
+    expect(store.threads.get("tool-tail")?.state).toMatchObject({
+      compactions: [
+        {
+          endSeqExclusive: 4,
+          schemaVersion: 1,
+          startSeq: 0,
+          summary: { content: "tool turn summarized", role: "system" },
+        },
+      ],
+      schemaVersion: 2,
+    });
+
+    await collect(await thread.send("after-summary"));
+
+    const followUpCall = model.model.doGenerateCalls.at(-1);
+    expect(JSON.stringify(followUpCall)).toContain("tool turn summarized");
+    expect(JSON.stringify(followUpCall)).toContain("follow-up");
+    expect(JSON.stringify(followUpCall)).toContain("after-summary");
+  });
+
+  it("does not surface summary failures as turn errors or corrupt stored history", async () => {
+    const store = new SpyStore();
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(() => {
+        calls += 1;
+        if (calls === 1) {
+          return [assistantMessage("FIRST")];
+        }
+        if (calls === 2) {
+          return [assistantMessage("SECOND")];
+        }
+        throw new Error("summary failed");
+      }),
+    });
+    const thread = agent.thread("summary-fails");
+
+    await collect(await thread.send("old"));
+    const events = await collect(await thread.send("tail"));
+
+    expect(eventTypes(events)).not.toContain("turn-error");
+    await waitForModelCalls(() => calls, 3);
+    expect(store.threads.get("summary-fails")?.state).toEqual({
+      history: [
+        userTextToModelMessage(userText("old")),
+        storedAssistantText("FIRST"),
+        userTextToModelMessage(userText("tail")),
+        storedAssistantText("SECOND"),
+      ],
+      schemaVersion: 1,
+    });
+  });
+
+  it("does not surface compaction commit conflicts as turn errors or corrupt stored history", async () => {
+    const store = new ConflictOnCommitStore();
+    store.conflictOnCommit = 5;
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        calls += 1;
+        if (calls === 1) {
+          return [assistantMessage("FIRST")];
+        }
+        if (calls === 2) {
+          return [assistantMessage("SECOND")];
+        }
+        if (calls === 3) {
+          return [assistantMessage("summary loses conflict")];
+        }
+        return [assistantMessage("RECOVERED")];
+      }),
+    });
+    const thread = agent.thread("summary-conflict");
+
+    await collect(await thread.send("old"));
+    const events = await collect(await thread.send("tail"));
+
+    expect(eventTypes(events)).not.toContain("turn-error");
+    await waitForModelCalls(() => calls, 3);
+    expect(store.threads.get("summary-conflict")?.state).toEqual({
+      history: [
+        userTextToModelMessage(userText("old")),
+        storedAssistantText("FIRST"),
+        userTextToModelMessage(userText("tail")),
+        storedAssistantText("SECOND"),
+      ],
+      schemaVersion: 1,
+    });
+
+    await collect(await thread.send("after conflict"));
+
+    expect(seenHistory.at(-1)).toEqual([
+      userTextToModelMessage(userText("old")),
+      assistantMessage("FIRST"),
+      userTextToModelMessage(userText("tail")),
+      assistantMessage("SECOND"),
+      userTextToModelMessage(userText("after conflict")),
+    ]);
+  });
+
+  it("rolls back in-memory compaction state when compaction commit throws", async () => {
+    const store = new RejectOnCompactionCommitStore();
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        calls += 1;
+        if (calls === 1) {
+          return [assistantMessage("FIRST")];
+        }
+        if (calls === 2) {
+          return [assistantMessage("SECOND")];
+        }
+        if (calls === 3) {
+          return [assistantMessage("summary fails to commit")];
+        }
+        return [assistantMessage("AFTER FAILURE")];
+      }),
+    });
+    const thread = agent.thread("summary-rejected");
+
+    await collect(await thread.send("old"));
+    await collect(await thread.send("tail"));
+    await waitForModelCalls(() => calls, 3);
+
+    await collect(await thread.send("after failure"));
+
+    expect(seenHistory.at(-1)).toContainEqual(
+      userTextToModelMessage(userText("after failure"))
+    );
+    expect(store.threads.get("summary-rejected")?.state).toMatchObject({
+      history: [
+        userTextToModelMessage(userText("old")),
+        storedAssistantText("FIRST"),
+        userTextToModelMessage(userText("tail")),
+        storedAssistantText("SECOND"),
+        userTextToModelMessage(userText("after failure")),
+        storedAssistantText("AFTER FAILURE"),
+      ],
+      schemaVersion: 1,
+    });
+  });
+
+  it("does not let stale background summaries override a newer compactable range", async () => {
+    const store = new SpyStore();
+    const staleSummaryStarted = createDeferred();
+    const staleSummaryRelease = createDeferred();
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(async () => {
+        calls += 1;
+        if (calls === 1) {
+          return [assistantMessage("FIRST")];
+        }
+        if (calls === 2) {
+          return [assistantMessage("SECOND")];
+        }
+        if (calls === 3) {
+          staleSummaryStarted.resolve();
+          await staleSummaryRelease.promise;
+          return [assistantMessage("STALE SUMMARY")];
+        }
+        if (calls === 4) {
+          return [assistantMessage("THIRD")];
+        }
+        return [assistantMessage("FRESH BROADER SUMMARY")];
+      }),
+    });
+    const thread = agent.thread("stale-background-summary");
+
+    await collect(await thread.send("old"));
+    await collect(await thread.send("middle"));
+    await staleSummaryStarted.promise;
+    await collect(await thread.send("tail"));
+    staleSummaryRelease.resolve();
+    await waitForModelCalls(() => calls, 5);
+
+    expect(store.threads.get("stale-background-summary")?.state).toMatchObject({
+      compactions: [
+        {
+          endSeqExclusive: 4,
+          schemaVersion: 1,
+          startSeq: 0,
+          summary: {
+            content: "FRESH BROADER SUMMARY",
+            role: "system",
+          },
+        },
+      ],
+      schemaVersion: 2,
+    });
+    expect(
+      JSON.stringify(store.threads.get("stale-background-summary")?.state)
+    ).not.toContain("STALE SUMMARY");
+  });
+});

--- a/packages/runtime/src/thread/handle/automatic-compaction.test-support.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction.test-support.ts
@@ -1,0 +1,38 @@
+import type { ModelMessage } from "ai";
+import { expect, vi } from "vitest";
+import { Agent } from "../../agent/core/agent";
+
+export interface AutoCompactionConfig {
+  readonly minMessages: number;
+  readonly retainMessages: number;
+}
+
+export type AutoCompactionAgentOptions = ConstructorParameters<
+  typeof Agent
+>[0] & {
+  readonly autoCompaction?: AutoCompactionConfig;
+};
+
+export const agentWithAutoCompaction = (
+  options: AutoCompactionAgentOptions
+): Agent => new Agent(options);
+
+export const storedAssistantText = (text: string): ModelMessage => ({
+  content: [{ providerOptions: undefined, text, type: "text" }],
+  role: "assistant",
+});
+
+export const waitForModelCalls = async (
+  calls: () => number,
+  expected: number
+): Promise<void> => {
+  await vi.waitFor(() => expect(calls()).toBeGreaterThanOrEqual(expected), {
+    interval: 5,
+    timeout: 200,
+  });
+};
+
+export const nextMacrotask = (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });

--- a/packages/runtime/src/thread/handle/automatic-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction.test.ts
@@ -1,0 +1,173 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createStore,
+  readCompactionRows,
+  readRows,
+} from "../../platform/cloudflare/storage/sqlite/thread-store.test-support";
+import {
+  assistantMessage,
+  createCallbackModel,
+  createDeferred,
+  eventTypes,
+  userText,
+} from "../../testing/test-fixtures";
+import { userTextToModelMessage } from "../protocol/mapping";
+import {
+  agentWithAutoCompaction,
+  storedAssistantText,
+  waitForModelCalls,
+} from "./automatic-compaction.test-support";
+import { collect, SpyStore } from "./test-support";
+
+describe("Agent thread automatic compaction", () => {
+  it("summarizes old history in the background and uses the summary plus latest tail on the next model call", async () => {
+    const store = new SpyStore();
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        calls += 1;
+        if (calls === 1) {
+          return [assistantMessage("old done")];
+        }
+        if (calls === 2) {
+          return [assistantMessage("tail done")];
+        }
+        if (calls === 3) {
+          return [assistantMessage("old exchange summarized")];
+        }
+        return [assistantMessage("after compaction")];
+      }),
+    });
+    const thread = agent.thread("auto");
+
+    await collect(await thread.send("old"));
+    await collect(await thread.send("tail"));
+    await waitForModelCalls(() => calls, 3);
+
+    expect(store.threads.get("auto")?.state).toEqual({
+      compactions: [
+        {
+          endSeqExclusive: 2,
+          schemaVersion: 1,
+          startSeq: 0,
+          summary: { content: "old exchange summarized", role: "system" },
+        },
+      ],
+      history: [
+        userTextToModelMessage(userText("old")),
+        storedAssistantText("old done"),
+        userTextToModelMessage(userText("tail")),
+        storedAssistantText("tail done"),
+      ],
+      schemaVersion: 2,
+    });
+
+    await collect(await thread.send("next"));
+
+    expect(seenHistory[3]).toEqual([
+      { content: "old exchange summarized", role: "system" },
+      userTextToModelMessage(userText("tail")),
+      assistantMessage("tail done"),
+      userTextToModelMessage(userText("next")),
+    ]);
+  });
+
+  it("stores automatic compaction as a SQLite compaction row", async () => {
+    const { storage, store } = createStore();
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(() => {
+        calls += 1;
+        if (calls === 1) {
+          return [assistantMessage("sqlite old done")];
+        }
+        if (calls === 2) {
+          return [assistantMessage("sqlite tail done")];
+        }
+        return [assistantMessage("sqlite summary")];
+      }),
+    });
+    const thread = agent.thread("sqlite-auto");
+
+    await collect(await thread.send("old"));
+    await collect(await thread.send("tail"));
+    await waitForModelCalls(() => calls, 3);
+
+    expect(readRows(storage, "sqlite-auto")).toHaveLength(4);
+    expect(readCompactionRows(storage, "sqlite-auto")).toEqual([
+      {
+        end_seq_exclusive: 2,
+        ordinal: 0,
+        start_seq: 0,
+        summary: JSON.stringify({
+          content: "sqlite summary",
+          role: "system",
+        }),
+      },
+    ]);
+  });
+
+  it("closes the triggering turn before the background summary finishes", async () => {
+    const store = new SpyStore();
+    const summaryStarted = createDeferred();
+    const summaryRelease = createDeferred();
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 4, retainMessages: 1 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(async () => {
+        calls += 1;
+        if (calls === 1) {
+          return [assistantMessage("first done")];
+        }
+        if (calls === 2) {
+          return [assistantMessage("second done")];
+        }
+        summaryStarted.resolve();
+        await summaryRelease.promise;
+        return [assistantMessage("first exchange summarized")];
+      }),
+    });
+    const thread = agent.thread("non-blocking-summary");
+
+    await collect(await thread.send("first"));
+    const secondEvents = await collect(await thread.send("second"));
+
+    expect(eventTypes(secondEvents)).toContain("turn-end");
+    expect(store.threads.get("non-blocking-summary")?.state).toEqual({
+      history: [
+        userTextToModelMessage(userText("first")),
+        storedAssistantText("first done"),
+        userTextToModelMessage(userText("second")),
+        storedAssistantText("second done"),
+      ],
+      schemaVersion: 1,
+    });
+
+    await summaryStarted.promise;
+    summaryRelease.resolve();
+    await vi.waitFor(() =>
+      expect(store.threads.get("non-blocking-summary")?.state).toMatchObject({
+        compactions: [
+          {
+            endSeqExclusive: 2,
+            schemaVersion: 1,
+            startSeq: 0,
+            summary: {
+              content: "first exchange summarized",
+              role: "system",
+            },
+          },
+        ],
+        schemaVersion: 2,
+      })
+    );
+  });
+});

--- a/packages/runtime/src/thread/handle/persistence.test.ts
+++ b/packages/runtime/src/thread/handle/persistence.test.ts
@@ -26,6 +26,11 @@ import {
   SpyStore,
 } from "./test-support";
 
+const storedAssistantText = (text: string): ModelMessage => ({
+  content: [{ providerOptions: undefined, text, type: "text" }],
+  role: "assistant",
+});
+
 describe("Agent thread persistence", () => {
   it("file thread store preserves image content parts across reload", async () => {
     const input = userMessage([
@@ -231,6 +236,51 @@ describe("Agent thread persistence", () => {
     expect(finalCommit?.next.state).not.toBeInstanceOf(Array);
     expect(finalCommit?.next).not.toHaveProperty("version");
     expect(store.commits[0]?.expectedVersion).toBeNull();
+  });
+
+  it("compacts model context without dropping full stored history", async () => {
+    const store = new SpyStore();
+    const seenHistory: ModelMessage[][] = [];
+    const agent = new Agent({
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([
+          assistantMessage(`DONE ${seenHistory.length}`),
+        ]);
+      }),
+    });
+    const thread = agent.thread("compact");
+
+    await collect(await thread.send("old"));
+    await thread.compact({
+      endSeqExclusive: 2,
+      startSeq: 0,
+      summary: "old exchange summarized",
+    });
+    await collect(await thread.send("tail"));
+
+    expect(seenHistory[1]).toEqual([
+      { content: "old exchange summarized", role: "system" },
+      userTextToModelMessage(userText("tail")),
+    ]);
+    expect(store.threads.get("compact")?.state).toEqual({
+      compactions: [
+        {
+          endSeqExclusive: 2,
+          schemaVersion: 1,
+          startSeq: 0,
+          summary: { content: "old exchange summarized", role: "system" },
+        },
+      ],
+      history: [
+        userTextToModelMessage(userText("old")),
+        storedAssistantText("DONE 1"),
+        userTextToModelMessage(userText("tail")),
+        storedAssistantText("DONE 2"),
+      ],
+      schemaVersion: 2,
+    });
   });
 
   it("refreshes stored state after commit conflicts so the handle can recover", async () => {

--- a/packages/runtime/src/thread/handle/test-support.ts
+++ b/packages/runtime/src/thread/handle/test-support.ts
@@ -96,3 +96,22 @@ export class ConflictOnCommitStore extends SpyStore {
     return super.commit(key, next, options);
   }
 }
+
+export class RejectOnCompactionCommitStore extends SpyStore {
+  override commit(
+    key: string,
+    next: ThreadStoreCommit,
+    options: { expectedVersion: string | null }
+  ): Promise<CommitResult> {
+    if (
+      typeof next.state === "object" &&
+      next.state !== null &&
+      "schemaVersion" in next.state &&
+      next.state.schemaVersion === 2
+    ) {
+      return Promise.reject(new Error("compaction commit failed"));
+    }
+
+    return super.commit(key, next, options);
+  }
+}

--- a/packages/runtime/src/thread/handle/thread.ts
+++ b/packages/runtime/src/thread/handle/thread.ts
@@ -22,6 +22,7 @@ import {
 import { processQueuedInput } from "../runtime/turn-processor";
 import { threadKilledError, threadTerminalError } from "../state/thread-errors";
 import {
+  type ThreadCompactionInput,
   type ThreadPersistenceOptions,
   ThreadState,
 } from "../state/thread-state";
@@ -29,6 +30,7 @@ import {
 export type { AgentInput, ThreadInput, UserInput } from "../input/input";
 export type { AgentTurn } from "../protocol/turn";
 export type { NotifyOptions } from "../runtime/notification";
+export type { ThreadCompactionInput } from "../state/thread-state";
 
 export class AgentThread {
   readonly #events: ThreadEventDispatcher;
@@ -143,6 +145,20 @@ export class AgentThread {
 
     await addSteeringInput(runtimeInput, input);
     return run;
+  }
+
+  async compact(input: ThreadCompactionInput): Promise<void> {
+    if (this.#killed || this.#deletePromise) {
+      throw threadTerminalError(this.#killed);
+    }
+
+    await this.#state.ensureLoaded();
+
+    if (this.#killed || this.#deletePromise) {
+      throw threadTerminalError(this.#killed);
+    }
+
+    await this.#state.compact(input);
   }
 
   interrupt(): void {

--- a/packages/runtime/src/thread/runtime/auto-compaction.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction.ts
@@ -1,0 +1,241 @@
+import type { ModelMessage } from "ai";
+import { generateModelStep, type ModelGenerationOptions } from "../../llm/llm";
+import { ModelMessageHistory } from "../state/history";
+import type { ThreadCompactionRecord } from "../state/snapshot";
+import type { ThreadState } from "../state/thread-state";
+
+export interface ThreadAutoCompactionOptions {
+  readonly minMessages: number;
+  readonly retainMessages: number;
+}
+
+interface AutoCompactionRange {
+  readonly endSeqExclusive: number;
+  readonly startSeq: number;
+}
+
+const activeCompactions = new WeakSet<ThreadState>();
+
+export function scheduleThreadAutoCompaction({
+  model,
+  policy,
+  state,
+}: {
+  readonly model: ModelGenerationOptions;
+  readonly policy?: ThreadAutoCompactionOptions;
+  readonly state: ThreadState;
+}): void {
+  if (!policy) {
+    return;
+  }
+
+  if (activeCompactions.has(state)) {
+    return;
+  }
+  activeCompactions.add(state);
+  queueMicrotask(() => {
+    const backgroundCompaction = compactThreadInBackground({
+      model,
+      policy,
+      state,
+    }).finally(() => {
+      activeCompactions.delete(state);
+    });
+    backgroundCompaction.catch(() => undefined);
+  });
+}
+
+async function compactThreadInBackground({
+  model,
+  policy,
+  state,
+}: {
+  readonly model: ModelGenerationOptions;
+  readonly policy: ThreadAutoCompactionOptions;
+  readonly state: ThreadState;
+}): Promise<void> {
+  try {
+    for (;;) {
+      const history = state.modelSnapshot();
+      const compactions = state.compactionSnapshot();
+      const range = selectAutoCompactionRange({
+        compactions,
+        history,
+        policy,
+      });
+      if (!range) {
+        return;
+      }
+
+      const summary = await summarizeCompactionRange({
+        history: summaryHistoryForRange({ compactions, history, range }),
+        model,
+      });
+      if (summary.length === 0) {
+        return;
+      }
+
+      const latestRange = selectAutoCompactionRange({
+        compactions: state.compactionSnapshot(),
+        history: state.modelSnapshot(),
+        policy,
+      });
+      if (!sameRange(range, latestRange)) {
+        continue;
+      }
+
+      await state.compact({ ...range, summary });
+    }
+  } catch {
+    return;
+  }
+}
+
+export function selectAutoCompactionRange({
+  compactions,
+  history,
+  policy,
+}: {
+  readonly compactions: readonly ThreadCompactionRecord[];
+  readonly history: readonly ModelMessage[];
+  readonly policy: ThreadAutoCompactionOptions;
+}): AutoCompactionRange | undefined {
+  if (history.length < policy.minMessages) {
+    return;
+  }
+
+  let endSeqExclusive = history.length - policy.retainMessages;
+  while (
+    endSeqExclusive > 0 &&
+    !isSafeCompactionBoundary(history, endSeqExclusive)
+  ) {
+    endSeqExclusive -= 1;
+  }
+
+  if (endSeqExclusive <= 0) {
+    return;
+  }
+
+  const alreadyCovered = compactions.some(
+    (record) =>
+      record.startSeq === 0 && record.endSeqExclusive >= endSeqExclusive
+  );
+  if (alreadyCovered) {
+    return;
+  }
+
+  return { endSeqExclusive, startSeq: 0 };
+}
+
+async function summarizeCompactionRange({
+  history,
+  model,
+}: {
+  readonly history: readonly ModelMessage[];
+  readonly model: ModelGenerationOptions;
+}): Promise<string> {
+  const output = await generateModelStep({
+    history: [
+      {
+        content:
+          "Summarize the following prior thread messages for future turns. Preserve durable facts, user preferences, decisions, unresolved tasks, and tool results. Be concise.",
+        role: "system",
+      },
+      ...history,
+    ],
+    instructions: model.instructions,
+    model: model.model,
+    signal: new AbortController().signal,
+  });
+  return output
+    .flatMap((message) =>
+      message.role === "assistant" ? messageContentText(message.content) : []
+    )
+    .join("\n\n")
+    .trim();
+}
+
+function summaryHistoryForRange({
+  compactions,
+  history,
+  range,
+}: {
+  readonly compactions: readonly ThreadCompactionRecord[];
+  readonly history: readonly ModelMessage[];
+  readonly range: AutoCompactionRange;
+}): ModelMessage[] {
+  const prefixHistory = history.slice(range.startSeq, range.endSeqExclusive);
+  if (range.startSeq !== 0) {
+    return prefixHistory.map((message) => structuredClone(message));
+  }
+
+  const prefixCompactions = compactions.filter(
+    (record) => record.endSeqExclusive <= range.endSeqExclusive
+  );
+  return new ModelMessageHistory(
+    prefixHistory,
+    undefined,
+    prefixCompactions
+  ).modelContextSnapshot();
+}
+
+function sameRange(
+  left: AutoCompactionRange,
+  right: AutoCompactionRange | undefined
+): boolean {
+  return (
+    right !== undefined &&
+    left.startSeq === right.startSeq &&
+    left.endSeqExclusive === right.endSeqExclusive
+  );
+}
+
+function isSafeCompactionBoundary(
+  history: readonly ModelMessage[],
+  endSeqExclusive: number
+): boolean {
+  const previous = history[endSeqExclusive - 1];
+  const next = history[endSeqExclusive];
+  if (next?.role === "tool") {
+    return false;
+  }
+  return previous?.role === "assistant" && !messageHasToolCall(previous);
+}
+
+function messageHasToolCall(message: ModelMessage | undefined): boolean {
+  if (message?.role !== "assistant") {
+    return false;
+  }
+
+  const content: unknown = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+
+  return content.some(
+    (part) => isObjectRecord(part) && part.type === "tool-call"
+  );
+}
+
+function messageContentText(content: unknown): string[] {
+  if (typeof content === "string") {
+    return [content];
+  }
+  if (!Array.isArray(content)) {
+    return [JSON.stringify(content)];
+  }
+
+  return content.flatMap((part) => {
+    if (typeof part === "string") {
+      return [part];
+    }
+    if (isObjectRecord(part) && typeof part.text === "string") {
+      return [part.text];
+    }
+    return [];
+  });
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}

--- a/packages/runtime/src/thread/runtime/execution.ts
+++ b/packages/runtime/src/thread/runtime/execution.ts
@@ -5,9 +5,11 @@ import type {
 } from "../../execution/host/types";
 import type { RuntimeToolExecutionContext } from "../../llm/llm";
 import type { ThreadState } from "../state/thread-state";
+import type { ThreadAutoCompactionOptions } from "./auto-compaction";
 import { createThreadToolExecutionContext } from "./execution-checkpoints";
 
 export interface ThreadExecutionOptions {
+  readonly autoCompaction?: ThreadAutoCompactionOptions;
   readonly executionHost?: ExecutionHost;
 }
 

--- a/packages/runtime/src/thread/runtime/turn-processor.ts
+++ b/packages/runtime/src/thread/runtime/turn-processor.ts
@@ -15,6 +15,7 @@ import type { AgentEvent } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
 import { errorMessage } from "../state/thread-errors";
 import type { ThreadState } from "../state/thread-state";
+import { scheduleThreadAutoCompaction } from "./auto-compaction";
 import { drainRuntimeInput } from "./drain";
 import type { ThreadEventDispatcher } from "./events";
 import {
@@ -125,6 +126,13 @@ export async function processQueuedInput({
       run,
       runtimeInput,
     });
+    if (result === "completed" && input) {
+      scheduleThreadAutoCompaction({
+        model,
+        policy: execution.autoCompaction,
+        state,
+      });
+    }
   } catch (error) {
     const turnError = error instanceof Error ? error : new Error(String(error));
     await executionRun?.complete(executionStatusForError(turnError));

--- a/packages/runtime/src/thread/state/history.ts
+++ b/packages/runtime/src/thread/state/history.ts
@@ -1,23 +1,56 @@
 import type { ModelMessage } from "ai";
 import type { UserInput } from "../input/input";
 import { userInputToModelMessage } from "../protocol/mapping";
+import {
+  type ThreadCompactionRecord,
+  validateThreadCompactionRecord,
+} from "./snapshot";
 
 export class ModelMessageHistory {
+  readonly #compactions: ThreadCompactionRecord[] = [];
   readonly #modelHistory: ModelMessage[] = [];
   readonly #onChange?: (snapshot: ModelMessage[]) => void;
 
   constructor(
     history?: ModelMessage[],
-    onChange?: (snapshot: ModelMessage[]) => void
+    onChange?: (snapshot: ModelMessage[]) => void,
+    compactions: readonly ThreadCompactionRecord[] = []
   ) {
     if (history) {
       this.#modelHistory = structuredClone(history);
     }
+    this.#compactions = compactions.map((record) =>
+      validateThreadCompactionRecord(record, this.#modelHistory.length)
+    );
     this.#onChange = onChange;
   }
 
   modelSnapshot(): ModelMessage[] {
     return structuredClone(this.#modelHistory);
+  }
+
+  modelContextSnapshot(
+    options: { readonly maxMessages?: number } = {}
+  ): ModelMessage[] {
+    const compacted = applyCompactions(this.#modelHistory, this.#compactions);
+    if (
+      options.maxMessages === undefined ||
+      compacted.length <= options.maxMessages
+    ) {
+      return compacted;
+    }
+    return compacted.slice(Math.max(0, compacted.length - options.maxMessages));
+  }
+
+  compactionSnapshot(): ThreadCompactionRecord[] {
+    return structuredClone(this.#compactions);
+  }
+
+  recordCompaction(record: ThreadCompactionRecord): void {
+    this.#compactions.push(
+      validateThreadCompactionRecord(record, this.#modelHistory.length)
+    );
+    this.#triggerChange();
   }
 
   appendUserInput(input: UserInput): void {
@@ -33,10 +66,76 @@ export class ModelMessageHistory {
   rollback(snapshot: ModelMessage[]): void {
     this.#modelHistory.length = 0;
     this.#modelHistory.push(...structuredClone(snapshot));
+    for (let index = this.#compactions.length - 1; index >= 0; index -= 1) {
+      const record = this.#compactions[index];
+      if (!record || record.endSeqExclusive > this.#modelHistory.length) {
+        this.#compactions.splice(index, 1);
+      }
+    }
     this.#triggerChange();
   }
 
   #triggerChange(): void {
     this.#onChange?.(this.modelSnapshot());
   }
+}
+
+function applyCompactions(
+  history: readonly ModelMessage[],
+  compactions: readonly ThreadCompactionRecord[]
+): ModelMessage[] {
+  const kept = nonOverlappedCompactions(history.length, compactions);
+  if (kept.length === 0) {
+    return history.map((message) => structuredClone(message));
+  }
+
+  const byStart = new Map<number, ThreadCompactionRecord>();
+  for (const record of kept) {
+    byStart.set(record.startSeq, record);
+  }
+
+  const output: ModelMessage[] = [];
+  for (let index = 0; index < history.length; ) {
+    const record = byStart.get(index);
+    if (record) {
+      output.push(structuredClone(record.summary));
+      index = record.endSeqExclusive;
+      continue;
+    }
+
+    const message = history[index];
+    if (message) {
+      output.push(structuredClone(message));
+    }
+    index += 1;
+  }
+  return output;
+}
+
+function nonOverlappedCompactions(
+  historyLength: number,
+  compactions: readonly ThreadCompactionRecord[]
+): ThreadCompactionRecord[] {
+  const kept: ThreadCompactionRecord[] = [];
+  for (let index = compactions.length - 1; index >= 0; index -= 1) {
+    const record = compactions[index];
+    if (!record || record.endSeqExclusive > historyLength) {
+      continue;
+    }
+    if (kept.some((keptRecord) => overlaps(record, keptRecord))) {
+      continue;
+    }
+    kept.push(record);
+  }
+  return kept.sort((left, right) => left.startSeq - right.startSeq);
+}
+
+function overlaps(
+  left: ThreadCompactionRecord,
+  right: ThreadCompactionRecord
+): boolean {
+  return (
+    left.startSeq < right.endSeqExclusive &&
+    right.startSeq < left.endSeqExclusive
+  );
 }

--- a/packages/runtime/src/thread/state/snapshot.test.ts
+++ b/packages/runtime/src/thread/state/snapshot.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { assistantMessage } from "../../testing/test-fixtures";
-import { decodeStoredThreadSnapshot, encodeThreadSnapshot } from "./snapshot";
+import { assistantMessage, userText } from "../../testing/test-fixtures";
+import { userTextToModelMessage } from "../protocol/mapping";
+import { ModelMessageHistory } from "./history";
+import {
+  decodeStoredThreadSnapshot,
+  decodeStoredThreadState,
+  encodeThreadSnapshot,
+  ThreadCompactionValidationError,
+} from "./snapshot";
 
 describe("thread snapshot", () => {
   it("encodes model continuation state as a versioned runtime snapshot", () => {
@@ -27,6 +34,118 @@ describe("thread snapshot", () => {
 
     expect(decoded).toEqual(history);
     expect(decoded).not.toBe(history);
+  });
+
+  it("encodes v2 snapshots only when compactions exist", () => {
+    const history = [
+      userTextToModelMessage(userText("old")),
+      assistantMessage("ok"),
+    ];
+    const snapshot = encodeThreadSnapshot(history, [
+      {
+        endSeqExclusive: 1,
+        schemaVersion: 1,
+        startSeq: 0,
+        summary: { content: "old turns summarized", role: "system" },
+      },
+    ]);
+
+    expect(snapshot).toEqual({
+      compactions: [
+        {
+          endSeqExclusive: 1,
+          schemaVersion: 1,
+          startSeq: 0,
+          summary: { content: "old turns summarized", role: "system" },
+        },
+      ],
+      history,
+      schemaVersion: 2,
+    });
+  });
+
+  it("decodes v2 snapshots with compacted context while preserving full history", () => {
+    const history = [
+      userTextToModelMessage(userText("old 1")),
+      assistantMessage("old 2"),
+      userTextToModelMessage(userText("tail")),
+    ];
+    const decoded = decodeStoredThreadState({
+      state: {
+        compactions: [
+          {
+            endSeqExclusive: 2,
+            schemaVersion: 1,
+            startSeq: 0,
+            summary: { content: "summary", role: "system" },
+          },
+        ],
+        history,
+        schemaVersion: 2,
+      },
+      version: "1",
+    });
+
+    expect(decoded.history).toEqual(history);
+    expect(
+      new ModelMessageHistory(
+        decoded.history,
+        undefined,
+        decoded.compactions
+      ).modelContextSnapshot()
+    ).toEqual([
+      { content: "summary", role: "system" },
+      userTextToModelMessage(userText("tail")),
+    ]);
+  });
+
+  it("prefers newer overlapping compactions in model context", () => {
+    const history = [
+      userTextToModelMessage(userText("old 1")),
+      assistantMessage("old 2"),
+      userTextToModelMessage(userText("old 3")),
+      assistantMessage("tail"),
+    ];
+    const modelHistory = new ModelMessageHistory(history, undefined, [
+      {
+        endSeqExclusive: 2,
+        schemaVersion: 1,
+        startSeq: 0,
+        summary: { content: "older summary", role: "system" },
+      },
+      {
+        endSeqExclusive: 3,
+        schemaVersion: 1,
+        startSeq: 1,
+        summary: { content: "newer summary", role: "system" },
+      },
+    ]);
+
+    expect(modelHistory.modelContextSnapshot()).toEqual([
+      userTextToModelMessage(userText("old 1")),
+      { content: "newer summary", role: "system" },
+      assistantMessage("tail"),
+    ]);
+  });
+
+  it("rejects malformed thread compaction records", () => {
+    expect(() =>
+      decodeStoredThreadState({
+        state: {
+          compactions: [
+            {
+              endSeqExclusive: 0,
+              schemaVersion: 1,
+              startSeq: 0,
+              summary: { content: "summary", role: "system" },
+            },
+          ],
+          history: [],
+          schemaVersion: 2,
+        },
+        version: "1",
+      })
+    ).toThrow(ThreadCompactionValidationError);
   });
 
   it("rejects unsupported stored thread state versions", () => {

--- a/packages/runtime/src/thread/state/snapshot.ts
+++ b/packages/runtime/src/thread/state/snapshot.ts
@@ -6,25 +6,121 @@ export interface AgentThreadSnapshotV1 {
   readonly schemaVersion: 1;
 }
 
+export interface ThreadCompactionRecord {
+  readonly endSeqExclusive: number;
+  readonly schemaVersion: 1;
+  readonly startSeq: number;
+  readonly summary: ModelMessage;
+}
+
+export interface AgentThreadSnapshotV2 {
+  readonly compactions: ThreadCompactionRecord[];
+  readonly history: ModelMessage[];
+  readonly schemaVersion: 2;
+}
+
+export type AgentThreadSnapshot = AgentThreadSnapshotV1 | AgentThreadSnapshotV2;
+
+export interface DecodedThreadState {
+  readonly compactions: ThreadCompactionRecord[];
+  readonly history: ModelMessage[];
+}
+
+export class ThreadCompactionValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ThreadCompactionValidationError";
+  }
+}
+
 export function encodeThreadSnapshot(
-  history: ModelMessage[]
-): AgentThreadSnapshotV1 {
-  return { schemaVersion: 1, history: structuredClone(history) };
+  history: ModelMessage[],
+  compactions: readonly ThreadCompactionRecord[] = []
+): AgentThreadSnapshot {
+  const clonedHistory = structuredClone(history);
+  if (compactions.length === 0) {
+    return { schemaVersion: 1, history: clonedHistory };
+  }
+
+  const clonedCompactions = compactions.map((record) =>
+    validateThreadCompactionRecord(record, clonedHistory.length)
+  );
+  return {
+    compactions: clonedCompactions,
+    history: clonedHistory,
+    schemaVersion: 2,
+  };
 }
 
 export function decodeStoredThreadSnapshot(
   stored: StoredThread | null
 ): ModelMessage[] {
+  return decodeStoredThreadState(stored).history;
+}
+
+export function decodeStoredThreadState(
+  stored: StoredThread | null
+): DecodedThreadState {
   if (!stored) {
-    return [];
+    return { compactions: [], history: [] };
   }
 
   const snapshot = stored.state;
   if (isThreadSnapshotV1(snapshot)) {
-    return structuredClone(snapshot.history);
+    return { compactions: [], history: structuredClone(snapshot.history) };
+  }
+
+  if (isThreadSnapshotV2(snapshot)) {
+    const history = structuredClone(snapshot.history);
+    const compactions = snapshot.compactions.map((record) =>
+      validateThreadCompactionRecord(record, history.length)
+    );
+    return { compactions, history };
   }
 
   throw new Error("Unsupported stored thread state");
+}
+
+export function isAgentThreadSnapshot(
+  value: unknown
+): value is AgentThreadSnapshot {
+  return isThreadSnapshotV1(value) || isThreadSnapshotV2(value);
+}
+
+export function validateThreadCompactionRecord(
+  record: ThreadCompactionRecord,
+  historyLength?: number
+): ThreadCompactionRecord {
+  if (record.schemaVersion !== 1) {
+    throw new ThreadCompactionValidationError(
+      "Unsupported thread compaction schema version"
+    );
+  }
+  if (!Number.isInteger(record.startSeq) || record.startSeq < 0) {
+    throw new ThreadCompactionValidationError(
+      "Thread compaction startSeq must be a non-negative integer"
+    );
+  }
+  if (
+    !Number.isInteger(record.endSeqExclusive) ||
+    record.endSeqExclusive <= record.startSeq
+  ) {
+    throw new ThreadCompactionValidationError(
+      "Thread compaction endSeqExclusive must be greater than startSeq"
+    );
+  }
+  if (historyLength !== undefined && record.endSeqExclusive > historyLength) {
+    throw new ThreadCompactionValidationError(
+      "Thread compaction range exceeds thread history"
+    );
+  }
+  if (!isModelMessage(record.summary)) {
+    throw new ThreadCompactionValidationError(
+      "Thread compaction summary must be a model message"
+    );
+  }
+
+  return structuredClone(record);
 }
 
 function isThreadSnapshotV1(value: unknown): value is AgentThreadSnapshotV1 {
@@ -35,5 +131,50 @@ function isThreadSnapshotV1(value: unknown): value is AgentThreadSnapshotV1 {
     value.schemaVersion === 1 &&
     "history" in value &&
     Array.isArray(value.history)
+  );
+}
+
+function isThreadSnapshotV2(value: unknown): value is AgentThreadSnapshotV2 {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "schemaVersion" in value &&
+    value.schemaVersion === 2 &&
+    "history" in value &&
+    Array.isArray(value.history) &&
+    "compactions" in value &&
+    Array.isArray(value.compactions) &&
+    value.compactions.every(isThreadCompactionRecordShape)
+  );
+}
+
+function isThreadCompactionRecordShape(
+  value: unknown
+): value is ThreadCompactionRecord {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "schemaVersion" in value &&
+    value.schemaVersion === 1 &&
+    "startSeq" in value &&
+    typeof value.startSeq === "number" &&
+    "endSeqExclusive" in value &&
+    typeof value.endSeqExclusive === "number" &&
+    "summary" in value &&
+    isModelMessage(value.summary)
+  );
+}
+
+function isModelMessage(value: unknown): value is ModelMessage {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "role" in value &&
+    typeof value.role === "string" &&
+    (value.role === "system" ||
+      value.role === "user" ||
+      value.role === "assistant" ||
+      value.role === "tool") &&
+    "content" in value
   );
 }

--- a/packages/runtime/src/thread/state/thread-state.ts
+++ b/packages/runtime/src/thread/state/thread-state.ts
@@ -1,7 +1,11 @@
 import type { ModelMessage } from "ai";
 import type { ThreadStore } from "../store/types";
 import { ModelMessageHistory } from "./history";
-import { decodeStoredThreadSnapshot, encodeThreadSnapshot } from "./snapshot";
+import {
+  decodeStoredThreadState,
+  encodeThreadSnapshot,
+  type ThreadCompactionRecord,
+} from "./snapshot";
 
 export interface ThreadPersistenceOptions {
   readonly key: string;
@@ -13,6 +17,12 @@ export interface ThreadCheckpointReference {
   readonly schemaVersion: 1;
   readonly threadKey: string;
   readonly threadVersion: string | null;
+}
+
+export interface ThreadCompactionInput {
+  readonly endSeqExclusive: number;
+  readonly startSeq: number;
+  readonly summary: string;
 }
 
 export class ThreadCommitConflictError extends Error {
@@ -61,6 +71,14 @@ export class ThreadState {
     return this.#history.modelSnapshot();
   }
 
+  modelContextSnapshot(): ModelMessage[] {
+    return this.#history.modelContextSnapshot();
+  }
+
+  compactionSnapshot(): ThreadCompactionRecord[] {
+    return this.#history.compactionSnapshot();
+  }
+
   threadCheckpointReference(): ThreadCheckpointReference {
     return {
       kind: "thread-reference",
@@ -80,12 +98,45 @@ export class ThreadState {
     this.#history.rollback(snapshot);
   }
 
+  async compact(input: ThreadCompactionInput): Promise<void> {
+    if (this.#deleteRequested || this.#deleted) {
+      return;
+    }
+
+    const previous = {
+      compactions: this.#history.compactionSnapshot(),
+      history: this.#history.modelSnapshot(),
+      storeVersion: this.#storeVersion,
+    };
+    const record: ThreadCompactionRecord = {
+      endSeqExclusive: input.endSeqExclusive,
+      schemaVersion: 1,
+      startSeq: input.startSeq,
+      summary: { content: input.summary, role: "system" },
+    };
+    this.#history.recordCompaction(record);
+    try {
+      await this.commit();
+    } catch (error) {
+      if (!(error instanceof ThreadCommitConflictError)) {
+        this.#storeVersion = previous.storeVersion;
+        this.#history = new ModelMessageHistory(
+          previous.history,
+          undefined,
+          previous.compactions
+        );
+      }
+      throw error;
+    }
+  }
+
   async commit(): Promise<void> {
     if (this.#deleteRequested || this.#deleted) {
       return;
     }
 
     const snapshot = this.#history.modelSnapshot();
+    const compactions = this.#history.compactionSnapshot();
     await this.#enqueueWrite(async () => {
       if (this.#deleteRequested || this.#deleted) {
         return;
@@ -93,7 +144,7 @@ export class ThreadState {
 
       const result = await this.#persistence.store.commit(
         this.#persistence.key,
-        { state: encodeThreadSnapshot(snapshot) },
+        { state: encodeThreadSnapshot(snapshot, compactions) },
         { expectedVersion: this.#storeVersion ?? null }
       );
 
@@ -112,6 +163,7 @@ export class ThreadState {
     }
 
     const previous = {
+      compactions: this.#history.compactionSnapshot(),
       history: this.#history.modelSnapshot(),
       loaded: this.#loaded,
       storeVersion: this.#storeVersion,
@@ -126,7 +178,11 @@ export class ThreadState {
         this.#deleteRequested = false;
         this.#loaded = previous.loaded;
         this.#storeVersion = previous.storeVersion;
-        this.#history = new ModelMessageHistory(previous.history);
+        this.#history = new ModelMessageHistory(
+          previous.history,
+          undefined,
+          previous.compactions
+        );
         throw error;
       }
 
@@ -156,6 +212,11 @@ export class ThreadState {
   async #replaceWithStoredThread(): Promise<void> {
     const stored = await this.#persistence.store.load(this.#persistence.key);
     this.#storeVersion = stored?.version;
-    this.#history = new ModelMessageHistory(decodeStoredThreadSnapshot(stored));
+    const state = decodeStoredThreadState(stored);
+    this.#history = new ModelMessageHistory(
+      state.history,
+      undefined,
+      state.compactions
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add opt-in Agent autoCompaction policy for long-running threads
- persist compaction summaries while preserving the full durable thread history
- harden Cloudflare SQLite transaction usage around thread compaction storage

## Verification
- pnpm boundaries
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm verify:release
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in automatic thread compaction to keep model context small while preserving the full durable history. Also adds a manual compaction API and persists compaction summaries in Cloudflare SQLite with transactional writes.

- **New Features**
  - `AgentOptions.autoCompaction` (validated `minMessages` and `retainMessages`); off by default.
  - Background compaction after successful user turns; non‑blocking, skips notify‑only turns, keeps tool call/result adjacency, and avoids unsafe boundaries.
  - Manual API: `ThreadHandle.compact({ startSeq, endSeqExclusive, summary })`.
  - Model context uses compacted summaries + recent tail via `modelContextSnapshot()`; full history remains durable.
  - Prompting: system history is hoisted into `instructions` for better provider compatibility.

- **Migration**
  - To enable: `new Agent({ model, autoCompaction: { minMessages, retainMessages }, ... })`.
  - Optional manual compaction: `thread.compact({ startSeq, endSeqExclusive, summary })`.
  - No breaking changes; existing threads continue as before.

<sup>Written for commit 41736e7e0cd039588e84ae2833b97611b877032a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

