### PR TITLE
feat(runtime): add assistant text-stream helpers over turn.events()

### DIFF
--- a/.changeset/runtime-assistant-text-helpers.md
+++ b/.changeset/runtime-assistant-text-helpers.md
@@ -1,0 +1,10 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add `streamAssistantText(turn)` and `collectAssistantText(turn)` root exports as
+thin, ergonomic wrappers over `turn.events()` for the common visible-text-only
+consumption case. They preserve the canonical single-consumer event contract:
+each helper consumes `turn.events()` exactly once and drops every non-visible
+event. Use `turn.events()` directly when you need tool, lifecycle, or telemetry
+events.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -49,6 +49,26 @@ consume the events for the turn to progress. This is what lets code react to
 `turn-start`, `step-start`, and `step-end` before the next model snapshot is
 created.
 
+For the common "I only want the visible assistant text" case, the root export
+ships two thin helpers over `turn.events()`. They do not replace the structured
+stream and do not change its contract: each helper consumes `turn.events()`
+exactly once, so the turn is still single-consumer.
+
+```ts
+import { collectAssistantText, streamAssistantText } from "@minpeter/pss-runtime";
+
+// Incremental: yields each visible assistant-output chunk in order.
+for await (const chunk of streamAssistantText(await agent.send("Hello"))) {
+  process.stdout.write(chunk);
+}
+
+// One-shot: drains the turn and returns the concatenated assistant text.
+const text = await collectAssistantText(await agent.send("Hello"));
+```
+
+Reach for `turn.events()` directly whenever you need tool calls, lifecycle, or
+telemetry events; the helpers intentionally drop everything except visible text.
+
 `model` is the single public constructor key for model execution. Pass an AI SDK
 `LanguageModel` object and configure runtime-owned prompting through
 `instructions`, `tools`, and `toolChoice`:

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -30,11 +30,13 @@ import type {
 } from "../index";
 import {
   Agent,
+  collectAssistantText,
   isControlAgentEvent,
   isLifecycleAgentEvent,
   isTelemetryAgentEvent,
   isVisibleAgentEvent,
   runPluginsForEvent,
+  streamAssistantText,
 } from "../index";
 
 type EmptyHostIsRejected =
@@ -97,6 +99,16 @@ describe("runtime public exports", () => {
       isTelemetryAgentEvent
     );
     expect(runtime).toHaveProperty("isControlAgentEvent", isControlAgentEvent);
+  });
+
+  it("exports assistant text-stream helpers from the package root", async () => {
+    const runtime = await import("../index");
+
+    expect(runtime).toHaveProperty("streamAssistantText", streamAssistantText);
+    expect(runtime).toHaveProperty(
+      "collectAssistantText",
+      collectAssistantText
+    );
   });
 
   it("does not expose runtime-owned subagent helpers from the package root", async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -59,6 +59,10 @@ export {
   isToolAgentEvent,
   isVisibleAgentEvent,
 } from "./thread/protocol/events";
+export {
+  collectAssistantText,
+  streamAssistantText,
+} from "./thread/protocol/text-stream";
 export type { AgentTurn } from "./thread/protocol/turn";
 export type {
   CommitResult,

--- a/packages/runtime/src/thread/protocol/text-stream.test.ts
+++ b/packages/runtime/src/thread/protocol/text-stream.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "./events";
+import { collectAssistantText, streamAssistantText } from "./text-stream";
+import type { AgentTurn } from "./turn";
+
+function turnFromEvents(events: readonly AgentEvent[]): AgentTurn {
+  let consumed = false;
+  return {
+    events(): AsyncIterable<AgentEvent> {
+      if (consumed) {
+        throw new Error("AgentTurn.events() can only be consumed once");
+      }
+      consumed = true;
+      let index = 0;
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+          return {
+            next(): Promise<IteratorResult<AgentEvent>> {
+              if (index >= events.length) {
+                return Promise.resolve({ done: true, value: undefined });
+              }
+              const value = events[index];
+              index += 1;
+              return Promise.resolve({ done: false, value });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("assistant text-stream helpers", () => {
+  const events: readonly AgentEvent[] = [
+    { type: "turn-start" },
+    { type: "assistant-reasoning", text: "internal" },
+    { type: "assistant-output", text: "Hello, " },
+    { type: "tool-call", input: {}, toolCallId: "1", toolName: "noop" },
+    { type: "assistant-output", text: "world" },
+    { type: "turn-end" },
+  ];
+
+  it("yields only visible assistant text chunks in order", async () => {
+    const chunks: string[] = [];
+    for await (const chunk of streamAssistantText(turnFromEvents(events))) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["Hello, ", "world"]);
+  });
+
+  it("concatenates visible assistant text", async () => {
+    expect(await collectAssistantText(turnFromEvents(events))).toBe(
+      "Hello, world"
+    );
+  });
+
+  it("consumes the turn stream once", async () => {
+    const turn = turnFromEvents(events);
+    await collectAssistantText(turn);
+
+    await expect(collectAssistantText(turn)).rejects.toThrow(
+      "AgentTurn.events() can only be consumed once"
+    );
+  });
+});

--- a/packages/runtime/src/thread/protocol/text-stream.ts
+++ b/packages/runtime/src/thread/protocol/text-stream.ts
@@ -1,0 +1,26 @@
+import type { AgentEvent } from "./events";
+import type { AgentTurn } from "./turn";
+
+function isAssistantOutput(
+  event: AgentEvent
+): event is Extract<AgentEvent, { type: "assistant-output" }> {
+  return event.type === "assistant-output";
+}
+
+export async function* streamAssistantText(
+  turn: AgentTurn
+): AsyncGenerator<string> {
+  for await (const event of turn.events()) {
+    if (isAssistantOutput(event)) {
+      yield event.text;
+    }
+  }
+}
+
+export async function collectAssistantText(turn: AgentTurn): Promise<string> {
+  let text = "";
+  for await (const chunk of streamAssistantText(turn)) {
+    text += chunk;
+  }
+  return text;
+}


### PR DESCRIPTION
## What

Adds two small, root-exported convenience helpers built on top of the canonical `turn.events()` stream:

- `streamAssistantText(turn)` — async-iterates only the visible `assistant-output` text chunks, in order.
- `collectAssistantText(turn)` — drains a turn and returns the concatenated assistant text.

## Why

The "I only want the assistant's visible text" pattern is duplicated across examples (`examples/basic/src/drain.ts`, `examples/local-file-agent/src/drain.ts`, `examples/*/src/print-run.ts`), each re-implementing the `for await (... ) { case "assistant-output": ... }` switch. These helpers give consumers an ergonomic path for the common case without re-deriving event handling.

This follows the design principle that the runtime stays a small core: the helpers are **ergonomics only**, not a new model. They do **not** replace `turn.events()` and do **not** change its contract.

## Canonical contract preserved

- Each helper consumes `turn.events()` **exactly once** — the turn stays single-consumer (covered by a unit test asserting a second consume throws).
- Non-visible events (tool, lifecycle, telemetry, reasoning) are intentionally dropped; callers that need them keep using `turn.events()` directly.
- Structured example printers (`drain.ts`, `print-run.ts`) are deliberately **left unchanged** because they render tool/lifecycle events too — switching them to the text helper would be a feature regression.

## Guards

- `packages/runtime/src/contracts/root-api.test.ts`: presence guard for both new root exports.
- `packages/runtime/src/thread/protocol/text-stream.test.ts`: order, concatenation, and single-consumer behavior.
- README documents usage and when to prefer `turn.events()`.
- `.changeset/runtime-assistant-text-helpers.md` (patch).

## Verification

All run on the worktree branch:

- `pnpm lint` — clean
- `pnpm boundaries` — no issues
- `pnpm --filter @minpeter/pss-runtime typecheck` — clean
- `pnpm --filter @minpeter/pss-runtime test` — 72 files / 363 tests pass
- `pnpm typecheck` (root) — 9/9
- `pnpm test` (root) — 10 files / 41 tests pass
- `pnpm build` — ok
- `pnpm verify:release` — passed
- Manual: imported both helpers from built `dist/index.js` and confirmed chunked text, concatenation, and single-consumer throw.

## Notes / uncertainty

- Naming: chose `streamAssistantText` / `collectAssistantText` to avoid the AI-SDK `toTextStream` shape and to make it explicit these are assistant-text only. Open to renaming if you prefer a different convention.
- Scope intentionally minimal (visible text only). A `assistant-reasoning`-inclusive variant was considered but left out to keep the surface small.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two root-exported helpers to `@minpeter/pss-runtime` for consuming only the assistant’s visible text: `streamAssistantText(turn)` and `collectAssistantText(turn)`. They wrap `turn.events()` and keep the single-consumer contract.

- **New Features**
  - `streamAssistantText(turn)`: yields `assistant-output` text chunks in order.
  - `collectAssistantText(turn)`: drains the turn and returns concatenated visible text.
  - Non-visible events are dropped; keep using `turn.events()` if you need tool/lifecycle/telemetry. Docs and tests included.

<sup>Written for commit 183dbd4ae51b9ee028d419cf715dc63933c18fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

