### PR TITLE
Add runtime OpenTelemetry trace adapter

### DIFF
--- a/.changeset/runtime-otel-adapter.md
+++ b/.changeset/runtime-otel-adapter.md
@@ -1,0 +1,6 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add `@minpeter/pss-runtime/otel` with `traceAgentTurn` for recording runtime
+`AgentTurn` event streams as OpenTelemetry spans and metadata-only span events.

--- a/.changeset/runtime-otel-adapter.md
+++ b/.changeset/runtime-otel-adapter.md
@@ -2,5 +2,6 @@
 "@minpeter/pss-runtime": patch
 ---
 
-Add `@minpeter/pss-runtime/otel` with `traceAgentTurn` for recording runtime
-`AgentTurn` event streams as OpenTelemetry spans and metadata-only span events.
+Add `@minpeter/pss-runtime/otel` with `openTelemetry()` agent instrumentation
+and `traceAgentTurn()` for recording runtime `AgentTurn` event streams as
+OpenTelemetry spans and metadata-only span events.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -202,6 +202,38 @@ Return one of:
 Plugins run in registration order. Each `transform` updates the event seen by
 later plugins, so transforms chain sequentially.
 
+## OpenTelemetry
+
+The OpenTelemetry adapter lives on its own subpath so the runtime root stays
+small:
+
+```ts
+import { Agent } from "@minpeter/pss-runtime";
+import { traceAgentTurn } from "@minpeter/pss-runtime/otel";
+
+const agent = new Agent({ model });
+const turn = await agent.send("Hello");
+const tracedTurn = traceAgentTurn(turn);
+
+for await (const event of tracedTurn.events()) {
+  if (event.type === "assistant-output") {
+    process.stdout.write(event.text);
+  }
+}
+```
+
+`traceAgentTurn(turn)` returns an `AgentTurn` whose `events()` iterator yields
+the original `AgentEvent` objects while recording a `pss.runtime.turn` span with
+`pss.runtime.event` events. It closes the span on `turn-end`, marks `turn-error`
+as `ERROR` with a sanitized exception, and marks `turn-abort` as an aborted
+error span.
+
+The package depends only on `@opentelemetry/api`; applications still configure
+the OpenTelemetry SDK/exporter. By default, event attributes summarize
+assistant text, reasoning, inputs, and tool payloads by length/type rather than
+recording raw content or error messages. Applications can add caller-owned
+metadata with the `eventAttributes` option.
+
 ### Input `meta.source`
 
 The runtime attaches `meta` on input events at API boundaries. Plugins can route

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -205,28 +205,40 @@ later plugins, so transforms chain sequentially.
 ## OpenTelemetry
 
 The OpenTelemetry adapter lives on its own subpath so the runtime root stays
-small:
+small. Add it to `AgentOptions.instrumentations` to trace every turn returned
+by the agent:
 
 ```ts
 import { Agent } from "@minpeter/pss-runtime";
-import { traceAgentTurn } from "@minpeter/pss-runtime/otel";
+import { openTelemetry } from "@minpeter/pss-runtime/otel";
 
-const agent = new Agent({ model });
+const agent = new Agent({
+  instrumentations: [
+    openTelemetry({
+      spanAttributes: { "app.agent": "support" },
+      tracerName: "my-app",
+    }),
+  ],
+  model,
+});
 const turn = await agent.send("Hello");
-const tracedTurn = traceAgentTurn(turn);
 
-for await (const event of tracedTurn.events()) {
+for await (const event of turn.events()) {
   if (event.type === "assistant-output") {
     process.stdout.write(event.text);
   }
 }
 ```
 
-`traceAgentTurn(turn)` returns an `AgentTurn` whose `events()` iterator yields
-the original `AgentEvent` objects while recording a `pss.runtime.turn` span with
-`pss.runtime.event` events. It closes the span on `turn-end`, marks `turn-error`
-as `ERROR` with a sanitized exception, and marks `turn-abort` as an aborted
-error span.
+`openTelemetry()` is an observe-only agent instrumentation. It wraps returned
+`AgentTurn` objects while preserving their `events()` iterator behavior and
+original `AgentEvent` objects. It records a `pss.runtime.turn` span with
+`pss.runtime.event` events, closes the span on `turn-end`, marks `turn-error` as
+`ERROR` with a sanitized exception, and marks `turn-abort` as an aborted error
+span.
+
+For a single turn, `traceAgentTurn(turn)` exposes the same adapter as a manual
+wrapper.
 
 The package depends only on `@opentelemetry/api`; applications still configure
 the OpenTelemetry SDK/exporter. By default, event attributes summarize

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,6 +11,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./otel": {
+      "@minpeter/pss-source": "./src/otel/index.ts",
+      "types": "./dist/otel/index.d.ts",
+      "import": "./dist/otel/index.js"
+    },
     "./platform/memory": {
       "@minpeter/pss-source": "./src/platform/memory/index.ts",
       "types": "./dist/platform/memory/index.d.ts",
@@ -69,6 +74,7 @@
     "lint": "ultracite check ."
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
     "ai": "7.0.0-canary.176"
   },
   "devDependencies": {

--- a/packages/runtime/src/agent/core/agent.test.ts
+++ b/packages/runtime/src/agent/core/agent.test.ts
@@ -4,11 +4,27 @@ import {
   createMockLanguageModelV4,
   mockLanguageModelV4Text,
 } from "../../testing/mock-language-model-v4-test-utils";
-import { Agent, type AgentOptions } from "./agent";
+import {
+  assistantMessage,
+  createCallbackModel,
+  createDeferred,
+} from "../../testing/test-fixtures";
+import {
+  Agent,
+  type AgentInstrumentation,
+  type AgentInstrumentationContext,
+  type AgentOptions,
+} from "./agent";
 import { threadStoreKey } from "./thread-entry";
 
 const fakeModel = createMockLanguageModelV4([mockLanguageModelV4Text("DONE")]);
 const functionModel = () => Promise.resolve([]);
+const invalidInstrumentationEntryPattern =
+  /options\.instrumentations entry must provide wrapTurn/;
+const invalidInstrumentationReturnPattern =
+  /wrapTurn\(\) must return an AgentTurn/;
+const invalidInstrumentationsArrayPattern =
+  /options\.instrumentations must be an array/;
 const invalidModelPattern = /invalid options\.model/;
 const missingModelPattern = /missing options\.model/;
 const missingOptionsPattern = /Agent options are required/;
@@ -25,6 +41,7 @@ const forbiddenAgentSubagentSurface = [
 
 const acceptsModelOptions: AgentOptions = {
   instructions: "Use the injected model.",
+  instrumentations: [],
   model: fakeModel,
   plugins: [],
   toolChoice: "auto",
@@ -114,6 +131,143 @@ describe("Agent", () => {
   it("uses the default thread for agent.send", async () => {
     const agent = new Agent({ model: fakeModel });
     await expect(agent.send("hello")).resolves.toBeDefined();
+  });
+
+  it("applies agent instrumentations to returned turns", async () => {
+    const contexts: AgentInstrumentationContext[] = [];
+    const observedTypes: string[] = [];
+    const instrumentation: AgentInstrumentation = {
+      name: "test",
+      wrapTurn: (turn, context) => {
+        contexts.push(context);
+        return {
+          async *events() {
+            for await (const event of turn.events()) {
+              observedTypes.push(event.type);
+              yield event;
+            }
+          },
+        };
+      },
+    };
+    const agent = new Agent({
+      instrumentations: [instrumentation],
+      model: fakeModel,
+      namespace: "tenant",
+    });
+
+    await collectRun(await agent.thread("observed").send("hello"));
+    await collectRun(await agent.thread("observed").steer("again"));
+
+    expect(contexts).toEqual([
+      {
+        namespace: "tenant",
+        operation: "send",
+        threadKey: "observed",
+      },
+      {
+        namespace: "tenant",
+        operation: "steer",
+        threadKey: "observed",
+      },
+    ]);
+    expect(observedTypes).toContain("assistant-output");
+    expect(observedTypes).toContain("turn-end");
+  });
+
+  it("applies fresh instrumentation context when live steer returns the active turn", async () => {
+    const contexts: AgentInstrumentationContext[] = [];
+    const modelGate = createDeferred();
+    const instrumentation: AgentInstrumentation = {
+      wrapTurn: (turn, context) => {
+        contexts.push(context);
+        return turn;
+      },
+    };
+    const agent = new Agent({
+      instrumentations: [instrumentation],
+      model: createCallbackModel(async () => {
+        await modelGate.promise;
+        return [assistantMessage("DONE")];
+      }),
+    });
+    const thread = agent.thread("active-steer");
+    const sendRun = await thread.send("initial");
+
+    await thread.steer("runtime input");
+    modelGate.resolve();
+    await collectRun(sendRun);
+
+    expect(contexts).toEqual([
+      {
+        operation: "send",
+        threadKey: "active-steer",
+      },
+      {
+        operation: "steer",
+        threadKey: "active-steer",
+      },
+    ]);
+  });
+
+  it("snapshots agent instrumentations at construction", async () => {
+    const observedNames: string[] = [];
+    const instrumentations: AgentInstrumentation[] = [
+      {
+        name: "initial",
+        wrapTurn: (turn) => {
+          observedNames.push("initial");
+          return turn;
+        },
+      },
+    ];
+    const agent = new Agent({ instrumentations, model: fakeModel });
+
+    instrumentations.push({
+      name: "late",
+      wrapTurn: (turn) => {
+        observedNames.push("late");
+        return turn;
+      },
+    });
+
+    await collectRun(await agent.send("hello"));
+
+    expect(observedNames).toEqual(["initial"]);
+  });
+
+  it("rejects malformed agent instrumentations with actionable errors", () => {
+    expect(() =>
+      Reflect.construct(Agent, [
+        {
+          instrumentations: {},
+          model: fakeModel,
+        },
+      ])
+    ).toThrow(invalidInstrumentationsArrayPattern);
+    expect(() =>
+      Reflect.construct(Agent, [
+        {
+          instrumentations: [{}],
+          model: fakeModel,
+        },
+      ])
+    ).toThrow(invalidInstrumentationEntryPattern);
+  });
+
+  it("rejects invalid turns returned by agent instrumentations", async () => {
+    const agent = new Agent({
+      instrumentations: [
+        {
+          wrapTurn: () => null as unknown as ReturnType<Agent["send"]>,
+        } as unknown as AgentInstrumentation,
+      ],
+      model: fakeModel,
+    });
+
+    await expect(agent.send("hello")).rejects.toThrow(
+      invalidInstrumentationReturnPattern
+    );
   });
 
   it("reuses handles for named threads", () => {

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -9,6 +9,12 @@ import { stableAgentNamespace } from "../identity/namespace";
 import { resumeAgentTurn } from "../resume/resume";
 import { threadStoreForHost } from "./host-thread-store";
 import {
+  type AgentInstrumentation,
+  type AgentInstrumentationContext,
+  applyAgentInstrumentations,
+  normalizeAgentInstrumentations,
+} from "./instrumentation";
+import {
   type AgentAutoCompactionOptions,
   type AgentModelOptions,
   type AgentOptions,
@@ -24,6 +30,11 @@ import {
 
 export type { AgentHost } from "../../execution/host/types";
 export type { ThreadCompactionInput } from "../../thread/handle/thread";
+export type {
+  AgentInstrumentation,
+  AgentInstrumentationContext,
+  AgentInstrumentationOperation,
+} from "./instrumentation";
 export type { AgentAutoCompactionOptions, AgentOptions } from "./options";
 export type {
   ThreadAddress,
@@ -38,6 +49,7 @@ export class Agent {
   readonly #ownerNamespace: string;
   readonly #store: ThreadStore;
   readonly #host: AgentHost;
+  readonly #instrumentations: readonly AgentInstrumentation[];
   readonly #plugins: readonly AgentPlugin[];
   readonly #notificationOverlays?: AgentOptions["notificationOverlays"];
   readonly #autoCompaction?: AgentAutoCompactionOptions;
@@ -53,6 +65,9 @@ export class Agent {
     this.#host = options.host ?? createInMemoryExecutionHost();
     this.host = this.#host;
     this.#store = threadStoreForHost(this.#host);
+    this.#instrumentations = normalizeAgentInstrumentations(
+      options.instrumentations
+    );
     this.#plugins = options.plugins ?? [];
     this.#notificationOverlays = options.notificationOverlays;
     this.#autoCompaction = normalizeAgentAutoCompactionOptions(
@@ -103,7 +118,7 @@ export class Agent {
       host,
       ownerNamespace: this.#ownerNamespace,
       resumeNotification: (notification) =>
-        this.#resumeNotification(notification),
+        this.#resumeNotification(notification, runId),
       runId,
     });
   }
@@ -145,8 +160,18 @@ export class Agent {
         thread.overlay(input);
         return publicHandle;
       },
-      send: (input) => thread.send(input),
-      steer: (input) => thread.steer(input),
+      send: async (input) =>
+        this.#instrumentTurn(await thread.send(input), {
+          namespace: this.namespace,
+          operation: "send",
+          threadKey: key,
+        }),
+      steer: async (input) =>
+        this.#instrumentTurn(await thread.steer(input), {
+          namespace: this.namespace,
+          operation: "steer",
+          threadKey: key,
+        }),
     };
     const entry: AgentThreadEntry = {
       notify: (input, options) => thread.notify(input, options),
@@ -160,8 +185,11 @@ export class Agent {
     this.#threads.delete(key);
   }
 
-  #resumeNotification(notification: NotificationRecord): Promise<AgentTurn> {
-    return this.#threadEntry(notification.threadKey).notify(
+  async #resumeNotification(
+    notification: NotificationRecord,
+    runId: string
+  ): Promise<AgentTurn> {
+    const turn = await this.#threadEntry(notification.threadKey).notify(
       notification.input,
       {
         observerEvents: notification.observerEvents,
@@ -171,5 +199,22 @@ export class Agent {
         ],
       }
     );
+    return this.#instrumentTurn(turn, {
+      namespace: this.namespace,
+      operation: "resume",
+      runId,
+      threadKey: notification.threadKey,
+    });
+  }
+
+  #instrumentTurn(
+    turn: AgentTurn,
+    context: AgentInstrumentationContext
+  ): AgentTurn {
+    if (this.#instrumentations.length === 0) {
+      return turn;
+    }
+
+    return applyAgentInstrumentations(turn, this.#instrumentations, context);
   }
 }

--- a/packages/runtime/src/agent/core/instrumentation.ts
+++ b/packages/runtime/src/agent/core/instrumentation.ts
@@ -1,0 +1,71 @@
+import type { AgentTurn } from "../../thread/protocol/turn";
+
+export type AgentInstrumentationOperation = "resume" | "send" | "steer";
+
+export interface AgentInstrumentationContext {
+  readonly namespace?: string;
+  readonly operation: AgentInstrumentationOperation;
+  readonly runId?: string;
+  readonly threadKey?: string;
+}
+
+export interface AgentInstrumentation {
+  readonly name?: string;
+  wrapTurn(turn: AgentTurn, context: AgentInstrumentationContext): AgentTurn;
+}
+
+export function normalizeAgentInstrumentations(
+  value: unknown
+): readonly AgentInstrumentation[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new TypeError("Agent: options.instrumentations must be an array.");
+  }
+
+  const instrumentations = [...value];
+  for (const instrumentation of instrumentations) {
+    assertAgentInstrumentation(instrumentation);
+  }
+  return Object.freeze(instrumentations);
+}
+
+export function applyAgentInstrumentations(
+  turn: AgentTurn,
+  instrumentations: readonly AgentInstrumentation[],
+  context: AgentInstrumentationContext
+): AgentTurn {
+  let instrumentedTurn = turn;
+  for (const instrumentation of instrumentations) {
+    instrumentedTurn = instrumentation.wrapTurn(instrumentedTurn, context);
+    assertAgentTurn(instrumentedTurn);
+  }
+  return instrumentedTurn;
+}
+
+function assertAgentInstrumentation(
+  value: unknown
+): asserts value is AgentInstrumentation {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    typeof (value as { readonly wrapTurn?: unknown }).wrapTurn !== "function"
+  ) {
+    throw new TypeError(
+      "Agent: each options.instrumentations entry must provide wrapTurn()."
+    );
+  }
+}
+
+function assertAgentTurn(value: unknown): asserts value is AgentTurn {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    typeof (value as { readonly events?: unknown }).events !== "function"
+  ) {
+    throw new TypeError(
+      "Agent: options.instrumentations entry wrapTurn() must return an AgentTurn."
+    );
+  }
+}

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -3,6 +3,10 @@ import type { AgentHost } from "../../execution/host/types";
 import type { AgentToolChoice } from "../../llm/llm";
 import type { AgentInput, UserInput } from "../../thread/input/input";
 import type { AgentPlugin } from "../../thread/plugins/pipeline";
+import {
+  type AgentInstrumentation,
+  normalizeAgentInstrumentations,
+} from "./instrumentation";
 
 export interface AgentAutoCompactionOptions {
   readonly minMessages: number;
@@ -13,6 +17,7 @@ export interface AgentOptions {
   readonly autoCompaction?: AgentAutoCompactionOptions | false;
   readonly host?: AgentHost;
   readonly instructions?: string;
+  readonly instrumentations?: readonly AgentInstrumentation[];
   readonly model: LanguageModel;
   readonly namespace?: string;
   readonly notificationOverlays?: readonly (AgentInput | UserInput)[];
@@ -45,8 +50,10 @@ export function assertAgentOptions(
 
   const candidate = options as {
     readonly autoCompaction?: AgentOptions["autoCompaction"];
+    readonly instrumentations?: AgentOptions["instrumentations"];
   };
   normalizeAgentAutoCompactionOptions(candidate.autoCompaction);
+  normalizeAgentInstrumentations(candidate.instrumentations);
 }
 
 export function normalizeAgentAutoCompactionOptions(

--- a/packages/runtime/src/agent/resume/notification-resume.test.ts
+++ b/packages/runtime/src/agent/resume/notification-resume.test.ts
@@ -8,7 +8,7 @@ import {
   userText,
 } from "../../testing/test-fixtures";
 import { collect } from "../../thread/handle/test-support";
-import { Agent } from "../core/agent";
+import { Agent, type AgentInstrumentationContext } from "../core/agent";
 import { agentNamespace } from "../identity/namespace";
 import {
   createThreadLoadFailingHost,
@@ -20,9 +20,18 @@ describe("host notification resume", () => {
   it("host resumes parent notification run once without direct prompt resume surface", async () => {
     const host = createInMemoryExecutionHost();
     const seenHistory: ModelMessage[][] = [];
+    const contexts: AgentInstrumentationContext[] = [];
     let calls = 0;
     const agent = new Agent({
       host,
+      instrumentations: [
+        {
+          wrapTurn: (turn, context) => {
+            contexts.push(context);
+            return turn;
+          },
+        },
+      ],
       model: createCallbackModel(({ history }) => {
         calls += 1;
         seenHistory.push([...history]);
@@ -71,6 +80,14 @@ describe("host notification resume", () => {
       "assistant-output",
       "step-end",
       "turn-end",
+    ]);
+    expect(contexts).toEqual([
+      {
+        namespace: "notify-owner",
+        operation: "resume",
+        runId: notification.runId,
+        threadKey: "default",
+      },
     ]);
     expect(seenHistory).toHaveLength(1);
     expect(JSON.stringify(seenHistory[0])).toContain("bg_1");

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type {
   CheckpointStore,
@@ -35,6 +37,7 @@ import {
   runPluginsForEvent,
   threadStoreKey as runtimeThreadStoreKey,
 } from "../index";
+import type { TraceAgentTurnOptions } from "../otel";
 
 type EmptyHostIsRejected =
   Record<string, never> extends AgentHost ? true : false;
@@ -231,6 +234,41 @@ describe("runtime public exports", () => {
       ExecutionStore["transaction"]
     >();
     expect(agentHost.kind).toBe("thread");
+  });
+
+  it("declares the OpenTelemetry adapter as an observability subpath", async () => {
+    const runtime = await import("../index");
+    const otel = await import("../otel");
+    const packageJson = JSON.parse(
+      await readFile(
+        fileURLToPath(new URL("../../package.json", import.meta.url)),
+        "utf8"
+      )
+    ) as {
+      exports: Record<string, { "@minpeter/pss-source": string }>;
+    };
+
+    expect(runtime).not.toHaveProperty("traceAgentTurn");
+    expect(runtime).not.toHaveProperty("createOpenTelemetryPlugin");
+    expect(runtime).not.toHaveProperty("recordAgentEvent");
+    expect(runtime).not.toHaveProperty("agentEventAttributes");
+    expect(otel).toHaveProperty("traceAgentTurn");
+    expect(otel).not.toHaveProperty("createOpenTelemetryPlugin");
+    expect(otel).not.toHaveProperty("recordAgentEvent");
+    expect(otel).not.toHaveProperty("agentEventAttributes");
+    expect(packageJson.exports["./otel"]).toMatchObject({
+      "@minpeter/pss-source": "./src/otel/index.ts",
+      import: "./dist/otel/index.js",
+      types: "./dist/otel/index.d.ts",
+    });
+    const options = {
+      eventAttributes: (event: AgentEvent) => ({
+        "test.event_type": event.type,
+      }),
+      eventName: "test.event",
+      tracerName: "test-tracer",
+    } satisfies TraceAgentTurnOptions;
+    expect(options.eventName).toBe("test.event");
   });
 
   it("exports Node file thread inspection from the file adapter only", async () => {

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -20,6 +20,8 @@ import type {
   AgentEvent,
   AgentHost,
   AgentInput,
+  AgentInstrumentation,
+  AgentInstrumentationOperation,
   AgentOptions,
   ControlAgentEvent,
   LifecycleAgentEvent,
@@ -150,8 +152,18 @@ describe("runtime public exports", () => {
       retainMessages: 4,
     } satisfies AgentAutoCompactionOptions;
     const model = {} as AgentOptions["model"];
+    const instrumentation = {
+      name: "test",
+      wrapTurn: (turn, context) => {
+        const operation =
+          context.operation satisfies AgentInstrumentationOperation;
+        expect(operation).toBe("send");
+        return turn;
+      },
+    } satisfies AgentInstrumentation;
     const enabledOptions = {
       autoCompaction,
+      instrumentations: [instrumentation],
       model,
       notificationOverlays: ["runtime context"],
     } satisfies AgentOptions;
@@ -179,6 +191,7 @@ describe("runtime public exports", () => {
       ReturnType<typeof runtimeThreadStoreKey>
     >().toEqualTypeOf<string>();
     expect(enabledOptions.autoCompaction).toEqual(autoCompaction);
+    expect(enabledOptions.instrumentations).toEqual([instrumentation]);
     expect(enabledOptions.notificationOverlays).toEqual(["runtime context"]);
     expect(disabledOptions.autoCompaction).toBe(false);
     expect(compaction.startSeq).toBe(0);
@@ -249,9 +262,11 @@ describe("runtime public exports", () => {
     };
 
     expect(runtime).not.toHaveProperty("traceAgentTurn");
+    expect(runtime).not.toHaveProperty("openTelemetry");
     expect(runtime).not.toHaveProperty("createOpenTelemetryPlugin");
     expect(runtime).not.toHaveProperty("recordAgentEvent");
     expect(runtime).not.toHaveProperty("agentEventAttributes");
+    expect(otel).toHaveProperty("openTelemetry");
     expect(otel).toHaveProperty("traceAgentTurn");
     expect(otel).not.toHaveProperty("createOpenTelemetryPlugin");
     expect(otel).not.toHaveProperty("recordAgentEvent");

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,9 @@
 export {
   Agent,
   type AgentAutoCompactionOptions,
+  type AgentInstrumentation,
+  type AgentInstrumentationContext,
+  type AgentInstrumentationOperation,
   type AgentOptions,
   type ThreadAddress,
   type ThreadCompactionInput,

--- a/packages/runtime/src/otel/attributes.ts
+++ b/packages/runtime/src/otel/attributes.ts
@@ -1,0 +1,188 @@
+import type { Attributes } from "@opentelemetry/api";
+import type {
+  AgentEvent,
+  UserInput,
+  UserMessageContentPart,
+} from "../thread/protocol/events";
+
+export function defaultAgentEventAttributes(event: AgentEvent): Attributes {
+  const base: Attributes = { "pss.event.type": event.type };
+
+  switch (event.type) {
+    case "assistant-output":
+      return { ...base, "pss.assistant_output.text_length": event.text.length };
+    case "assistant-reasoning":
+      return {
+        ...base,
+        "pss.assistant_reasoning.text_length": event.text.length,
+      };
+    case "runtime-input":
+      return {
+        ...base,
+        "pss.runtime_input.placement": event.placement,
+        ...inputAttributes(
+          "pss.runtime_input",
+          event.input,
+          event.meta ?? event.input.meta
+        ),
+      };
+    case "step-end":
+    case "step-start":
+    case "turn-end":
+    case "turn-start":
+      return base;
+    case "tool-call":
+      return {
+        ...base,
+        "pss.tool.call_id": event.toolCallId,
+        "pss.tool.input.type": payloadType(event.input),
+        "pss.tool.name": event.toolName,
+        ...payloadSummaryAttributes("pss.tool.input", event.input),
+      };
+    case "tool-result":
+      return {
+        ...base,
+        "pss.tool.call_id": event.toolCallId,
+        "pss.tool.name": event.toolName,
+        "pss.tool.output.type": payloadType(event.output),
+        ...payloadSummaryAttributes("pss.tool.output", event.output),
+      };
+    case "turn-abort":
+      return { ...base, "pss.turn.abort": true };
+    case "turn-error":
+      return { ...base, "pss.turn.error": true };
+    case "user-input":
+      return { ...base, ...inputAttributes("pss.user_input", event) };
+    default:
+      return assertNever(event);
+  }
+}
+
+export function cleanAttributes(
+  attributes: Attributes
+): Attributes | undefined {
+  const cleaned: Attributes = {};
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined && value !== null) {
+      cleaned[key] = value;
+    }
+  }
+
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+}
+
+export function mergeAttributes(
+  base: Attributes,
+  extra: Attributes | undefined
+): Attributes | undefined {
+  return cleanAttributes(extra === undefined ? base : { ...base, ...extra });
+}
+
+function inputAttributes(
+  prefix: string,
+  input: UserInput,
+  meta = input.meta
+): Attributes {
+  const metaAttributes = meta?.source
+    ? { "pss.input.source": meta.source }
+    : {};
+
+  if ("text" in input) {
+    return {
+      ...metaAttributes,
+      [`${prefix}.kind`]: "text",
+      ...textContentAttributes(prefix, input.text),
+    };
+  }
+
+  const summary = messageContentSummary(input.content);
+  return {
+    ...metaAttributes,
+    [`${prefix}.file_count`]: summary.fileCount,
+    [`${prefix}.image_count`]: summary.imageCount,
+    [`${prefix}.kind`]: "message",
+    [`${prefix}.part_count`]: input.content.length,
+    [`${prefix}.text_length`]: summary.textLength,
+    [`${prefix}.text_part_count`]: summary.textPartCount,
+  };
+}
+
+function messageContentSummary(content: readonly UserMessageContentPart[]) {
+  let fileCount = 0;
+  let imageCount = 0;
+  let textLength = 0;
+  let textPartCount = 0;
+
+  for (const part of content) {
+    switch (part.type) {
+      case "file":
+        fileCount += 1;
+        break;
+      case "image":
+        imageCount += 1;
+        break;
+      case "text":
+        textLength += part.text.length;
+        textPartCount += 1;
+        break;
+      default:
+        assertNever(part);
+    }
+  }
+
+  return { fileCount, imageCount, textLength, textPartCount };
+}
+
+function payloadType(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  return typeof value;
+}
+
+function payloadSummaryAttributes(prefix: string, value: unknown): Attributes {
+  if (typeof value === "string") {
+    return { [`${prefix}.text_length`]: value.length };
+  }
+  if (Array.isArray(value)) {
+    return { [`${prefix}.item_count`]: value.length };
+  }
+  if (typeof value === "object" && value !== null) {
+    const keyCount = objectKeyCount(value);
+    return keyCount === undefined ? {} : { [`${prefix}.key_count`]: keyCount };
+  }
+  return {};
+}
+
+function objectKeyCount(value: object): number | undefined {
+  try {
+    return Object.keys(value).length;
+  } catch {
+    return;
+  }
+}
+
+function textContentAttributes(
+  prefix: string,
+  text: string | readonly string[]
+): Attributes {
+  if (typeof text === "string") {
+    return {
+      [`${prefix}.part_count`]: 1,
+      [`${prefix}.text_length`]: text.length,
+    };
+  }
+
+  return {
+    [`${prefix}.part_count`]: text.length,
+    [`${prefix}.text_length`]: text.reduce((sum, part) => sum + part.length, 0),
+  };
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected AgentEvent variant: ${String(value)}`);
+}

--- a/packages/runtime/src/otel/index.test.ts
+++ b/packages/runtime/src/otel/index.test.ts
@@ -1,0 +1,287 @@
+import { SpanStatusCode } from "@opentelemetry/api";
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../thread/protocol/events";
+import type { AgentTurn } from "../thread/protocol/turn";
+import { traceAgentTurn } from "./index";
+import {
+  collectEvents,
+  eventTypes,
+  RecordingTracer,
+  spanNamed,
+} from "./test-support";
+
+describe("traceAgentTurn", () => {
+  it("returns an AgentTurn that yields original events and records spans", async () => {
+    const sourceEvents = [
+      { meta: { source: "send" }, text: "private user", type: "user-input" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { text: "private answer", type: "assistant-output" },
+      { text: "private reasoning", type: "assistant-reasoning" },
+      {
+        input: { query: "private tool input" },
+        toolCallId: "call-1",
+        toolName: "search",
+        type: "tool-call",
+      },
+      {
+        output: { result: "private tool output" },
+        toolCallId: "call-1",
+        toolName: "search",
+        type: "tool-result",
+      },
+      { type: "step-end" },
+      { type: "turn-end" },
+    ] satisfies readonly AgentEvent[];
+    const tracer = new RecordingTracer();
+    const tracedTurn = traceAgentTurn(turnFrom(sourceEvents), {
+      eventAttributes: (event) =>
+        event.type === "turn-start" ? { "test.extra": "kept" } : undefined,
+      spanAttributes: { "test.case": "happy" },
+      tracer,
+    });
+
+    expect(tracedTurn.events).toEqual(expect.any(Function));
+    const collected = await collectEvents(tracedTurn.events());
+
+    expect(collected).toHaveLength(sourceEvents.length);
+    expect(collected[0]).toBe(sourceEvents[0]);
+    expect(collected[3]).toBe(sourceEvents[3]);
+    expect(collected[6]).toBe(sourceEvents[6]);
+    expect(tracer.spans.map((span) => span.name)).toEqual([
+      "pss.runtime.turn",
+      "pss.runtime.step",
+      "pss.runtime.tool",
+    ]);
+    expect(tracer.spans.every((span) => span.ended)).toBe(true);
+    expect(spanNamed(tracer, "pss.runtime.turn").status).toEqual({
+      code: SpanStatusCode.OK,
+    });
+    expect(spanNamed(tracer, "pss.runtime.turn").spanAttributes).toMatchObject({
+      "pss.runtime.component": "@minpeter/pss-runtime",
+      "pss.runtime.span.kind": "turn",
+      "test.case": "happy",
+    });
+    expect(eventTypes(spanNamed(tracer, "pss.runtime.turn"))).toEqual(
+      sourceEvents.map((event) => event.type)
+    );
+    expect(eventAttributesFor(tracer, "turn-start")).toMatchObject({
+      "pss.event.type": "turn-start",
+      "test.extra": "kept",
+    });
+    expect(eventAttributesFor(tracer, "tool-call")).toMatchObject({
+      "pss.tool.call_id": "call-1",
+      "pss.tool.input.type": "object",
+      "pss.tool.name": "search",
+    });
+  });
+
+  it("keeps default telemetry metadata-only, including errors", async () => {
+    const secrets = [
+      "private user",
+      "private image",
+      "private file",
+      "private runtime input",
+      "private answer",
+      "private reasoning",
+      "private tool input",
+      "private failure",
+    ];
+    const tracer = new RecordingTracer();
+
+    await collectEvents(
+      traceAgentTurn(
+        turnFrom([
+          {
+            content: [
+              { text: secrets[0], type: "text" },
+              { image: secrets[1], type: "image" },
+              {
+                data: { text: secrets[2], type: "text" },
+                mediaType: "text/plain",
+                type: "file",
+              },
+            ],
+            meta: { source: "send" },
+            type: "user-input",
+          },
+          {
+            input: { text: secrets[3], type: "user-input" },
+            meta: { source: "notify" },
+            placement: "turn-start",
+            type: "runtime-input",
+          },
+          { type: "turn-start" },
+          { type: "step-start" },
+          { text: secrets[4], type: "assistant-output" },
+          { text: secrets[5], type: "assistant-reasoning" },
+          {
+            input: { secret: secrets[6] },
+            toolCallId: "call-1",
+            toolName: "search",
+            type: "tool-call",
+          },
+          { message: secrets[7], type: "turn-error" },
+        ]),
+        { tracer }
+      ).events()
+    );
+
+    const telemetry = JSON.stringify({
+      exceptions: tracer.spans.flatMap((span) =>
+        span.exceptions.map((error) => error.message)
+      ),
+      spans: tracer.spans,
+      statuses: tracer.spans.map((span) => span.status),
+    });
+    for (const secret of secrets) {
+      expect(telemetry).not.toContain(secret);
+    }
+    expect(spanNamed(tracer, "pss.runtime.turn").status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message: "turn error",
+    });
+    expect(
+      spanNamed(tracer, "pss.runtime.turn").exceptions.map(
+        (error) => error.message
+      )
+    ).toEqual(["Agent turn failed"]);
+    expect(eventAttributesFor(tracer, "user-input")).toMatchObject({
+      "pss.input.source": "send",
+      "pss.user_input.file_count": 1,
+      "pss.user_input.image_count": 1,
+      "pss.user_input.text_part_count": 1,
+    });
+    expect(eventAttributesFor(tracer, "runtime-input")).toMatchObject({
+      "pss.input.source": "notify",
+      "pss.runtime_input.kind": "text",
+      "pss.runtime_input.text_length": secrets[3].length,
+    });
+  });
+
+  it("does not let payload summarization consume or throw from tool payloads", async () => {
+    const sourceEvents = [
+      { type: "turn-start" },
+      {
+        input: {
+          secret: "private tool input",
+          toJSON: () => {
+            throw new Error("payload side effect");
+          },
+        },
+        toolCallId: "call-1",
+        toolName: "search",
+        type: "tool-call",
+      },
+      {
+        output: {
+          result: "private tool output",
+          toJSON: () => {
+            throw new Error("payload side effect");
+          },
+        },
+        toolCallId: "call-1",
+        toolName: "search",
+        type: "tool-result",
+      },
+      { type: "turn-end" },
+    ] satisfies readonly AgentEvent[];
+    const tracer = new RecordingTracer();
+
+    const collected = await collectEvents(
+      traceAgentTurn(turnFrom(sourceEvents), { tracer }).events()
+    );
+
+    expect(collected[1]).toBe(sourceEvents[1]);
+    expect(collected[2]).toBe(sourceEvents[2]);
+    expect(eventAttributesFor(tracer, "tool-call")).toMatchObject({
+      "pss.tool.call_id": "call-1",
+      "pss.tool.input.key_count": 2,
+      "pss.tool.input.type": "object",
+    });
+    expect(eventAttributesFor(tracer, "tool-result")).toMatchObject({
+      "pss.tool.call_id": "call-1",
+      "pss.tool.output.key_count": 2,
+      "pss.tool.output.type": "object",
+    });
+    expect(JSON.stringify(tracer.spans)).not.toContain("private tool");
+  });
+
+  it("handles aborts, orphan tool results, duplicate tools, and step replacement", async () => {
+    const tracer = new RecordingTracer();
+
+    await collectEvents(
+      traceAgentTurn(
+        turnFrom([
+          { type: "turn-start" },
+          { type: "step-start" },
+          { type: "step-start" },
+          {
+            input: "first",
+            toolCallId: "call-1",
+            toolName: "search",
+            type: "tool-call",
+          },
+          {
+            input: "second",
+            toolCallId: "call-1",
+            toolName: "search",
+            type: "tool-call",
+          },
+          {
+            output: "done",
+            toolCallId: "missing",
+            toolName: "lookup",
+            type: "tool-result",
+          },
+          { type: "turn-abort" },
+        ]),
+        { tracer }
+      ).events()
+    );
+
+    expect(spanNamed(tracer, "pss.runtime.turn").status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message: "turn aborted",
+    });
+    expect(
+      spanNamed(tracer, "pss.runtime.turn")
+        .events.filter((event) => event.name === "pss.runtime.diagnostic")
+        .map((event) => event.attributes?.["pss.diagnostic.reason"])
+    ).toEqual([
+      "step span replaced",
+      "tool span replaced",
+      "orphan tool result",
+    ]);
+    expect(
+      tracer.spans.filter((span) => span.name === "pss.runtime.step")
+    ).toHaveLength(2);
+    expect(
+      tracer.spans.filter((span) => span.name === "pss.runtime.tool")
+    ).toHaveLength(2);
+    expect(tracer.spans.every((span) => span.ended)).toBe(true);
+  });
+});
+
+async function* eventsFrom(events: readonly AgentEvent[]) {
+  await Promise.resolve();
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function eventAttributesFor(tracer: RecordingTracer, type: AgentEvent["type"]) {
+  const event = spanNamed(tracer, "pss.runtime.turn").events.find(
+    (candidate) => candidate.attributes?.["pss.event.type"] === type
+  );
+  if (!event?.attributes) {
+    throw new Error(`Missing recorded event attributes for ${type}`);
+  }
+  return event.attributes;
+}
+
+function turnFrom(events: readonly AgentEvent[]): AgentTurn {
+  return {
+    events: () => eventsFrom(events),
+  };
+}

--- a/packages/runtime/src/otel/index.test.ts
+++ b/packages/runtime/src/otel/index.test.ts
@@ -1,8 +1,13 @@
 import { SpanStatusCode } from "@opentelemetry/api";
 import { describe, expect, it } from "vitest";
+import { Agent } from "../agent/core/agent";
+import {
+  createMockLanguageModelV4,
+  mockLanguageModelV4Text,
+} from "../testing/mock-language-model-v4-test-utils";
 import type { AgentEvent } from "../thread/protocol/events";
 import type { AgentTurn } from "../thread/protocol/turn";
-import { traceAgentTurn } from "./index";
+import { openTelemetry, traceAgentTurn } from "./index";
 import {
   collectEvents,
   eventTypes,
@@ -11,6 +16,30 @@ import {
 } from "./test-support";
 
 describe("traceAgentTurn", () => {
+  it("creates an Agent instrumentation for constructor-level tracing", async () => {
+    const tracer = new RecordingTracer();
+    const agent = new Agent({
+      instrumentations: [
+        openTelemetry({
+          spanAttributes: { "test.case": "agent-instrumentation" },
+          tracer,
+        }),
+      ],
+      model: createMockLanguageModelV4([mockLanguageModelV4Text("DONE")]),
+    });
+
+    const collected = await collectEvents((await agent.send("hello")).events());
+
+    expect(collected.map((event) => event.type)).toContain("assistant-output");
+    expect(collected.map((event) => event.type)).toContain("turn-end");
+    expect(spanNamed(tracer, "pss.runtime.turn").spanAttributes).toMatchObject({
+      "pss.runtime.component": "@minpeter/pss-runtime",
+      "pss.runtime.span.kind": "turn",
+      "test.case": "agent-instrumentation",
+    });
+    expect(spanNamed(tracer, "pss.runtime.turn").ended).toBe(true);
+  });
+
   it("returns an AgentTurn that yields original events and records spans", async () => {
     const sourceEvents = [
       { meta: { source: "send" }, text: "private user", type: "user-input" },

--- a/packages/runtime/src/otel/index.ts
+++ b/packages/runtime/src/otel/index.ts
@@ -1,0 +1,104 @@
+import type { AgentEvent } from "../thread/protocol/events";
+import type { AgentTurn } from "../thread/protocol/turn";
+import {
+  closeTraceState,
+  INCOMPLETE_SPAN_STATUS,
+  recordRuntimeTraceEvent,
+  SOURCE_ERROR_STATUS,
+  TURN_OK_STATUS,
+} from "./trace-state";
+import {
+  createTraceState,
+  type TraceAgentTurnOptions,
+  type TraceAgentTurnState,
+} from "./types";
+
+export type {
+  TraceAgentTurnEventAttributes,
+  TraceAgentTurnOptions,
+  TraceAgentTurnSpan,
+  TraceAgentTurnTracer,
+} from "./types";
+
+export function traceAgentTurn(
+  turn: AgentTurn,
+  options: TraceAgentTurnOptions = {}
+): AgentTurn {
+  return {
+    events: () =>
+      new TracedAgentEventIterator(
+        turn.events()[Symbol.asyncIterator](),
+        createTraceState(options)
+      ),
+  };
+}
+
+class TracedAgentEventIterator implements AsyncIterableIterator<AgentEvent> {
+  readonly #source: AsyncIterator<AgentEvent>;
+  readonly #state: TraceAgentTurnState;
+  #closed = false;
+  #nextPending = false;
+
+  constructor(source: AsyncIterator<AgentEvent>, state: TraceAgentTurnState) {
+    this.#source = source;
+    this.#state = state;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<AgentEvent> {
+    return this;
+  }
+
+  async next(): Promise<IteratorResult<AgentEvent>> {
+    if (this.#closed) {
+      return { done: true, value: undefined };
+    }
+    if (this.#nextPending) {
+      throw new Error(
+        "AgentTurn.events() does not allow concurrent next() calls"
+      );
+    }
+
+    this.#nextPending = true;
+    try {
+      const next = await this.#source.next();
+      if (next.done) {
+        this.#closed = true;
+        closeTraceState(this.#state, {
+          childStatus: INCOMPLETE_SPAN_STATUS,
+          turnStatus: TURN_OK_STATUS,
+        });
+        return { done: true, value: undefined };
+      }
+
+      recordRuntimeTraceEvent(this.#state, next.value);
+      return { done: false, value: next.value };
+    } catch (error) {
+      this.#closed = true;
+      closeTraceState(this.#state, {
+        childStatus: SOURCE_ERROR_STATUS,
+        exception: new Error("Agent turn source failed"),
+        turnStatus: SOURCE_ERROR_STATUS,
+      });
+      throw error;
+    } finally {
+      this.#nextPending = false;
+    }
+  }
+
+  async return(): Promise<IteratorResult<AgentEvent>> {
+    if (this.#closed) {
+      return { done: true, value: undefined };
+    }
+
+    try {
+      await this.#source.return?.();
+    } finally {
+      this.#closed = true;
+      closeTraceState(this.#state, {
+        childStatus: INCOMPLETE_SPAN_STATUS,
+      });
+    }
+
+    return { done: true, value: undefined };
+  }
+}

--- a/packages/runtime/src/otel/index.ts
+++ b/packages/runtime/src/otel/index.ts
@@ -1,3 +1,4 @@
+import type { AgentInstrumentation } from "../index";
 import type { AgentEvent } from "../thread/protocol/events";
 import type { AgentTurn } from "../thread/protocol/turn";
 import {
@@ -19,6 +20,15 @@ export type {
   TraceAgentTurnSpan,
   TraceAgentTurnTracer,
 } from "./types";
+
+export function openTelemetry(
+  options: TraceAgentTurnOptions = {}
+): AgentInstrumentation {
+  return {
+    name: "openTelemetry",
+    wrapTurn: (turn) => traceAgentTurn(turn, options),
+  };
+}
 
 export function traceAgentTurn(
   turn: AgentTurn,

--- a/packages/runtime/src/otel/iterator.test.ts
+++ b/packages/runtime/src/otel/iterator.test.ts
@@ -1,0 +1,173 @@
+import { SpanStatusCode } from "@opentelemetry/api";
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "../thread/protocol/events";
+import type { AgentTurn } from "../thread/protocol/turn";
+import { traceAgentTurn } from "./index";
+import { collectEvents, RecordingTracer, spanNamed } from "./test-support";
+
+describe("traceAgentTurn iterator behavior", () => {
+  it("propagates source errors after closing spans with sanitized telemetry", async () => {
+    const tracer = new RecordingTracer();
+
+    await expect(
+      collectEvents(
+        traceAgentTurn(throwingTurn(new Error("private source failure")), {
+          tracer,
+        }).events()
+      )
+    ).rejects.toThrow("private source failure");
+
+    const telemetry = JSON.stringify({
+      exceptions: tracer.spans.flatMap((span) =>
+        span.exceptions.map((error) => error.message)
+      ),
+      statuses: tracer.spans.map((span) => span.status),
+    });
+    expect(telemetry).not.toContain("private source failure");
+    expect(spanNamed(tracer, "pss.runtime.turn").status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message: "source iterator failed",
+    });
+    expect(tracer.spans.every((span) => span.ended)).toBe(true);
+  });
+
+  it("preserves second events() and concurrent next() failures", async () => {
+    const tracedTurn = traceAgentTurn(singleUseTurn([{ type: "turn-start" }]), {
+      tracer: new RecordingTracer(),
+    });
+    tracedTurn.events();
+
+    expect(() => tracedTurn.events()).toThrow(
+      "AgentTurn.events() can only be consumed once"
+    );
+
+    const deferred = createDeferred<IteratorResult<AgentEvent>>();
+    const iterator = traceAgentTurn(
+      turnFromIterator({
+        next: () => deferred.promise,
+      }),
+      { tracer: new RecordingTracer() }
+    )
+      .events()
+      [Symbol.asyncIterator]();
+    const firstNext = iterator.next();
+
+    await expect(iterator.next()).rejects.toThrow(
+      "AgentTurn.events() does not allow concurrent next() calls"
+    );
+    deferred.resolve({ done: false, value: { type: "turn-start" } });
+    await expect(firstNext).resolves.toEqual({
+      done: false,
+      value: { type: "turn-start" },
+    });
+  });
+
+  it("calls source return() and closes spans on early return", async () => {
+    let sourceReturned = false;
+    const tracer = new RecordingTracer();
+    const iterator = traceAgentTurn(
+      {
+        events: () =>
+          (async function* () {
+            try {
+              yield { type: "turn-start" } satisfies AgentEvent;
+              await new Promise(() => undefined);
+            } finally {
+              sourceReturned = true;
+            }
+          })(),
+      },
+      { tracer }
+    )
+      .events()
+      [Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: "turn-start" },
+    });
+    await expect(iterator.return?.()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    expect(sourceReturned).toBe(true);
+    expect(spanNamed(tracer, "pss.runtime.turn").ended).toBe(true);
+    expect(spanNamed(tracer, "pss.runtime.turn").status).toBeUndefined();
+  });
+
+  it("closes open spans on source completion and allows an empty stream", async () => {
+    const partialTracer = new RecordingTracer();
+    const partialEvents = await collectEvents(
+      traceAgentTurn(
+        singleUseTurn([
+          { text: "visible only to source", type: "assistant-output" },
+        ]),
+        { tracer: partialTracer }
+      ).events()
+    );
+
+    expect(partialEvents).toHaveLength(1);
+    expect(spanNamed(partialTracer, "pss.runtime.turn").status).toEqual({
+      code: SpanStatusCode.OK,
+    });
+    expect(spanNamed(partialTracer, "pss.runtime.turn").ended).toBe(true);
+
+    const emptyTracer = new RecordingTracer();
+    expect(
+      await collectEvents(
+        traceAgentTurn(singleUseTurn([]), { tracer: emptyTracer }).events()
+      )
+    ).toEqual([]);
+    expect(emptyTracer.spans).toEqual([]);
+  });
+});
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+async function* eventsFrom(events: readonly AgentEvent[]) {
+  await Promise.resolve();
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function singleUseTurn(events: readonly AgentEvent[]): AgentTurn {
+  let started = false;
+  return {
+    events: () => {
+      if (started) {
+        throw new Error("AgentTurn.events() can only be consumed once");
+      }
+      started = true;
+      return eventsFrom(events);
+    },
+  };
+}
+
+function throwingTurn(error: Error): AgentTurn {
+  return {
+    events: () =>
+      (async function* () {
+        await Promise.resolve();
+        yield { type: "turn-start" } satisfies AgentEvent;
+        yield { type: "step-start" } satisfies AgentEvent;
+        throw error;
+      })(),
+  };
+}
+
+function turnFromIterator(iterator: AsyncIterator<AgentEvent>): AgentTurn {
+  return {
+    events: () => ({
+      ...iterator,
+      [Symbol.asyncIterator]: () => iterator,
+    }),
+  };
+}

--- a/packages/runtime/src/otel/test-support.ts
+++ b/packages/runtime/src/otel/test-support.ts
@@ -1,0 +1,72 @@
+import type { Attributes, SpanOptions, SpanStatus } from "@opentelemetry/api";
+import type { AgentEvent } from "../thread/protocol/events";
+import type { TraceAgentTurnSpan, TraceAgentTurnTracer } from "./index";
+
+export interface RecordedSpanEvent {
+  readonly attributes: Attributes | undefined;
+  readonly name: string;
+}
+
+export class RecordingSpan implements TraceAgentTurnSpan {
+  readonly events: RecordedSpanEvent[] = [];
+  readonly exceptions: Error[] = [];
+  readonly name: string;
+  readonly spanAttributes: Attributes | undefined;
+  ended = false;
+  status: SpanStatus | undefined;
+
+  constructor(name: string, attributes?: Attributes) {
+    this.name = name;
+    this.spanAttributes = attributes;
+  }
+
+  addEvent(name: string, attributes?: Attributes): this {
+    this.events.push({ attributes, name });
+    return this;
+  }
+
+  end(): void {
+    this.ended = true;
+  }
+
+  recordException(exception: Error): void {
+    this.exceptions.push(exception);
+  }
+
+  setStatus(status: SpanStatus): this {
+    this.status = status;
+    return this;
+  }
+}
+
+export class RecordingTracer implements TraceAgentTurnTracer {
+  readonly spans: RecordingSpan[] = [];
+
+  startSpan(name: string, options?: SpanOptions): RecordingSpan {
+    const span = new RecordingSpan(name, options?.attributes);
+    this.spans.push(span);
+    return span;
+  }
+}
+
+export async function collectEvents(events: AsyncIterable<AgentEvent>) {
+  const collected: AgentEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+export function eventTypes(span: RecordingSpan) {
+  return span.events
+    .filter((event) => event.name === "pss.runtime.event")
+    .map((event) => event.attributes?.["pss.event.type"]);
+}
+
+export function spanNamed(tracer: RecordingTracer, name: string) {
+  const span = tracer.spans.find((candidate) => candidate.name === name);
+  if (!span) {
+    throw new Error(`Missing span ${name}`);
+  }
+  return span;
+}

--- a/packages/runtime/src/otel/trace-state.ts
+++ b/packages/runtime/src/otel/trace-state.ts
@@ -1,0 +1,259 @@
+import { type SpanStatus, SpanStatusCode } from "@opentelemetry/api";
+import type {
+  AgentEvent,
+  ToolCall,
+  ToolResult,
+} from "../thread/protocol/events";
+import {
+  cleanAttributes,
+  defaultAgentEventAttributes,
+  mergeAttributes,
+} from "./attributes";
+import type {
+  CloseTraceStateOptions,
+  TraceAgentTurnEventAttributes,
+  TraceAgentTurnSpan,
+  TraceAgentTurnState,
+} from "./types";
+
+export const INCOMPLETE_SPAN_STATUS = {
+  code: SpanStatusCode.ERROR,
+  message: "span closed before completion",
+} satisfies SpanStatus;
+export const SOURCE_ERROR_STATUS = {
+  code: SpanStatusCode.ERROR,
+  message: "source iterator failed",
+} satisfies SpanStatus;
+export const TURN_ABORT_STATUS = {
+  code: SpanStatusCode.ERROR,
+  message: "turn aborted",
+} satisfies SpanStatus;
+export const TURN_ERROR_STATUS = {
+  code: SpanStatusCode.ERROR,
+  message: "turn error",
+} satisfies SpanStatus;
+export const TURN_OK_STATUS = { code: SpanStatusCode.OK } satisfies SpanStatus;
+
+export function recordRuntimeTraceEvent(
+  state: TraceAgentTurnState,
+  event: AgentEvent
+): void {
+  const attributes = traceEventAttributes(state, event);
+  const turnSpan = ensureTurnSpan(state);
+  turnSpan.addEvent(state.options.eventName, attributes);
+
+  switch (event.type) {
+    case "step-start":
+      startStepSpan(state, attributes);
+      return;
+    case "step-end":
+      closeStepSpan(state, TURN_OK_STATUS, attributes);
+      return;
+    case "tool-call":
+      startToolSpan(state, event, attributes);
+      return;
+    case "tool-result":
+      closeToolSpan(state, event, attributes);
+      return;
+    case "turn-end":
+      closeTraceState(state, {
+        childStatus: INCOMPLETE_SPAN_STATUS,
+        turnStatus: TURN_OK_STATUS,
+      });
+      return;
+    case "turn-abort":
+      closeTraceState(state, {
+        childStatus: TURN_ABORT_STATUS,
+        turnStatus: TURN_ABORT_STATUS,
+      });
+      return;
+    case "turn-error":
+      closeTraceState(state, {
+        childStatus: TURN_ERROR_STATUS,
+        exception: new Error("Agent turn failed"),
+        turnStatus: TURN_ERROR_STATUS,
+      });
+      return;
+    case "assistant-output":
+    case "assistant-reasoning":
+    case "runtime-input":
+    case "turn-start":
+    case "user-input":
+      return;
+    default:
+      assertNever(event);
+  }
+}
+
+export function closeTraceState(
+  state: TraceAgentTurnState,
+  options: CloseTraceStateOptions = {}
+): void {
+  closeToolSpans(state, options.childStatus);
+  closeStepSpan(state, options.childStatus);
+  closeTurnSpan(state, options.turnStatus, options.exception);
+}
+
+function startStepSpan(
+  state: TraceAgentTurnState,
+  eventAttributes: TraceAgentTurnEventAttributes | undefined
+): void {
+  if (state.stepSpan) {
+    addDiagnosticEvent(state, "step span replaced");
+    closeStepSpan(state, INCOMPLETE_SPAN_STATUS);
+  }
+
+  const span = startSpan(state, state.options.stepSpanName, {
+    "pss.runtime.span.kind": "step",
+  });
+  span.addEvent(state.options.eventName, eventAttributes);
+  state.stepSpan = span;
+}
+
+function closeStepSpan(
+  state: TraceAgentTurnState,
+  status?: SpanStatus,
+  eventAttributes?: TraceAgentTurnEventAttributes | undefined
+): void {
+  const span = state.stepSpan;
+  if (!span) {
+    return;
+  }
+  if (eventAttributes) {
+    span.addEvent(state.options.eventName, eventAttributes);
+  }
+  endSpan(span, status);
+  state.stepSpan = undefined;
+}
+
+function startToolSpan(
+  state: TraceAgentTurnState,
+  event: ToolCall,
+  eventAttributes: TraceAgentTurnEventAttributes | undefined
+): void {
+  const existing = state.toolSpans.get(event.toolCallId);
+  if (existing) {
+    addDiagnosticEvent(state, "tool span replaced", {
+      "pss.tool.call_id": event.toolCallId,
+      "pss.tool.name": event.toolName,
+    });
+    endSpan(existing, INCOMPLETE_SPAN_STATUS);
+  }
+
+  const span = startSpan(state, state.options.toolSpanName, {
+    "pss.runtime.span.kind": "tool",
+    "pss.tool.call_id": event.toolCallId,
+    "pss.tool.name": event.toolName,
+  });
+  span.addEvent(state.options.eventName, eventAttributes);
+  state.toolSpans.set(event.toolCallId, span);
+}
+
+function closeToolSpan(
+  state: TraceAgentTurnState,
+  event: ToolResult,
+  eventAttributes: TraceAgentTurnEventAttributes | undefined
+): void {
+  const span = state.toolSpans.get(event.toolCallId);
+  if (!span) {
+    addDiagnosticEvent(state, "orphan tool result", {
+      "pss.tool.call_id": event.toolCallId,
+      "pss.tool.name": event.toolName,
+    });
+    return;
+  }
+
+  span.addEvent(state.options.eventName, eventAttributes);
+  endSpan(span, TURN_OK_STATUS);
+  state.toolSpans.delete(event.toolCallId);
+}
+
+function closeToolSpans(
+  state: TraceAgentTurnState,
+  status: SpanStatus | undefined
+): void {
+  for (const span of state.toolSpans.values()) {
+    endSpan(span, status);
+  }
+  state.toolSpans.clear();
+}
+
+function ensureTurnSpan(state: TraceAgentTurnState): TraceAgentTurnSpan {
+  const current = state.turnSpan;
+  if (current) {
+    return current;
+  }
+
+  const span = startSpan(state, state.options.turnSpanName, {
+    "pss.runtime.span.kind": "turn",
+  });
+  state.turnSpan = span;
+  return span;
+}
+
+function closeTurnSpan(
+  state: TraceAgentTurnState,
+  status: SpanStatus | undefined,
+  exception: Error | undefined
+): void {
+  const span = state.turnSpan;
+  if (!span) {
+    return;
+  }
+  if (exception) {
+    span.recordException(exception);
+  }
+  endSpan(span, status);
+  state.turnSpan = undefined;
+}
+
+function startSpan(
+  state: TraceAgentTurnState,
+  name: string,
+  attributes: TraceAgentTurnEventAttributes
+): TraceAgentTurnSpan {
+  return state.options.tracer.startSpan(name, {
+    attributes: cleanAttributes({
+      ...state.options.spanAttributes,
+      ...attributes,
+    }),
+  });
+}
+
+function traceEventAttributes(
+  state: TraceAgentTurnState,
+  event: AgentEvent
+): TraceAgentTurnEventAttributes | undefined {
+  return mergeAttributes(
+    defaultAgentEventAttributes(event),
+    state.options.eventAttributes?.(event)
+  );
+}
+
+function addDiagnosticEvent(
+  state: TraceAgentTurnState,
+  reason: string,
+  attributes: TraceAgentTurnEventAttributes = {}
+): void {
+  ensureTurnSpan(state).addEvent(
+    "pss.runtime.diagnostic",
+    cleanAttributes({
+      "pss.diagnostic.reason": reason,
+      ...attributes,
+    })
+  );
+}
+
+function endSpan(
+  span: TraceAgentTurnSpan,
+  status: SpanStatus | undefined
+): void {
+  if (status) {
+    span.setStatus(status);
+  }
+  span.end();
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected AgentEvent variant: ${JSON.stringify(value)}`);
+}

--- a/packages/runtime/src/otel/types.ts
+++ b/packages/runtime/src/otel/types.ts
@@ -1,0 +1,101 @@
+import {
+  type Attributes,
+  type SpanOptions,
+  type SpanStatus,
+  trace,
+} from "@opentelemetry/api";
+import type { AgentEvent } from "../thread/protocol/events";
+
+export const DEFAULT_EVENT_NAME = "pss.runtime.event";
+export const DEFAULT_STEP_SPAN_NAME = "pss.runtime.step";
+export const DEFAULT_TOOL_SPAN_NAME = "pss.runtime.tool";
+export const DEFAULT_TURN_SPAN_NAME = "pss.runtime.turn";
+export const RUNTIME_COMPONENT = "@minpeter/pss-runtime";
+
+export type TraceAgentTurnEventAttributes = Attributes;
+
+export interface TraceAgentTurnSpan {
+  addEvent(
+    name: string,
+    attributes?: TraceAgentTurnEventAttributes
+  ): TraceAgentTurnSpan;
+  end(): void;
+  recordException(exception: Error): void;
+  setStatus(status: SpanStatus): TraceAgentTurnSpan;
+}
+
+export interface TraceAgentTurnTracer {
+  startSpan(name: string, options?: SpanOptions): TraceAgentTurnSpan;
+}
+
+export interface TraceAgentTurnOptions {
+  readonly eventAttributes?: (
+    event: AgentEvent
+  ) => TraceAgentTurnEventAttributes | undefined;
+  readonly eventName?: string;
+  readonly spanAttributes?: TraceAgentTurnEventAttributes;
+  readonly stepSpanName?: string;
+  readonly toolSpanName?: string;
+  readonly tracer?: TraceAgentTurnTracer;
+  readonly tracerName?: string;
+  readonly tracerVersion?: string;
+  readonly turnSpanName?: string;
+}
+
+export interface ResolvedTraceAgentTurnOptions {
+  readonly eventAttributes?: (
+    event: AgentEvent
+  ) => TraceAgentTurnEventAttributes | undefined;
+  readonly eventName: string;
+  readonly spanAttributes: TraceAgentTurnEventAttributes;
+  readonly stepSpanName: string;
+  readonly toolSpanName: string;
+  readonly tracer: TraceAgentTurnTracer;
+  readonly turnSpanName: string;
+}
+
+export interface TraceAgentTurnState {
+  readonly options: ResolvedTraceAgentTurnOptions;
+  stepSpan: TraceAgentTurnSpan | undefined;
+  readonly toolSpans: Map<string, TraceAgentTurnSpan>;
+  turnSpan: TraceAgentTurnSpan | undefined;
+}
+
+export interface CloseTraceStateOptions {
+  readonly childStatus?: SpanStatus;
+  readonly exception?: Error;
+  readonly turnStatus?: SpanStatus;
+}
+
+export function createTraceState(
+  options: TraceAgentTurnOptions
+): TraceAgentTurnState {
+  return {
+    options: resolveOptions(options),
+    stepSpan: undefined,
+    toolSpans: new Map(),
+    turnSpan: undefined,
+  };
+}
+
+function resolveOptions(
+  options: TraceAgentTurnOptions
+): ResolvedTraceAgentTurnOptions {
+  return {
+    eventAttributes: options.eventAttributes,
+    eventName: options.eventName ?? DEFAULT_EVENT_NAME,
+    spanAttributes: {
+      "pss.runtime.component": RUNTIME_COMPONENT,
+      ...options.spanAttributes,
+    },
+    stepSpanName: options.stepSpanName ?? DEFAULT_STEP_SPAN_NAME,
+    toolSpanName: options.toolSpanName ?? DEFAULT_TOOL_SPAN_NAME,
+    tracer:
+      options.tracer ??
+      trace.getTracer(
+        options.tracerName ?? RUNTIME_COMPONENT,
+        options.tracerVersion
+      ),
+    turnSpanName: options.turnSpanName ?? DEFAULT_TURN_SPAN_NAME,
+  };
+}

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: [
     "src/index.ts",
+    "src/otel/index.ts",
     "src/platform/cloudflare/index.ts",
     "src/platform/file/index.ts",
     "src/platform/memory/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       ai:
         specifier: 7.0.0-canary.176
         version: 7.0.0-canary.176(zod@4.4.3)
@@ -4307,8 +4310,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opentelemetry/api@1.9.1':
-    optional: true
+  '@opentelemetry/api@1.9.1': {}
 
   '@oxc-project/types@0.130.0': {}
 

--- a/scripts/file-size.test.mjs
+++ b/scripts/file-size.test.mjs
@@ -13,6 +13,7 @@ const sourceFilesWithCurrentEdits = [
   "scripts/verify-release-artifacts/runtime-public-surface.mjs",
   "scripts/verify-release-artifacts/shared.mjs",
   "scripts/verify-release-artifacts-package.test.mjs",
+  "scripts/verify-release-artifacts-runtime-otel.test.mjs",
   "scripts/verify-release-artifacts-runtime.test.mjs",
   "scripts/verify-release-artifacts-runtime-subpaths.test.mjs",
 ];

--- a/scripts/verify-release-artifacts-runtime-otel.test.mjs
+++ b/scripts/verify-release-artifacts-runtime-otel.test.mjs
@@ -32,6 +32,7 @@ describe("verifyReleaseArtifacts runtime OpenTelemetry declaration checks", () =
       "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export TraceAgentTurnOptions",
       "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export TraceAgentTurnSpan",
       "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export TraceAgentTurnTracer",
+      "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export openTelemetry",
       "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export traceAgentTurn",
     ]);
   });

--- a/scripts/verify-release-artifacts-runtime-otel.test.mjs
+++ b/scripts/verify-release-artifacts-runtime-otel.test.mjs
@@ -1,0 +1,38 @@
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { verifyReleaseArtifacts } from "./verify-release-artifacts/core.mjs";
+import {
+  cleanupFixtures,
+  createFixture,
+} from "./verify-release-artifacts.fixture.mjs";
+
+afterEach(cleanupFixtures);
+
+function runtimeOtelDeclaration(cwd) {
+  return join(cwd, "packages", "runtime", "dist", "otel", "index.d.ts");
+}
+
+describe("verifyReleaseArtifacts runtime OpenTelemetry declaration checks", () => {
+  it("requires the runtime otel declaration entrypoint", () => {
+    const cwd = createFixture();
+    rmSync(runtimeOtelDeclaration(cwd));
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
+      "packages/runtime/dist/otel/index.d.ts: missing otel runtime declaration",
+    ]);
+  });
+
+  it("checks required OpenTelemetry adapter exports", () => {
+    const cwd = createFixture();
+    writeFileSync(runtimeOtelDeclaration(cwd), "export {};\n");
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
+      "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export TraceAgentTurnEventAttributes",
+      "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export TraceAgentTurnOptions",
+      "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export TraceAgentTurnSpan",
+      "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export TraceAgentTurnTracer",
+      "packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export traceAgentTurn",
+    ]);
+  });
+});

--- a/scripts/verify-release-artifacts-runtime.test.mjs
+++ b/scripts/verify-release-artifacts-runtime.test.mjs
@@ -49,7 +49,7 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      `export type { AgentMessage, ${forbiddenModelName}, AgentRun, AgentTool, AgentTools, CreateLlmOptions, Llm, LlmContext, LlmOutput, LlmOutputPart, ${removedRuntimeModelNames.join(", ")}, RuntimeInput } from "./llm";\nexport type { AgentHost } from "./execution/types";\nexport type { AgentTurn } from "./thread";\n`
+      `export type { AgentMessage, ${forbiddenModelName}, AgentRun, AgentTool, AgentTools, CreateLlmOptions, Llm, LlmContext, LlmOutput, LlmOutputPart, ${removedRuntimeModelNames.join(", ")}, RuntimeInput } from "./llm";\nexport type { AgentInstrumentation, AgentInstrumentationContext, AgentInstrumentationOperation } from "./agent";\nexport type { AgentHost } from "./execution/types";\nexport type { AgentTurn } from "./thread";\n`
     );
 
     expect(
@@ -176,6 +176,9 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
     );
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
       "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentHost",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentInstrumentation",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentInstrumentationContext",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentInstrumentationOperation",
       "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentTurn",
       "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeInput",
     ]);

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -31,6 +31,11 @@ export const runtimeFileDeclaration = [
   'export type { NodeFileAgentContext, NodeFileAgentContextFactoryOptions, NodeFileAgentContextOptions, NodeFileExecutionHostOptions, NodeFileThreadHostOptions, NodeScheduledThreadPrompt, NodeScheduledWorkAppendOptions, NodeScheduledWorkDrainOptions, NodeScheduledWorkDrainResult, NodeScheduledWorkListOptions, NodeScheduledWorkRunContext } from "./index";',
   "",
 ].join("\n");
+export const runtimeOtelDeclaration = [
+  'export { traceAgentTurn } from "./index";',
+  'export type { TraceAgentTurnEventAttributes, TraceAgentTurnOptions, TraceAgentTurnSpan, TraceAgentTurnTracer } from "./index";',
+  "",
+].join("\n");
 
 let tempRoots = [];
 
@@ -161,6 +166,13 @@ function writeRuntimeDeclarationFixtures(cwd, packageName) {
       "index.d.ts"
     ),
     runtimeFileDeclaration
+  );
+  mkdirSync(join(cwd, "packages", packageName, "dist", "otel"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(cwd, "packages", packageName, "dist", "otel", "index.d.ts"),
+    runtimeOtelDeclaration
   );
   writeFileSync(
     join(cwd, "packages", packageName, "dist", "llm.d.ts"),

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -7,6 +7,7 @@ export const cliBinReadFailurePattern =
 export const forbiddenModelName = ["Agent", "Model"].join("");
 export const runtimeRootDeclaration = [
   'export type { AgentHost } from "./execution/types";',
+  'export type { AgentInstrumentation, AgentInstrumentationContext, AgentInstrumentationOperation } from "./agent";',
   'export type { AgentTurn, RuntimeInput } from "./thread";',
   "",
 ].join("\n");
@@ -32,7 +33,7 @@ export const runtimeFileDeclaration = [
   "",
 ].join("\n");
 export const runtimeOtelDeclaration = [
-  'export { traceAgentTurn } from "./index";',
+  'export { openTelemetry, traceAgentTurn } from "./index";',
   'export type { TraceAgentTurnEventAttributes, TraceAgentTurnOptions, TraceAgentTurnSpan, TraceAgentTurnTracer } from "./index";',
   "",
 ].join("\n");

--- a/scripts/verify-release-artifacts/runtime-checks.mjs
+++ b/scripts/verify-release-artifacts/runtime-checks.mjs
@@ -9,6 +9,7 @@ import {
   REQUIRED_RUNTIME_EXECUTION_EXPORTS,
   REQUIRED_RUNTIME_FILE_EXPORTS,
   REQUIRED_RUNTIME_MEMORY_EXPORTS,
+  REQUIRED_RUNTIME_OTEL_EXPORTS,
   REQUIRED_RUNTIME_ROOT_EXPORTS,
 } from "./runtime-public-surface.mjs";
 import { listFiles, packageDistPath, relativeToCwd } from "./shared.mjs";
@@ -65,6 +66,12 @@ export function findRuntimeDeclarationLeaks({ cwd, packages }) {
       ),
       requiredExports: REQUIRED_RUNTIME_FILE_EXPORTS,
       surface: "file",
+    }),
+    ...findRuntimeDeclarationExportLeaks({
+      cwd,
+      file: join(packageDistPath(cwd, "runtime"), "otel", "index.d.ts"),
+      requiredExports: REQUIRED_RUNTIME_OTEL_EXPORTS,
+      surface: "otel",
     }),
     ...findRuntimePublicPatternLeaks({ cwd }),
   ];

--- a/scripts/verify-release-artifacts/runtime-public-surface.mjs
+++ b/scripts/verify-release-artifacts/runtime-public-surface.mjs
@@ -1,5 +1,8 @@
 export const REQUIRED_RUNTIME_ROOT_EXPORTS = [
   "AgentHost",
+  "AgentInstrumentation",
+  "AgentInstrumentationContext",
+  "AgentInstrumentationOperation",
   "AgentTurn",
   "RuntimeInput",
 ];
@@ -69,7 +72,7 @@ export const REQUIRED_RUNTIME_FILE_EXPORTS =
   );
 
 export const REQUIRED_RUNTIME_OTEL_EXPORTS =
-  "TraceAgentTurnEventAttributes TraceAgentTurnOptions TraceAgentTurnSpan TraceAgentTurnTracer traceAgentTurn".split(
+  "TraceAgentTurnEventAttributes TraceAgentTurnOptions TraceAgentTurnSpan TraceAgentTurnTracer openTelemetry traceAgentTurn".split(
     " "
   );
 

--- a/scripts/verify-release-artifacts/runtime-public-surface.mjs
+++ b/scripts/verify-release-artifacts/runtime-public-surface.mjs
@@ -68,6 +68,11 @@ export const REQUIRED_RUNTIME_FILE_EXPORTS =
     " "
   );
 
+export const REQUIRED_RUNTIME_OTEL_EXPORTS =
+  "TraceAgentTurnEventAttributes TraceAgentTurnOptions TraceAgentTurnSpan TraceAgentTurnTracer traceAgentTurn".split(
+    " "
+  );
+
 export const FORBIDDEN_RUNTIME_ROOT_NAMES = [
   ...[
     "AgentMessage AgentModel AgentLoopResult AgentRun AgentRunInput AgentTool AgentTools",


### PR DESCRIPTION
## Summary
- add `@minpeter/pss-runtime/otel` with `traceAgentTurn(turn, options?)` returning an `AgentTurn` wrapper
- record turn, step, tool, and runtime event telemetry through `@opentelemetry/api` only; applications still configure SDK/exporters
- keep telemetry metadata-only by default: content/error/tool payloads are summarized by type/count/length and raw payload inclusion is not a first-party option
- add docs, changeset, root export guard, release verifier coverage, and dist import smoke coverage

## Review fix
- removed JSON.stringify-based tool payload summarization so a throwing `toJSON()` cannot break the wrapped event stream
- runtime-input now prefers wrapper `event.meta` for `pss.input.source`

## Verification
- `pnpm --filter @minpeter/pss-runtime exec vitest run --reporter verbose src/otel/index.test.ts src/otel/iterator.test.ts`
- `pnpm --filter @minpeter/pss-runtime exec vitest run --reporter verbose src/contracts/root-api.test.ts src/thread/plugins/events.test.ts src/thread/plugins/intercept.test.ts`
- `pnpm exec vitest run --reporter verbose scripts/verify-release-artifacts-runtime-otel.test.mjs scripts/verify-release-artifacts-runtime.test.mjs scripts/file-size.test.mjs`
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm verify:release`
- `pnpm boundaries`
- `git diff --check`
- built package smoke import for `@minpeter/pss-runtime/otel` with a throwing `toJSON()` tool payload

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry tracing for runtime turns and introduces agent instrumentation hooks. You can instrument all turns via `openTelemetry()` or wrap a single turn with `traceAgentTurn()`; spans are metadata-only.

- **New Features**
  - Added `openTelemetry(options?)` agent instrumentation for `AgentOptions.instrumentations` to trace every returned turn; emits `pss.runtime.turn/step/tool` spans with `pss.runtime.event` events and no raw content.
  - `traceAgentTurn(turn, options?)` remains available for one-off wrapping; closes spans on end/return, marks aborts/errors, and logs diagnostics for orphan tool results or replacements.
  - New agent instrumentation API: `options.instrumentations` with `wrapTurn(turn, context)`; validates entries and that `wrapTurn()` returns an `AgentTurn`, and snapshots the list at construction.
  - Instrumentation context includes `operation` (`send`/`steer`/`resume`), `threadKey`, optional `namespace`, and `runId` on resumes.
  - Ships types and subpath at `@minpeter/pss-runtime/otel` (`TraceAgentTurnOptions`, `TraceAgentTurnSpan`, `TraceAgentTurnTracer`, `TraceAgentTurnEventAttributes`); root exports `AgentInstrumentation*` types; depends only on `@opentelemetry/api`.

- **Bug Fixes**
  - Removed JSON.stringify-based tool payload summarization to avoid `toJSON()` side effects and crashes.
  - `runtime-input` now prefers wrapper `event.meta` for `pss.input.source`.

<sup>Written for commit 2b3128c7ff037450b0ff8377e564528e9ddb298c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

