### PR TITLE
feat(coding-agent): help command + graceful unknown commands, silence dts sourcemap warning

### DIFF
--- a/.changeset/coding-agent-cli-help.md
+++ b/.changeset/coding-agent-cli-help.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-coding-agent": patch
+---
+
+Add `help`/`--help`/`-h` to the `pss` CLI and make unknown commands print usage and exit with code 1 instead of throwing.

--- a/apps/coding-agent/src/cli.test.ts
+++ b/apps/coding-agent/src/cli.test.ts
@@ -5,6 +5,44 @@ import { describe, expect, it } from "vitest";
 import { runCodingAgentCli } from "./cli";
 
 describe("coding-agent CLI", () => {
+  it("prints usage when help is requested", async () => {
+    let output = "";
+
+    const exitCode = await runCodingAgentCli({
+      argv: ["--help"],
+      start: () =>
+        Promise.reject(new Error("TUI should not start for help output")),
+      stdout: {
+        write(text: string): void {
+          output += text;
+        },
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain("Usage: pss [command]\n");
+    expect(output).toContain("inspect-thread");
+  });
+
+  it("returns an error code with usage when the command is unknown", async () => {
+    let output = "";
+
+    const exitCode = await runCodingAgentCli({
+      argv: ["wat"],
+      start: () =>
+        Promise.reject(new Error("TUI should not start for unknown commands")),
+      stdout: {
+        write(text: string): void {
+          output += text;
+        },
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(output).toContain("Unknown pss command: wat\n\n");
+    expect(output).toContain("Usage: pss [command]\n");
+  });
+
   it("routes inspect-thread through the local inspection surface", async () => {
     const directory = await mkdtemp(join(tmpdir(), "pss-coding-agent-cli-"));
     let output = "";

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -34,6 +34,11 @@ export async function runCodingAgentCli({
     return 0;
   }
 
+  if (command === "help" || command === "--help" || command === "-h") {
+    stdout.write(`${formatUsage()}\n`);
+    return 0;
+  }
+
   if (command === "inspect-thread") {
     const config = resolveCodingAgentThreadConfig(env, cwd, home);
     const report = await inspectCodingAgentThread(config);
@@ -41,5 +46,17 @@ export async function runCodingAgentCli({
     return 0;
   }
 
-  throw new Error(`Unknown pss command: ${command}`);
+  stdout.write(`Unknown pss command: ${command}\n\n${formatUsage()}\n`);
+  return 1;
+}
+
+function formatUsage(): string {
+  return [
+    "Usage: pss [command]",
+    "",
+    "Commands:",
+    "  (no command)     Start the interactive TUI",
+    "  inspect-thread   Print a report for the configured thread",
+    "  help             Show this help message",
+  ].join("\n");
 }

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -16,4 +16,16 @@ export default defineConfig({
   fixedExtension: false,
   sourcemap: true,
   dts: true,
+  inputOptions: {
+    // The dts pipeline (rolldown-plugin-dts:fake-js) intentionally emits no
+    // sourcemap for `.d.ts` chunks, which triggers a spurious SOURCEMAP_BROKEN
+    // warning even though the published `.js.map` files are correct. Drop only
+    // that one log and let every other warning through.
+    onLog(level, log, defaultHandler) {
+      if (log.code === "SOURCEMAP_BROKEN") {
+        return;
+      }
+      defaultHandler(level, log);
+    },
+  },
 });


### PR DESCRIPTION
## 요약

`pss` CLI UX 개선과 runtime 빌드의 비치명적 sourcemap 경고 제거를 함께 처리합니다.

## 변경 사항

### coding-agent CLI (`apps/coding-agent/src/cli.ts`)
- `help` / `--help` / `-h` 명령을 추가해 usage를 출력합니다 (exit 0).
- 알 수 없는 명령은 throw 대신 usage를 출력하고 exit code `1`로 종료합니다.
- 위 동작을 검증하는 테스트를 `cli.test.ts`에 추가했습니다.

### runtime 빌드 경고 제거 (`packages/runtime/tsdown.config.ts`)
- `rolldown-plugin-dts:fake-js`가 `.d.ts` 청크에 대해 의도적으로 sourcemap을 생성하지 않아 발생하던 `SOURCEMAP_BROKEN` 경고만 선택적으로 필터링합니다.
- 실제 published `.js.map` 파일은 그대로 생성되며(97개), `.d.ts.map`은 기존처럼 산출/배포되지 않습니다.
- 다른 모든 경고는 그대로 통과합니다.

## 검증

- `pnpm boundaries` / `lint` / `typecheck` / `test` / `build` / `verify:release` 통과
- runtime `lint` / `typecheck` 통과, 빌드에서 `SOURCEMAP_BROKEN` 경고 사라짐 확인
- coding-agent `test` 통과 (8 files / 37 tests)
- 수동 확인: `pss --help` → usage, exit 0 / `pss wat` → usage + exit 1

## 참고

- Bori 테스트에서 보이던 `@workflow/serde` sourcemap 경고는 별도 repo의 third-party 패키지(`node_modules`)가 깨진 sourcemap을 배포해 발생하는 것으로, 이 repo에서는 수정 대상이 아닙니다.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add help support to the `pss` CLI and handle unknown commands gracefully. Also silence a noisy dts sourcemap warning in the runtime build to reduce non-actionable logs.

- **New Features**
  - `help`/`--help`/`-h` prints usage and exits 0.
  - Unknown commands print usage and exit 1 instead of throwing.
  - Added tests for both behaviors.

- **Bug Fixes**
  - Suppress only the `SOURCEMAP_BROKEN` warning from the dts pipeline (`rolldown-plugin-dts:fake-js`) in the runtime build.
  - `.js.map` files still publish; no `.d.ts.map` as before; all other warnings remain.

<sup>Written for commit bf0708601e77cc1b0f3881ae1a576200c0956c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

