### PR TITLE
[codex] Move coding-agent thread inspection into runtime

### DIFF
--- a/.changeset/coding-agent-local-compaction.md
+++ b/.changeset/coding-agent-local-compaction.md
@@ -1,0 +1,12 @@
+---
+"@minpeter/pss-coding-agent": patch
+---
+
+Add local thread compaction configuration and inspection support to the coding
+agent CLI.
+
+The TUI now shows the active thread key and auto-compaction policy, accepts
+`PSS_THREAD_*` storage settings with legacy `PSS_SESSION_*` aliases, and can
+enable runtime auto-compaction through `PSS_AUTO_COMPACTION_MIN_MESSAGES` plus
+`PSS_AUTO_COMPACTION_RETAIN_MESSAGES`. The CLI also adds `pss inspect-thread`
+for checking the configured local thread file without starting the TUI.

--- a/.changeset/coding-agent-local-compaction.md
+++ b/.changeset/coding-agent-local-compaction.md
@@ -9,4 +9,6 @@ The TUI now shows the active thread key and auto-compaction policy, accepts
 `PSS_THREAD_*` storage settings with legacy `PSS_SESSION_*` aliases, and can
 enable runtime auto-compaction through `PSS_AUTO_COMPACTION_MIN_MESSAGES` plus
 `PSS_AUTO_COMPACTION_RETAIN_MESSAGES`. The CLI also adds `pss inspect-thread`
-for checking the configured local thread file without starting the TUI.
+for checking the configured local thread file without starting the TUI. The
+coding agent now uses the runtime Node platform host and runtime-owned file
+thread inspection helper for local thread storage.

--- a/.changeset/runtime-node-thread-inspection.md
+++ b/.changeset/runtime-node-thread-inspection.md
@@ -1,0 +1,6 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add `inspectNodeFileThread` and `nodeFileThreadStorageFile` to the Node platform
+adapter for runtime-owned local thread storage inspection.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -42,9 +42,9 @@ already printed final-looking text. Adding input on every `step-end` can keep
 the turn running indefinitely.
 
 Runtime additions emit `runtime-input`: runtime/API-originated input mapped
-internally to the model's user role, separate from human `user-text` and
-`user-message` events. `thread.send(input)` starts or enqueues a new turn;
-`thread.steer(input)` steers the active turn or starts a normal turn when idle.
+internally to the model's user role, separate from human `user-input` events.
+`thread.send(input)` starts or enqueues a new turn; `thread.steer(input)` steers
+the active turn or starts a normal turn when idle.
 
 ## CLI
 
@@ -64,6 +64,10 @@ Inspect the configured local thread without starting the TUI:
 ```sh
 pss inspect-thread
 ```
+
+The inspection command uses the runtime Node adapter to decode stored thread
+snapshots, so the CLI reports the same file path, message count, compaction
+records, and version that runtime storage uses.
 
 The `pss` TUI starts a plain conversational agent with no built-in tools. To run
 the TUI with tools, call `startTui({ tools })` from your own entrypoint (for

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -59,6 +59,12 @@ pss
 
 CLI commands: `pss`, `pss-coding-agent`.
 
+Inspect the configured local thread without starting the TUI:
+
+```sh
+pss inspect-thread
+```
+
 The `pss` TUI starts a plain conversational agent with no built-in tools. To run
 the TUI with tools, call `startTui({ tools })` from your own entrypoint (for
 example to wire `@minpeter/pss-web-tools`):
@@ -78,17 +84,28 @@ turn.
 
 Set `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL` for the model.
 
-The TUI persists runtime-owned session state to files by default:
+The TUI persists runtime-owned thread state to files by default:
 
-- `PSS_SESSION_DIR` overrides the store directory. Default: `~/.pss/sessions`.
-- `PSS_SESSION_KEY` overrides the conversation key. Default: `cwd:<current working directory>`.
+- `PSS_THREAD_DIR` overrides the store directory. Default: `~/.pss/threads`.
+- `PSS_THREAD_KEY` overrides the conversation key. Default: `cwd:<current working directory>`.
+- `PSS_SESSION_DIR` and `PSS_SESSION_KEY` remain accepted as legacy aliases.
+
+Local auto-compaction is disabled unless both thresholds are set:
+
+- `PSS_AUTO_COMPACTION_MIN_MESSAGES` starts compaction once stored history reaches this count.
+- `PSS_AUTO_COMPACTION_RETAIN_MESSAGES` keeps this many newest messages outside the summary.
+
+Both values must be positive integers, and retain messages must be smaller than
+minimum messages.
 
 Examples:
 
 ```sh
 pss
-PSS_SESSION_KEY=workspace:demo pss
-PSS_SESSION_DIR=.pss/sessions pss
+PSS_THREAD_KEY=workspace:demo pss
+PSS_THREAD_DIR=.pss/threads pss
+PSS_AUTO_COMPACTION_MIN_MESSAGES=24 PSS_AUTO_COMPACTION_RETAIN_MESSAGES=8 pss
+PSS_THREAD_KEY=workspace:demo pss inspect-thread
 ```
 
 ## Dev

--- a/apps/coding-agent/bin/pss.js
+++ b/apps/coding-agent/bin/pss.js
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
-import { startTui } from "../dist/tui.js";
+import { runCodingAgentCli } from "../dist/cli.js";
 
-await startTui();
+try {
+  const exitCode = await runCodingAgentCli();
+  if (exitCode !== 0) {
+    process.exitCode = exitCode;
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -21,6 +21,16 @@
       "types": "./dist/model.d.ts",
       "import": "./dist/model.js"
     },
+    "./thread-config": {
+      "@minpeter/pss-source": "./src/thread-config.ts",
+      "types": "./dist/thread-config.d.ts",
+      "import": "./dist/thread-config.js"
+    },
+    "./thread-inspect": {
+      "@minpeter/pss-source": "./src/thread-inspect.ts",
+      "types": "./dist/thread-inspect.d.ts",
+      "import": "./dist/thread-inspect.js"
+    },
     "./tui": {
       "@minpeter/pss-source": "./src/tui.ts",
       "types": "./dist/tui.d.ts",
@@ -46,6 +56,7 @@
     "provenance": true
   },
   "scripts": {
+    "start": "tsx --conditions=@minpeter/pss-source src/tui.ts",
     "build": "tsdown",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",

--- a/apps/coding-agent/src/cli.test.ts
+++ b/apps/coding-agent/src/cli.test.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCodingAgentCli } from "./cli";
+
+describe("coding-agent CLI", () => {
+  it("routes inspect-thread through the local inspection surface", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pss-coding-agent-cli-"));
+    let output = "";
+
+    try {
+      const exitCode = await runCodingAgentCli({
+        argv: ["inspect-thread"],
+        cwd: "/repo/demo",
+        env: {
+          PSS_THREAD_DIR: directory,
+          PSS_THREAD_KEY: "workspace:demo",
+        },
+        home: "/home/me",
+        stdout: {
+          write(text: string): void {
+            output += text;
+          },
+        },
+      });
+
+      expect(exitCode).toBe(0);
+      expect(output).toContain("threadKey: workspace:demo\n");
+      expect(output).toContain("messageCount: 0\n");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -1,0 +1,45 @@
+import { homedir } from "node:os";
+import { resolveCodingAgentThreadConfig } from "./thread-config";
+import {
+  formatThreadInspectionReport,
+  inspectCodingAgentThread,
+} from "./thread-inspect";
+import { startTui } from "./tui";
+
+interface CliWritable {
+  write(text: string): void;
+}
+
+interface RunCodingAgentCliOptions {
+  readonly argv?: readonly string[];
+  readonly cwd?: string;
+  readonly env?: Parameters<typeof resolveCodingAgentThreadConfig>[0];
+  readonly home?: string;
+  readonly start?: () => Promise<void>;
+  readonly stdout?: CliWritable;
+}
+
+export async function runCodingAgentCli({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  env = process.env,
+  home = homedir(),
+  start = startTui,
+  stdout = process.stdout,
+}: RunCodingAgentCliOptions = {}): Promise<number> {
+  const command = argv[0];
+
+  if (command === undefined) {
+    await start();
+    return 0;
+  }
+
+  if (command === "inspect-thread") {
+    const config = resolveCodingAgentThreadConfig(env, cwd, home);
+    const report = await inspectCodingAgentThread(config);
+    stdout.write(`${formatThreadInspectionReport(report)}\n`);
+    return 0;
+  }
+
+  throw new Error(`Unknown pss command: ${command}`);
+}

--- a/apps/coding-agent/src/index.ts
+++ b/apps/coding-agent/src/index.ts
@@ -13,4 +13,13 @@ export type {
 export { createCodingLanguageModel } from "./model";
 export type { CodingAgentThreadConfig } from "./thread-config";
 export { resolveCodingAgentThreadConfig } from "./thread-config";
+export type {
+  ThreadInspectionCompaction,
+  ThreadInspectionReport,
+} from "./thread-inspect";
+export {
+  formatThreadInspectionReport,
+  inspectCodingAgentThread,
+  storageFileForThread,
+} from "./thread-inspect";
 export { type StartTuiOptions, startTui } from "./tui";

--- a/apps/coding-agent/src/thread-config.test.ts
+++ b/apps/coding-agent/src/thread-config.test.ts
@@ -6,6 +6,7 @@ describe("resolveCodingAgentThreadConfig", () => {
     expect(
       resolveCodingAgentThreadConfig({}, "/repo/demo", "/home/me")
     ).toEqual({
+      autoCompaction: false,
       directory: "/home/me/.pss/threads",
       key: "cwd:/repo/demo",
     });
@@ -22,6 +23,7 @@ describe("resolveCodingAgentThreadConfig", () => {
         "/home/me"
       )
     ).toEqual({
+      autoCompaction: false,
       directory: ".pss/threads",
       key: "workspace:demo",
     });
@@ -38,6 +40,7 @@ describe("resolveCodingAgentThreadConfig", () => {
         "/home/me"
       )
     ).toEqual({
+      autoCompaction: false,
       directory: ".pss/sessions",
       key: "workspace:legacy",
     });
@@ -51,8 +54,74 @@ describe("resolveCodingAgentThreadConfig", () => {
         "/home/me"
       )
     ).toEqual({
+      autoCompaction: false,
       directory: "/home/me/.pss/threads",
       key: "cwd:/repo/demo",
     });
+  });
+
+  it("enables auto compaction from explicit positive integer env values", () => {
+    expect(
+      resolveCodingAgentThreadConfig(
+        {
+          PSS_AUTO_COMPACTION_MIN_MESSAGES: "12",
+          PSS_AUTO_COMPACTION_RETAIN_MESSAGES: "4",
+        },
+        "/repo/demo",
+        "/home/me"
+      )
+    ).toEqual({
+      autoCompaction: { minMessages: 12, retainMessages: 4 },
+      directory: "/home/me/.pss/threads",
+      key: "cwd:/repo/demo",
+    });
+  });
+
+  it.each([
+    {
+      env: { PSS_AUTO_COMPACTION_MIN_MESSAGES: "12" },
+      message:
+        "PSS_AUTO_COMPACTION_MIN_MESSAGES and PSS_AUTO_COMPACTION_RETAIN_MESSAGES must be set together.",
+      name: "missing retain threshold",
+    },
+    {
+      env: { PSS_AUTO_COMPACTION_RETAIN_MESSAGES: "4" },
+      message:
+        "PSS_AUTO_COMPACTION_MIN_MESSAGES and PSS_AUTO_COMPACTION_RETAIN_MESSAGES must be set together.",
+      name: "missing minimum threshold",
+    },
+    {
+      env: {
+        PSS_AUTO_COMPACTION_MIN_MESSAGES: "12.5",
+        PSS_AUTO_COMPACTION_RETAIN_MESSAGES: "4",
+      },
+      message: "PSS_AUTO_COMPACTION_MIN_MESSAGES must be a positive integer.",
+      name: "fractional minimum threshold",
+    },
+    {
+      env: {
+        PSS_AUTO_COMPACTION_MIN_MESSAGES: "12",
+        PSS_AUTO_COMPACTION_RETAIN_MESSAGES: "0",
+      },
+      message:
+        "PSS_AUTO_COMPACTION_RETAIN_MESSAGES must be a positive integer.",
+      name: "zero retain threshold",
+    },
+    {
+      env: {
+        PSS_AUTO_COMPACTION_MIN_MESSAGES: "4",
+        PSS_AUTO_COMPACTION_RETAIN_MESSAGES: "4",
+      },
+      message:
+        "PSS_AUTO_COMPACTION_RETAIN_MESSAGES must be smaller than PSS_AUTO_COMPACTION_MIN_MESSAGES.",
+      name: "retain threshold equals minimum threshold",
+    },
+  ] as const)("rejects malformed auto compaction env: $name", ({
+    env,
+    message,
+  }) => {
+    expect(() =>
+      resolveCodingAgentThreadConfig(env, "/repo/demo", "/home/me")
+    ).toThrow(message);
   });
 });

--- a/apps/coding-agent/src/thread-config.ts
+++ b/apps/coding-agent/src/thread-config.ts
@@ -1,7 +1,10 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { AgentOptions } from "@minpeter/pss-runtime";
 
 interface ThreadConfigEnv {
+  readonly PSS_AUTO_COMPACTION_MIN_MESSAGES?: string;
+  readonly PSS_AUTO_COMPACTION_RETAIN_MESSAGES?: string;
   readonly PSS_SESSION_DIR?: string;
   readonly PSS_SESSION_KEY?: string;
   readonly PSS_THREAD_DIR?: string;
@@ -9,6 +12,7 @@ interface ThreadConfigEnv {
 }
 
 export interface CodingAgentThreadConfig {
+  readonly autoCompaction: AgentOptions["autoCompaction"];
   readonly directory: string;
   readonly key: string;
 }
@@ -19,6 +23,7 @@ export function resolveCodingAgentThreadConfig(
   home = homedir()
 ): CodingAgentThreadConfig {
   return {
+    autoCompaction: resolveAutoCompaction(env),
     directory:
       nonEmpty(env.PSS_THREAD_DIR) ??
       nonEmpty(env.PSS_SESSION_DIR) ??
@@ -28,6 +33,49 @@ export function resolveCodingAgentThreadConfig(
       nonEmpty(env.PSS_SESSION_KEY) ??
       `cwd:${cwd}`,
   };
+}
+
+function resolveAutoCompaction(
+  env: ThreadConfigEnv
+): AgentOptions["autoCompaction"] {
+  const minMessagesValue = nonEmpty(env.PSS_AUTO_COMPACTION_MIN_MESSAGES);
+  const retainMessagesValue = nonEmpty(env.PSS_AUTO_COMPACTION_RETAIN_MESSAGES);
+
+  if (minMessagesValue === undefined && retainMessagesValue === undefined) {
+    return false;
+  }
+
+  if (minMessagesValue === undefined || retainMessagesValue === undefined) {
+    throw new Error(
+      "PSS_AUTO_COMPACTION_MIN_MESSAGES and PSS_AUTO_COMPACTION_RETAIN_MESSAGES must be set together."
+    );
+  }
+
+  const minMessages = parsePositiveIntegerEnv(
+    "PSS_AUTO_COMPACTION_MIN_MESSAGES",
+    minMessagesValue
+  );
+  const retainMessages = parsePositiveIntegerEnv(
+    "PSS_AUTO_COMPACTION_RETAIN_MESSAGES",
+    retainMessagesValue
+  );
+
+  if (retainMessages >= minMessages) {
+    throw new Error(
+      "PSS_AUTO_COMPACTION_RETAIN_MESSAGES must be smaller than PSS_AUTO_COMPACTION_MIN_MESSAGES."
+    );
+  }
+
+  return { minMessages, retainMessages };
+}
+
+function parsePositiveIntegerEnv(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
+  return parsed;
 }
 
 function nonEmpty(value: string | undefined): string | undefined {

--- a/apps/coding-agent/src/thread-inspect.test.ts
+++ b/apps/coding-agent/src/thread-inspect.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  formatThreadInspectionReport,
+  inspectCodingAgentThread,
+} from "./thread-inspect";
+
+const threadFileName = (key: string): string =>
+  `${Buffer.from(key).toString("base64url")}.json`;
+
+async function tempDir(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "pss-coding-agent-inspect-"));
+}
+
+describe("thread inspection", () => {
+  it("reports schemaVersion 2 compaction records from local thread storage", async () => {
+    const directory = await tempDir();
+    const key = "inspect:key";
+    const summary = { content: "old context summarized", role: "system" };
+    const summaryBytes = Buffer.byteLength(JSON.stringify(summary), "utf8");
+
+    try {
+      await writeFile(
+        join(directory, threadFileName(key)),
+        `${JSON.stringify(
+          {
+            state: {
+              compactions: [
+                {
+                  endSeqExclusive: 2,
+                  schemaVersion: 1,
+                  startSeq: 0,
+                  summary,
+                },
+              ],
+              history: [
+                { content: "one", role: "user" },
+                { content: "two", role: "assistant" },
+                { content: "three", role: "user" },
+              ],
+              schemaVersion: 2,
+            },
+            version: "7",
+          },
+          null,
+          2
+        )}\n`,
+        "utf8"
+      );
+
+      const report = await inspectCodingAgentThread({
+        autoCompaction: { minMessages: 12, retainMessages: 4 },
+        directory,
+        key,
+      });
+
+      expect(formatThreadInspectionReport(report)).toBe(`threadKey: inspect:key
+storageFile: ${join(directory, threadFileName(key))}
+messageCount: 3
+compactionCount: 1
+compactions:
+  - startSeq=0 endSeqExclusive=2 summaryBytes=${summaryBytes}
+summaryBytes: ${summaryBytes}
+autoCompaction: min=12 retain=4`);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("reports zero counts for a missing local thread", async () => {
+    const directory = await tempDir();
+    const key = "missing:key";
+
+    try {
+      const report = await inspectCodingAgentThread({
+        autoCompaction: false,
+        directory,
+        key,
+      });
+
+      expect(formatThreadInspectionReport(report)).toBe(`threadKey: missing:key
+storageFile: ${join(directory, threadFileName(key))}
+messageCount: 0
+compactionCount: 0
+compactions: none
+summaryBytes: 0
+autoCompaction: off`);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/coding-agent/src/thread-inspect.test.ts
+++ b/apps/coding-agent/src/thread-inspect.test.ts
@@ -58,6 +58,7 @@ describe("thread inspection", () => {
 
       expect(formatThreadInspectionReport(report)).toBe(`threadKey: inspect:key
 storageFile: ${join(directory, threadFileName(key))}
+version: 7
 messageCount: 3
 compactionCount: 1
 compactions:
@@ -82,6 +83,7 @@ autoCompaction: min=12 retain=4`);
 
       expect(formatThreadInspectionReport(report)).toBe(`threadKey: missing:key
 storageFile: ${join(directory, threadFileName(key))}
+version: none
 messageCount: 0
 compactionCount: 0
 compactions: none

--- a/apps/coding-agent/src/thread-inspect.ts
+++ b/apps/coding-agent/src/thread-inspect.ts
@@ -1,0 +1,169 @@
+import { join } from "node:path";
+import { FileThreadStore } from "@minpeter/pss-runtime/thread-store/file";
+import { z } from "zod";
+import type { CodingAgentThreadConfig } from "./thread-config";
+
+const modelMessageSchema = z
+  .object({
+    content: z.unknown(),
+    role: z.enum(["system", "user", "assistant", "tool"]),
+  })
+  .passthrough();
+
+const compactionSchema = z
+  .object({
+    endSeqExclusive: z.number().int(),
+    schemaVersion: z.literal(1),
+    startSeq: z.number().int().nonnegative(),
+    summary: modelMessageSchema,
+  })
+  .passthrough();
+
+const snapshotV1Schema = z
+  .object({
+    history: z.array(modelMessageSchema),
+    schemaVersion: z.literal(1),
+  })
+  .passthrough();
+
+const snapshotV2Schema = z
+  .object({
+    compactions: z.array(compactionSchema),
+    history: z.array(modelMessageSchema),
+    schemaVersion: z.literal(2),
+  })
+  .passthrough();
+
+const snapshotSchema = z.union([snapshotV1Schema, snapshotV2Schema]);
+
+type ThreadSnapshot = z.infer<typeof snapshotSchema>;
+type ThreadCompaction = z.infer<typeof compactionSchema>;
+
+export interface ThreadInspectionCompaction {
+  readonly endSeqExclusive: number;
+  readonly startSeq: number;
+  readonly summaryBytes: number;
+}
+
+export interface ThreadInspectionReport {
+  readonly autoCompaction: CodingAgentThreadConfig["autoCompaction"];
+  readonly compactionCount: number;
+  readonly compactions: readonly ThreadInspectionCompaction[];
+  readonly messageCount: number;
+  readonly storageFile: string;
+  readonly summaryBytes: number;
+  readonly threadKey: string;
+}
+
+export async function inspectCodingAgentThread(
+  config: CodingAgentThreadConfig
+): Promise<ThreadInspectionReport> {
+  const stored = await new FileThreadStore(config.directory).load(config.key);
+  const state = decodeThreadState(stored?.state);
+  const compactions = state.compactions.map((record) => ({
+    endSeqExclusive: record.endSeqExclusive,
+    startSeq: record.startSeq,
+    summaryBytes: jsonByteLength(record.summary),
+  }));
+  const summaryBytes = compactions.reduce(
+    (total, record) => total + record.summaryBytes,
+    0
+  );
+
+  return {
+    autoCompaction: config.autoCompaction,
+    compactionCount: compactions.length,
+    compactions,
+    messageCount: state.messageCount,
+    storageFile: storageFileForThread(config.directory, config.key),
+    summaryBytes,
+    threadKey: config.key,
+  };
+}
+
+export function formatThreadInspectionReport(
+  report: ThreadInspectionReport
+): string {
+  const compactions =
+    report.compactions.length === 0
+      ? "compactions: none"
+      : `compactions:\n${report.compactions
+          .map(
+            (record) =>
+              `  - startSeq=${record.startSeq} endSeqExclusive=${record.endSeqExclusive} summaryBytes=${record.summaryBytes}`
+          )
+          .join("\n")}`;
+
+  return [
+    `threadKey: ${report.threadKey}`,
+    `storageFile: ${report.storageFile}`,
+    `messageCount: ${report.messageCount}`,
+    `compactionCount: ${report.compactionCount}`,
+    compactions,
+    `summaryBytes: ${report.summaryBytes}`,
+    `autoCompaction: ${formatAutoCompaction(report.autoCompaction)}`,
+  ].join("\n");
+}
+
+export function storageFileForThread(directory: string, key: string): string {
+  return join(directory, `${Buffer.from(key).toString("base64url")}.json`);
+}
+
+function decodeThreadState(state: unknown): {
+  readonly compactions: readonly ThreadCompaction[];
+  readonly messageCount: number;
+} {
+  if (state === undefined) {
+    return { compactions: [], messageCount: 0 };
+  }
+
+  const parsed = snapshotSchema.safeParse(state);
+  if (!parsed.success) {
+    throw new Error("Unsupported stored thread state");
+  }
+
+  validateSnapshotCompactions(parsed.data);
+
+  if (parsed.data.schemaVersion === 1) {
+    return { compactions: [], messageCount: parsed.data.history.length };
+  }
+
+  return {
+    compactions: parsed.data.compactions,
+    messageCount: parsed.data.history.length,
+  };
+}
+
+function validateSnapshotCompactions(snapshot: ThreadSnapshot): void {
+  if (snapshot.schemaVersion !== 2) {
+    return;
+  }
+
+  for (const record of snapshot.compactions) {
+    if (record.endSeqExclusive <= record.startSeq) {
+      throw new Error(
+        "Thread compaction endSeqExclusive must be greater than startSeq"
+      );
+    }
+    if (record.endSeqExclusive > snapshot.history.length) {
+      throw new Error("Thread compaction range exceeds thread history");
+    }
+  }
+}
+
+function jsonByteLength(value: unknown): number {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) {
+    throw new Error("Thread compaction summary could not be encoded");
+  }
+
+  return Buffer.byteLength(encoded, "utf8");
+}
+
+function formatAutoCompaction(
+  autoCompaction: CodingAgentThreadConfig["autoCompaction"]
+): string {
+  return autoCompaction
+    ? `min=${autoCompaction.minMessages} retain=${autoCompaction.retainMessages}`
+    : "off";
+}

--- a/apps/coding-agent/src/thread-inspect.ts
+++ b/apps/coding-agent/src/thread-inspect.ts
@@ -1,83 +1,29 @@
-import { join } from "node:path";
-import { FileThreadStore } from "@minpeter/pss-runtime/thread-store/file";
-import { z } from "zod";
+import {
+  inspectNodeFileThread,
+  type NodeFileThreadInspection,
+  type NodeFileThreadInspectionCompaction,
+  nodeFileThreadStorageFile,
+} from "@minpeter/pss-runtime/node";
 import type { CodingAgentThreadConfig } from "./thread-config";
 
-const modelMessageSchema = z
-  .object({
-    content: z.unknown(),
-    role: z.enum(["system", "user", "assistant", "tool"]),
-  })
-  .passthrough();
+export type ThreadInspectionCompaction = NodeFileThreadInspectionCompaction;
 
-const compactionSchema = z
-  .object({
-    endSeqExclusive: z.number().int(),
-    schemaVersion: z.literal(1),
-    startSeq: z.number().int().nonnegative(),
-    summary: modelMessageSchema,
-  })
-  .passthrough();
-
-const snapshotV1Schema = z
-  .object({
-    history: z.array(modelMessageSchema),
-    schemaVersion: z.literal(1),
-  })
-  .passthrough();
-
-const snapshotV2Schema = z
-  .object({
-    compactions: z.array(compactionSchema),
-    history: z.array(modelMessageSchema),
-    schemaVersion: z.literal(2),
-  })
-  .passthrough();
-
-const snapshotSchema = z.union([snapshotV1Schema, snapshotV2Schema]);
-
-type ThreadSnapshot = z.infer<typeof snapshotSchema>;
-type ThreadCompaction = z.infer<typeof compactionSchema>;
-
-export interface ThreadInspectionCompaction {
-  readonly endSeqExclusive: number;
-  readonly startSeq: number;
-  readonly summaryBytes: number;
-}
-
-export interface ThreadInspectionReport {
+export interface ThreadInspectionReport extends NodeFileThreadInspection {
   readonly autoCompaction: CodingAgentThreadConfig["autoCompaction"];
-  readonly compactionCount: number;
   readonly compactions: readonly ThreadInspectionCompaction[];
-  readonly messageCount: number;
-  readonly storageFile: string;
-  readonly summaryBytes: number;
-  readonly threadKey: string;
 }
 
 export async function inspectCodingAgentThread(
   config: CodingAgentThreadConfig
 ): Promise<ThreadInspectionReport> {
-  const stored = await new FileThreadStore(config.directory).load(config.key);
-  const state = decodeThreadState(stored?.state);
-  const compactions = state.compactions.map((record) => ({
-    endSeqExclusive: record.endSeqExclusive,
-    startSeq: record.startSeq,
-    summaryBytes: jsonByteLength(record.summary),
-  }));
-  const summaryBytes = compactions.reduce(
-    (total, record) => total + record.summaryBytes,
-    0
-  );
+  const inspection = await inspectNodeFileThread({
+    directory: config.directory,
+    key: config.key,
+  });
 
   return {
     autoCompaction: config.autoCompaction,
-    compactionCount: compactions.length,
-    compactions,
-    messageCount: state.messageCount,
-    storageFile: storageFileForThread(config.directory, config.key),
-    summaryBytes,
-    threadKey: config.key,
+    ...inspection,
   };
 }
 
@@ -97,6 +43,7 @@ export function formatThreadInspectionReport(
   return [
     `threadKey: ${report.threadKey}`,
     `storageFile: ${report.storageFile}`,
+    `version: ${report.version ?? "none"}`,
     `messageCount: ${report.messageCount}`,
     `compactionCount: ${report.compactionCount}`,
     compactions,
@@ -106,58 +53,7 @@ export function formatThreadInspectionReport(
 }
 
 export function storageFileForThread(directory: string, key: string): string {
-  return join(directory, `${Buffer.from(key).toString("base64url")}.json`);
-}
-
-function decodeThreadState(state: unknown): {
-  readonly compactions: readonly ThreadCompaction[];
-  readonly messageCount: number;
-} {
-  if (state === undefined) {
-    return { compactions: [], messageCount: 0 };
-  }
-
-  const parsed = snapshotSchema.safeParse(state);
-  if (!parsed.success) {
-    throw new Error("Unsupported stored thread state");
-  }
-
-  validateSnapshotCompactions(parsed.data);
-
-  if (parsed.data.schemaVersion === 1) {
-    return { compactions: [], messageCount: parsed.data.history.length };
-  }
-
-  return {
-    compactions: parsed.data.compactions,
-    messageCount: parsed.data.history.length,
-  };
-}
-
-function validateSnapshotCompactions(snapshot: ThreadSnapshot): void {
-  if (snapshot.schemaVersion !== 2) {
-    return;
-  }
-
-  for (const record of snapshot.compactions) {
-    if (record.endSeqExclusive <= record.startSeq) {
-      throw new Error(
-        "Thread compaction endSeqExclusive must be greater than startSeq"
-      );
-    }
-    if (record.endSeqExclusive > snapshot.history.length) {
-      throw new Error("Thread compaction range exceeds thread history");
-    }
-  }
-}
-
-function jsonByteLength(value: unknown): number {
-  const encoded = JSON.stringify(value);
-  if (encoded === undefined) {
-    throw new Error("Thread compaction summary could not be encoded");
-  }
-
-  return Buffer.byteLength(encoded, "utf8");
+  return nodeFileThreadStorageFile({ directory, key });
 }
 
 function formatAutoCompaction(

--- a/apps/coding-agent/src/tui-runner.test.ts
+++ b/apps/coding-agent/src/tui-runner.test.ts
@@ -1,8 +1,27 @@
 import type { AgentEvent } from "@minpeter/pss-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { createTuiRunner, formatEvent } from "./tui-runner";
+import { createTuiRunner, formatEvent, formatTuiHeader } from "./tui-runner";
 
 describe("TUI runner", () => {
+  it("formats the header when compaction is disabled", () => {
+    expect(
+      formatTuiHeader({ autoCompaction: false, threadKey: "cwd:/repo/demo" })
+    ).toBe(
+      "\x1b[1mpss-next\x1b[0m \x1b[2m(thread cwd:/repo/demo \u00b7 compaction off \u00b7 Esc to interrupt \u00b7 Ctrl-C to quit)\x1b[0m"
+    );
+  });
+
+  it("formats the header when compaction is enabled", () => {
+    expect(
+      formatTuiHeader({
+        autoCompaction: { minMessages: 12, retainMessages: 4 },
+        threadKey: "workspace:demo",
+      })
+    ).toBe(
+      "\x1b[1mpss-next\x1b[0m \x1b[2m(thread workspace:demo \u00b7 compaction min=12 retain=4 \u00b7 Esc to interrupt \u00b7 Ctrl-C to quit)\x1b[0m"
+    );
+  });
+
   it("renders runtime input distinctly from human input", () => {
     expect(formatEvent({ text: "hello", type: "user-input" })).toBe(
       "\x1b[36myou\x1b[0m: hello"

--- a/apps/coding-agent/src/tui-runner.ts
+++ b/apps/coding-agent/src/tui-runner.ts
@@ -1,5 +1,6 @@
 import type {
   AgentEvent,
+  AgentOptions,
   AgentTurn,
   ThreadHandle,
   UserInput,
@@ -29,6 +30,21 @@ export interface TuiRunner {
 
 const dimText = "\x1b[2m";
 const resetText = "\x1b[0m";
+
+export interface TuiHeaderOptions {
+  readonly autoCompaction: AgentOptions["autoCompaction"];
+  readonly threadKey: string;
+}
+
+export function formatTuiHeader({
+  autoCompaction,
+  threadKey,
+}: TuiHeaderOptions): string {
+  const compactionText = autoCompaction
+    ? `compaction min=${autoCompaction.minMessages} retain=${autoCompaction.retainMessages}`
+    : "compaction off";
+  return `\x1b[1mpss-next\x1b[0m \x1b[2m(thread ${safeInlineText(threadKey)} \u00b7 ${compactionText} \u00b7 Esc to interrupt \u00b7 Ctrl-C to quit)\x1b[0m`;
+}
 
 export const formatUserTextContent = (text: UserTextContent): string =>
   typeof text === "string" ? text : text.join("\n");

--- a/apps/coding-agent/src/tui.ts
+++ b/apps/coding-agent/src/tui.ts
@@ -9,7 +9,7 @@ import {
   TUI,
 } from "@earendil-works/pi-tui";
 import { Agent, type AgentOptions } from "@minpeter/pss-runtime";
-import { FileThreadStore } from "@minpeter/pss-runtime/thread-store/file";
+import { createNodeFileThreadHost } from "@minpeter/pss-runtime/node";
 import type { ToolSet } from "ai";
 import { createCodingLanguageModel } from "./model";
 import { resolveCodingAgentThreadConfig } from "./thread-config";
@@ -27,10 +27,7 @@ export interface StartTuiOptions {
 export async function startTui(options: StartTuiOptions = {}): Promise<void> {
   const threadConfig = resolveCodingAgentThreadConfig();
   const agentOptions: AgentOptions = {
-    host: {
-      kind: "thread",
-      threadStore: new FileThreadStore(threadConfig.directory),
-    },
+    host: createNodeFileThreadHost({ directory: threadConfig.directory }),
     instructions:
       "Answer in 2 short sentences and 280 characters or fewer unless the user explicitly asks for detail. Avoid headings.",
     model: createCodingLanguageModel(),

--- a/apps/coding-agent/src/tui.ts
+++ b/apps/coding-agent/src/tui.ts
@@ -13,8 +13,7 @@ import { FileThreadStore } from "@minpeter/pss-runtime/thread-store/file";
 import type { ToolSet } from "ai";
 import { createCodingLanguageModel } from "./model";
 import { resolveCodingAgentThreadConfig } from "./thread-config";
-import { createTuiRunner } from "./tui-runner";
-import { safeInlineText } from "./tui-tool-printer";
+import { createTuiRunner, formatTuiHeader } from "./tui-runner";
 
 export interface StartTuiOptions {
   /**
@@ -35,6 +34,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<void> {
     instructions:
       "Answer in 2 short sentences and 280 characters or fewer unless the user explicitly asks for detail. Avoid headings.",
     model: createCodingLanguageModel(),
+    autoCompaction: threadConfig.autoCompaction,
     tools: options.tools,
   };
   const agent = new Agent(agentOptions);
@@ -48,7 +48,10 @@ export async function startTui(options: StartTuiOptions = {}): Promise<void> {
 
   tui.addChild(
     new Text(
-      `\x1b[1mpss-next\x1b[0m \x1b[2m(thread ${safeInlineText(threadConfig.key)} · Esc to interrupt · Ctrl-C to quit)\x1b[0m`,
+      formatTuiHeader({
+        autoCompaction: threadConfig.autoCompaction,
+        threadKey: threadConfig.key,
+      }),
       1,
       0
     )

--- a/apps/coding-agent/tsdown.config.ts
+++ b/apps/coding-agent/tsdown.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/env.ts", "src/model.ts", "src/tui.ts"],
+  entry: [
+    "src/index.ts",
+    "src/cli.ts",
+    "src/env.ts",
+    "src/model.ts",
+    "src/thread-config.ts",
+    "src/thread-inspect.ts",
+    "src/tui.ts",
+  ],
   unbundle: true,
   root: "src",
   fixedExtension: false,

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -187,10 +187,9 @@ const agent = new Agent({
 For most events, `on` is observe-only: return nothing (or `{ action: "continue" }`)
 and the runtime emits the event unchanged.
 
-Three input event types support intercept returns:
+Two input event types support intercept returns:
 
-- `user-text`
-- `user-message`
+- `user-input`
 - `runtime-input`
 
 Return one of:
@@ -221,7 +220,7 @@ history persistence and model mapping. It never reaches the LLM prompt.
 ### Delegate prompt wrapping
 
 Child agents receive delegated prompts with `meta.source === "delegate"`. Wrap or
-rewrite them with a plugin instead of agent-level prompt shims:
+rewrite text input with a plugin instead of agent-level prompt shims:
 
 ```ts
 import type { AgentPlugin, UserText } from "@minpeter/pss-runtime";
@@ -230,7 +229,11 @@ import { Agent } from "@minpeter/pss-runtime";
 const pokeTagsPlugin: AgentPlugin = {
   name: "poke-tags",
   on: ({ event }) => {
-    if (event.type !== "user-text" || event.meta?.source !== "delegate") {
+    if (
+      event.type !== "user-input" ||
+      event.meta?.source !== "delegate" ||
+      !("text" in event)
+    ) {
       return;
     }
 
@@ -281,12 +284,12 @@ or `agent.resume(runId)` for host-scheduled durable work.
 Each accepted call returns one `AgentTurn`. Drain that turn's `events()` stream to
 observe the turn; each `AgentTurn.events()` stream is single-consumer.
 
-Input APIs accept the same input shapes: strings, arrays of strings,
-`{ type: "user-text", text }`, and multipart `{ type: "user-message", content }`
-values. Active steering and host resume input emit `runtime-input` events. A
-`runtime-input` is runtime/API-originated input mapped internally to the model's
-user role. It is distinct from human-origin `user-text` and `user-message`
-events.
+Input APIs accept strings, arrays of strings, or multipart arrays such as
+`[{ type: "text", text: "hello" }, { type: "image", image }]`. The runtime
+normalizes accepted `send` input into `user-input` events. Active steering and
+host resume input emit `runtime-input` events. A `runtime-input` is
+runtime/API-originated input mapped internally to the model's user role. It is
+distinct from human-origin `user-input` events.
 
 Runtime input windows are tied to synchronized events:
 
@@ -363,6 +366,20 @@ const agent = new Agent({
   model,
   namespace: "support-agent",
 });
+```
+
+Use `inspectNodeFileThread` when local tooling needs to inspect the exact file
+runtime uses for a thread:
+
+```ts
+import { inspectNodeFileThread } from "@minpeter/pss-runtime/node";
+
+const report = await inspectNodeFileThread({
+  directory: ".pss/threads",
+  key: "room:123:user:456",
+});
+
+console.log(report.messageCount, report.compactionCount, report.storageFile);
 ```
 
 A `host: { kind: "thread", threadStore }` object is a `ThreadHost`-only host.
@@ -473,7 +490,7 @@ import {
 
 await dispatchCloudflareAgentNotification({
   idempotencyKey: `reminder:${reminderId}`,
-  input: { type: "user-text", text: reminderText },
+  input: reminderText,
   namespace: "support-agent",
   prefix: "agent",
   threadKey: `room:${roomId}:user:${userId}`,

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -283,4 +283,14 @@ describe("runtime public exports", () => {
       types: "./dist/platform/node/index.d.ts",
     });
   });
+
+  it("exports Node file thread inspection from the Node adapter only", async () => {
+    const runtime = await import("../index");
+    const nodeAdapter = await import("../platform/node");
+
+    expect(runtime).not.toHaveProperty("inspectNodeFileThread");
+    expect(runtime).not.toHaveProperty("nodeFileThreadStorageFile");
+    expect(nodeAdapter).toHaveProperty("inspectNodeFileThread");
+    expect(nodeAdapter).toHaveProperty("nodeFileThreadStorageFile");
+  });
 });

--- a/packages/runtime/src/platform/node/index.ts
+++ b/packages/runtime/src/platform/node/index.ts
@@ -33,4 +33,11 @@ export type {
   NodeScheduledWorkRunContext,
 } from "./host/scheduled-work-types";
 export { FileExecutionStore } from "./storage/file-execution-store";
+export {
+  inspectNodeFileThread,
+  type NodeFileThreadInspection,
+  type NodeFileThreadInspectionCompaction,
+  type NodeFileThreadInspectionOptions,
+  nodeFileThreadStorageFile,
+} from "./storage/file-thread-inspection";
 export { FileThreadStore } from "./storage/file-thread-store";

--- a/packages/runtime/src/platform/node/storage/file-thread-inspection.test.ts
+++ b/packages/runtime/src/platform/node/storage/file-thread-inspection.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { encodeThreadSnapshot } from "../../../thread/state/snapshot";
+import {
+  inspectNodeFileThread,
+  nodeFileThreadStorageFile,
+} from "./file-thread-inspection";
+import { FileThreadStore } from "./file-thread-store";
+
+async function tempDir(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "pss-runtime-file-inspect-"));
+}
+
+describe("inspectNodeFileThread", () => {
+  it("reports stored history and compaction metadata from the node file store", async () => {
+    const directory = await tempDir();
+    const threadKey = "inspect:thread";
+    const summary = {
+      content: "older context summary",
+      role: "system",
+    } as const;
+    const summaryBytes = Buffer.byteLength(JSON.stringify(summary), "utf8");
+
+    try {
+      const store = new FileThreadStore(directory);
+      await store.commit(
+        threadKey,
+        {
+          state: encodeThreadSnapshot(
+            [
+              { content: "first", role: "user" },
+              { content: "second", role: "assistant" },
+              { content: "third", role: "user" },
+            ],
+            [
+              {
+                endSeqExclusive: 2,
+                schemaVersion: 1,
+                startSeq: 0,
+                summary,
+              },
+            ]
+          ),
+        },
+        { expectedVersion: null }
+      );
+
+      await expect(
+        inspectNodeFileThread({ directory, key: threadKey })
+      ).resolves.toEqual({
+        compactionCount: 1,
+        compactions: [
+          {
+            endSeqExclusive: 2,
+            startSeq: 0,
+            summaryBytes,
+          },
+        ],
+        messageCount: 3,
+        storageFile: nodeFileThreadStorageFile({ directory, key: threadKey }),
+        summaryBytes,
+        threadKey,
+        version: "1",
+      });
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("reports a missing thread as empty while preserving its storage path", async () => {
+    const directory = await tempDir();
+    const threadKey = "missing:thread";
+
+    try {
+      await expect(
+        inspectNodeFileThread({ directory, key: threadKey })
+      ).resolves.toEqual({
+        compactionCount: 0,
+        compactions: [],
+        messageCount: 0,
+        storageFile: nodeFileThreadStorageFile({ directory, key: threadKey }),
+        summaryBytes: 0,
+        threadKey,
+        version: null,
+      });
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/runtime/src/platform/node/storage/file-thread-inspection.ts
+++ b/packages/runtime/src/platform/node/storage/file-thread-inspection.ts
@@ -1,0 +1,67 @@
+import { join } from "node:path";
+import { decodeStoredThreadState } from "../../../thread/state/snapshot";
+import { FileThreadStore } from "./file-thread-store";
+
+export interface NodeFileThreadInspectionOptions {
+  readonly directory: string;
+  readonly key: string;
+}
+
+export interface NodeFileThreadInspectionCompaction {
+  readonly endSeqExclusive: number;
+  readonly startSeq: number;
+  readonly summaryBytes: number;
+}
+
+export interface NodeFileThreadInspection {
+  readonly compactionCount: number;
+  readonly compactions: readonly NodeFileThreadInspectionCompaction[];
+  readonly messageCount: number;
+  readonly storageFile: string;
+  readonly summaryBytes: number;
+  readonly threadKey: string;
+  readonly version: string | null;
+}
+
+export async function inspectNodeFileThread({
+  directory,
+  key,
+}: NodeFileThreadInspectionOptions): Promise<NodeFileThreadInspection> {
+  const stored = await new FileThreadStore(directory).load(key);
+  const state = decodeStoredThreadState(stored);
+  const compactions = state.compactions.map((record) => ({
+    endSeqExclusive: record.endSeqExclusive,
+    startSeq: record.startSeq,
+    summaryBytes: jsonByteLength(record.summary),
+  }));
+  const summaryBytes = compactions.reduce(
+    (total, record) => total + record.summaryBytes,
+    0
+  );
+
+  return {
+    compactionCount: compactions.length,
+    compactions,
+    messageCount: state.history.length,
+    storageFile: nodeFileThreadStorageFile({ directory, key }),
+    summaryBytes,
+    threadKey: key,
+    version: stored?.version ?? null,
+  };
+}
+
+export function nodeFileThreadStorageFile({
+  directory,
+  key,
+}: NodeFileThreadInspectionOptions): string {
+  return join(directory, `${Buffer.from(key).toString("base64url")}.json`);
+}
+
+function jsonByteLength(value: unknown): number {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) {
+    throw new Error("Thread compaction summary could not be encoded");
+  }
+
+  return Buffer.byteLength(encoded, "utf8");
+}


### PR DESCRIPTION
## Summary
- add local thread compaction inspection commands to `apps/coding-agent`
- move reusable node file-thread inspection into `@minpeter/pss-runtime/node`
- keep the root runtime API clean while documenting the node-only inspection helpers

## Impact
- local coding-agent users can inspect file-backed thread state from the CLI
- the coding-agent no longer owns storage inspection parsing that belongs to the runtime node platform layer
- prerelease changesets are included for both coding-agent and runtime

## Verification
- `pnpm boundaries`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm verify:release`
- targeted runtime and coding-agent vitest/typecheck checks
- CLI `inspect-thread` smoke
- TUI tmux smoke


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local thread inspection command to the coding agent CLI and moves file-backed thread inspection into the runtime’s Node adapter, keeping the core API clean. Also adds env-configurable auto-compaction and shows thread/compaction info in the TUI.

- **New Features**
  - `pss inspect-thread` prints the configured thread’s file, version, message count, and compactions via the runtime Node adapter.
  - Auto-compaction via `PSS_AUTO_COMPACTION_MIN_MESSAGES` and `PSS_AUTO_COMPACTION_RETAIN_MESSAGES`; TUI header shows thread key and compaction status.
  - New storage envs: `PSS_THREAD_DIR`, `PSS_THREAD_KEY` (legacy `PSS_SESSION_*` still work).

- **Refactors**
  - Moved inspection logic into `@minpeter/pss-runtime/node` as `inspectNodeFileThread` and `nodeFileThreadStorageFile`; root runtime exports stay unchanged.
  - TUI now uses `createNodeFileThreadHost` for file-backed threads.
  - Runtime docs and examples updated to use `user-input` instead of `user-text`/`user-message`.

<sup>Written for commit fedd6befbfbbc47c966bfd5b812760a5945def05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

