### PR TITLE
[codex] Improve worker-agent operational checks

### DIFF
--- a/apps/worker-agent/package.json
+++ b/apps/worker-agent/package.json
@@ -14,7 +14,8 @@
     "ship:worker": "wrangler deploy --env=\"\"",
     "ship:webhook": "tsx scripts/telegram.ts webhook",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "ultracite check ."
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "3.0.0-canary.56",

--- a/apps/worker-agent/wrangler.jsonc
+++ b/apps/worker-agent/wrangler.jsonc
@@ -42,11 +42,11 @@
   },
   "observability": {
     "logs": {
-      "enabled": false,
+      "enabled": true,
       "invocation_logs": true
     },
     "traces": {
-      "enabled": false
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add the missing worker-agent lint script so package-local lint matches the runtime/coding-agent Ultracite convention.
- Enable worker-agent Wrangler logs and traces while preserving invocation logs.

## Why
worker-agent already had test and typecheck scripts, but no package-local lint entry. Its Wrangler config also only kept invocation logs enabled while full logs/traces were disabled, leaving less operational visibility than intended.

## Validation
- pnpm --filter @minpeter/pss-worker-agent lint
- pnpm --filter @minpeter/pss-worker-agent typecheck
- pnpm --filter @minpeter/pss-worker-agent test
- git diff --check HEAD~1 HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local lint script to `@minpeter/pss-worker-agent` using `ultracite`, and enables full `wrangler` logs and traces to improve operability. Aligns the package with our linting convention and increases runtime visibility while keeping invocation logs.

<sup>Written for commit a60d1ff65f263494b2722714e245eeae5513dd19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

