### PR TITLE
Add noncanonical runtime overlays

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -29,6 +29,7 @@
     "runtime-subagents",
     "runtime-thread-key-surface",
     "runtime-turn-step-naming",
+    "runtime-user-input",
     "sqlite-event-checkpoint-stores",
     "sqlite-session-store",
     "sync-main-dependencies",

--- a/.changeset/runtime-user-input.md
+++ b/.changeset/runtime-user-input.md
@@ -1,0 +1,18 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Unify user-originated thread events as `user-input` and simplify public thread
+input to plain text, text arrays, or content-part arrays. Object-shaped
+`user-text` and `user-message` inputs are no longer part of the public
+`send()`/`steer()` surface; notification/resume internals still persist a typed
+`user-input` payload.
+
+Add noncanonical `thread.overlay(input)` for next-turn runtime context.
+Overlays accept the same input shapes as `send()`, are chainable, and enter the
+next turn as `runtime-input` before the user message rather than as another
+human `user-input` event. Overlay context is visible to the current model turn
+but is excluded from stored thread history and automatic compaction summaries.
+
+Add notification resume overlays so durable notification turns can inject fresh
+per-run context without baking that context into the canonical thread log.

--- a/apps/coding-agent/src/tui-runner.test.ts
+++ b/apps/coding-agent/src/tui-runner.test.ts
@@ -4,12 +4,12 @@ import { createTuiRunner, formatEvent } from "./tui-runner";
 
 describe("TUI runner", () => {
   it("renders runtime input distinctly from human input", () => {
-    expect(formatEvent({ text: "hello", type: "user-text" })).toBe(
+    expect(formatEvent({ text: "hello", type: "user-input" })).toBe(
       "\x1b[36myou\x1b[0m: hello"
     );
     expect(
       formatEvent({
-        input: { text: "extra", type: "user-text" },
+        input: { text: "extra", type: "user-input" },
         placement: "step-end",
         type: "runtime-input",
       })
@@ -18,7 +18,7 @@ describe("TUI runner", () => {
 
   it("starts idle submissions with thread.send and consumes the run", async () => {
     const run = createRun([
-      { text: "hello", type: "user-text" },
+      { text: "hello", type: "user-input" },
       { type: "turn-end" },
     ]);
     const thread = {
@@ -43,7 +43,7 @@ describe("TUI runner", () => {
   it("steers active submissions without sending a new turn", async () => {
     let releaseEvent: (() => void) | undefined;
     const run = createRun([
-      { text: "initial", type: "user-text" },
+      { text: "initial", type: "user-input" },
       new Promise<AgentEvent>((resolve) => {
         releaseEvent = () => resolve({ type: "turn-end" });
       }),
@@ -72,13 +72,13 @@ describe("TUI runner", () => {
   it("consumes a distinct run returned by active steering", async () => {
     let releaseActive: (() => void) | undefined;
     const activeRun = createRun([
-      { text: "initial", type: "user-text" },
+      { text: "initial", type: "user-input" },
       new Promise<AgentEvent>((resolve) => {
         releaseActive = () => resolve({ type: "turn-end" });
       }),
     ]);
     const fallbackRun = createRun([
-      { text: "fallback", type: "user-text" },
+      { text: "fallback", type: "user-input" },
       { type: "turn-end" },
     ]);
     const lines: string[] = [];
@@ -106,7 +106,7 @@ describe("TUI runner", () => {
 
   it("renders active steering errors", async () => {
     const run = createRun([
-      { text: "initial", type: "user-text" },
+      { text: "initial", type: "user-input" },
       new Promise<AgentEvent>(() => undefined),
     ]);
     const lines: string[] = [];
@@ -151,7 +151,7 @@ describe("TUI runner", () => {
     let releaseEvent: (() => void) | undefined;
     let releaseAfterTerminal: (() => void) | undefined;
     const run = createRun([
-      { text: "initial", type: "user-text" },
+      { text: "initial", type: "user-input" },
       new Promise<AgentEvent>((resolve) => {
         releaseEvent = () => resolve({ type: "turn-abort" });
       }),

--- a/apps/coding-agent/src/tui-runner.ts
+++ b/apps/coding-agent/src/tui-runner.ts
@@ -3,7 +3,6 @@ import type {
   AgentTurn,
   ThreadHandle,
   UserInput,
-  UserMessage,
   UserMessageContentPart,
   UserTextContent,
 } from "@minpeter/pss-runtime";
@@ -36,10 +35,8 @@ export const formatUserTextContent = (text: UserTextContent): string =>
 
 export const formatEvent = (event: AgentEvent): string | undefined => {
   switch (event.type) {
-    case "user-text":
-      return `\x1b[36myou\x1b[0m: ${safeText(formatUserTextContent(event.text))}`;
-    case "user-message":
-      return `\x1b[36myou\x1b[0m: ${safeText(formatUserMessageContent(event))}`;
+    case "user-input":
+      return `\x1b[36myou\x1b[0m: ${safeText(formatUserInput(event))}`;
     case "runtime-input":
       return `${dimText}runtime: ${safeText(formatRuntimeInput(event.input))}${resetText}`;
     case "assistant-text":
@@ -143,19 +140,29 @@ function errorMessage(error: unknown): string {
 }
 
 function formatRuntimeInput(input: UserInput): string {
-  if (isUserText(input)) {
+  if ("text" in input) {
     return formatUserTextContent(input.text);
   }
 
-  if (isUserMessage(input)) {
-    return formatUserMessageContent(input);
+  if ("content" in input) {
+    return formatUserMessageContent(input.content);
   }
 
   return safeInlineText(String(input));
 }
 
-function formatUserMessageContent(message: UserMessage): string {
-  return message.content.map(formatUserMessagePart).join("\n");
+function formatUserInput(input: UserInput): string {
+  if ("text" in input) {
+    return formatUserTextContent(input.text);
+  }
+
+  return formatUserMessageContent(input.content);
+}
+
+function formatUserMessageContent(
+  content: readonly UserMessageContentPart[]
+): string {
+  return content.map(formatUserMessagePart).join("\n");
 }
 
 function formatUserMessagePart(part: UserMessageContentPart): string {
@@ -176,29 +183,5 @@ function isTerminalTurnEvent(event: AgentEvent): boolean {
     event.type === "turn-end" ||
     event.type === "turn-error" ||
     event.type === "turn-abort"
-  );
-}
-
-function isUserMessage(input: unknown): input is UserMessage {
-  return (
-    typeof input === "object" &&
-    input !== null &&
-    "type" in input &&
-    input.type === "user-message" &&
-    "content" in input &&
-    Array.isArray(input.content)
-  );
-}
-
-function isUserText(
-  input: unknown
-): input is { text: UserTextContent; type: "user-text" } {
-  return (
-    typeof input === "object" &&
-    input !== null &&
-    "type" in input &&
-    input.type === "user-text" &&
-    "text" in input &&
-    (typeof input.text === "string" || Array.isArray(input.text))
   );
 }

--- a/examples/background-subagent/src/app-agent.ts
+++ b/examples/background-subagent/src/app-agent.ts
@@ -1,4 +1,4 @@
-import type { Agent, AgentTurn } from "@minpeter/pss-runtime";
+import type { Agent, AgentInput, AgentTurn } from "@minpeter/pss-runtime";
 import type {
   ExecutionHost,
   NotificationRecord,
@@ -134,7 +134,7 @@ async function enqueueCompletionNotification({
         `<system-reminder>Background task ${taskId} completed.`,
         "Use background_output with the task_id to inspect the stored result.</system-reminder>",
       ].join(" "),
-      type: "user-text",
+      type: "user-input",
     },
     notificationId,
     ownerNamespace: run.ownerNamespace,
@@ -197,9 +197,13 @@ async function resumeCompletionNotification({
 
   const notificationRun = await coordinator
     .thread(notification.threadKey)
-    .send(notification.input);
+    .send(userInputToAgentInput(notification.input));
   await host.store.turns.update({ ...run, status: "completed" });
   return notificationRun;
+}
+
+function userInputToAgentInput(input: NotificationRecord["input"]): AgentInput {
+  return "text" in input ? input.text : input.content;
 }
 
 async function claimOwnedNotification({

--- a/examples/background-subagent/src/app-owned-background.test.ts
+++ b/examples/background-subagent/src/app-owned-background.test.ts
@@ -69,7 +69,7 @@ describe("app-owned background delegation", () => {
     const idempotencyKey = `background-complete:${parentThreadKey}:${job.id}`;
     await host.store.notifications.enqueue({
       idempotencyKey,
-      input: { text: "already queued", type: "user-text" },
+      input: { text: "already queued", type: "user-input" },
       notificationId: `notification:${job.id}`,
       ownerNamespace,
       runId: `notification:${job.id}`,

--- a/examples/background-subagent/src/background-delegation.ts
+++ b/examples/background-subagent/src/background-delegation.ts
@@ -216,14 +216,7 @@ export function readDurableBackgroundDelegationState(
 }
 
 function isAgentInput(value: unknown): value is AgentInput {
-  if (typeof value === "string" || Array.isArray(value)) {
-    return true;
-  }
-
-  return (
-    isRecord(value) &&
-    (value.type === "user-text" || value.type === "user-message")
-  );
+  return typeof value === "string" || Array.isArray(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/examples/background-subagent/src/conversation-plugin.ts
+++ b/examples/background-subagent/src/conversation-plugin.ts
@@ -4,7 +4,11 @@ export function createConversationTagPlugin(): AgentPlugin {
   return {
     name: "conversation-tag",
     on: ({ event }) => {
-      if (event.type !== "user-text" || typeof event.text !== "string") {
+      if (
+        event.type !== "user-input" ||
+        !("text" in event) ||
+        typeof event.text !== "string"
+      ) {
         return;
       }
 

--- a/examples/background-subagent/src/delegate-tool.ts
+++ b/examples/background-subagent/src/delegate-tool.ts
@@ -28,7 +28,7 @@ export function createDelegateToReaderTool(options: {
         throw new Error("Delegation was aborted before it started.");
       }
 
-      const prompt = delegateUserInput(input.prompt, { delegateToolName });
+      const prompt = delegateUserInput(input.prompt);
       const childThreadKey = defaultChildThreadKey(
         options.parentAgentNamespace,
         options.parentThreadKey,

--- a/examples/sync-subagent/src/conversation-plugin.ts
+++ b/examples/sync-subagent/src/conversation-plugin.ts
@@ -4,7 +4,11 @@ export function createConversationTagPlugin(): AgentPlugin {
   return {
     name: "conversation-tag",
     on: ({ event }) => {
-      if (event.type !== "user-text" || typeof event.text !== "string") {
+      if (
+        event.type !== "user-input" ||
+        !("text" in event) ||
+        typeof event.text !== "string"
+      ) {
         return;
       }
 

--- a/examples/sync-subagent/src/delegate-tool.ts
+++ b/examples/sync-subagent/src/delegate-tool.ts
@@ -27,7 +27,7 @@ export function createDelegateToReaderTool(options: {
         throw new Error("Delegation was aborted before it started.");
       }
 
-      const prompt = delegateUserInput(input.prompt, { delegateToolName });
+      const prompt = delegateUserInput(input.prompt);
       const childThreadKey = defaultChildThreadKey(
         options.parentAgentNamespace,
         options.parentThreadKey,

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @minpeter/pss-runtime
 
+## 0.1.0-next.21
+
+### Patch Changes
+
+- Unify user-originated thread events as `user-input` and simplify public thread
+  input to plain text, text arrays, or content-part arrays. Object-shaped
+  `user-text` and `user-message` inputs are no longer part of the public
+  `send()`/`steer()` surface; notification/resume internals still persist a typed
+  `user-input` payload.
+
+  Add noncanonical `thread.overlay(input)` for next-turn runtime context.
+  Overlays accept the same input shapes as `send()`, are chainable, and enter the
+  next turn as `runtime-input` before the user message rather than as another
+  human `user-input` event. Overlay context is visible to the current model turn
+  but is excluded from stored thread history and automatic compaction summaries.
+
+  Add notification resume overlays so durable notification turns can inject fresh
+  per-run context without baking that context into the canonical thread log.
+
 ## 0.1.0-next.20
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minpeter/pss-runtime",
-  "version": "0.1.0-next.20",
+  "version": "0.1.0-next.21",
   "description": "Generic agent runtime for threads, model loops, and synchronized run events.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime/scripts/inspect-storage.ts
+++ b/packages/runtime/scripts/inspect-storage.ts
@@ -132,8 +132,8 @@ async function writeDemoScenario(runtimeHost: ExecutionHost): Promise<void> {
   const notification: NotificationRecord = {
     idempotencyKey: ids.idempotencyKey,
     input: {
-      content: "배송 알림이 들어왔어. 이어서 처리해줘.",
-      type: "user-text",
+      text: "배송 알림이 들어왔어. 이어서 처리해줘.",
+      type: "user-input",
     },
     notificationId: ids.notificationId,
     ownerNamespace: "demo-agent",

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -39,6 +39,7 @@ export class Agent {
   readonly #store: ThreadStore;
   readonly #host: AgentHost;
   readonly #plugins: readonly AgentPlugin[];
+  readonly #notificationOverlays?: AgentOptions["notificationOverlays"];
   readonly #autoCompaction?: AgentAutoCompactionOptions;
   readonly host: AgentHost;
   readonly namespace?: string;
@@ -53,6 +54,7 @@ export class Agent {
     this.host = this.#host;
     this.#store = threadStoreForHost(this.#host);
     this.#plugins = options.plugins ?? [];
+    this.#notificationOverlays = options.notificationOverlays;
     this.#autoCompaction = normalizeAgentAutoCompactionOptions(
       options.autoCompaction
     );
@@ -77,6 +79,10 @@ export class Agent {
 
   send(input: AgentInput): Promise<AgentTurn> {
     return this.thread("default").send(input);
+  }
+
+  overlay(input: AgentInput): ThreadHandle {
+    return this.thread("default").overlay(input);
   }
 
   /**
@@ -135,6 +141,10 @@ export class Agent {
         return Promise.resolve();
       },
       interrupt: () => thread.interrupt(),
+      overlay: (input) => {
+        thread.overlay(input);
+        return publicHandle;
+      },
       send: (input) => thread.send(input),
       steer: (input) => thread.steer(input),
     };
@@ -153,7 +163,13 @@ export class Agent {
   #resumeNotification(notification: NotificationRecord): Promise<AgentTurn> {
     return this.#threadEntry(notification.threadKey).notify(
       notification.input,
-      { observerEvents: notification.observerEvents }
+      {
+        observerEvents: notification.observerEvents,
+        overlays: [
+          ...(notification.overlays ?? []),
+          ...(this.#notificationOverlays ?? []),
+        ],
+      }
     );
   }
 }

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -1,6 +1,7 @@
 import type { LanguageModel, ToolSet } from "ai";
 import type { AgentHost } from "../../execution/host/types";
 import type { AgentToolChoice } from "../../llm/llm";
+import type { AgentInput, UserInput } from "../../thread/input/input";
 import type { AgentPlugin } from "../../thread/plugins/pipeline";
 
 export interface AgentAutoCompactionOptions {
@@ -14,6 +15,7 @@ export interface AgentOptions {
   readonly instructions?: string;
   readonly model: LanguageModel;
   readonly namespace?: string;
+  readonly notificationOverlays?: readonly (AgentInput | UserInput)[];
   readonly plugins?: readonly AgentPlugin[];
   readonly toolChoice?: AgentToolChoice;
   readonly tools?: ToolSet;

--- a/packages/runtime/src/agent/core/thread-entry.ts
+++ b/packages/runtime/src/agent/core/thread-entry.ts
@@ -2,6 +2,7 @@ import type {
   AgentInput,
   NotifyOptions,
   ThreadCompactionInput,
+  UserInput,
 } from "../../thread/handle/thread";
 import type { AgentTurn } from "../../thread/protocol/turn";
 import { namespacePart } from "../identity/namespace";
@@ -23,12 +24,16 @@ export interface ThreadHandle {
   delete(): Promise<void>;
   dispose(): Promise<void>;
   interrupt(): void;
+  overlay(input: AgentInput): ThreadHandle;
   send(input: AgentInput): Promise<AgentTurn>;
   steer(input: AgentInput): Promise<AgentTurn>;
 }
 
 export interface AgentThreadEntry {
-  notify(input: AgentInput, options?: NotifyOptions): Promise<AgentTurn>;
+  notify(
+    input: AgentInput | UserInput,
+    options?: NotifyOptions
+  ): Promise<AgentTurn>;
   readonly publicHandle: ThreadHandle;
 }
 

--- a/packages/runtime/src/agent/resume/notification-resume.test.ts
+++ b/packages/runtime/src/agent/resume/notification-resume.test.ts
@@ -29,6 +29,7 @@ describe("host notification resume", () => {
         return Promise.resolve([assistantMessage("NOTIFIED")]);
       }),
       namespace: "notify-owner",
+      notificationOverlays: ["volatile resume context"],
     });
     const notification = {
       idempotencyKey: "background-complete:bg_1",
@@ -65,6 +66,7 @@ describe("host notification resume", () => {
       "assistant-reasoning",
       "turn-start",
       "runtime-input",
+      "runtime-input",
       "step-start",
       "assistant-text",
       "step-end",
@@ -72,6 +74,7 @@ describe("host notification resume", () => {
     ]);
     expect(seenHistory).toHaveLength(1);
     expect(JSON.stringify(seenHistory[0])).toContain("bg_1");
+    expect(JSON.stringify(seenHistory[0])).toContain("volatile resume context");
 
     const duplicateRun = await agent.resume(notification.runId);
     expect(duplicateRun).toBeNull();

--- a/packages/runtime/src/contracts/execution-store/contract.ts
+++ b/packages/runtime/src/contracts/execution-store/contract.ts
@@ -36,7 +36,7 @@ export function describeExecutionStoreContract({
         await tx.events.append("run-1", { type: "turn-start" });
         await tx.notifications.enqueue({
           idempotencyKey: "notify-1",
-          input: { text: "ready", type: "user-text" },
+          input: { text: "ready", type: "user-input" },
           notificationId: "notification-1",
           runId: "run-1",
           threadKey: "thread-1",
@@ -216,7 +216,7 @@ export function describeExecutionStoreContract({
 
     it("dedupes notifications by idempotency key", async () => {
       const store = createStore();
-      const input = { text: "ready", type: "user-text" } as const;
+      const input = { text: "ready", type: "user-input" } as const;
 
       await expect(
         store.notifications.enqueue({

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -19,6 +19,7 @@ import type {
   AgentAutoCompactionOptions,
   AgentEvent,
   AgentHost,
+  AgentInput,
   AgentOptions,
   ControlAgentEvent,
   LifecycleAgentEvent,
@@ -149,6 +150,7 @@ describe("runtime public exports", () => {
     const enabledOptions = {
       autoCompaction,
       model,
+      notificationOverlays: ["runtime context"],
     } satisfies AgentOptions;
     const disabledOptions = {
       autoCompaction: false,
@@ -163,7 +165,15 @@ describe("runtime public exports", () => {
     expectTypeOf<
       Parameters<ThreadHandle["compact"]>[0]
     >().toEqualTypeOf<ThreadCompactionInput>();
+    expectTypeOf<
+      Parameters<ThreadHandle["overlay"]>[0]
+    >().toEqualTypeOf<AgentInput>();
+    expectTypeOf<
+      ReturnType<ThreadHandle["overlay"]>
+    >().toEqualTypeOf<ThreadHandle>();
+    expectTypeOf<ReturnType<Agent["overlay"]>>().toEqualTypeOf<ThreadHandle>();
     expect(enabledOptions.autoCompaction).toEqual(autoCompaction);
+    expect(enabledOptions.notificationOverlays).toEqual(["runtime context"]);
     expect(disabledOptions.autoCompaction).toBe(false);
     expect(compaction.startSeq).toBe(0);
   });

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -11,14 +11,14 @@ describe("dispatchAgentNotification", () => {
     const first = await dispatchAgentNotification({
       host,
       idempotencyKey: "reminder:1",
-      input: { text: "Reminder fired", type: "user-text" },
+      input: { text: "Reminder fired", type: "user-input" },
       namespace: "agent-a",
       threadKey: "room:1:user:2",
     });
     const second = await dispatchAgentNotification({
       host,
       idempotencyKey: "reminder:1",
-      input: { text: "Reminder fired again", type: "user-text" },
+      input: { text: "Reminder fired again", type: "user-input" },
       namespace: "agent-a",
       threadKey: "room:1:user:2",
     });
@@ -41,7 +41,7 @@ describe("dispatchAgentNotification", () => {
       host.store.notifications.getByIdempotencyKey(run?.dedupeKey ?? "")
     ).resolves.toMatchObject({
       idempotencyKey: run?.dedupeKey,
-      input: { text: "Reminder fired", type: "user-text" },
+      input: { text: "Reminder fired", type: "user-input" },
       ownerNamespace: agentNamespace("agent-a"),
       runId: first.runId,
       threadKey: "room:1:user:2",
@@ -55,21 +55,21 @@ describe("dispatchAgentNotification", () => {
     const first = await dispatchAgentNotification({
       host,
       idempotencyKey: "reminder:shared",
-      input: { text: "Agent A reminder", type: "user-text" },
+      input: { text: "Agent A reminder", type: "user-input" },
       namespace: "agent-a",
       threadKey: "room:1:user:1",
     });
     const second = await dispatchAgentNotification({
       host,
       idempotencyKey: "reminder:shared",
-      input: { text: "Agent B reminder", type: "user-text" },
+      input: { text: "Agent B reminder", type: "user-input" },
       namespace: "agent-b",
       threadKey: "room:1:user:2",
     });
     const duplicateFirst = await dispatchAgentNotification({
       host,
       idempotencyKey: "reminder:shared",
-      input: { text: "ignored duplicate", type: "user-text" },
+      input: { text: "ignored duplicate", type: "user-input" },
       namespace: "agent-a",
       threadKey: "room:1:user:1",
     });
@@ -92,7 +92,7 @@ describe("dispatchAgentNotification", () => {
     const first = await dispatchAgentNotification({
       host: baseHost,
       idempotencyKey: "reminder:race",
-      input: { text: "first", type: "user-text" },
+      input: { text: "first", type: "user-input" },
       namespace: "agent-a",
       threadKey: "room:1:user:2",
     });
@@ -101,7 +101,7 @@ describe("dispatchAgentNotification", () => {
     const duplicate = await dispatchAgentNotification({
       host: racingHost,
       idempotencyKey: "reminder:race",
-      input: { text: "duplicate", type: "user-text" },
+      input: { text: "duplicate", type: "user-input" },
       namespace: "agent-a",
       threadKey: "room:1:user:2",
     });

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.ts
@@ -12,6 +12,7 @@ export interface DispatchAgentNotificationInput {
   readonly input: UserInput;
   readonly namespace: string;
   readonly observerEvents?: readonly AgentEvent[];
+  readonly overlays?: readonly UserInput[];
   readonly threadKey: string;
 }
 
@@ -72,6 +73,7 @@ export async function dispatchAgentNotification(
     input: input.input,
     notificationId,
     observerEvents: input.observerEvents,
+    overlays: input.overlays,
     ownerNamespace,
     runId,
     threadKey: input.threadKey,

--- a/packages/runtime/src/execution/host/types.ts
+++ b/packages/runtime/src/execution/host/types.ts
@@ -130,6 +130,7 @@ export interface NotificationRecord {
   readonly input: UserInput;
   readonly notificationId: string;
   readonly observerEvents?: readonly AgentEvent[];
+  readonly overlays?: readonly UserInput[];
   readonly ownerNamespace?: string;
   readonly runId: string;
   readonly status: NotificationStatus;

--- a/packages/runtime/src/llm/llm.test.ts
+++ b/packages/runtime/src/llm/llm.test.ts
@@ -8,7 +8,7 @@ import {
   loadAgent,
   loadModelStepRunner,
 } from "../testing/llm-test-utils";
-import { assistantMessage, userText } from "../testing/test-fixtures";
+import { assistantMessage } from "../testing/test-fixtures";
 
 const generateTextMock = getGenerateTextMock();
 
@@ -153,7 +153,7 @@ describe("Agent tool wiring", () => {
       tools: injectedTools,
     });
 
-    await drainRun(await agent.send(userText("use injected tools")));
+    await drainRun(await agent.send("use injected tools"));
 
     expect(generateTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -172,7 +172,7 @@ describe("Agent tool wiring", () => {
       toolChoice: "required",
     });
 
-    await drainRun(await agent.send(userText("force tool choice")));
+    await drainRun(await agent.send("force tool choice"));
 
     expect(generateTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -186,7 +186,7 @@ describe("Agent tool wiring", () => {
     const Agent = await loadAgent();
     const agent = new Agent({ model: fakeModel });
 
-    await drainRun(await agent.send(userText("run without product tools")));
+    await drainRun(await agent.send("run without product tools"));
 
     expect(generateTextMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/runtime/src/llm/tool-call-id.test.ts
+++ b/packages/runtime/src/llm/tool-call-id.test.ts
@@ -13,7 +13,6 @@ import {
   assistantMessage,
   toolCallPart,
   toolResultFor,
-  userText,
 } from "../testing/test-fixtures";
 
 const generateTextMock = getGenerateTextMock();
@@ -129,7 +128,7 @@ describe("runtime tool call ids", () => {
       },
     });
 
-    const events = await collectRun(await agent.send(userText("delegate")));
+    const events = await collectRun(await agent.send("delegate"));
     const toolCall = events.find((event) => event.type === "tool-call");
     const toolResult = events.find((event) => event.type === "tool-result");
 

--- a/packages/runtime/src/platform/cloudflare/alarm/thread-prompt-retry.test.ts
+++ b/packages/runtime/src/platform/cloudflare/alarm/thread-prompt-retry.test.ts
@@ -119,7 +119,7 @@ async function createScheduledNotification(idempotencyKey: string): Promise<{
 
   await host.store.notifications.enqueue({
     idempotencyKey,
-    input: { text: "Reminder fired", type: "user-text" },
+    input: { text: "Reminder fired", type: "user-input" },
     notificationId: `${idempotencyKey}:notification`,
     runId,
     threadKey,

--- a/packages/runtime/src/platform/cloudflare/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/platform/cloudflare/dispatch/notification-dispatch.test.ts
@@ -15,7 +15,7 @@ describe("dispatchCloudflareAgentNotification", () => {
     const dispatched = await dispatchCloudflareAgentNotification({
       host,
       idempotencyKey: "background:ready",
-      input: { text: "Background signal", type: "user-text" },
+      input: { text: "Background signal", type: "user-input" },
       namespace: "agent-a",
       threadKey: "room:1:user:2",
     });
@@ -44,7 +44,7 @@ describe("dispatchCloudflareAgentNotification", () => {
 
     const first = await dispatchCloudflareAgentNotification({
       idempotencyKey: "connector:oauth:done",
-      input: { text: "Connector OAuth completed", type: "user-text" },
+      input: { text: "Connector OAuth completed", type: "user-input" },
       namespace: "agent-a",
       prefix: "bori-agent",
       threadKey: "room:1:user:2",
@@ -52,7 +52,7 @@ describe("dispatchCloudflareAgentNotification", () => {
     });
     const second = await dispatchCloudflareAgentNotification({
       idempotencyKey: "connector:oauth:done",
-      input: { text: "ignored duplicate", type: "user-text" },
+      input: { text: "ignored duplicate", type: "user-input" },
       namespace: "agent-a",
       prefix: "bori-agent",
       threadKey: "room:1:user:2",
@@ -104,7 +104,7 @@ describe("dispatchCloudflareAgentNotification", () => {
 
     await dispatchCloudflareAgentNotification({
       idempotencyKey: "connector:oauth:done",
-      input: { text: "Connector OAuth completed", type: "user-text" },
+      input: { text: "Connector OAuth completed", type: "user-input" },
       namespace: "agent-a",
       prefix: "bori-agent",
       threadKey: "room:1:user:2",

--- a/packages/runtime/src/platform/cloudflare/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/platform/cloudflare/dispatch/notification-dispatch.ts
@@ -13,6 +13,7 @@ interface DispatchCloudflareAgentNotificationBase {
   readonly input: UserInput;
   readonly namespace: string;
   readonly observerEvents?: readonly AgentEvent[];
+  readonly overlays?: readonly UserInput[];
   readonly threadKey: string;
 }
 
@@ -34,6 +35,7 @@ export function dispatchCloudflareAgentNotification({
   input,
   namespace,
   observerEvents,
+  overlays,
   prefix,
   threadKey,
   storage,
@@ -49,6 +51,7 @@ export function dispatchCloudflareAgentNotification({
     input,
     namespace,
     observerEvents,
+    overlays,
     threadKey,
   });
 }

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
@@ -58,7 +58,7 @@ describe("Cloudflare Durable Object host adapter", () => {
     });
     await host.store.notifications.enqueue({
       idempotencyKey,
-      input: { text: "ready", type: "user-text" },
+      input: { text: "ready", type: "user-input" },
       notificationId: "notification-delayed",
       runId: notificationRunId,
       threadKey: "example",

--- a/packages/runtime/src/platform/cloudflare/storage/execution/storage-metrics.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/storage-metrics.test.ts
@@ -54,7 +54,7 @@ describe("storage metrics", () => {
     );
     await host.store.notifications.enqueue({
       idempotencyKey: `${runId}:notification`,
-      input: { text: "다".repeat(480), type: "user-text" },
+      input: { text: "다".repeat(480), type: "user-input" },
       notificationId: `${runId}:notification`,
       runId,
       status: "pending",

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-contract.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-contract.test.ts
@@ -25,7 +25,7 @@ describe("DurableObjectExecutionStore payload guards", () => {
       storage,
     });
     const record = notificationRecord("notify-big", {
-      input: { text: "x".repeat(300), type: "user-text" },
+      input: { text: "x".repeat(300), type: "user-input" },
     });
 
     await expect(store.notifications.enqueue(record)).resolves.toEqual({
@@ -184,7 +184,7 @@ function notificationRecord(
 ): NotificationRecord {
   return {
     idempotencyKey,
-    input: { text: "wake up", type: "user-text" },
+    input: { text: "wake up", type: "user-input" },
     notificationId: "notification-1",
     runId: "run-1",
     threadKey: "thread-1",

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-oversized-payload.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-oversized-payload.test.ts
@@ -74,7 +74,7 @@ describe("DurableObjectExecutionStore oversized payload stress", () => {
     });
     await host.store.notifications.enqueue({
       idempotencyKey: `${runId}:notification`,
-      input: { text: oversizedUserInput, type: "user-text" },
+      input: { text: oversizedUserInput, type: "user-input" },
       notificationId: `${runId}:notification`,
       runId,
       status: "pending",
@@ -102,7 +102,7 @@ describe("DurableObjectExecutionStore oversized payload stress", () => {
       );
     expect(claimedNotification).toMatchObject({
       ok: true,
-      record: { input: { text: oversizedUserInput, type: "user-text" } },
+      record: { input: { text: oversizedUserInput, type: "user-input" } },
     });
     expect(countRows(sql, "pss_thread_message_chunk")).toBeGreaterThan(0);
     expect(countRows(sql, "pss_payload_chunk")).toBeGreaterThan(0);
@@ -182,7 +182,7 @@ describe("DurableObjectExecutionStore oversized payload stress", () => {
     await timed(timings, "notification enqueue", () =>
       host.store.notifications.enqueue({
         idempotencyKey: `${latencyRunId}:notification`,
-        input: { text: hugeUserInput, type: "user-text" },
+        input: { text: hugeUserInput, type: "user-input" },
         notificationId: `${latencyRunId}:notification`,
         runId: latencyRunId,
         status: "pending",

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-stress-scenario.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-stress-scenario.ts
@@ -168,7 +168,7 @@ async function writeThreadTurns(input: WriteThreadTurnsInput): Promise<number> {
         idempotencyKey: notificationKey,
         input: {
           text: notificationContent(runId, input.notificationPayloadBytes),
-          type: "user-text",
+          type: "user-input",
         },
         notificationId: notificationKey,
         runId,

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-stress.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-stress.test.ts
@@ -144,7 +144,7 @@ describe("DurableObjectExecutionStore storage stress", () => {
           const notificationKey = `${runId}:notify`;
           await host.store.notifications.enqueue({
             idempotencyKey: notificationKey,
-            input: { text: `notify ${runId}`, type: "user-text" },
+            input: { text: `notify ${runId}`, type: "user-input" },
             notificationId: `${runId}:notification`,
             runId,
             status: "pending",

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/bootstrap.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/bootstrap.test.ts
@@ -109,7 +109,7 @@ describe("createCloudflareDurableObjectHost store selection", () => {
         );
         await tx.notifications.enqueue({
           idempotencyKey: "notify-rollback",
-          input: { text: "resume", type: "user-text" },
+          input: { text: "resume", type: "user-input" },
           notificationId: "notification-rollback",
           runId: "run-rollback",
           threadKey: "thread-rollback",

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/event-store-roundtrip.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/event-store-roundtrip.test.ts
@@ -27,7 +27,7 @@ describe("DurableObjectSqliteEventStore AgentEvent round-trip", () => {
 
 function agentEventVariants(): readonly AgentEvent[] {
   return [
-    { meta: { source: "send" }, text: "hello", type: "user-text" },
+    { meta: { source: "send" }, text: "hello", type: "user-input" },
     {
       content: [
         { text: "multipart text", type: "text" },
@@ -47,10 +47,10 @@ function agentEventVariants(): readonly AgentEvent[] {
         },
       ],
       meta: { source: "notify" },
-      type: "user-message",
+      type: "user-input",
     },
     {
-      input: { text: "runtime says continue", type: "user-text" },
+      input: { text: "runtime says continue", type: "user-input" },
       meta: { source: "steer" },
       placement: "step-start",
       type: "runtime-input",

--- a/packages/runtime/src/platform/node/host/file-execution-host.test.ts
+++ b/packages/runtime/src/platform/node/host/file-execution-host.test.ts
@@ -40,7 +40,7 @@ describe("createNodeFileExecutionHost", () => {
       const dispatched = await dispatchAgentNotification({
         host: firstHost,
         idempotencyKey: "local-reminder:1",
-        input: { text: "local reminder fired", type: "user-text" },
+        input: { text: "local reminder fired", type: "user-input" },
         namespace: "local-owner",
         observerEvents: [
           {

--- a/packages/runtime/src/platform/node/storage/file-execution-store-test-support.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store-test-support.ts
@@ -95,7 +95,7 @@ export function notificationRecord(
 ): NotificationRecord {
   return {
     idempotencyKey,
-    input: { text: "ready", type: "user-text" },
+    input: { text: "ready", type: "user-input" },
     notificationId: `${idempotencyKey}:notification`,
     runId: "run-1",
     threadKey: "thread-1",

--- a/packages/runtime/src/platform/node/storage/file-execution-store/schemas.ts
+++ b/packages/runtime/src/platform/node/storage/file-execution-store/schemas.ts
@@ -105,12 +105,22 @@ export function parseNotificationRecord(
   ) {
     throw invalidFile(file, "expected agent observer events");
   }
+  const overlays = Array.isArray(value.overlays)
+    ? value.overlays.filter(isUserInput)
+    : undefined;
+  if (
+    Array.isArray(value.overlays) &&
+    overlays?.length !== value.overlays.length
+  ) {
+    throw invalidFile(file, "expected notification overlays");
+  }
 
   return {
     idempotencyKey: value.idempotencyKey,
     input: value.input,
     notificationId: value.notificationId,
     ...(observerEvents ? { observerEvents } : {}),
+    ...(overlays ? { overlays } : {}),
     ...(typeof value.ownerNamespace === "string"
       ? { ownerNamespace: value.ownerNamespace }
       : {}),
@@ -171,9 +181,10 @@ function isAgentEvent(value: unknown): value is AgentEvent {
 function isUserInput(value: unknown): value is UserInput {
   return (
     isRecord(value) &&
-    ((value.type === "user-text" &&
-      (typeof value.text === "string" || isStringArray(value.text))) ||
-      (value.type === "user-message" && Array.isArray(value.content)))
+    value.type === "user-input" &&
+    (typeof value.text === "string" ||
+      isStringArray(value.text) ||
+      Array.isArray(value.content))
   );
 }
 

--- a/packages/runtime/src/testing/input-fixtures.ts
+++ b/packages/runtime/src/testing/input-fixtures.ts
@@ -6,25 +6,25 @@ import type {
 } from "../thread/protocol/events";
 
 export const userText = (text: UserTextContent): UserText => ({
-  type: "user-text",
+  type: "user-input",
   text,
 });
 
 export const sentUserText = (text: UserTextContent): UserText => ({
   meta: { source: "send" },
   text,
-  type: "user-text",
+  type: "user-input",
 });
 
 export const userMessage = (content: UserMessageContent): UserMessage => ({
-  type: "user-message",
+  type: "user-input",
   content,
 });
 
 export const sentUserMessage = (content: UserMessageContent): UserMessage => ({
   content,
   meta: { source: "send" },
-  type: "user-message",
+  type: "user-input",
 });
 
 export const steerRuntimeInput = (
@@ -34,7 +34,7 @@ export const steerRuntimeInput = (
   input: {
     meta: { source: "steer", streaming: "steer" as const },
     text,
-    type: "user-text" as const,
+    type: "user-input" as const,
   },
   meta: { source: "steer" as const, streaming: "steer" as const },
   placement,
@@ -48,9 +48,23 @@ export const notifyRuntimeInput = (
   input: {
     meta: { source: "notify" as const },
     text,
-    type: "user-text" as const,
+    type: "user-input" as const,
   },
   meta: { source: "notify" as const },
+  placement,
+  type: "runtime-input" as const,
+});
+
+export const overlayRuntimeInput = (
+  text: UserTextContent,
+  placement: "step-end" | "step-start" | "turn-start" = "turn-start"
+) => ({
+  input: {
+    meta: { source: "overlay" as const },
+    text,
+    type: "user-input" as const,
+  },
+  meta: { source: "overlay" as const },
   placement,
   type: "runtime-input" as const,
 });
@@ -62,7 +76,7 @@ export const steerRuntimeInputMessage = (
   input: {
     content,
     meta: { source: "steer" as const, streaming: "steer" as const },
-    type: "user-message" as const,
+    type: "user-input" as const,
   },
   meta: { source: "steer" as const, streaming: "steer" as const },
   placement,

--- a/packages/runtime/src/thread/handle/automatic-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction.test.ts
@@ -114,6 +114,58 @@ describe("Agent thread automatic compaction", () => {
     ]);
   });
 
+  it("does not summarize one-turn overlays during automatic compaction", async () => {
+    const store = new SpyStore();
+    const seenHistory: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = agentWithAutoCompaction({
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        calls += 1;
+        if (calls === 1) {
+          return [assistantMessage("old done")];
+        }
+        if (calls === 2) {
+          return [assistantMessage("tail done")];
+        }
+        if (calls === 3) {
+          return [assistantMessage("summary without overlay")];
+        }
+        return [assistantMessage("after compaction")];
+      }),
+    });
+    const thread = agent.thread("overlay-auto");
+
+    await collect(await thread.overlay("volatile context").send("old"));
+    await collect(await thread.send("tail"));
+    await waitForModelCalls(() => calls, 3);
+
+    expect(seenHistory[0]).toEqual([
+      userTextToModelMessage(userText("volatile context")),
+      userTextToModelMessage(userText("old")),
+    ]);
+    expect(JSON.stringify(seenHistory[2])).not.toContain("volatile context");
+    expect(store.threads.get("overlay-auto")?.state).toMatchObject({
+      compactions: [
+        {
+          endSeqExclusive: 2,
+          schemaVersion: 1,
+          startSeq: 0,
+          summary: { content: "summary without overlay", role: "system" },
+        },
+      ],
+      history: [
+        userTextToModelMessage(userText("old")),
+        storedAssistantText("old done"),
+        userTextToModelMessage(userText("tail")),
+        storedAssistantText("tail done"),
+      ],
+      schemaVersion: 2,
+    });
+  });
+
   it("closes the triggering turn before the background summary finishes", async () => {
     const store = new SpyStore();
     const summaryStarted = createDeferred();

--- a/packages/runtime/src/thread/handle/notify.test.ts
+++ b/packages/runtime/src/thread/handle/notify.test.ts
@@ -25,7 +25,7 @@ describe("AgentThread.notify", () => {
     const events = await collectAgentTurn(await thread.send("hello"));
 
     expect(eventTypes(events)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "step-start",
       "assistant-text",
@@ -59,6 +59,42 @@ describe("AgentThread.notify", () => {
     expect(events).not.toContainEqual(userText(notification));
     expect(seenHistory).toEqual([
       [userTextToModelMessage(userText(notification))],
+    ]);
+  });
+
+  it("applies notification overlays without carrying them into future turns", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const thread = createThread("notify-overlay", ({ history }) => {
+      seenHistory.push([...history]);
+      return Promise.resolve([assistantMessage("DONE")]);
+    });
+
+    const notifiedEvents = await collectAgentTurn(
+      await thread.notify("background done", {
+        overlays: ["volatile notification context"],
+      })
+    );
+    await collectAgentTurn(await thread.send("next"));
+
+    expect(eventTypes(notifiedEvents)).toEqual([
+      "turn-start",
+      "runtime-input",
+      "runtime-input",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("volatile notification context")),
+        userTextToModelMessage(userText("background done")),
+      ],
+      [
+        userTextToModelMessage(userText("background done")),
+        assistantMessage("DONE"),
+        userTextToModelMessage(userText("next")),
+      ],
     ]);
   });
 
@@ -105,7 +141,7 @@ describe("AgentThread.notify", () => {
 
     expect(notifiedRun).toBe(secondRun);
     expect(eventTypes(secondEvents)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "runtime-input",
       "step-start",

--- a/packages/runtime/src/thread/handle/persistence.test.ts
+++ b/packages/runtime/src/thread/handle/persistence.test.ts
@@ -13,7 +13,6 @@ import {
   createCallbackModel,
   createDeferred,
   eventTypes,
-  userMessage,
   userText,
 } from "../../testing/test-fixtures";
 import type { AgentEvent } from "../protocol/events";
@@ -33,7 +32,7 @@ const storedAssistantText = (text: string): ModelMessage => ({
 
 describe("Agent thread persistence", () => {
   it("file thread store preserves image content parts across reload", async () => {
-    const input = userMessage([
+    const input = [
       { type: "text", text: "remember this image" },
       {
         type: "image",
@@ -46,7 +45,7 @@ describe("Agent thread persistence", () => {
         filename: "note.txt",
         mediaType: "text/plain",
       },
-    ]);
+    ] as const;
     const directory = await mkdtemp(join(tmpdir(), "pss-runtime-image-store-"));
     const store = new FileThreadStore(directory);
 
@@ -121,6 +120,39 @@ describe("Agent thread persistence", () => {
       assistantMessage("DONE"),
       userTextToModelMessage(userText("second")),
     ]);
+  });
+
+  it("keeps overlay visible to one turn without persisting it", async () => {
+    const store = new SpyStore();
+    const seenHistory: ModelMessage[][] = [];
+    const agent = new Agent({
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([
+          assistantMessage(`DONE ${seenHistory.length}`),
+        ]);
+      }),
+    });
+    const thread = agent.thread("overlay");
+
+    await collect(await thread.overlay("volatile context").send("first"));
+    await collect(await thread.send("second"));
+
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("volatile context")),
+        userTextToModelMessage(userText("first")),
+      ],
+      [
+        userTextToModelMessage(userText("first")),
+        assistantMessage("DONE 1"),
+        userTextToModelMessage(userText("second")),
+      ],
+    ]);
+    expect(JSON.stringify(store.threads.get("overlay")?.state)).not.toContain(
+      "volatile context"
+    );
   });
 
   it("isolates named thread keys and resumes same-key state", async () => {

--- a/packages/runtime/src/thread/handle/terminal-state.test.ts
+++ b/packages/runtime/src/thread/handle/terminal-state.test.ts
@@ -34,7 +34,10 @@ describe("Agent thread terminal state", () => {
     llmGate.resolve();
 
     expect(eventTypes(await firstEvents)).toContain("turn-error");
-    expect(eventTypes(await secondEvents)).toEqual(["user-text", "turn-error"]);
+    expect(eventTypes(await secondEvents)).toEqual([
+      "user-input",
+      "turn-error",
+    ]);
     await expect(thread.steer("late")).rejects.toThrow("Thread killed");
   });
 
@@ -57,7 +60,7 @@ describe("Agent thread terminal state", () => {
       throw new Error("thread.dispose() did not close the active run");
     }
     expect(eventTypes(events)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "step-start",
       "turn-error",
@@ -92,7 +95,7 @@ describe("Agent thread terminal state", () => {
       throw new Error("thread.dispose() did not close the terminal event run");
     }
     expect(eventTypes(events)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "step-start",
       "assistant-text",
@@ -153,7 +156,7 @@ describe("Agent thread terminal state", () => {
       throw new Error("thread.delete() did not close the active run");
     }
     expect(eventTypes(events)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "step-start",
       "turn-error",

--- a/packages/runtime/src/thread/handle/thread.test.ts
+++ b/packages/runtime/src/thread/handle/thread.test.ts
@@ -4,9 +4,10 @@ import { Agent } from "../../agent/core/agent";
 import {
   assistantMessage,
   createCallbackModel,
+  eventTypes,
+  overlayRuntimeInput,
   sentUserMessage,
   sentUserText,
-  userMessage,
   userText,
 } from "../../testing/test-fixtures";
 import { userTextToModelMessage } from "../protocol/mapping";
@@ -121,7 +122,7 @@ describe("Agent thread API", () => {
     );
   });
 
-  it("rejects malformed explicit user-message input before queueing", async () => {
+  it("rejects malformed content parts before queueing", async () => {
     const agent = new Agent({
       model: createCallbackModel(() =>
         Promise.resolve([assistantMessage("DONE")])
@@ -129,16 +130,13 @@ describe("Agent thread API", () => {
     });
 
     await expect(
-      agent.send({
-        type: "user-message",
-        content: [{ type: "file", data: "abc" }],
-      } as never)
+      agent.send([{ type: "file", data: "abc" }] as never)
     ).rejects.toThrow(
       'Agent input content parts must be { type: "text", text }, { type: "image", image }, or { type: "file", data, mediaType }.'
     );
   });
 
-  it("rejects explicit user-message content that is not an array", async () => {
+  it("rejects explicit user input objects before queueing", async () => {
     const agent = new Agent({
       model: createCallbackModel(() =>
         Promise.resolve([assistantMessage("DONE")])
@@ -147,15 +145,15 @@ describe("Agent thread API", () => {
 
     await expect(
       agent.send({
-        content: "not-content-parts",
-        type: "user-message",
+        type: "user-input",
+        text: "not-public-input",
       } as never)
     ).rejects.toThrow(
-      "Agent input must be text, text parts, content parts, user-text, or user-message."
+      "Agent input must be text, text parts, or content parts."
     );
   });
 
-  it("thread.send accepts user-message events", async () => {
+  it("thread.send accepts multipart content parts", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
       model: createCallbackModel(({ history }) => {
@@ -165,12 +163,10 @@ describe("Agent thread API", () => {
     });
 
     await collect(
-      await agent.thread("custom").send(
-        userMessage([
-          { type: "text", text: "summarize" },
-          { type: "image", image: "iVBORw0KGgo=" },
-        ])
-      )
+      await agent.thread("custom").send([
+        { type: "text", text: "summarize" },
+        { type: "image", image: "iVBORw0KGgo=" },
+      ])
     );
 
     expect(seenHistory).toEqual([
@@ -192,7 +188,7 @@ describe("Agent thread API", () => {
     ]);
   });
 
-  it("thread.send accepts user-text events", async () => {
+  it("thread.send accepts text", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
       model: createCallbackModel(({ history }) => {
@@ -201,10 +197,49 @@ describe("Agent thread API", () => {
       }),
     });
 
-    await collect(
-      await agent.thread("custom").send({ type: "user-text", text: "hello" })
-    );
+    await collect(await agent.thread("custom").send("hello"));
 
     expect(seenHistory).toEqual([[userTextToModelMessage(userText("hello"))]]);
+  });
+
+  it("thread.overlay injects next-turn runtime context before send input", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const agent = new Agent({
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      }),
+    });
+    const thread = agent.thread("custom");
+
+    const returned = thread.overlay("profile: warm tone");
+    const events = await collect(
+      await returned.overlay("locale: ko").send("hello")
+    );
+
+    expect(returned).toBe(thread);
+    expect(eventTypes(events)).toEqual([
+      "user-input",
+      "turn-start",
+      "runtime-input",
+      "runtime-input",
+      "step-start",
+      "assistant-text",
+      "step-end",
+      "turn-end",
+    ]);
+    expect(events).toContainEqual(
+      overlayRuntimeInput("profile: warm tone", "turn-start")
+    );
+    expect(events).toContainEqual(
+      overlayRuntimeInput("locale: ko", "turn-start")
+    );
+    expect(seenHistory).toEqual([
+      [
+        userTextToModelMessage(userText("profile: warm tone")),
+        userTextToModelMessage(userText("locale: ko")),
+        userTextToModelMessage(userText("hello")),
+      ],
+    ]);
   });
 });

--- a/packages/runtime/src/thread/handle/thread.ts
+++ b/packages/runtime/src/thread/handle/thread.ts
@@ -1,5 +1,5 @@
 import type { ModelGenerationOptions } from "../../llm/llm";
-import type { AgentInput } from "../input/input";
+import type { AgentInput, UserInput } from "../input/input";
 import { attachInputMeta, userInputFromEvent } from "../input/input-meta";
 import { normalizeAgentInput } from "../input/input-normalization";
 import {
@@ -37,6 +37,7 @@ export class AgentThread {
   readonly #execution: ThreadExecutionOptions;
   readonly #inputQueue: QueuedInput[] = [];
   readonly #model: ModelGenerationOptions;
+  readonly #pendingOverlays: QueuedRuntimeInput[] = [];
   readonly #pendingRuntimeInputs: QueuedRuntimeInput[] = [];
   readonly #threadKey: string;
   readonly #state: ThreadState;
@@ -76,9 +77,6 @@ export class AgentThread {
       throw threadTerminalError(this.#killed);
     }
 
-    const runtimeInput = createRuntimeInputState(
-      this.#pendingRuntimeInputs.splice(0)
-    );
     const normalized = normalizeAgentInput(input);
     const acceptedInput =
       normalized.meta === undefined
@@ -92,14 +90,15 @@ export class AgentThread {
     }
 
     const queuedInput = userInputFromEvent(
-      emitted.type === "user-text" || emitted.type === "user-message"
-        ? emitted
-        : acceptedInput
+      emitted.type === "user-input" ? emitted : acceptedInput
+    );
+    const runtimeInput = createRuntimeInputState(
+      this.#pendingRuntimeInputs.splice(0)
     );
     this.#inputQueue.push({
       initialEvents: [],
       input: structuredClone(queuedInput),
-      preUserRuntimeInputs: [],
+      preUserRuntimeInputs: this.#pendingOverlays.splice(0),
       run,
       runtimeInput,
     });
@@ -107,8 +106,23 @@ export class AgentThread {
     return run;
   }
 
+  overlay(input: AgentInput): this {
+    if (this.#killed || this.#deletePromise) {
+      throw threadTerminalError(this.#killed);
+    }
+
+    this.#pendingOverlays.push({
+      canonical: false,
+      input: attachInputMeta(normalizeAgentInput(input), {
+        source: "overlay",
+      }),
+      placement: "turn-start",
+    });
+    return this;
+  }
+
   async notify(
-    input: AgentInput,
+    input: AgentInput | UserInput,
     options: NotifyOptions = {}
   ): Promise<AgentTurn> {
     if (this.#killed || this.#deletePromise) {
@@ -183,6 +197,7 @@ export class AgentThread {
 
     this.#killed = true;
     const killedError = threadKilledError();
+    this.#pendingOverlays.length = 0;
     this.#pendingRuntimeInputs.length = 0;
     this.#activeAbort?.abort();
     closeKilledRuntimeInputs({

--- a/packages/runtime/src/thread/input/delegate-input.ts
+++ b/packages/runtime/src/thread/input/delegate-input.ts
@@ -1,22 +1,9 @@
-import type { UserInput } from "./input";
-import { attachInputMeta } from "./input-meta";
+import type { AgentInput } from "./input";
 
-export function delegateUserInput(
-  prompt: unknown,
-  options: { readonly delegateToolName?: string } = {}
-): UserInput {
+export function delegateUserInput(prompt: unknown): AgentInput {
   if (typeof prompt !== "string") {
     throw new TypeError("Delegate prompt must be a plain string.");
   }
 
-  return attachInputMeta(
-    {
-      type: "user-text",
-      text: prompt,
-    },
-    {
-      delegateToolName: options.delegateToolName,
-      source: "delegate",
-    }
-  );
+  return prompt;
 }

--- a/packages/runtime/src/thread/input/input-meta-types.ts
+++ b/packages/runtime/src/thread/input/input-meta-types.ts
@@ -1,4 +1,4 @@
-export type InputSource = "delegate" | "notify" | "send" | "steer";
+export type InputSource = "delegate" | "notify" | "overlay" | "send" | "steer";
 
 export interface InputEventMeta {
   readonly delegateToolName?: string;

--- a/packages/runtime/src/thread/input/input-meta.test.ts
+++ b/packages/runtime/src/thread/input/input-meta.test.ts
@@ -9,11 +9,11 @@ import {
 } from "./input-meta";
 
 describe("input-meta helpers", () => {
-  it("attaches meta to user-text without mutating unrelated fields", () => {
+  it("attaches meta to user-input without mutating unrelated fields", () => {
     expect(
-      attachInputMeta({ type: "user-text", text: "hello" }, { source: "send" })
+      attachInputMeta({ type: "user-input", text: "hello" }, { source: "send" })
     ).toEqual({
-      type: "user-text",
+      type: "user-input",
       text: "hello",
       meta: { source: "send" },
     });
@@ -21,11 +21,11 @@ describe("input-meta helpers", () => {
 
   it("strips meta from user input before model mapping", () => {
     const input = attachInputMeta(
-      { type: "user-text", text: "hello" },
+      { type: "user-input", text: "hello" },
       { source: "send" }
     );
-    if (input.type !== "user-text") {
-      throw new Error("expected user-text");
+    if (input.type !== "user-input") {
+      throw new Error("expected user-input");
     }
 
     expect(userTextToModelMessage(input)).toEqual({
@@ -36,25 +36,25 @@ describe("input-meta helpers", () => {
 
   it("stripInputMeta is idempotent", () => {
     const withMeta = attachInputMeta(
-      { type: "user-text", text: "hello" },
+      { type: "user-input", text: "hello" },
       { source: "delegate", delegateToolName: "poke" }
     );
     const stripped = stripInputMeta(withMeta);
 
     expect(stripInputMeta(stripped)).toEqual(stripped);
-    expect(stripped).toEqual({ type: "user-text", text: "hello" });
+    expect(stripped).toEqual({ type: "user-input", text: "hello" });
   });
 
   it("stripEventMeta removes meta from runtime-input", () => {
     const event: RuntimeInput = attachRuntimeInputMeta(
-      { type: "user-text", text: "steer me" },
+      { type: "user-input", text: "steer me" },
       "step-end",
       { source: "steer", streaming: "steer" }
     );
 
     expect(stripEventMeta(event)).toEqual({
       type: "runtime-input",
-      input: { type: "user-text", text: "steer me" },
+      input: { type: "user-input", text: "steer me" },
       placement: "step-end",
     });
   });

--- a/packages/runtime/src/thread/input/input-meta.ts
+++ b/packages/runtime/src/thread/input/input-meta.ts
@@ -1,17 +1,13 @@
 import type { AgentEvent, RuntimeInput } from "../protocol/events";
-import type { UserInput, UserMessage, UserText } from "./input";
+import type { UserInput } from "./input";
 import type { InputEventMeta } from "./input-meta-types";
 
 export type { InputEventMeta, InputSource } from "./input-meta-types";
 
-export function attachInputMeta(
-  input: UserInput,
+export function attachInputMeta<T extends UserInput>(
+  input: T,
   meta: InputEventMeta
-): UserText | UserMessage {
-  if (input.type === "user-text") {
-    return { ...input, meta };
-  }
-
+): T & { readonly meta: InputEventMeta } {
   return { ...input, meta };
 }
 
@@ -29,17 +25,12 @@ export function attachRuntimeInputMeta(
 }
 
 export function stripInputMeta(input: UserInput): UserInput {
-  if (input.type === "user-text") {
-    const { meta: _meta, ...rest } = input;
-    return rest;
-  }
-
   const { meta: _meta, ...rest } = input;
   return rest;
 }
 
 export function stripEventMeta(event: AgentEvent): AgentEvent {
-  if (event.type === "user-text" || event.type === "user-message") {
+  if (event.type === "user-input") {
     return stripInputMeta(event);
   }
 
@@ -54,6 +45,6 @@ export function stripEventMeta(event: AgentEvent): AgentEvent {
   return event;
 }
 
-export function userInputFromEvent(event: UserText | UserMessage): UserInput {
+export function userInputFromEvent(event: UserInput): UserInput {
   return stripInputMeta(event);
 }

--- a/packages/runtime/src/thread/input/input-normalization.ts
+++ b/packages/runtime/src/thread/input/input-normalization.ts
@@ -1,22 +1,16 @@
-import type {
-  AgentInput,
-  UserInput,
-  UserMessage,
-  UserMessageContentPart,
-  UserText,
-} from "./input";
+import type { AgentInput, UserInput, UserMessageContentPart } from "./input";
 
 export function normalizeAgentInput(input: AgentInput): UserInput {
   if (typeof input === "string") {
     return {
-      type: "user-text",
+      type: "user-input",
       text: input,
     };
   }
 
   if (isStringArrayInput(input)) {
     return {
-      type: "user-text",
+      type: "user-input",
       text: structuredClone(input),
     };
   }
@@ -24,23 +18,24 @@ export function normalizeAgentInput(input: AgentInput): UserInput {
   if (isArrayInput(input)) {
     assertUserMessageContent(input);
     return {
-      type: "user-message",
+      type: "user-input",
       content: structuredClone(input),
     };
   }
 
-  if (isUserMessage(input)) {
-    assertUserMessageContent(input.content);
-    return structuredClone(input);
-  }
-
-  if (isUserText(input)) {
-    return structuredClone(input);
-  }
-
   throw new TypeError(
-    "Agent input must be text, text parts, content parts, user-text, or user-message."
+    "Agent input must be text, text parts, or content parts."
   );
+}
+
+export function normalizeInternalAgentInput(
+  input: AgentInput | UserInput
+): UserInput {
+  if (isUserInput(input)) {
+    return structuredClone(input);
+  }
+
+  return normalizeAgentInput(input);
 }
 
 function isStringArrayInput(input: unknown): input is readonly string[] {
@@ -53,25 +48,34 @@ function isArrayInput(
   return Array.isArray(input);
 }
 
-function isUserMessage(input: AgentInput): input is UserMessage {
-  return (
-    input !== null &&
-    typeof input === "object" &&
-    !isArrayInput(input) &&
-    input.type === "user-message" &&
-    "content" in input &&
-    Array.isArray(input.content)
-  );
+function isUserInput(input: unknown): input is UserInput {
+  if (!isRecord(input)) {
+    return false;
+  }
+
+  if (input.type !== "user-input") {
+    return false;
+  }
+
+  if ("text" in input && isUserText(input)) {
+    return true;
+  }
+
+  const content = input.content;
+  if (Array.isArray(content)) {
+    assertUserMessageContent(content);
+    return true;
+  }
+
+  return false;
 }
 
-function isUserText(input: AgentInput): input is UserText {
-  return (
-    input !== null &&
-    typeof input === "object" &&
-    !isArrayInput(input) &&
-    input.type === "user-text" &&
-    (typeof input.text === "string" || isStringArrayInput(input.text))
-  );
+function isUserText(input: Record<string, unknown>): boolean {
+  return typeof input.text === "string" || isStringArrayInput(input.text);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function assertUserMessageContent(

--- a/packages/runtime/src/thread/input/input.ts
+++ b/packages/runtime/src/thread/input/input.ts
@@ -5,7 +5,7 @@ export type UserTextContent = string | readonly string[];
 export interface UserText {
   meta?: InputEventMeta;
   text: UserTextContent;
-  type: "user-text";
+  type: "user-input";
 }
 
 export interface UserMessageTextPart {
@@ -43,15 +43,14 @@ export type UserMessageContent = readonly UserMessageContentPart[];
 export interface UserMessage {
   content: UserMessageContent;
   meta?: InputEventMeta;
-  type: "user-message";
+  type: "user-input";
 }
 
 export type UserInput = UserMessage | UserText;
 export type AgentInput =
   | readonly string[]
   | readonly UserMessageContentPart[]
-  | string
-  | UserInput;
+  | string;
 export type ThreadInput = AgentInput;
 
 /** @deprecated Use ThreadInput or AgentInput. */

--- a/packages/runtime/src/thread/input/runtime-input-emit.ts
+++ b/packages/runtime/src/thread/input/runtime-input-emit.ts
@@ -33,8 +33,12 @@ export async function commitPreUserRuntimeInputs(
 
     committed.push(processed);
     const input = runtimeInputHistoryFromEvent(processed, queued);
-    state.appendUserInput(input);
-    await state.commit();
+    if (queued.canonical === false) {
+      state.appendTransientUserInput(input);
+    } else {
+      state.appendUserInput(input);
+      await state.commit();
+    }
   }
 
   return committed;

--- a/packages/runtime/src/thread/input/runtime-input.ts
+++ b/packages/runtime/src/thread/input/runtime-input.ts
@@ -7,6 +7,7 @@ import { normalizeAgentInput } from "./input-normalization";
 export type RuntimeInputPlacement = RuntimeInput["placement"];
 
 export interface QueuedRuntimeInput {
+  readonly canonical?: boolean;
   readonly input: UserInput;
   readonly placement: RuntimeInputPlacement;
 }

--- a/packages/runtime/src/thread/plugins/events.test.ts
+++ b/packages/runtime/src/thread/plugins/events.test.ts
@@ -29,7 +29,7 @@ describe("Agent thread plugin events", () => {
     const events = await collect(await agent.send("hello"));
 
     expect(eventTypes(events)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "step-start",
       "assistant-text",
@@ -37,7 +37,7 @@ describe("Agent thread plugin events", () => {
       "turn-end",
     ]);
     expect(pluginCalls).toEqual([
-      "user-text:0",
+      "user-input:0",
       "turn-start:1",
       "step-start:1",
       "assistant-text:2",
@@ -97,7 +97,7 @@ describe("Agent thread plugin events", () => {
     );
 
     expect(eventTypes(firstEvents)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "step-start",
       "assistant-text",
@@ -105,7 +105,7 @@ describe("Agent thread plugin events", () => {
       "turn-error",
     ]);
     expect(eventTypes(secondEvents)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "step-start",
       "assistant-text",

--- a/packages/runtime/src/thread/plugins/intercept.test.ts
+++ b/packages/runtime/src/thread/plugins/intercept.test.ts
@@ -16,10 +16,10 @@ describe("thread plugin intercept integration", () => {
   it("routes by meta.source=send in a unified on handler", async () => {
     const tagPlugin: AgentPlugin = {
       on: ({ event }) => {
-        if (event.type !== "user-text" || event.meta?.source !== "send") {
+        if (event.type !== "user-input" || event.meta?.source !== "send") {
           return;
         }
-        if (typeof event.text !== "string") {
+        if (!("text" in event) || typeof event.text !== "string") {
           return;
         }
         return {
@@ -57,7 +57,7 @@ describe("thread plugin intercept integration", () => {
 
     await collect(await agent.send("hello"));
 
-    expect(seen).toContain("user-text");
+    expect(seen).toContain("user-input");
     expect(seen).toContain("turn-end");
   });
 
@@ -94,7 +94,11 @@ describe("thread plugin intercept integration", () => {
       plugins: [
         {
           on: ({ event }) => {
-            if (event.type !== "user-text" || typeof event.text !== "string") {
+            if (
+              event.type !== "user-input" ||
+              !("text" in event) ||
+              typeof event.text !== "string"
+            ) {
               return;
             }
             return {

--- a/packages/runtime/src/thread/plugins/pipeline.test.ts
+++ b/packages/runtime/src/thread/plugins/pipeline.test.ts
@@ -5,10 +5,14 @@ import { type AgentPlugin, runPluginsForEvent } from "./pipeline";
 const emptyHistory: AgentEventContext["history"] = [];
 
 describe("runPluginsForEvent", () => {
-  it("chains transforms on user-text in plugin registration order", async () => {
+  it("chains transforms on user-input in plugin registration order", async () => {
     const prefixA: AgentPlugin = {
       on: ({ event }) => {
-        if (event.type !== "user-text" || typeof event.text !== "string") {
+        if (
+          event.type !== "user-input" ||
+          !("text" in event) ||
+          typeof event.text !== "string"
+        ) {
           return;
         }
         return {
@@ -19,7 +23,11 @@ describe("runPluginsForEvent", () => {
     };
     const prefixB: AgentPlugin = {
       on: ({ event }) => {
-        if (event.type !== "user-text" || typeof event.text !== "string") {
+        if (
+          event.type !== "user-input" ||
+          !("text" in event) ||
+          typeof event.text !== "string"
+        ) {
           return;
         }
         return {
@@ -30,13 +38,13 @@ describe("runPluginsForEvent", () => {
     };
 
     const result = await runPluginsForEvent([prefixA, prefixB], {
-      event: { type: "user-text", text: "hello" },
+      event: { type: "user-input", text: "hello" },
       history: emptyHistory,
     });
 
     expect(result).toEqual({
       kind: "emit",
-      event: { type: "user-text", text: "B:A:hello" },
+      event: { type: "user-input", text: "B:A:hello" },
     });
   });
 
@@ -46,7 +54,7 @@ describe("runPluginsForEvent", () => {
     };
 
     const result = await runPluginsForEvent([handledPlugin], {
-      event: { type: "user-text", text: "hello" },
+      event: { type: "user-input", text: "hello" },
       history: emptyHistory,
     });
 
@@ -57,7 +65,7 @@ describe("runPluginsForEvent", () => {
     const transformTurnStart: AgentPlugin = {
       on: () => ({
         action: "transform",
-        event: { type: "user-text", text: "should-not-apply" },
+        event: { type: "user-input", text: "should-not-apply" },
       }),
     };
 
@@ -77,12 +85,12 @@ describe("runPluginsForEvent", () => {
         runPluginsForEvent(
           [{ on: () => value as ReturnType<NonNullable<AgentPlugin["on"]>> }],
           {
-            event: { type: "user-text", text: "hello" },
+            event: { type: "user-input", text: "hello" },
             history: emptyHistory,
           }
         )
       ).resolves.toEqual({
-        event: { type: "user-text", text: "hello" },
+        event: { type: "user-input", text: "hello" },
         kind: "emit",
       });
     }

--- a/packages/runtime/src/thread/plugins/pipeline.ts
+++ b/packages/runtime/src/thread/plugins/pipeline.ts
@@ -49,11 +49,7 @@ export function runPluginsForEvent(
 function isInterceptableEvent(
   event: AgentEvent
 ): event is InterceptableAgentEvent {
-  return (
-    event.type === "user-text" ||
-    event.type === "user-message" ||
-    event.type === "runtime-input"
-  );
+  return event.type === "user-input" || event.type === "runtime-input";
 }
 
 function normalizeInterceptResult(

--- a/packages/runtime/src/thread/plugins/send-intercept.test.ts
+++ b/packages/runtime/src/thread/plugins/send-intercept.test.ts
@@ -12,11 +12,15 @@ import type { AgentPlugin } from "../plugins/pipeline";
 import { userTextToModelMessage } from "../protocol/mapping";
 
 describe("thread.send intercept", () => {
-  it("queues transformed user-text into model history", async () => {
+  it("queues transformed user-input into model history", async () => {
     const seenHistory: ModelMessage[][] = [];
     const transformPlugin: AgentPlugin = {
       on: ({ event }) => {
-        if (event.type !== "user-text" || typeof event.text !== "string") {
+        if (
+          event.type !== "user-input" ||
+          !("text" in event) ||
+          typeof event.text !== "string"
+        ) {
           return;
         }
         return {

--- a/packages/runtime/src/thread/protocol/events.ts
+++ b/packages/runtime/src/thread/protocol/events.ts
@@ -18,7 +18,7 @@ export type { InputEventMeta, InputSource } from "../input/input-meta-types";
 export interface RuntimeInput {
   /**
    * Runtime/API-originated model input inserted into the current turn.
-   * This is distinct from human-originated user-text and user-message input.
+   * This is distinct from human-originated user-input.
    */
   input: UserInput;
   meta?: InputEventMeta;
@@ -79,8 +79,7 @@ export type AgentEventListener = (event: AgentEvent) => void;
 
 const visibleAgentEventTypes = {
   "assistant-text": true,
-  "user-message": true,
-  "user-text": true,
+  "user-input": true,
 } satisfies Partial<Record<AgentEvent["type"], true>>;
 
 const lifecycleAgentEventTypes = {

--- a/packages/runtime/src/thread/protocol/mapping.ts
+++ b/packages/runtime/src/thread/protocol/mapping.ts
@@ -27,7 +27,7 @@ type ModelEvent = AssistantReasoning | AssistantText | ToolCall | ToolResult;
 // UserInput -> AI SDK UserModelMessage
 export function userInputToModelMessage(input: UserInput): UserModelMessage {
   const stripped = stripInputMeta(input);
-  if (stripped.type === "user-message") {
+  if ("content" in stripped) {
     return userMessageToModelMessage(stripped);
   }
 

--- a/packages/runtime/src/thread/protocol/turn.test.ts
+++ b/packages/runtime/src/thread/protocol/turn.test.ts
@@ -12,7 +12,7 @@ const expectPending = async (promise: Promise<unknown>) => {
 describe("AgentTurn", () => {
   it("delivers events emitted before events consumption", async () => {
     const run = new BufferedAgentTurn();
-    run.emit({ type: "user-text", text: "hello" });
+    run.emit({ type: "user-input", text: "hello" });
     run.emit({ type: "turn-end" });
     run.close();
 
@@ -22,7 +22,7 @@ describe("AgentTurn", () => {
     }
 
     expect(events).toEqual([
-      { type: "user-text", text: "hello" },
+      { type: "user-input", text: "hello" },
       { type: "turn-end" },
     ]);
   });

--- a/packages/runtime/src/thread/runtime/events.test.ts
+++ b/packages/runtime/src/thread/runtime/events.test.ts
@@ -14,10 +14,14 @@ function createDispatcher(
 }
 
 describe("ThreadEventDispatcher.emitRunEvent", () => {
-  it("returns transformed user-text and emits the transformed event", async () => {
+  it("returns transformed user-input and emits the transformed event", async () => {
     const transformPlugin: AgentPlugin = {
       on: ({ event }) => {
-        if (event.type !== "user-text" || typeof event.text !== "string") {
+        if (
+          event.type !== "user-input" ||
+          !("text" in event) ||
+          typeof event.text !== "string"
+        ) {
           return;
         }
         return {
@@ -30,20 +34,20 @@ describe("ThreadEventDispatcher.emitRunEvent", () => {
     const run = new BufferedAgentTurn();
 
     const emitted = await dispatcher.emitRunEvent(run, {
-      type: "user-text",
+      type: "user-input",
       text: "hello",
     });
 
-    expect(emitted).toEqual({ type: "user-text", text: "TAG:hello" });
+    expect(emitted).toEqual({ type: "user-input", text: "TAG:hello" });
     const iterator = run.events()[Symbol.asyncIterator]();
     expect((await iterator.next()).value).toEqual({
-      type: "user-text",
+      type: "user-input",
       text: "TAG:hello",
     });
     await iterator.return?.();
   });
 
-  it("returns handled without emitting user-text to the run", async () => {
+  it("returns handled without emitting user-input to the run", async () => {
     const handledPlugin: AgentPlugin = {
       on: () => ({ action: "handled" }),
     };
@@ -51,7 +55,7 @@ describe("ThreadEventDispatcher.emitRunEvent", () => {
     const run = new BufferedAgentTurn();
 
     const emitted = await dispatcher.emitRunEvent(run, {
-      type: "user-text",
+      type: "user-input",
       text: "hello",
     });
 
@@ -113,7 +117,7 @@ describe("ThreadEventDispatcher.emitRunBoundaryEvent", () => {
     const transformPlugin: AgentPlugin = {
       on: () => ({
         action: "transform",
-        event: { type: "user-text", text: "ignored" },
+        event: { type: "user-input", text: "ignored" },
       }),
     };
     const dispatcher = createDispatcher([transformPlugin]);

--- a/packages/runtime/src/thread/runtime/notification.ts
+++ b/packages/runtime/src/thread/runtime/notification.ts
@@ -1,6 +1,6 @@
-import type { AgentInput } from "../input/input";
+import type { AgentInput, UserInput } from "../input/input";
 import { attachInputMeta } from "../input/input-meta";
-import { normalizeAgentInput } from "../input/input-normalization";
+import { normalizeInternalAgentInput } from "../input/input-normalization";
 import {
   createRuntimeInputState,
   type QueuedInput,
@@ -15,6 +15,7 @@ import { errorMessage } from "../state/thread-errors";
 export interface NotifyOptions {
   readonly deferWhenUnobserved?: boolean;
   readonly observerEvents?: readonly AgentEvent[];
+  readonly overlays?: readonly (AgentInput | UserInput)[];
 }
 
 interface QueueThreadNotificationOptions {
@@ -30,19 +31,22 @@ interface QueueThreadNotificationOptions {
 }
 
 export async function queueThreadNotification(
-  input: AgentInput,
+  input: AgentInput | UserInput,
   options: NotifyOptions,
   state: QueueThreadNotificationOptions
 ): Promise<AgentTurn> {
   const queuedRuntimeInput: QueuedRuntimeInput = {
-    input: attachInputMeta(normalizeAgentInput(input), { source: "notify" }),
+    input: attachInputMeta(normalizeInternalAgentInput(input), {
+      source: "notify",
+    }),
     placement: "turn-start",
   };
+  const queuedOverlays = createNotificationOverlays(options.overlays ?? []);
   const observerEvents = cloneObserverEvents(options.observerEvents ?? []);
   const queuedTurn = state.inputQueue[0];
   if (queuedTurn) {
     queuedTurn.initialEvents.push(...observerEvents);
-    queuedTurn.preUserRuntimeInputs.push(queuedRuntimeInput);
+    queuedTurn.preUserRuntimeInputs.push(...queuedOverlays, queuedRuntimeInput);
     return queuedTurn.run;
   }
 
@@ -52,6 +56,9 @@ export async function queueThreadNotification(
     for (const event of observerEvents) {
       await state.emitObserverEvent(activeRun, event);
     }
+    for (const overlay of queuedOverlays) {
+      queueRuntimeInput(runtimeInput, { ...overlay, placement: "step-end" });
+    }
     queueRuntimeInput(runtimeInput, {
       input: structuredClone(queuedRuntimeInput.input),
       placement: "step-end",
@@ -60,6 +67,7 @@ export async function queueThreadNotification(
   }
 
   if (options.deferWhenUnobserved === true) {
+    state.pendingRuntimeInputs.push(...queuedOverlays);
     state.pendingRuntimeInputs.push(queuedRuntimeInput);
     const deferredRun = new BufferedAgentTurn();
     deferredRun.close();
@@ -69,7 +77,7 @@ export async function queueThreadNotification(
   const run = new BufferedAgentTurn();
   state.inputQueue.push({
     initialEvents: observerEvents,
-    preUserRuntimeInputs: [],
+    preUserRuntimeInputs: queuedOverlays,
     run,
     runtimeInput: createRuntimeInputState([queuedRuntimeInput]),
   });
@@ -89,4 +97,16 @@ export function startThreadQueueDrain(
 
 function cloneObserverEvents(events: readonly AgentEvent[]): AgentEvent[] {
   return events.map((event) => structuredClone(event));
+}
+
+function createNotificationOverlays(
+  overlays: readonly (AgentInput | UserInput)[]
+): QueuedRuntimeInput[] {
+  return overlays.map((input) => ({
+    canonical: false,
+    input: attachInputMeta(normalizeInternalAgentInput(input), {
+      source: "overlay",
+    }),
+    placement: "turn-start",
+  }));
 }

--- a/packages/runtime/src/thread/runtime/turn-processor.ts
+++ b/packages/runtime/src/thread/runtime/turn-processor.ts
@@ -117,6 +117,7 @@ export async function processQueuedInput({
       toolExecution: executionRun?.toolExecution,
     });
 
+    state.clearTransientInputs();
     await state.commit();
     await executionRun?.complete(executionStatusForResult(result));
     await closeSuccessfulTurn({

--- a/packages/runtime/src/thread/runtime/windows.test.ts
+++ b/packages/runtime/src/thread/runtime/windows.test.ts
@@ -89,7 +89,7 @@ describe("Agent thread runtime input windows", () => {
     const finalHistory = [...secondStepHistory, assistantMessage("DONE")];
 
     expect(pluginCalls).toEqual([
-      "user-text:2",
+      "user-input:2",
       "turn-start:3",
       "runtime-input:3",
       "step-start:4",
@@ -103,7 +103,7 @@ describe("Agent thread runtime input windows", () => {
       "turn-end:8",
     ]);
     expect(eventTypes(events)).toEqual([
-      "user-text",
+      "user-input",
       "turn-start",
       "runtime-input",
       "step-start",
@@ -127,8 +127,8 @@ describe("Agent thread runtime input windows", () => {
     );
     expect(seenHistory).toEqual([firstStepHistory, secondStepHistory]);
     expect(trace).toEqual([
-      "plugin:user-text",
-      "event:user-text",
+      "plugin:user-input",
+      "event:user-input",
       "plugin:turn-start",
       "event:turn-start",
       "plugin:runtime-input",

--- a/packages/runtime/src/thread/state/history.ts
+++ b/packages/runtime/src/thread/state/history.ts
@@ -10,6 +10,7 @@ export class ModelMessageHistory {
   readonly #compactions: ThreadCompactionRecord[] = [];
   readonly #modelHistory: ModelMessage[] = [];
   readonly #onChange?: (snapshot: ModelMessage[]) => void;
+  readonly #transientMessages: TransientModelMessage[] = [];
 
   constructor(
     history?: ModelMessage[],
@@ -32,7 +33,11 @@ export class ModelMessageHistory {
   modelContextSnapshot(
     options: { readonly maxMessages?: number } = {}
   ): ModelMessage[] {
-    const compacted = applyCompactions(this.#modelHistory, this.#compactions);
+    const compacted = applyCompactions(
+      this.#modelHistory,
+      this.#compactions,
+      this.#transientMessages
+    );
     if (
       options.maxMessages === undefined ||
       compacted.length <= options.maxMessages
@@ -58,14 +63,26 @@ export class ModelMessageHistory {
     this.#triggerChange();
   }
 
+  appendTransientUserInput(input: UserInput): void {
+    this.#transientMessages.push({
+      index: this.#modelHistory.length,
+      message: userInputToModelMessage(input),
+    });
+  }
+
   appendModelMessage(message: ModelMessage): void {
     this.#modelHistory.push(structuredClone(message));
     this.#triggerChange();
   }
 
+  clearTransientInputs(): void {
+    this.#transientMessages.length = 0;
+  }
+
   rollback(snapshot: ModelMessage[]): void {
     this.#modelHistory.length = 0;
     this.#modelHistory.push(...structuredClone(snapshot));
+    this.clearTransientInputs();
     for (let index = this.#compactions.length - 1; index >= 0; index -= 1) {
       const record = this.#compactions[index];
       if (!record || record.endSeqExclusive > this.#modelHistory.length) {
@@ -82,11 +99,16 @@ export class ModelMessageHistory {
 
 function applyCompactions(
   history: readonly ModelMessage[],
-  compactions: readonly ThreadCompactionRecord[]
+  compactions: readonly ThreadCompactionRecord[],
+  transientMessages: readonly TransientModelMessage[] = []
 ): ModelMessage[] {
   const kept = nonOverlappedCompactions(history.length, compactions);
   if (kept.length === 0) {
-    return history.map((message) => structuredClone(message));
+    return applyTransientMessages(
+      history.map((message) => structuredClone(message)),
+      history.length,
+      transientMessages
+    );
   }
 
   const byStart = new Map<number, ThreadCompactionRecord>();
@@ -96,6 +118,7 @@ function applyCompactions(
 
   const output: ModelMessage[] = [];
   for (let index = 0; index < history.length; ) {
+    appendTransientMessages(output, transientMessages, index);
     const record = byStart.get(index);
     if (record) {
       output.push(structuredClone(record.summary));
@@ -109,7 +132,46 @@ function applyCompactions(
     }
     index += 1;
   }
+  appendTransientMessages(output, transientMessages, history.length);
   return output;
+}
+
+interface TransientModelMessage {
+  readonly index: number;
+  readonly message: ModelMessage;
+}
+
+function applyTransientMessages(
+  history: ModelMessage[],
+  historyLength: number,
+  transientMessages: readonly TransientModelMessage[]
+): ModelMessage[] {
+  if (transientMessages.length === 0) {
+    return history;
+  }
+
+  const output: ModelMessage[] = [];
+  for (let index = 0; index < historyLength; index += 1) {
+    appendTransientMessages(output, transientMessages, index);
+    const message = history[index];
+    if (message) {
+      output.push(message);
+    }
+  }
+  appendTransientMessages(output, transientMessages, historyLength);
+  return output;
+}
+
+function appendTransientMessages(
+  output: ModelMessage[],
+  transientMessages: readonly TransientModelMessage[],
+  index: number
+): void {
+  for (const transient of transientMessages) {
+    if (transient.index === index) {
+      output.push(structuredClone(transient.message));
+    }
+  }
 }
 
 function nonOverlappedCompactions(

--- a/packages/runtime/src/thread/state/thread-state.ts
+++ b/packages/runtime/src/thread/state/thread-state.ts
@@ -94,6 +94,16 @@ export class ThreadState {
     this.#history.appendUserInput(input);
   }
 
+  appendTransientUserInput(
+    input: Parameters<ModelMessageHistory["appendTransientUserInput"]>[0]
+  ) {
+    this.#history.appendTransientUserInput(input);
+  }
+
+  clearTransientInputs(): void {
+    this.#history.clearTransientInputs();
+  }
+
   rollback(snapshot: ModelMessage[]): void {
     this.#history.rollback(snapshot);
   }

--- a/scripts/cloudflare-example.test.mjs
+++ b/scripts/cloudflare-example.test.mjs
@@ -66,7 +66,7 @@ describe("cloudflare durable object adapter", () => {
     });
     await host.store.notifications.enqueue({
       idempotencyKey,
-      input: { text: "ready", type: "user-text" },
+      input: { text: "ready", type: "user-input" },
       notificationId: "notification-delayed",
       runId: notificationRunId,
       status: "pending",

--- a/scripts/examples.test.mjs
+++ b/scripts/examples.test.mjs
@@ -185,7 +185,7 @@ describe("examples workspace packages", () => {
     expect(agentsSource).toContain("read_file: createReadFileTool()");
 
     expect(conversationPluginSource).toContain('action: "transform"');
-    expect(conversationPluginSource).toContain("user-text");
+    expect(conversationPluginSource).toContain("user-input");
 
     expect(delegateToolSource).toContain("delegate_to_reader");
     expect(delegateToolSource).toContain("delegateUserInput");


### PR DESCRIPTION
## Summary
- unify runtime user-originated inputs/events around `user-input`
- add chainable noncanonical `thread.overlay()` and `AgentOptions.notificationOverlays`
- keep overlays visible to the current model turn while excluding them from persisted thread history and automatic compaction summaries
- version `@minpeter/pss-runtime` to `0.1.0-next.21`

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm verify:release`
- manual overlay smoke driver: overlay appears in the first model history and is absent from the next turn history

## Release note
Local `pnpm release:next` built successfully but npm publish failed because this shell is not authenticated (`npm whoami` returns 401). This PR should publish through the existing `v0.1` release workflow with Trusted Publishing after merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds noncanonical runtime overlays and unifies human events under `user-input` to simplify inputs and enable per-run context that doesn’t persist.

- **New Features**
  - `thread.overlay(input)`: chainable, inserts `runtime-input` before the user message for the next turn; excluded from history and compaction.
  - `notificationOverlays` in `AgentOptions`: default overlays applied when resuming notifications; also supported by dispatch helpers.
  - Unified human events as `user-input`; TUI and plugins now handle a single user event type.
  - Bump `@minpeter/pss-runtime` to `0.1.0-next.21`.

- **Migration**
  - Replace `user-text`/`user-message` AgentInput with plain `string`, `string[]`, or `UserMessageContentPart[]`.
  - Update plugin guards to `event.type === "user-input"` and check `"text" in event` when needed.
  - Use `thread.overlay(input)` for transient, per-run context instead of sending extra user events.
  - Notifications: pass overlays via dispatch helpers and/or set defaults with `notificationOverlays`.
  - `delegateUserInput(prompt)` now returns an `AgentInput` string; remove the options param.

<sup>Written for commit 307f8fdd69a31b69c672656282aaf010e33d73de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

