### PR TITLE
feat(runtime): add channel adapter contract

### DIFF
--- a/.changeset/runtime-channel-adapter-contract.md
+++ b/.changeset/runtime-channel-adapter-contract.md
@@ -1,0 +1,7 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add a minimal channel adapter contract on the `./channel` subpath so delivery
+adapters can map inbound channel messages to thread turns and project visible
+assistant output without widening the runtime package root.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -77,6 +77,57 @@ for await (const event of turn.events()) {
 
 `agent.send(...)` is shorthand for `agent.thread("default").send(...)`.
 
+## Channel Adapters
+
+Use `@minpeter/pss-runtime/channel` when a product channel needs a small typed
+boundary around runtime turns. The channel adapter resolves an inbound message to
+a thread key and runtime input; the app still owns `agent.thread(...).send(...)`
+and drains `turn.events()`.
+
+```ts
+import { Agent } from "@minpeter/pss-runtime";
+import {
+  projectChannelAssistantDelivery,
+  type ChannelAssistantDelivery,
+  type ChannelInboundMessage,
+} from "@minpeter/pss-runtime/channel";
+
+interface ChatMessage {
+  roomId: string;
+  text: string;
+  userId: string;
+}
+
+function toChannelInbound(message: ChatMessage): ChannelInboundMessage {
+  return {
+    input: message.text,
+    threadKey: { key: message.userId, scope: message.roomId },
+  };
+}
+
+async function deliverChatMessage(
+  delivery: ChannelAssistantDelivery
+): Promise<void> {
+  await postChatMessage(delivery.text);
+}
+
+const agent = new Agent({ model });
+const inbound = toChannelInbound(inboundMessage);
+const turn = await agent.thread(inbound.threadKey).send(inbound.input);
+
+for await (const event of turn.events()) {
+  const delivery = projectChannelAssistantDelivery(event);
+  if (delivery !== undefined) {
+    await deliverChatMessage(delivery);
+  }
+}
+```
+
+The default projector emits deliveries only for non-empty `assistant-output`
+events. Lifecycle, tool, telemetry, runtime-input, and user-input events remain
+available to the app through `turn.events()`, but are not published to channels
+by default.
+
 For model providers that support multimodal input, send JSON-serializable content
 parts through the same API. String input and `readonly string[]` remain supported
 shortcuts for text-only turns.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,6 +11,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./channel": {
+      "@minpeter/pss-source": "./src/channel/index.ts",
+      "types": "./dist/channel/index.d.ts",
+      "import": "./dist/channel/index.js"
+    },
     "./thread-store/memory": {
       "@minpeter/pss-source": "./src/thread/store/memory.ts",
       "types": "./dist/thread/store/memory.d.ts",

--- a/packages/runtime/src/channel/index.test.ts
+++ b/packages/runtime/src/channel/index.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { AgentEvent, AgentInput, ThreadKey } from "../index";
+import { Agent } from "../index";
+import {
+  createMockLanguageModelV4,
+  mockLanguageModelV4Text,
+} from "../testing/mock-language-model-v4-test-utils";
+import {
+  type ChannelAssistantDelivery,
+  type ChannelInboundMessage,
+  projectChannelAssistantDelivery,
+} from "./index";
+
+interface TestInboundMessage {
+  readonly messageId: string;
+  readonly roomId: string;
+  readonly text: string;
+  readonly userId: string;
+}
+
+interface TestChannelMetadata {
+  readonly channel: "test";
+  readonly messageId: string;
+}
+
+describe("runtime channel adapter contract", () => {
+  it("lets adapters resolve channel input and deliver assistant output from turn events", async () => {
+    const inboundMessage = {
+      messageId: "msg-1",
+      roomId: "room-7",
+      text: "hello from a channel",
+      userId: "user-9",
+    } satisfies TestInboundMessage;
+    const normalizeChatMessage = (
+      message: TestInboundMessage
+    ): ChannelInboundMessage => ({
+      input: message.text,
+      threadKey: { key: message.userId, scope: message.roomId },
+    });
+    const delivered: Array<
+      ChannelAssistantDelivery & { readonly metadata: TestChannelMetadata }
+    > = [];
+
+    expectTypeOf<ChannelInboundMessage["input"]>().toEqualTypeOf<AgentInput>();
+    expectTypeOf<
+      ChannelInboundMessage["threadKey"]
+    >().toEqualTypeOf<ThreadKey>();
+
+    const agent = new Agent({
+      model: createMockLanguageModelV4([
+        mockLanguageModelV4Text("channel reply"),
+      ]),
+    });
+    const inbound = normalizeChatMessage(inboundMessage);
+    const turn = await agent.thread(inbound.threadKey).send(inbound.input);
+
+    for await (const event of turn.events()) {
+      const delivery = projectChannelAssistantDelivery(event);
+      if (delivery !== undefined) {
+        delivered.push({
+          ...delivery,
+          metadata: { channel: "test", messageId: inboundMessage.messageId },
+        });
+      }
+    }
+
+    expect(delivered).toEqual([
+      {
+        metadata: { channel: "test", messageId: "msg-1" },
+        text: "channel reply",
+        type: "assistant-text",
+      },
+    ]);
+  });
+
+  it("projects only non-empty assistant output into channel deliveries", () => {
+    const ignoredEvents = [
+      { type: "turn-start" },
+      { type: "step-start" },
+      { text: "thinking", type: "assistant-reasoning" },
+      { text: "user said hi", type: "user-input" },
+      {
+        input: { text: "runtime says continue", type: "user-input" },
+        placement: "turn-start",
+        type: "runtime-input",
+      },
+      {
+        input: { city: "Seoul" },
+        toolCallId: "call-1",
+        toolName: "weather",
+        type: "tool-call",
+      },
+      {
+        output: { ok: true },
+        toolCallId: "call-1",
+        toolName: "weather",
+        type: "tool-result",
+      },
+      { type: "step-end" },
+      { message: "failed", type: "turn-error" },
+      { type: "turn-abort" },
+      { type: "turn-end" },
+      { text: "   ", type: "assistant-output" },
+    ] satisfies readonly AgentEvent[];
+
+    expect(ignoredEvents.map(projectChannelAssistantDelivery)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    expectTypeOf<
+      Parameters<typeof projectChannelAssistantDelivery>[0]
+    >().toEqualTypeOf<AgentEvent>();
+    expectTypeOf<
+      ReturnType<typeof projectChannelAssistantDelivery>
+    >().toEqualTypeOf<ChannelAssistantDelivery | undefined>();
+    expect(
+      projectChannelAssistantDelivery({
+        text: " visible reply ",
+        type: "assistant-output",
+      })
+    ).toEqual({ text: " visible reply ", type: "assistant-text" });
+  });
+});

--- a/packages/runtime/src/channel/index.ts
+++ b/packages/runtime/src/channel/index.ts
@@ -16,7 +16,7 @@ export type ChannelAssistantDelivery = ChannelAssistantTextDelivery;
 export function projectChannelAssistantDelivery(
   event: AgentEvent
 ): ChannelAssistantDelivery | undefined {
-  if (event.type !== "assistant-output" || event.text.trim() === "") {
+  if (event.type !== "assistant-output" || !event.text?.trim()) {
     return;
   }
 

--- a/packages/runtime/src/channel/index.ts
+++ b/packages/runtime/src/channel/index.ts
@@ -1,0 +1,24 @@
+// biome-ignore-all lint/performance/noBarrelFile: Public package subpath entrypoint required by package exports.
+import type { AgentEvent, AgentInput, ThreadKey } from "../index";
+
+export interface ChannelInboundMessage {
+  readonly input: AgentInput;
+  readonly threadKey: ThreadKey;
+}
+
+export interface ChannelAssistantTextDelivery {
+  readonly text: string;
+  readonly type: "assistant-text";
+}
+
+export type ChannelAssistantDelivery = ChannelAssistantTextDelivery;
+
+export function projectChannelAssistantDelivery(
+  event: AgentEvent
+): ChannelAssistantDelivery | undefined {
+  if (event.type !== "assistant-output" || event.text.trim() === "") {
+    return;
+  }
+
+  return { text: event.text, type: "assistant-text" };
+}

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -55,6 +55,13 @@ const forbiddenModelAdapterRootExports = [
   ["Runtime", "Llm", "Output", "Part"].join(""),
   ["create", "Llm"].join(""),
 ] as const;
+const forbiddenChannelAdapterRootExports = [
+  ["Channel", "Adapter"].join(""),
+  ["Channel", "Inbound", "Message"].join(""),
+  ["Channel", "Assistant", "Delivery"].join(""),
+  ["Channel", "Assistant", "Text", "Delivery"].join(""),
+  ["project", "Channel", "Assistant", "Delivery"].join(""),
+] as const;
 
 describe("runtime public exports", () => {
   it("does not expose internal agent loop runner from package root", async () => {
@@ -111,6 +118,14 @@ describe("runtime public exports", () => {
     const runtime = await import("../index");
 
     for (const forbiddenName of forbiddenModelAdapterRootExports) {
+      expect(runtime).not.toHaveProperty(forbiddenName);
+    }
+  });
+
+  it("does not expose channel adapter contracts from the package root", async () => {
+    const runtime = await import("../index");
+
+    for (const forbiddenName of forbiddenChannelAdapterRootExports) {
       expect(runtime).not.toHaveProperty(forbiddenName);
     }
   });
@@ -248,6 +263,23 @@ describe("runtime public exports", () => {
     });
     expect(packageJson.exports["./session-store/memory"]).toBeUndefined();
     expect(packageJson.exports["./session-store/file"]).toBeUndefined();
+  });
+
+  it("declares the channel adapter contract as a package subpath", async () => {
+    const packageJson = JSON.parse(
+      await readFile(
+        fileURLToPath(new URL("../../package.json", import.meta.url)),
+        "utf8"
+      )
+    ) as {
+      exports: Record<string, { "@minpeter/pss-source": string }>;
+    };
+
+    expect(packageJson.exports["./channel"]).toMatchObject({
+      "@minpeter/pss-source": "./src/channel/index.ts",
+      import: "./dist/channel/index.js",
+      types: "./dist/channel/index.d.ts",
+    });
   });
 
   it("declares the Cloudflare adapter as a platform implementation subpath", async () => {

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: [
     "src/index.ts",
+    "src/channel/index.ts",
     "src/platform/cloudflare/index.ts",
     "src/platform/node/index.ts",
     "src/execution/index.ts",

--- a/scripts/runtime-docs.test.mjs
+++ b/scripts/runtime-docs.test.mjs
@@ -32,4 +32,22 @@ describe("runtime docs", () => {
     expect(readme).toContain("const durableHost: DurableBackgroundHost = {");
     expect(readme).toContain("transaction,");
   });
+
+  it("documents channel adapters as app-owned event projection", () => {
+    const readme = readRepoFile("packages/runtime/README.md");
+    const changeset = readRepoFile(
+      ".changeset/runtime-channel-adapter-contract.md"
+    );
+
+    expect(readme).toContain("projectChannelAssistantDelivery(event)");
+    expect(readme).toContain(
+      "agent.thread(inbound.threadKey).send(inbound.input)"
+    );
+    expect(readme).toContain("for await (const event of turn.events())");
+    expect(readme).toContain("type ChannelInboundMessage");
+    expect(changeset).toContain('"@minpeter/pss-runtime": patch');
+    expect(readme).not.toContain(["Channel", "Runtime"].join(""));
+    expect(readme).not.toContain(["Channel", "Loop"].join(""));
+    expect(readme).not.toContain(["run", "Channel"].join(""));
+  });
 });

--- a/scripts/verify-release-artifacts-runtime-channel.test.mjs
+++ b/scripts/verify-release-artifacts-runtime-channel.test.mjs
@@ -1,0 +1,37 @@
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { verifyReleaseArtifacts } from "./verify-release-artifacts/core.mjs";
+import {
+  cleanupFixtures,
+  createFixture,
+} from "./verify-release-artifacts.fixture.mjs";
+
+afterEach(cleanupFixtures);
+
+function runtimeChannelDeclaration(cwd) {
+  return join(cwd, "packages", "runtime", "dist", "channel", "index.d.ts");
+}
+
+describe("verifyReleaseArtifacts runtime channel declaration checks", () => {
+  it("requires the runtime channel declaration entrypoint", () => {
+    const cwd = createFixture();
+    rmSync(runtimeChannelDeclaration(cwd));
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
+      "packages/runtime/dist/channel/index.d.ts: missing channel runtime declaration",
+    ]);
+  });
+
+  it("checks channel adapter contracts on the channel declaration subpath", () => {
+    const cwd = createFixture();
+    writeFileSync(runtimeChannelDeclaration(cwd), "export {};\n");
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
+      "packages/runtime/dist/channel/index.d.ts: missing explicit channel runtime export ChannelAssistantDelivery",
+      "packages/runtime/dist/channel/index.d.ts: missing explicit channel runtime export ChannelAssistantTextDelivery",
+      "packages/runtime/dist/channel/index.d.ts: missing explicit channel runtime export ChannelInboundMessage",
+      "packages/runtime/dist/channel/index.d.ts: missing explicit channel runtime export projectChannelAssistantDelivery",
+    ]);
+  });
+});

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -28,6 +28,11 @@ export const runtimeNodeDeclaration = [
   'export type { NodeFileAgentContext, NodeFileAgentContextFactoryOptions, NodeFileAgentContextOptions, NodeFileExecutionHostOptions, NodeFileThreadHostOptions, NodeScheduledThreadPrompt, NodeScheduledWorkAppendOptions, NodeScheduledWorkDrainOptions, NodeScheduledWorkDrainResult, NodeScheduledWorkListOptions, NodeScheduledWorkRunContext } from "./index";',
   "",
 ].join("\n");
+export const runtimeChannelDeclaration = [
+  'export { projectChannelAssistantDelivery } from "./index";',
+  'export type { ChannelAssistantDelivery, ChannelAssistantTextDelivery, ChannelInboundMessage } from "./index";',
+  "",
+].join("\n");
 
 let tempRoots = [];
 
@@ -143,6 +148,13 @@ function writeRuntimeDeclarationFixtures(cwd, packageName) {
       "index.d.ts"
     ),
     runtimeNodeDeclaration
+  );
+  mkdirSync(join(cwd, "packages", packageName, "dist", "channel"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(cwd, "packages", packageName, "dist", "channel", "index.d.ts"),
+    runtimeChannelDeclaration
   );
   writeFileSync(
     join(cwd, "packages", packageName, "dist", "llm.d.ts"),

--- a/scripts/verify-release-artifacts/runtime-checks.mjs
+++ b/scripts/verify-release-artifacts/runtime-checks.mjs
@@ -2,11 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { listFiles, packageDistPath, relativeToCwd } from "./shared.mjs";
 
-const REQUIRED_RUNTIME_ROOT_EXPORTS = [
-  "AgentHost",
-  "AgentTurn",
-  "RuntimeInput",
-];
+const REQUIRED_RUNTIME_ROOT_EXPORTS = names("AgentHost AgentTurn RuntimeInput");
 const REQUIRED_RUNTIME_EXECUTION_EXPORTS = [
   "CheckpointStore",
   "createInMemoryExecutionHost",
@@ -60,10 +56,12 @@ const REQUIRED_RUNTIME_CLOUDFLARE_EXPORTS = [
   "listScheduledCloudflareThreadPrompts",
   "rescheduleCloudflareAlarm",
 ];
-const REQUIRED_RUNTIME_NODE_EXPORTS =
-  "FileExecutionStore FileThreadStore NodeFileAgentContext NodeFileAgentContextFactoryOptions NodeFileAgentContextOptions NodeFileExecutionHostOptions NodeFileThreadHostOptions NodeScheduledThreadPrompt NodeScheduledWorkAppendOptions NodeScheduledWorkDrainOptions NodeScheduledWorkDrainResult NodeScheduledWorkListOptions NodeScheduledWorkRunContext ackScheduledNodeRun ackScheduledNodeThreadPrompt appendScheduledNodeRun appendScheduledNodeThreadPrompt createNodeFileAgentContext createNodeFileExecutionHost createNodeFileScheduler createNodeFileThreadHost drainScheduledNodeWork listScheduledNodeRuns listScheduledNodeThreadPrompts".split(
-    " "
-  );
+const REQUIRED_RUNTIME_NODE_EXPORTS = names(
+  "FileExecutionStore FileThreadStore NodeFileAgentContext NodeFileAgentContextFactoryOptions NodeFileAgentContextOptions NodeFileExecutionHostOptions NodeFileThreadHostOptions NodeScheduledThreadPrompt NodeScheduledWorkAppendOptions NodeScheduledWorkDrainOptions NodeScheduledWorkDrainResult NodeScheduledWorkListOptions NodeScheduledWorkRunContext ackScheduledNodeRun ackScheduledNodeThreadPrompt appendScheduledNodeRun appendScheduledNodeThreadPrompt createNodeFileAgentContext createNodeFileExecutionHost createNodeFileScheduler createNodeFileThreadHost drainScheduledNodeWork listScheduledNodeRuns listScheduledNodeThreadPrompts"
+);
+const REQUIRED_RUNTIME_CHANNEL_EXPORTS = names(
+  "ChannelAssistantDelivery ChannelAssistantTextDelivery ChannelInboundMessage projectChannelAssistantDelivery"
+);
 const FORBIDDEN_RUNTIME_ROOT_NAMES = [
   ...[
     "AgentMessage AgentModel AgentLoopResult AgentRun AgentRunInput AgentTool AgentTools",
@@ -95,9 +93,7 @@ const FORBIDDEN_RUNTIME_ROOT_NAMES = [
   ["Runtime", "Llm", "Context"].join(""),
   ["Runtime", "Llm", "Output"].join(""),
   ["Runtime", "Llm", "Output", "Part"].join(""),
-  "runAgentLoop",
-  "ToolExecutionNeedsRecoveryError",
-  "SessionHost",
+  ...names("runAgentLoop ToolExecutionNeedsRecoveryError SessionHost"),
 ];
 const FORBIDDEN_RUNTIME_PUBLIC_PATTERNS = [
   {
@@ -132,6 +128,10 @@ const FORBIDDEN_RUNTIME_SUBAGENT_NAMES = [
   ["register", "Subagents"].join(""),
 ];
 const RUNTIME_PUBLIC_ARTIFACT_RE = /\.(?:d\.ts|[cm]?js)$/;
+
+function names(value) {
+  return value.split(" ");
+}
 
 export function findRuntimeDeclarationLeaks({ cwd, packages }) {
   if (!packages.includes("runtime")) {
@@ -172,6 +172,12 @@ export function findRuntimeDeclarationLeaks({ cwd, packages }) {
       ),
       requiredExports: REQUIRED_RUNTIME_NODE_EXPORTS,
       surface: "node",
+    }),
+    ...findRuntimeDeclarationExportLeaks({
+      cwd,
+      file: join(packageDistPath(cwd, "runtime"), "channel", "index.d.ts"),
+      requiredExports: REQUIRED_RUNTIME_CHANNEL_EXPORTS,
+      surface: "channel",
     }),
     ...findRuntimePublicPatternLeaks({ cwd }),
   ];


### PR DESCRIPTION
## Summary
- Add `@minpeter/pss-runtime/channel` as the only new runtime channel subpath.
- Expose the minimal app-owned adapter contract: `ChannelInboundMessage`, `ChannelAssistantTextDelivery`, `ChannelAssistantDelivery`, and `projectChannelAssistantDelivery`.
- Keep `Agent -> thread -> turn -> events()` as the control flow, with no runtime-owned channel loop or provider adapter.
- Add focused tests, root API guardrails, docs, changeset, and release-artifact verification for `dist/channel/index.d.ts`.

## Verification
- `pnpm --filter @minpeter/pss-runtime exec vitest run src/channel/index.test.ts src/contracts/root-api.test.ts`
- `pnpm exec vitest run scripts/runtime-docs.test.mjs scripts/verify-release-artifacts-runtime.test.mjs scripts/verify-release-artifacts-runtime-channel.test.mjs scripts/file-size.test.mjs`
- `pnpm lint`
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm verify:release`
- `pnpm boundaries`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`
- built-package import smoke test for `@minpeter/pss-runtime/channel`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal channel adapter contract under `@minpeter/pss-runtime/channel` so apps can map channel messages to threads and deliver assistant text from turn events. Control stays in the app; no runtime-owned channel loop.

- **New Features**
  - New subpath: `@minpeter/pss-runtime/channel`.
  - Exposes `ChannelInboundMessage`, `ChannelAssistantTextDelivery`, `ChannelAssistantDelivery`, and `projectChannelAssistantDelivery`.
  - Projector emits deliveries only for non-empty `assistant-output` events.
  - Docs include a simple adapter example; root exports are guarded; build entry and release checks require explicit channel declarations on `dist/channel/index.d.ts`.

- **Migration**
  - Import from `@minpeter/pss-runtime/channel`.
  - Map inbound channel data to `ChannelInboundMessage` and call `agent.thread(inbound.threadKey).send(inbound.input)`.
  - Iterate `turn.events()`, pass each event to `projectChannelAssistantDelivery(event)`, and deliver `assistant-text` when returned.

<sup>Written for commit 53636014d4e455610e589c905cd0bf7a48c5ac4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

