### PR TITLE
[codex] channel-key conversation boundary + runtime thread inspection

### DIFF
--- a/.changeset/runtime-thread-inspection.md
+++ b/.changeset/runtime-thread-inspection.md
@@ -1,0 +1,9 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add read-only thread inspection to the core runtime: `Agent.inspectThread(thread)`
+and `ThreadHandle.inspect()` return a `ThreadInspection` snapshot (existence,
+stored version, message count, and compaction summary sizes) without committing
+or mutating thread state. Exports the `ThreadInspection` and
+`ThreadInspectionCompaction` types from the package root.

--- a/apps/worker-agent/package.json
+++ b/apps/worker-agent/package.json
@@ -7,6 +7,7 @@
     "pretypecheck": "pnpm -F @minpeter/pss-runtime build",
     "preship:worker": "pnpm -F @minpeter/pss-runtime build",
     "dev": "run-p dev:worker dev:relay",
+    "tui": "tsx --conditions=@minpeter/pss-source src/tui.ts",
     "dev:worker": "wrangler dev -e dev",
     "dev:relay": "tsx scripts/telegram.ts relay",
     "ship": "run-s ship:secrets ship:worker ship:webhook",
@@ -22,6 +23,8 @@
     "@chat-adapter/state-memory": "4.30.0",
     "@chat-adapter/telegram": "4.30.0",
     "@minpeter/pss-runtime": "workspace:*",
+    "@trpc/client": "11.18.0",
+    "@trpc/server": "11.18.0",
     "chat": "4.30.0",
     "zod": "^4.4.3"
   },

--- a/apps/worker-agent/src/agent-do.test.ts
+++ b/apps/worker-agent/src/agent-do.test.ts
@@ -1,17 +1,45 @@
-import { describe, expect, it } from "vitest";
+import { DurableObject } from "cloudflare:workers";
+import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  AgentDurableObject,
+  deliverToolOnlyTurn,
+  inspectDurableThread,
+  parseAgentRequest,
+  TOOL_ONLY_DELIVERY_RECOVERY_PROMPT,
+  type WorkerAgentThreadSender,
+} from "./agent-do";
+import { type ChannelAddress, channelKey } from "./channel";
+import type { Env } from "./env";
+import { SEND_MESSAGE_TOOL_NAME } from "./tools";
 
-import { parseAgentRequest } from "./agent-do";
+describe("AgentDurableObject Cloudflare contract", () => {
+  it("declares the exported class as a DurableObject subclass", () => {
+    expectTypeOf<InstanceType<typeof AgentDurableObject>>().toExtend<
+      DurableObject<Env>
+    >();
+    expect(Object.getPrototypeOf(AgentDurableObject.prototype)).toBe(
+      DurableObject.prototype
+    );
+  });
+});
 
 describe("AgentDurableObject request parsing", () => {
   it("trims valid text payloads", async () => {
     await expect(
       parseAgentRequest(
         new Request("https://agent.internal/turn", {
-          body: JSON.stringify({ text: " hello " }),
+          body: JSON.stringify({
+            channel: { id: " chat-1 ", kind: "telegram" },
+            text: " hello ",
+          }),
           method: "POST",
         })
       )
-    ).resolves.toEqual({ text: "hello" });
+    ).resolves.toEqual({
+      channel: { id: "chat-1", kind: "telegram" },
+      text: "hello",
+    });
   });
 
   it("rejects invalid JSON as missing text", async () => {
@@ -29,10 +57,166 @@ describe("AgentDurableObject request parsing", () => {
     await expect(
       parseAgentRequest(
         new Request("https://agent.internal/turn", {
-          body: JSON.stringify({ text: 1 }),
+          body: JSON.stringify({
+            channel: { id: "chat-1", kind: "telegram" },
+            text: 1,
+          }),
+          method: "POST",
+        })
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects payloads without a channel id", async () => {
+    await expect(
+      parseAgentRequest(
+        new Request("https://agent.internal/turn", {
+          body: JSON.stringify({
+            channel: { id: " ", kind: "telegram" },
+            text: "hello",
+          }),
+          method: "POST",
+        })
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects unknown channel kinds", async () => {
+    await expect(
+      parseAgentRequest(
+        new Request("https://agent.internal/turn", {
+          body: JSON.stringify({
+            channel: { id: "chat-1", kind: "discord" },
+            text: "hello",
+          }),
           method: "POST",
         })
       )
     ).resolves.toBeUndefined();
   });
 });
+
+describe("channel thread keys", () => {
+  it("namespaces threads by channel kind and id", () => {
+    const channel: ChannelAddress = { id: "chat-1", kind: "telegram" };
+
+    expect(channelKey(channel)).toBe("telegram:chat-1");
+  });
+});
+
+describe("Durable Object thread inspection", () => {
+  it("inspects the default runtime thread inside a conversation object", async () => {
+    const inspectedKeys: string[] = [];
+    const inspection = {
+      compactionCount: 0,
+      compactions: [],
+      exists: true,
+      messageCount: 2,
+      summaryBytes: 0,
+      threadKey: "default",
+      version: "v1",
+    };
+
+    await expect(
+      inspectDurableThread({
+        thread: (key) => {
+          inspectedKeys.push(key);
+          return {
+            inspect: () => Promise.resolve(inspection),
+          };
+        },
+      })
+    ).resolves.toEqual(inspection);
+    expect(inspectedKeys).toEqual(["default"]);
+  });
+});
+
+describe("tool-only turn delivery", () => {
+  it("returns delivered when the first turn sends a tool message", async () => {
+    const { inputs, thread } = threadWithTurns([
+      runWithEvents([sendMessageEvent()]),
+    ]);
+
+    await expect(deliverToolOnlyTurn(thread, "hello")).resolves.toEqual({
+      delivered: true,
+    });
+    expect(inputs).toEqual(["hello"]);
+  });
+
+  it("runs one recovery turn when the first turn misses tool delivery", async () => {
+    const { inputs, thread } = threadWithTurns([
+      runWithEvents([{ text: "assistant-only", type: "assistant-output" }]),
+      runWithEvents([sendMessageEvent()]),
+    ]);
+
+    await expect(deliverToolOnlyTurn(thread, "hello")).resolves.toEqual({
+      delivered: true,
+    });
+    expect(inputs).toEqual(["hello", TOOL_ONLY_DELIVERY_RECOVERY_PROMPT]);
+  });
+
+  it("returns a missing-send error when recovery also misses tool delivery", async () => {
+    const { inputs, thread } = threadWithTurns([
+      runWithEvents([{ text: "assistant-only", type: "assistant-output" }]),
+      runWithEvents([
+        { text: "still assistant-only", type: "assistant-output" },
+      ]),
+    ]);
+
+    await expect(deliverToolOnlyTurn(thread, "hello")).resolves.toEqual({
+      delivered: false,
+      error: "missing_send_message",
+    });
+    expect(inputs).toEqual(["hello", TOOL_ONLY_DELIVERY_RECOVERY_PROMPT]);
+  });
+});
+
+function threadWithTurns(turns: readonly AgentTurn[]): {
+  readonly inputs: string[];
+  readonly thread: WorkerAgentThreadSender;
+} {
+  const inputs: string[] = [];
+  let nextTurnIndex = 0;
+  return {
+    inputs,
+    thread: {
+      send: (input) => {
+        inputs.push(input);
+        const turn = turns[nextTurnIndex];
+        nextTurnIndex += 1;
+        if (!turn) {
+          throw new Error("No test turn queued.");
+        }
+        return Promise.resolve(turn);
+      },
+    },
+  };
+}
+
+function sendMessageEvent(): AgentEvent {
+  return {
+    output: {
+      type: "json",
+      value: {
+        delivered: true,
+        messageId: "msg-1",
+        threadId: "chat-1",
+      },
+    },
+    toolCallId: "call-1",
+    toolName: SEND_MESSAGE_TOOL_NAME,
+    type: "tool-result",
+  };
+}
+
+function runWithEvents(events: readonly AgentEvent[]): AgentTurn {
+  return {
+    events: () => eventStream(events),
+  };
+}
+
+async function* eventStream(
+  events: readonly AgentEvent[]
+): AsyncIterable<AgentEvent> {
+  yield* events;
+}

--- a/apps/worker-agent/src/agent-do.ts
+++ b/apps/worker-agent/src/agent-do.ts
@@ -1,25 +1,94 @@
-import type { Agent } from "@minpeter/pss-runtime";
+import { DurableObject } from "cloudflare:workers";
+import type {
+  Agent,
+  AgentEvent,
+  AgentTurn,
+  ThreadInspection,
+} from "@minpeter/pss-runtime";
 import {
   type CloudflareAgentContext,
   createCloudflareAgentContext,
 } from "@minpeter/pss-runtime/cloudflare";
+import { z } from "zod";
 
-import { collectAssistantOutput, createConfiguredAgent } from "./agent";
+import { collectTurnDelivery, createConfiguredAgent } from "./agent";
+import { type ChannelAddress, ChannelAddressSchema } from "./channel";
 import type { Env } from "./env";
+import { createTelegramMessageSink } from "./telegram-sink";
+import type { WorkerAgentSendMessageToolOptions } from "./tools";
+import { createTuiResponseMessageSink } from "./tui-response-sink";
 
 const SESSION_KEY = "default";
+const MISSING_SEND_MESSAGE_ERROR = "missing_send_message";
+export const TOOL_ONLY_DELIVERY_RECOVERY_PROMPT =
+  "Your previous user-triggered turn ended without a successful send_message tool result. The user still has not received your answer. Using the immediately preceding user request and any assistant text you already drafted, call send_message now. Do not answer in assistant text only.";
+const AgentRequestSchema = z
+  .object({
+    channel: ChannelAddressSchema,
+    text: z.string(),
+  })
+  .strict();
+const AgentInspectRequestSchema = z
+  .object({ inspect: z.literal(true) })
+  .strict();
 
 interface AgentRequestPayload {
+  readonly channel: ChannelAddress;
   readonly text: string;
 }
 
-export class AgentDurableObject {
+export interface WorkerAgentThreadSender {
+  send(input: string): Promise<AgentTurn>;
+}
+
+export interface DeliverToolOnlyTurnOptions {
+  readonly onAssistantOutput?: (text: string) => void;
+  readonly onEvent?: (event: AgentEvent) => void;
+}
+
+export type WorkerAgentDeliveryResponse =
+  | {
+      readonly delivered: true;
+      readonly messages?: readonly WorkerAgentDeliveredMessage[];
+    }
+  | {
+      readonly delivered: false;
+      readonly error: typeof MISSING_SEND_MESSAGE_ERROR;
+    };
+
+export interface WorkerAgentDeliveredMessage {
+  readonly messageId: string;
+  readonly text: string;
+  readonly threadId: string;
+}
+
+interface SendMessageToolSetup {
+  readonly messages: () => readonly WorkerAgentDeliveredMessage[];
+  readonly options: WorkerAgentSendMessageToolOptions;
+}
+
+interface DurableThreadInspector {
+  thread(key: string): {
+    inspect(): Promise<ThreadInspection>;
+  };
+}
+
+interface JsonRequestBody {
+  json(): Promise<unknown>;
+}
+
+export class AgentDurableObject extends DurableObject<Env> {
   readonly #context: CloudflareAgentContext<Agent>;
+  readonly #env: Env;
 
   constructor(state: DurableObjectState, env: Env) {
+    super(state, env);
+    this.#env = env;
     this.#context = createCloudflareAgentContext({
       createAgent: ({ env: agentEnv, host }) =>
-        createConfiguredAgent(agentEnv, host),
+        createConfiguredAgent(agentEnv, host, {
+          sendMessage: createSendMessageToolOptions(agentEnv, () => undefined),
+        }),
       env,
       storage: state.storage,
     });
@@ -30,21 +99,127 @@ export class AgentDurableObject {
       return new Response("method not allowed", { status: 405 });
     }
 
-    const payload = await parseAgentRequest(request);
-    if (!payload) {
-      return new Response("text required", { status: 400 });
+    if (await isAgentInspectRequest(request.clone())) {
+      const agent = createConfiguredAgent(this.#env, this.#context.host());
+      return Response.json(await inspectDurableThread(agent));
     }
 
-    const agent = this.#context.agent();
-    const run = await agent.thread(SESSION_KEY).send(payload.text);
-    const reply = await collectAssistantOutput(run);
+    const payload = await parseAgentRequest(request);
+    if (!payload) {
+      return new Response("text and channel required", { status: 400 });
+    }
 
-    return Response.json({ reply: reply || "(no response)" });
+    const sendMessage = createRequestSendMessageToolSetup(
+      this.#env,
+      payload.channel
+    );
+    const agent = createConfiguredAgent(this.#env, this.#context.host(), {
+      sendMessage: sendMessage.options,
+    });
+    const delivery = await deliverToolOnlyTurn(
+      agent.thread(SESSION_KEY),
+      payload.text
+    );
+
+    return Response.json(
+      withCapturedMessages(delivery, sendMessage.messages())
+    );
   }
 
   async alarm(): Promise<void> {
     await this.#context.drainAlarm();
   }
+}
+
+export function inspectDurableThread(
+  agent: DurableThreadInspector
+): Promise<ThreadInspection> {
+  return agent.thread(SESSION_KEY).inspect();
+}
+
+function createSendMessageToolOptions(
+  env: Env,
+  channel: () => ChannelAddress | undefined
+): WorkerAgentSendMessageToolOptions {
+  const userName = env.TELEGRAM_BOT_USERNAME?.trim();
+  return {
+    channel,
+    sink: createTelegramMessageSink({
+      botToken: env.TELEGRAM_BOT_TOKEN,
+      ...(userName ? { userName } : {}),
+    }),
+  };
+}
+
+function createRequestSendMessageToolSetup(
+  env: Env,
+  channel: ChannelAddress
+): SendMessageToolSetup {
+  switch (channel.kind) {
+    case "telegram":
+      return {
+        messages: () => [],
+        options: createSendMessageToolOptions(env, () => channel),
+      };
+    case "tui": {
+      const responseSink = createTuiResponseMessageSink();
+      return {
+        messages: responseSink.messages,
+        options: {
+          channel: () => channel,
+          sink: responseSink.sink,
+        },
+      };
+    }
+    default:
+      return assertNever(channel.kind);
+  }
+}
+
+function withCapturedMessages(
+  delivery: WorkerAgentDeliveryResponse,
+  messages: readonly WorkerAgentDeliveredMessage[]
+): WorkerAgentDeliveryResponse {
+  if (!delivery.delivered || messages.length === 0) {
+    return delivery;
+  }
+
+  return {
+    delivered: true,
+    messages,
+  };
+}
+
+export async function deliverToolOnlyTurn(
+  thread: WorkerAgentThreadSender,
+  text: string,
+  options: DeliverToolOnlyTurnOptions = {}
+): Promise<WorkerAgentDeliveryResponse> {
+  const collectOptions = {
+    ...(options.onAssistantOutput
+      ? { onAssistantOutput: options.onAssistantOutput }
+      : {}),
+    ...(options.onEvent ? { onEvent: options.onEvent } : {}),
+  };
+  const firstRun = await thread.send(text);
+  const firstDelivery = await collectTurnDelivery(firstRun, collectOptions);
+  if (firstDelivery.deliveredByTool) {
+    return { delivered: true };
+  }
+
+  const recoveryRun = await thread.send(TOOL_ONLY_DELIVERY_RECOVERY_PROMPT);
+  const recoveryDelivery = await collectTurnDelivery(
+    recoveryRun,
+    collectOptions
+  );
+  if (recoveryDelivery.deliveredByTool) {
+    return { delivered: true };
+  }
+
+  return {
+    delivered: false,
+    error: MISSING_SEND_MESSAGE_ERROR,
+  };
 }
 
 export async function parseAgentRequest(
@@ -60,15 +235,43 @@ export async function parseAgentRequest(
     throw error;
   }
 
-  if (
-    typeof payload !== "object" ||
-    payload === null ||
-    !("text" in payload) ||
-    typeof payload.text !== "string"
-  ) {
+  const result = AgentRequestSchema.safeParse(payload);
+  if (!result.success) {
     return;
   }
 
-  const text = payload.text.trim();
-  return text ? { text } : undefined;
+  const channelId = result.data.channel.id.trim();
+  const text = result.data.text.trim();
+  return channelId && text
+    ? { channel: { id: channelId, kind: result.data.channel.kind }, text }
+    : undefined;
+}
+
+async function isAgentInspectRequest(
+  request: JsonRequestBody
+): Promise<boolean> {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    if (error instanceof Error) {
+      return false;
+    }
+    throw error;
+  }
+
+  return AgentInspectRequestSchema.safeParse(payload).success;
+}
+
+function assertNever(value: never): never {
+  throw new AgentDurableObjectInvariantError(
+    `Unexpected channel variant: ${String(value)}`
+  );
+}
+
+class AgentDurableObjectInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentDurableObjectInvariantError";
+  }
 }

--- a/apps/worker-agent/src/agent.test.ts
+++ b/apps/worker-agent/src/agent.test.ts
@@ -1,7 +1,24 @@
 import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
 import { describe, expect, it } from "vitest";
 
-import { collectAssistantOutput, WORKER_AGENT_INSTRUCTIONS } from "./agent";
+import {
+  collectTurnDelivery,
+  WORKER_AGENT_AUTO_COMPACTION,
+  WORKER_AGENT_INSTRUCTIONS,
+} from "./agent";
+import { SEND_MESSAGE_TOOL_NAME } from "./tools";
+
+describe("worker-agent auto compaction", () => {
+  it("retains fewer messages than the compaction trigger", () => {
+    expect(WORKER_AGENT_AUTO_COMPACTION.minMessages).toBeGreaterThan(
+      WORKER_AGENT_AUTO_COMPACTION.retainMessages
+    );
+    expect(WORKER_AGENT_AUTO_COMPACTION).toEqual({
+      minMessages: 48,
+      retainMessages: 16,
+    });
+  });
+});
 
 describe("worker-agent instructions", () => {
   it("uses Apex as the assistant name", () => {
@@ -25,6 +42,10 @@ describe("worker-agent instructions", () => {
       "Some messaging platforms can make replies less natural",
       "Do not invent product facts, security claims, launch details, prices, or URLs",
       "Do not mention internal agents, tools, or implementation details",
+      "The user sees only messages you send by calling send_message",
+      "Every user-visible response must be sent with send_message",
+      "A successful send_message call is the only user-visible delivery signal",
+      "Assistant text is internal only",
       "Avoid botty phrases",
     ] as const;
 
@@ -49,24 +70,34 @@ describe("worker-agent instructions", () => {
         surface.toLowerCase()
       );
     }
+
+    const hybridRules = [
+      "The user normally sees your final text reply after the turn ends",
+      "answering normally is fine",
+      "the worker will deliver the final text",
+    ] as const;
+
+    for (const rule of hybridRules) {
+      expect(WORKER_AGENT_INSTRUCTIONS).not.toContain(rule);
+    }
   });
 });
 
-describe("collectAssistantOutput", () => {
-  it("joins assistant text events", async () => {
+describe("collectTurnDelivery", () => {
+  it("does not treat assistant text as delivered output", async () => {
     await expect(
-      collectAssistantOutput(
+      collectTurnDelivery(
         runWithEvents([
           { type: "assistant-output", text: "first" },
           { type: "assistant-output", text: "second" },
         ])
       )
-    ).resolves.toBe("first\nsecond");
+    ).resolves.toEqual({ deliveredByTool: false });
   });
 
   it("rejects when the run contains a turn-error without assistant text", async () => {
     await expect(
-      collectAssistantOutput(
+      collectTurnDelivery(
         runWithEvents([{ type: "turn-error", message: "model unavailable" }])
       )
     ).rejects.toThrow("model unavailable");
@@ -74,13 +105,59 @@ describe("collectAssistantOutput", () => {
 
   it("rejects when a turn-error follows assistant text", async () => {
     await expect(
-      collectAssistantOutput(
+      collectTurnDelivery(
         runWithEvents([
           { type: "assistant-output", text: "partial" },
           { type: "turn-error", message: "tool failed" },
         ])
       )
     ).rejects.toThrow("tool failed");
+  });
+
+  it("suppresses fallback text when send_message delivered an answer", async () => {
+    await expect(
+      collectTurnDelivery(
+        runWithEvents([
+          {
+            output: {
+              type: "json",
+              value: {
+                delivered: true,
+                messageId: "msg-1",
+                threadId: "chat-1",
+              },
+            },
+            toolCallId: "call-1",
+            toolName: SEND_MESSAGE_TOOL_NAME,
+            type: "tool-result",
+          },
+          { type: "assistant-output", text: "duplicate" },
+        ])
+      )
+    ).resolves.toEqual({ deliveredByTool: true });
+  });
+
+  it("treats any successful send_message result as delivered output", async () => {
+    await expect(
+      collectTurnDelivery(
+        runWithEvents([
+          {
+            output: {
+              type: "json",
+              value: {
+                delivered: true,
+                messageId: "msg-1",
+                threadId: "chat-1",
+              },
+            },
+            toolCallId: "call-1",
+            toolName: SEND_MESSAGE_TOOL_NAME,
+            type: "tool-result",
+          },
+          { type: "assistant-output", text: "duplicate" },
+        ])
+      )
+    ).resolves.toEqual({ deliveredByTool: true });
   });
 });
 

--- a/apps/worker-agent/src/agent.ts
+++ b/apps/worker-agent/src/agent.ts
@@ -1,25 +1,46 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import {
   Agent,
+  type AgentAutoCompactionOptions,
   type AgentEvent,
   type AgentHost,
+  type AgentPlugin,
   type AgentTurn,
 } from "@minpeter/pss-runtime";
 import { drainAgentTurn } from "@minpeter/pss-runtime/cloudflare";
 
-import type { Env } from "./env";
+import type { EnvironmentName } from "./env";
+import { createTurnObservabilityPlugin } from "./observability";
+import {
+  createWorkerAgentTools,
+  isDeliveredSendMessageToolOutput,
+  SEND_MESSAGE_TOOL_NAME,
+  type WorkerAgentSendMessageToolOptions,
+} from "./tools";
 
 const DEFAULT_BASE_URL = "https://apis.opengateway.ai/v1";
 const DEFAULT_MODEL = "minimax/MiniMax-M2.7";
+
+export const WORKER_AGENT_AUTO_COMPACTION: AgentAutoCompactionOptions = {
+  minMessages: 48,
+  retainMessages: 16,
+};
 
 export const WORKER_AGENT_INSTRUCTIONS =
   `You are Apex, a direct messaging assistant built by Minpeter.
 
 Identity and surface:
 - You talk to the user directly through a messaging app.
-- The user only sees your final text reply.
+- The user sees only messages you send by calling send_message.
 - Speak as one coherent assistant. Do not mention internal agents, tools, or implementation details.
 - Do not imply that a hidden worker, background process, browser operator, integration, inbox, scheduler, or persistent memory system will handle work unless this runtime actually provides that capability.
+
+Messaging tool:
+- Every user-visible response must be sent with send_message.
+- Use send_message for progress updates, split long answers, and ordinary short replies.
+- A successful send_message call is the only user-visible delivery signal.
+- After send_message succeeds for the answer, do not repeat the same answer in assistant text.
+- Assistant text is internal only and is not delivered to the user.
 
 Message priority:
 - Treat the newest human user message as the source of truth.
@@ -60,22 +81,73 @@ Platform and product boundaries:
 - If the user asks about capabilities this worker does not have, be direct about the limitation instead of pretending to dispatch work elsewhere.
 - Do not claim to remember, retrieve, or store private context beyond what is present in the conversation.`.trim();
 
-export function createConfiguredAgent(env: Env, host: AgentHost): Agent {
+export interface WorkerAgentRuntimeOptions {
+  readonly sendMessage?: WorkerAgentSendMessageToolOptions;
+}
+
+export interface WorkerAgentModelEnv {
+  readonly AI_API_KEY: string;
+  readonly AI_BASE_URL?: string;
+  readonly AI_MODEL?: string;
+  readonly ENVIRONMENT: EnvironmentName;
+}
+
+export interface WorkerAgentTurnDelivery {
+  readonly deliveredByTool: boolean;
+}
+
+export interface CollectTurnDeliveryOptions {
+  readonly onAssistantOutput?: (text: string) => void;
+  readonly onEvent?: (event: AgentEvent) => void;
+}
+
+export function createConfiguredAgent(
+  env: WorkerAgentModelEnv,
+  host: AgentHost,
+  options: WorkerAgentRuntimeOptions = {}
+): Agent {
   const provider = createOpenAICompatible({
     apiKey: env.AI_API_KEY,
     baseURL: env.AI_BASE_URL?.trim() || DEFAULT_BASE_URL,
     name: "custom",
   });
 
+  const plugins: readonly AgentPlugin[] = [
+    createTurnObservabilityPlugin({ label: env.ENVIRONMENT }),
+  ];
+  const tools = options.sendMessage
+    ? createWorkerAgentTools(options.sendMessage)
+    : undefined;
+
   return new Agent({
+    autoCompaction: WORKER_AGENT_AUTO_COMPACTION,
     host,
     instructions: WORKER_AGENT_INSTRUCTIONS,
     model: provider(env.AI_MODEL?.trim() || DEFAULT_MODEL),
+    plugins,
+    ...(tools ? { tools } : {}),
   });
 }
 
-export async function collectAssistantOutput(run: AgentTurn): Promise<string> {
-  const events = await drainAgentTurn(run);
+export async function collectTurnDelivery(
+  run: AgentTurn,
+  options: CollectTurnDeliveryOptions = {}
+): Promise<WorkerAgentTurnDelivery> {
+  const onEvent = options.onEvent;
+  const onAssistantOutput = options.onAssistantOutput;
+  const events = await drainAgentTurn(
+    run,
+    onEvent || onAssistantOutput
+      ? {
+          onEvent: (event) => {
+            onEvent?.(event);
+            if (event.type === "assistant-output") {
+              onAssistantOutput?.(event.text);
+            }
+          },
+        }
+      : {}
+  );
   const turnError = events.find(
     (event): event is Extract<AgentEvent, { type: "turn-error" }> =>
       event.type === "turn-error"
@@ -85,12 +157,12 @@ export async function collectAssistantOutput(run: AgentTurn): Promise<string> {
     throw new Error(turnError.message);
   }
 
-  return events
-    .filter(
-      (event): event is Extract<AgentEvent, { type: "assistant-output" }> =>
-        event.type === "assistant-output"
-    )
-    .map((event) => event.text)
-    .join("\n")
-    .trim();
+  const deliveredByTool = events.some(
+    (event) =>
+      event.type === "tool-result" &&
+      event.toolName === SEND_MESSAGE_TOOL_NAME &&
+      isDeliveredSendMessageToolOutput(event.output)
+  );
+
+  return { deliveredByTool };
 }

--- a/apps/worker-agent/src/channel.ts
+++ b/apps/worker-agent/src/channel.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const ChannelAddressSchema = z
+  .object({
+    id: z.string(),
+    kind: z.enum(["telegram", "tui"]),
+  })
+  .strict();
+
+export type ChannelAddress = z.infer<typeof ChannelAddressSchema>;
+
+export interface ChannelSentMessage {
+  readonly messageId: string;
+  readonly threadId: string;
+}
+
+export interface ChannelMessageSink {
+  send(channel: ChannelAddress, text: string): Promise<ChannelSentMessage>;
+}
+
+export function channelKey(channel: ChannelAddress): string {
+  return `${channel.kind}:${channel.id}`;
+}

--- a/apps/worker-agent/src/cloudflare-workers-test-shim.ts
+++ b/apps/worker-agent/src/cloudflare-workers-test-shim.ts
@@ -1,0 +1,9 @@
+export class DurableObject<Env = Cloudflare.Env, Props = unknown> {
+  protected readonly ctx: DurableObjectState<Props>;
+  protected readonly env: Env;
+
+  constructor(ctx: DurableObjectState<Props>, env: Env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}

--- a/apps/worker-agent/src/env.ts
+++ b/apps/worker-agent/src/env.ts
@@ -20,6 +20,7 @@ export interface Env {
   readonly TELEGRAM_BOT_TOKEN: string;
   readonly TELEGRAM_BOT_USERNAME?: string;
   readonly TELEGRAM_WEBHOOK_SECRET_TOKEN: string;
+  readonly WORKER_AGENT_TUI_TOKEN?: string;
 }
 
 export function isDevelopment(env: {

--- a/apps/worker-agent/src/index.ts
+++ b/apps/worker-agent/src/index.ts
@@ -1,12 +1,23 @@
 import type { Env } from "./env";
 import { handleTelegramWebhook } from "./telegram";
+import { handleTuiRpcRequest } from "./tui-rpc";
 
 // biome-ignore lint/performance/noBarrelFile: Wrangler requires Durable Object classes to be exported from the worker entrypoint.
 export { AgentDurableObject } from "./agent-do";
 export type { Env } from "./env";
 
+const TUI_RPC_PATHNAME = "/trpc";
+
 export default {
   fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    if (
+      url.pathname === TUI_RPC_PATHNAME ||
+      url.pathname.startsWith(`${TUI_RPC_PATHNAME}/`)
+    ) {
+      return handleTuiRpcRequest(request, env);
+    }
+
     return handleTelegramWebhook(request, env, ctx);
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/worker-agent/src/observability.test.ts
+++ b/apps/worker-agent/src/observability.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createTurnObservabilityPlugin,
+  describeEvent,
+  type TurnObservabilityEntry,
+} from "./observability";
+
+const HISTORY = [] as const;
+
+describe("describeEvent", () => {
+  it("captures tool events with the tool name", () => {
+    expect(
+      describeEvent(
+        { type: "tool-call", input: {}, toolCallId: "1", toolName: "search" },
+        "production"
+      )
+    ).toEqual({ event: "tool-call", label: "production", toolName: "search" });
+  });
+
+  it("captures turn-error with its message", () => {
+    expect(
+      describeEvent({ type: "turn-error", message: "boom" }, "dev")
+    ).toEqual({ event: "turn-error", label: "dev", message: "boom" });
+  });
+
+  it("captures lifecycle events without text payloads", () => {
+    expect(describeEvent({ type: "turn-end" })).toEqual({ event: "turn-end" });
+  });
+
+  it("ignores user-authored text events to avoid leaking content", () => {
+    expect(
+      describeEvent({ type: "user-input", text: "secret" })
+    ).toBeUndefined();
+    expect(
+      describeEvent({ type: "assistant-output", text: "secret" })
+    ).toBeUndefined();
+  });
+});
+
+describe("createTurnObservabilityPlugin", () => {
+  it("logs described events through the provided sink and never intercepts", async () => {
+    const entries: TurnObservabilityEntry[] = [];
+    const plugin = createTurnObservabilityPlugin({
+      label: "dev",
+      log: (entry) => entries.push(entry),
+    });
+
+    const toolResult = await plugin.on?.({
+      event: {
+        type: "tool-result",
+        output: {},
+        toolCallId: "1",
+        toolName: "x",
+      },
+      history: HISTORY,
+    });
+    const userInput = await plugin.on?.({
+      event: { type: "assistant-output", text: "hi" },
+      history: HISTORY,
+    });
+
+    expect(toolResult).toBeUndefined();
+    expect(userInput).toBeUndefined();
+    expect(entries).toEqual([
+      { event: "tool-result", label: "dev", toolName: "x" },
+    ]);
+  });
+});

--- a/apps/worker-agent/src/observability.ts
+++ b/apps/worker-agent/src/observability.ts
@@ -1,0 +1,63 @@
+import {
+  type AgentEvent,
+  type AgentEventContext,
+  type AgentPlugin,
+  isLifecycleAgentEvent,
+  isToolAgentEvent,
+} from "@minpeter/pss-runtime";
+
+export interface TurnObservabilityEntry {
+  readonly event: AgentEvent["type"];
+  readonly label?: string;
+  readonly message?: string;
+  readonly toolName?: string;
+}
+
+export interface TurnObservabilityOptions {
+  readonly label?: string;
+  readonly log?: (entry: TurnObservabilityEntry) => void;
+}
+
+function defaultLog(entry: TurnObservabilityEntry): void {
+  if (entry.event === "turn-error") {
+    console.error("worker-agent turn", entry);
+    return;
+  }
+  console.info("worker-agent turn", entry);
+}
+
+export function describeEvent(
+  event: AgentEvent,
+  label?: string
+): TurnObservabilityEntry | undefined {
+  if (isToolAgentEvent(event)) {
+    return { event: event.type, label, toolName: event.toolName };
+  }
+
+  if (isLifecycleAgentEvent(event)) {
+    return event.type === "turn-error"
+      ? { event: event.type, label, message: event.message }
+      : { event: event.type, label };
+  }
+
+  return;
+}
+
+export function createTurnObservabilityPlugin(
+  options: TurnObservabilityOptions = {}
+): AgentPlugin {
+  const log = options.log ?? defaultLog;
+
+  return {
+    name: "worker-agent.turn-observability",
+    on(context: AgentEventContext) {
+      // Only lifecycle/tool events are surfaced; user-authored text events are
+      // intentionally never logged so this hook cannot leak conversation content.
+      const entry = describeEvent(context.event, options.label);
+      if (entry) {
+        log(entry);
+      }
+      return;
+    },
+  };
+}

--- a/apps/worker-agent/src/telegram-delivery.test.ts
+++ b/apps/worker-agent/src/telegram-delivery.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { channelKey } from "./channel";
+import type { Env } from "./env";
+import { durableObjectName } from "./env";
+import { requestAgentDelivery } from "./telegram";
+
+const durableObjectMock = vi.hoisted(
+  (): {
+    readonly objectNames: string[];
+    readonly requests: Request[];
+    readonly responses: Response[];
+  } => ({
+    objectNames: [],
+    requests: [],
+    responses: [],
+  })
+);
+
+vi.mock("@minpeter/pss-runtime/cloudflare", () => ({
+  fetchCloudflareDurableObject: (options: unknown) => {
+    if (
+      !(
+        typeof options === "object" &&
+        options !== null &&
+        "request" in options &&
+        options.request instanceof Request &&
+        "objectName" in options &&
+        typeof options.objectName === "string"
+      )
+    ) {
+      throw new Error("Expected Durable Object fetch options.");
+    }
+    durableObjectMock.objectNames.push(options.objectName);
+    durableObjectMock.requests.push(options.request);
+    return Promise.resolve(
+      durableObjectMock.responses.shift() ?? Response.json({ delivered: true })
+    );
+  },
+}));
+
+describe("agent delivery request", () => {
+  beforeEach(() => {
+    durableObjectMock.objectNames.length = 0;
+    durableObjectMock.requests.length = 0;
+    durableObjectMock.responses.length = 0;
+  });
+
+  it("sends channel id to the agent Durable Object and accepts tool delivery", async () => {
+    const webhookEnv = createWebhookEnv(createDurableObjectNamespace("agent"));
+    durableObjectMock.responses.push(Response.json({ delivered: true }));
+
+    await expect(
+      requestAgentDelivery(webhookEnv, "channel-1", "hello")
+    ).resolves.toBeUndefined();
+
+    const [objectName] = durableObjectMock.objectNames;
+    expect(objectName).toBe(
+      durableObjectName(channelKey({ id: "channel-1", kind: "telegram" }))
+    );
+
+    const [request] = durableObjectMock.requests;
+    if (!request) {
+      throw new Error("Expected a Durable Object request.");
+    }
+    await expect(request.json()).resolves.toEqual({
+      channel: { id: "channel-1", kind: "telegram" },
+      text: "hello",
+    });
+  });
+
+  it("rejects when the agent Durable Object reports missing tool delivery", async () => {
+    const webhookEnv = createWebhookEnv(createDurableObjectNamespace("agent"));
+    durableObjectMock.responses.push(
+      Response.json({
+        delivered: false,
+        error: "missing_send_message",
+      })
+    );
+
+    await expect(
+      requestAgentDelivery(webhookEnv, "channel-1", "hello")
+    ).rejects.toThrow("agent did not deliver a send_message result");
+  });
+});
+
+function createWebhookEnv(namespace: DurableObjectNamespace): Env {
+  return {
+    AGENT_DO: namespace,
+    AI_API_KEY: "test-key",
+    ENVIRONMENT: "production",
+    TELEGRAM_BOT_TOKEN: "test-token",
+    TELEGRAM_WEBHOOK_SECRET_TOKEN: "secret",
+  };
+}
+
+function createDurableObjectNamespace(label: string): DurableObjectNamespace {
+  const namespace: DurableObjectNamespace = {
+    get(_id: DurableObjectId) {
+      throw new Error(`${label} namespace should not be fetched`);
+    },
+    getByName(_name: string) {
+      throw new Error(`${label} namespace should not be fetched`);
+    },
+    idFromString(id: string) {
+      return createDurableObjectId(id);
+    },
+    idFromName(name: string) {
+      return createDurableObjectId(name);
+    },
+    jurisdiction() {
+      return namespace;
+    },
+    newUniqueId() {
+      return createDurableObjectId(`${label}-unique`);
+    },
+  };
+  return namespace;
+}
+
+function createDurableObjectId(name: string): DurableObjectId {
+  return {
+    equals(other: DurableObjectId) {
+      return other.toString() === name;
+    },
+    name,
+    toString() {
+      return name;
+    },
+  };
+}

--- a/apps/worker-agent/src/telegram-sink.test.ts
+++ b/apps/worker-agent/src/telegram-sink.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createTelegramMessageSink,
+  TelegramMessageSinkError,
+} from "./telegram-sink";
+
+interface TelegramAdapterOptions {
+  readonly botToken?: unknown;
+  readonly mode?: unknown;
+  readonly userName?: unknown;
+}
+
+const telegramMock = vi.hoisted(
+  (): {
+    readonly adapters: TelegramAdapterOptions[];
+    readonly sent: string[];
+  } => ({
+    adapters: [],
+    sent: [],
+  })
+);
+
+vi.mock("@chat-adapter/telegram", () => ({
+  createTelegramAdapter: (options: TelegramAdapterOptions) => {
+    telegramMock.adapters.push(options);
+    return {
+      postChannelMessage: (channelId: string, text: string) => {
+        telegramMock.sent.push(`${channelId}:${text}`);
+        return Promise.resolve({ id: "tg-msg-1", threadId: channelId });
+      },
+    };
+  },
+}));
+
+describe("Telegram channel sink", () => {
+  beforeEach(() => {
+    telegramMock.adapters.length = 0;
+    telegramMock.sent.length = 0;
+  });
+
+  it("posts telegram channel messages through the Telegram adapter", async () => {
+    const sink = createTelegramMessageSink({
+      botToken: "token",
+      userName: "bot",
+    });
+
+    await expect(
+      sink.send({ id: "chat-1", kind: "telegram" }, "hello")
+    ).resolves.toEqual({
+      messageId: "tg-msg-1",
+      threadId: "chat-1",
+    });
+    expect(telegramMock.adapters).toEqual([
+      { botToken: "token", mode: "webhook", userName: "bot" },
+    ]);
+    expect(telegramMock.sent).toEqual(["chat-1:hello"]);
+  });
+
+  it("rejects non-telegram channels", async () => {
+    const sink = createTelegramMessageSink({ botToken: "token" });
+
+    await expect(
+      sink.send({ id: "local", kind: "tui" }, "hello")
+    ).rejects.toThrow(TelegramMessageSinkError);
+    expect(telegramMock.sent).toEqual([]);
+  });
+});

--- a/apps/worker-agent/src/telegram-sink.ts
+++ b/apps/worker-agent/src/telegram-sink.ts
@@ -1,0 +1,49 @@
+import { createTelegramAdapter } from "@chat-adapter/telegram";
+
+import type {
+  ChannelAddress,
+  ChannelMessageSink,
+  ChannelSentMessage,
+} from "./channel";
+
+export interface TelegramMessageSinkOptions {
+  readonly botToken: string;
+  readonly userName?: string;
+}
+
+export class TelegramMessageSinkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TelegramMessageSinkError";
+  }
+}
+
+export function createTelegramMessageSink({
+  botToken,
+  userName,
+}: TelegramMessageSinkOptions): ChannelMessageSink {
+  const adapter = createTelegramAdapter({
+    botToken,
+    mode: "webhook",
+    ...(userName ? { userName } : {}),
+  });
+
+  return {
+    send: async (
+      channel: ChannelAddress,
+      text: string
+    ): Promise<ChannelSentMessage> => {
+      if (channel.kind !== "telegram") {
+        throw new TelegramMessageSinkError(
+          "Telegram sink can only send to telegram channels."
+        );
+      }
+
+      const sent = await adapter.postChannelMessage(channel.id, text);
+      return {
+        messageId: sent.id,
+        threadId: sent.threadId,
+      };
+    },
+  };
+}

--- a/apps/worker-agent/src/telegram.test.ts
+++ b/apps/worker-agent/src/telegram.test.ts
@@ -66,7 +66,10 @@ describe("telegram conversation handling", () => {
 
     await replyToThread({
       env,
-      fetchReply: (channelId, text) => Promise.resolve(`${channelId}:${text}`),
+      deliverTurn: (channelId, text) => {
+        posts.push(`${channelId}:${text}`);
+        return resolved;
+      },
       message: { text: "hello" },
       subscribe: true,
       thread: {
@@ -83,6 +86,52 @@ describe("telegram conversation handling", () => {
     expect(posts).toEqual(["🧪 DEVELOPMENT ENVIRONMENT", "channel-1:hello"]);
   });
 
+  it("does not post an assistant-output fallback after agent delivery", async () => {
+    const posts: string[] = [];
+
+    await replyToThread({
+      env,
+      deliverTurn: () => resolved,
+      message: { text: "hello" },
+      thread: {
+        channelId: "channel-1",
+        post: (text: string) => {
+          posts.push(text);
+          return resolved;
+        },
+        subscribe: () => resolved,
+      },
+    });
+
+    expect(posts).toEqual(["🧪 DEVELOPMENT ENVIRONMENT"]);
+  });
+
+  it("posts the generic failure reply when tool-only delivery fails", async () => {
+    const posts: string[] = [];
+
+    await replyToThread({
+      env,
+      deliverTurn: async () => {
+        await resolved;
+        throw new Error("missing send_message");
+      },
+      message: { text: "hello" },
+      thread: {
+        channelId: "channel-1",
+        post: (text: string) => {
+          posts.push(text);
+          return resolved;
+        },
+        subscribe: () => resolved,
+      },
+    });
+
+    expect(posts).toEqual([
+      "🧪 DEVELOPMENT ENVIRONMENT",
+      "처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+    ]);
+  });
+
   it("does not leak internal failures to the chat thread", async () => {
     const errorLog = vi
       .spyOn(console, "error")
@@ -92,7 +141,7 @@ describe("telegram conversation handling", () => {
 
     await replyToThread({
       env,
-      fetchReply: async () => {
+      deliverTurn: async () => {
         await resolved;
         throw error;
       },

--- a/apps/worker-agent/src/telegram.ts
+++ b/apps/worker-agent/src/telegram.ts
@@ -4,6 +4,7 @@ import { fetchCloudflareDurableObject } from "@minpeter/pss-runtime/cloudflare";
 import { Chat, type Message, type MessageContext, type Thread } from "chat";
 import { z } from "zod";
 
+import { type ChannelAddress, channelKey } from "./channel";
 import {
   durableObjectName,
   type Env,
@@ -14,13 +15,20 @@ import {
 const DEV_NOTICE = "🧪 DEVELOPMENT ENVIRONMENT";
 const FAILURE_REPLY =
   "처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.";
-const AgentReplySchema = z.object({
-  reply: z.string().optional(),
-});
+const MISSING_SEND_MESSAGE_ERROR = "missing_send_message";
+const AgentDeliverySchema = z.discriminatedUnion("delivered", [
+  z.object({ delivered: z.literal(true) }).strict(),
+  z
+    .object({
+      delivered: z.literal(false),
+      error: z.literal(MISSING_SEND_MESSAGE_ERROR),
+    })
+    .strict(),
+]);
 
 let cachedBot: CachedBot | undefined;
 
-type ReplyFetcher = (channelId: string, text: string) => Promise<string>;
+type TurnDeliverer = (channelId: string, text: string) => Promise<void>;
 
 interface ConversationEnv {
   readonly ENVIRONMENT: Env["ENVIRONMENT"];
@@ -77,7 +85,8 @@ function createBot(env: Env, config: BotConfig): Chat {
     replyToThread({
       env,
       context,
-      fetchReply: (channelId, text) => requestAgentReply(env, channelId, text),
+      deliverTurn: (channelId, text) =>
+        requestAgentDelivery(env, channelId, text),
       message,
       subscribe: options?.subscribe ?? false,
       thread,
@@ -108,15 +117,15 @@ export function collectTurnText(
 
 export async function replyToThread({
   context,
+  deliverTurn,
   env,
-  fetchReply,
   message,
   subscribe,
   thread,
 }: {
   readonly context?: MessageContext;
+  readonly deliverTurn: TurnDeliverer;
   readonly env: ConversationEnv;
-  readonly fetchReply: ReplyFetcher;
   readonly message: ConversationMessage;
   readonly subscribe?: boolean;
   readonly thread: ConversationThread;
@@ -134,8 +143,7 @@ export async function replyToThread({
       await thread.post(DEV_NOTICE);
     }
 
-    const reply = await fetchReply(thread.channelId, text);
-    await thread.post(reply);
+    await deliverTurn(thread.channelId, text);
   } catch (error) {
     console.error("telegram handler failed", normalizeError(error));
     await thread.post(FAILURE_REPLY);
@@ -149,16 +157,20 @@ function normalizeError(error: unknown): Error {
   return new Error(`Non-Error thrown: ${String(error)}`);
 }
 
-async function requestAgentReply(
+export async function requestAgentDelivery(
   env: Env,
   channelId: string,
   text: string
-): Promise<string> {
+): Promise<void> {
+  const channel: ChannelAddress = { id: channelId, kind: "telegram" };
   const response = await fetchCloudflareDurableObject({
     namespace: env.AGENT_DO,
-    objectName: durableObjectName(channelId),
+    objectName: durableObjectName(channelKey(channel)),
     request: new Request("https://agent.internal/turn", {
-      body: JSON.stringify({ text }),
+      body: JSON.stringify({
+        channel,
+        text,
+      }),
       headers: { "content-type": "application/json" },
       method: "POST",
     }),
@@ -170,8 +182,12 @@ async function requestAgentReply(
     );
   }
 
-  const payload = AgentReplySchema.parse(await response.json());
-  return payload.reply?.trim() || "(no response)";
+  const payload = AgentDeliverySchema.parse(await response.json());
+  if (payload.delivered) {
+    return;
+  }
+
+  throw new Error("agent did not deliver a send_message result");
 }
 
 export function handleTelegramWebhook(

--- a/apps/worker-agent/src/tools.test.ts
+++ b/apps/worker-agent/src/tools.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelMessageSink } from "./channel";
+import {
+  createSendMessageTool,
+  SendMessageToolConfigError,
+  SendMessageToolInputError,
+} from "./tools";
+
+describe("send_message tool", () => {
+  it("sends trimmed text to the current channel", async () => {
+    const sent: string[] = [];
+    const sink: ChannelMessageSink = {
+      send: (channel, text) => {
+        sent.push(`${channel.kind}:${channel.id}:${text}`);
+        return Promise.resolve({
+          messageId: "msg-1",
+          threadId: `${channel.kind}:${channel.id}`,
+        });
+      },
+    };
+    const tool = createSendMessageTool({
+      channel: () => ({ id: "chat-1", kind: "telegram" }),
+      sink,
+    });
+
+    await expect(
+      tool.execute?.(
+        { text: " hello " },
+        {
+          abortSignal: new AbortController().signal,
+          context: undefined,
+          messages: [],
+          toolCallId: "call-1",
+        }
+      )
+    ).resolves.toEqual({
+      delivered: true,
+      messageId: "msg-1",
+      threadId: "telegram:chat-1",
+    });
+    expect(sent).toEqual(["telegram:chat-1:hello"]);
+  });
+
+  it("rejects the removed final flag as an unknown field", async () => {
+    const tool = createSendMessageTool({
+      channel: () => ({ id: "chat-1", kind: "telegram" }),
+      sink: {
+        send: () => {
+          throw new Error("send should not run for invalid input");
+        },
+      },
+    });
+
+    await expect(
+      tool.execute?.(
+        { final: true, text: "hello" },
+        {
+          abortSignal: new AbortController().signal,
+          context: undefined,
+          messages: [],
+          toolCallId: "call-1",
+        }
+      )
+    ).rejects.toThrow();
+  });
+
+  it("rejects blank text before sending", async () => {
+    const sent: string[] = [];
+    const tool = createSendMessageTool({
+      channel: () => ({ id: "chat-1", kind: "telegram" }),
+      sink: {
+        send: (channel, text) => {
+          sent.push(`${channel.kind}:${channel.id}:${text}`);
+          return Promise.resolve({
+            messageId: "msg-1",
+            threadId: `${channel.kind}:${channel.id}`,
+          });
+        },
+      },
+    });
+
+    await expect(
+      tool.execute?.(
+        { text: " " },
+        {
+          abortSignal: new AbortController().signal,
+          context: undefined,
+          messages: [],
+          toolCallId: "call-1",
+        }
+      )
+    ).rejects.toThrow(SendMessageToolInputError);
+    expect(sent).toEqual([]);
+  });
+
+  it("rejects missing channel id before sending", async () => {
+    const sent: string[] = [];
+    const tool = createSendMessageTool({
+      channel: () => undefined,
+      sink: {
+        send: (channel, text) => {
+          sent.push(`${channel.kind}:${channel.id}:${text}`);
+          return Promise.resolve({
+            messageId: "msg-1",
+            threadId: `${channel.kind}:${channel.id}`,
+          });
+        },
+      },
+    });
+
+    await expect(
+      tool.execute?.(
+        { text: "hello" },
+        {
+          abortSignal: new AbortController().signal,
+          context: undefined,
+          messages: [],
+          toolCallId: "call-1",
+        }
+      )
+    ).rejects.toThrow(SendMessageToolConfigError);
+    expect(sent).toEqual([]);
+  });
+});

--- a/apps/worker-agent/src/tools.ts
+++ b/apps/worker-agent/src/tools.ts
@@ -1,0 +1,121 @@
+import type { AgentOptions } from "@minpeter/pss-runtime";
+import { z } from "zod";
+
+import type { ChannelAddress, ChannelMessageSink } from "./channel";
+
+export const SEND_MESSAGE_TOOL_NAME = "send_message";
+const SendMessageToolInputSchema = z
+  .object({
+    text: z.string().describe("The exact user-visible message to send."),
+  })
+  .strict();
+
+export type SendMessageToolInput = z.infer<typeof SendMessageToolInputSchema>;
+
+export interface SendMessageToolResult {
+  readonly delivered: true;
+  readonly messageId: string;
+  readonly threadId: string;
+}
+
+export interface WorkerAgentSendMessageToolOptions {
+  readonly channel: () => ChannelAddress | undefined;
+  readonly sink: ChannelMessageSink;
+}
+
+type WorkerAgentToolSet = NonNullable<AgentOptions["tools"]>;
+type SendMessageTool = WorkerAgentToolSet["send_message"] & {
+  readonly retryPolicy: "manual-recovery";
+};
+
+export class SendMessageToolConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SendMessageToolConfigError";
+  }
+}
+
+export class SendMessageToolInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SendMessageToolInputError";
+  }
+}
+
+export function createWorkerAgentTools(
+  options: WorkerAgentSendMessageToolOptions
+): WorkerAgentToolSet {
+  return {
+    send_message: createSendMessageTool(options),
+  };
+}
+
+export function createSendMessageTool(
+  options: WorkerAgentSendMessageToolOptions
+): SendMessageTool {
+  return {
+    description: "Send a user-visible message to the current channel.",
+    execute: async (input: unknown): Promise<SendMessageToolResult> => {
+      const message = SendMessageToolInputSchema.parse(input);
+      const text = message.text.trim();
+      if (!text) {
+        throw new SendMessageToolInputError("send_message.text is required.");
+      }
+
+      const channel = options.channel();
+      if (!channel) {
+        throw new SendMessageToolConfigError(
+          "send_message requires a current channel."
+        );
+      }
+
+      const sent = await options.sink.send(channel, text);
+      return {
+        delivered: true,
+        messageId: sent.messageId,
+        threadId: sent.threadId,
+      };
+    },
+    inputSchema: SendMessageToolInputSchema,
+    retryPolicy: "manual-recovery",
+  };
+}
+
+export function isDeliveredSendMessageToolOutput(output: unknown): boolean {
+  if (isSendMessageToolResult(output)) {
+    return true;
+  }
+
+  if (isJsonToolOutput(output)) {
+    return isSendMessageToolResult(output.value);
+  }
+
+  return false;
+}
+
+function isSendMessageToolResult(
+  value: unknown
+): value is SendMessageToolResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "delivered" in value &&
+    value.delivered === true &&
+    "messageId" in value &&
+    typeof value.messageId === "string" &&
+    "threadId" in value &&
+    typeof value.threadId === "string"
+  );
+}
+
+function isJsonToolOutput(
+  value: unknown
+): value is { readonly type: "json"; readonly value: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "json" &&
+    "value" in value
+  );
+}

--- a/apps/worker-agent/src/tui-contract.ts
+++ b/apps/worker-agent/src/tui-contract.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+import { ChannelAddressSchema } from "./channel";
+
+export const ThreadInspectionSchema = z
+  .object({
+    compactionCount: z.number().int().nonnegative(),
+    compactions: z
+      .array(
+        z
+          .object({
+            endSeqExclusive: z.number().int().nonnegative(),
+            startSeq: z.number().int().nonnegative(),
+            summaryBytes: z.number().int().nonnegative(),
+          })
+          .strict()
+      )
+      .readonly(),
+    exists: z.boolean(),
+    messageCount: z.number().int().nonnegative(),
+    summaryBytes: z.number().int().nonnegative(),
+    threadKey: z.string(),
+    version: z.string().nullable(),
+  })
+  .strict();
+
+export const TuiInspectInputSchema = z
+  .object({
+    conversationKey: z.string(),
+  })
+  .strict();
+
+export const TuiInspectOutputSchema = ThreadInspectionSchema;
+
+export const TuiTurnInputSchema = z
+  .object({
+    channel: ChannelAddressSchema,
+    text: z.string(),
+  })
+  .strict();
+
+export const TuiTurnOutputSchema = z.discriminatedUnion("delivered", [
+  z
+    .object({
+      delivered: z.literal(true),
+      messages: z
+        .array(
+          z
+            .object({
+              messageId: z.string(),
+              text: z.string(),
+              threadId: z.string(),
+            })
+            .strict()
+        )
+        .readonly()
+        .optional(),
+    })
+    .strict(),
+  z
+    .object({
+      delivered: z.literal(false),
+      error: z.literal("missing_send_message"),
+    })
+    .strict(),
+]);
+
+export type TuiTurnInput = z.infer<typeof TuiTurnInputSchema>;
+export type TuiTurnOutput = z.infer<typeof TuiTurnOutputSchema>;
+export type TuiInspectInput = z.infer<typeof TuiInspectInputSchema>;
+export type TuiInspectOutput = z.infer<typeof TuiInspectOutputSchema>;

--- a/apps/worker-agent/src/tui-inspect.test.ts
+++ b/apps/worker-agent/src/tui-inspect.test.ts
@@ -1,0 +1,106 @@
+import type { ThreadInspection } from "@minpeter/pss-runtime";
+import { describe, expect, it } from "vitest";
+
+import {
+  deliverTuiInspect,
+  formatThreadInspection,
+  isTuiInspectCommand,
+  parseTuiInspectKey,
+} from "./tui-inspect";
+
+describe("TUI inspect command", () => {
+  it("recognizes the inspect command with and without an argument", () => {
+    expect(isTuiInspectCommand("/inspect")).toBe(true);
+    expect(isTuiInspectCommand("/inspect telegram:123")).toBe(true);
+    expect(isTuiInspectCommand("/inspector")).toBe(false);
+    expect(isTuiInspectCommand("hello")).toBe(false);
+  });
+
+  it("parses the requested key or leaves it undefined", () => {
+    expect(parseTuiInspectKey("/inspect telegram:123")).toBe("telegram:123");
+    expect(parseTuiInspectKey("/inspect   tui:local  ")).toBe("tui:local");
+    expect(parseTuiInspectKey("/inspect")).toBeUndefined();
+    expect(parseTuiInspectKey("hello")).toBeUndefined();
+  });
+
+  it("formats an existing session inspection with compactions", () => {
+    expect(
+      formatThreadInspection({
+        compactionCount: 1,
+        compactions: [{ endSeqExclusive: 4, startSeq: 0, summaryBytes: 12 }],
+        exists: true,
+        messageCount: 6,
+        summaryBytes: 12,
+        threadKey: "telegram:123",
+        version: "7",
+      })
+    ).toEqual([
+      "inspect telegram:123:",
+      "  version: 7",
+      "  messages: 6",
+      "  compactions: 1",
+      "  summary bytes: 12",
+      "  compaction [0, 4) 12B",
+    ]);
+  });
+
+  it("reports a missing session", () => {
+    expect(
+      formatThreadInspection({
+        compactionCount: 0,
+        compactions: [],
+        exists: false,
+        messageCount: 0,
+        summaryBytes: 0,
+        threadKey: "telegram:999",
+        version: null,
+      })
+    ).toEqual(["inspect telegram:999: no stored session"]);
+  });
+
+  it("inspects another session by key and prints the report", async () => {
+    const lines: string[] = [];
+    const inspection: ThreadInspection = {
+      compactionCount: 0,
+      compactions: [],
+      exists: true,
+      messageCount: 2,
+      summaryBytes: 0,
+      threadKey: "telegram:123",
+      version: "1",
+    };
+
+    await deliverTuiInspect({
+      defaultKey: "tui:local",
+      inspect: (key) => Promise.resolve({ ...inspection, threadKey: key }),
+      output: { writeLine: (line) => lines.push(line) },
+      text: "/inspect telegram:123",
+    });
+
+    expect(lines[0]).toBe("inspect telegram:123:");
+  });
+
+  it("falls back to the default key when none is provided", async () => {
+    const requestedKeys: string[] = [];
+
+    await deliverTuiInspect({
+      defaultKey: "tui:local",
+      inspect: (key) => {
+        requestedKeys.push(key);
+        return Promise.resolve({
+          compactionCount: 0,
+          compactions: [],
+          exists: false,
+          messageCount: 0,
+          summaryBytes: 0,
+          threadKey: key,
+          version: null,
+        });
+      },
+      output: { writeLine: () => undefined },
+      text: "/inspect",
+    });
+
+    expect(requestedKeys).toEqual(["tui:local"]);
+  });
+});

--- a/apps/worker-agent/src/tui-inspect.ts
+++ b/apps/worker-agent/src/tui-inspect.ts
@@ -1,0 +1,58 @@
+import type { ThreadInspection } from "@minpeter/pss-runtime";
+
+import type { TuiOutput } from "./tui-sink";
+
+const INSPECT_COMMAND = "/inspect";
+
+export interface DeliverTuiInspectOptions {
+  readonly defaultKey: string;
+  readonly inspect: (key: string) => Promise<ThreadInspection>;
+  readonly output: TuiOutput;
+  readonly text: string;
+}
+
+export function isTuiInspectCommand(text: string): boolean {
+  return text === INSPECT_COMMAND || text.startsWith(`${INSPECT_COMMAND} `);
+}
+
+export function parseTuiInspectKey(text: string): string | undefined {
+  if (!isTuiInspectCommand(text)) {
+    return;
+  }
+  return text.slice(INSPECT_COMMAND.length).trim() || undefined;
+}
+
+export async function deliverTuiInspect({
+  defaultKey,
+  inspect,
+  output,
+  text,
+}: DeliverTuiInspectOptions): Promise<void> {
+  const key = parseTuiInspectKey(text) ?? defaultKey;
+  const inspection = await inspect(key);
+  for (const line of formatThreadInspection(inspection)) {
+    output.writeLine(line);
+  }
+}
+
+export function formatThreadInspection(
+  inspection: ThreadInspection
+): readonly string[] {
+  if (!inspection.exists) {
+    return [`inspect ${inspection.threadKey}: no stored session`];
+  }
+
+  const lines = [
+    `inspect ${inspection.threadKey}:`,
+    `  version: ${inspection.version ?? "unknown"}`,
+    `  messages: ${inspection.messageCount}`,
+    `  compactions: ${inspection.compactionCount}`,
+    `  summary bytes: ${inspection.summaryBytes}`,
+  ];
+  for (const compaction of inspection.compactions) {
+    lines.push(
+      `  compaction [${compaction.startSeq}, ${compaction.endSeqExclusive}) ${compaction.summaryBytes}B`
+    );
+  }
+  return lines;
+}

--- a/apps/worker-agent/src/tui-remote.test.ts
+++ b/apps/worker-agent/src/tui-remote.test.ts
@@ -1,0 +1,188 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createRemoteTuiDeliveryClient } from "./tui-remote";
+
+const serverHandles: CloseableServer[] = [];
+
+describe("remote TUI tRPC client", () => {
+  afterEach(async () => {
+    await Promise.all(serverHandles.splice(0).map((server) => server.close()));
+  });
+
+  it("posts turns to the tRPC procedure path with bearer auth", async () => {
+    const requests: CapturedRequest[] = [];
+    const server = await startServer(async (request) => {
+      requests.push({
+        authorization: request.headers.get("authorization"),
+        body: await request.text(),
+        pathname: new URL(request.url).pathname,
+        search: new URL(request.url).searchParams,
+      });
+
+      return Response.json({
+        result: {
+          data: {
+            delivered: true,
+            messages: [
+              {
+                messageId: "tui-1",
+                text: "remote ok",
+                threadId: "tui:local",
+              },
+            ],
+          },
+        },
+      });
+    });
+    const client = createRemoteTuiDeliveryClient({
+      channel: { id: "local", kind: "tui" },
+      endpoint: `${server.origin}/trpc`,
+      token: "secret",
+    });
+
+    await expect(client.deliver("hello remote")).resolves.toEqual({
+      delivered: true,
+      messages: [
+        {
+          messageId: "tui-1",
+          text: "remote ok",
+          threadId: "tui:local",
+        },
+      ],
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      authorization: "Bearer secret",
+      pathname: "/trpc/tui.turn",
+    });
+    expect(JSON.parse(requests[0]?.body ?? "{}")).toMatchObject({
+      channel: { id: "local", kind: "tui" },
+      text: "hello remote",
+    });
+  });
+
+  it("queries remote inspections with bearer auth", async () => {
+    const requests: CapturedRequest[] = [];
+    const server = await startServer(async (request) => {
+      requests.push({
+        authorization: request.headers.get("authorization"),
+        body: await request.text(),
+        pathname: new URL(request.url).pathname,
+        search: new URL(request.url).searchParams,
+      });
+
+      return Response.json({
+        result: {
+          data: {
+            compactionCount: 0,
+            compactions: [],
+            exists: true,
+            messageCount: 1,
+            summaryBytes: 0,
+            threadKey: "telegram:123",
+            version: "v1",
+          },
+        },
+      });
+    });
+    const client = createRemoteTuiDeliveryClient({
+      channel: { id: "local", kind: "tui" },
+      endpoint: `${server.origin}/trpc`,
+      token: "secret",
+    });
+
+    await expect(client.inspect("telegram:123")).resolves.toEqual({
+      compactionCount: 0,
+      compactions: [],
+      exists: true,
+      messageCount: 1,
+      summaryBytes: 0,
+      threadKey: "telegram:123",
+      version: "v1",
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      authorization: "Bearer secret",
+      pathname: "/trpc/tui.inspect",
+    });
+    const input = requests[0]?.search.get("input") ?? "{}";
+    expect(JSON.parse(input)).toMatchObject({
+      conversationKey: "telegram:123",
+    });
+  });
+});
+
+interface CapturedRequest {
+  readonly authorization: string | null;
+  readonly body: string;
+  readonly pathname: string;
+  readonly search: URLSearchParams;
+}
+
+interface CloseableServer {
+  close(): Promise<void>;
+  readonly origin: string;
+}
+
+async function startServer(
+  handler: (request: Request) => Promise<Response>
+): Promise<CloseableServer> {
+  const server = createServer((incoming, outgoing) => {
+    const chunks: Buffer[] = [];
+    incoming.on("data", (chunk: Buffer) => chunks.push(chunk));
+    incoming.on("end", async () => {
+      const request = new Request(`http://127.0.0.1${incoming.url ?? "/"}`, {
+        body:
+          incoming.method === "GET" || incoming.method === "HEAD"
+            ? null
+            : Buffer.concat(chunks),
+        headers: headersFromIncomingRequest(incoming.headers),
+        method: incoming.method,
+      });
+      const response = await handler(request);
+      outgoing.writeHead(response.status, Object.fromEntries(response.headers));
+      outgoing.end(Buffer.from(await response.arrayBuffer()));
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected server address.");
+  }
+
+  const closeable = {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+  } satisfies CloseableServer;
+  serverHandles.push(closeable);
+  return closeable;
+}
+
+function headersFromIncomingRequest(
+  headers: Readonly<Record<string, string | readonly string[] | undefined>>
+): Headers {
+  const normalizedHeaders = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      normalizedHeaders.set(name, value);
+      continue;
+    }
+    if (value) {
+      normalizedHeaders.set(name, value.join(", "));
+    }
+  }
+  return normalizedHeaders;
+}

--- a/apps/worker-agent/src/tui-remote.ts
+++ b/apps/worker-agent/src/tui-remote.ts
@@ -1,0 +1,93 @@
+import type { ThreadInspection } from "@minpeter/pss-runtime";
+import { createTRPCClient, httpLink } from "@trpc/client";
+
+import type { WorkerAgentDeliveryResponse } from "./agent-do";
+import type { ChannelAddress } from "./channel";
+import { TuiInspectOutputSchema, TuiTurnOutputSchema } from "./tui-contract";
+import type { WorkerAgentRouter } from "./tui-rpc";
+
+const REMOTE_TUI_TIMEOUT_MS = 120_000;
+
+export interface RemoteTuiDeliveryClient {
+  deliver(text: string): Promise<WorkerAgentDeliveryResponse>;
+  inspect(conversationKey: string): Promise<ThreadInspection>;
+}
+
+export interface RemoteTuiDeliveryClientConfig {
+  readonly channel: ChannelAddress;
+  readonly endpoint: string;
+  readonly token?: string;
+}
+
+export function createRemoteTuiDeliveryClient(
+  config: RemoteTuiDeliveryClientConfig
+): RemoteTuiDeliveryClient {
+  const client = createTRPCClient<WorkerAgentRouter>({
+    links: [
+      httpLink({
+        headers: () =>
+          config.token ? { authorization: `Bearer ${config.token}` } : {},
+        url: config.endpoint,
+      }),
+    ],
+  });
+
+  return {
+    deliver: (text) => requestRemoteTuiDelivery({ client, config, text }),
+    inspect: (conversationKey) =>
+      requestRemoteTuiInspect({ client, conversationKey }),
+  };
+}
+
+export async function requestRemoteTuiDelivery({
+  client,
+  config,
+  text,
+}: RemoteTuiDeliveryRequest): Promise<WorkerAgentDeliveryResponse> {
+  const abort = new AbortController();
+  const timeout = setTimeout(() => abort.abort(), REMOTE_TUI_TIMEOUT_MS);
+  try {
+    const delivery = await client.tui.turn.mutate(
+      {
+        channel: config.channel,
+        text,
+      },
+      { signal: abort.signal }
+    );
+
+    return TuiTurnOutputSchema.parse(delivery);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function requestRemoteTuiInspect({
+  client,
+  conversationKey,
+}: RemoteTuiInspectRequest): Promise<ThreadInspection> {
+  const abort = new AbortController();
+  const timeout = setTimeout(() => abort.abort(), REMOTE_TUI_TIMEOUT_MS);
+  try {
+    const inspection = await client.tui.inspect.query(
+      {
+        conversationKey,
+      },
+      { signal: abort.signal }
+    );
+
+    return TuiInspectOutputSchema.parse(inspection);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+interface RemoteTuiDeliveryRequest {
+  readonly client: ReturnType<typeof createTRPCClient<WorkerAgentRouter>>;
+  readonly config: RemoteTuiDeliveryClientConfig;
+  readonly text: string;
+}
+
+interface RemoteTuiInspectRequest {
+  readonly client: ReturnType<typeof createTRPCClient<WorkerAgentRouter>>;
+  readonly conversationKey: string;
+}

--- a/apps/worker-agent/src/tui-response-sink.test.ts
+++ b/apps/worker-agent/src/tui-response-sink.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { createTuiResponseMessageSink } from "./tui-response-sink";
+
+describe("TUI response message sink", () => {
+  it("captures send_message output for a request-scoped TUI response", async () => {
+    const responseSink = createTuiResponseMessageSink();
+
+    await expect(
+      responseSink.sink.send({ id: "local", kind: "tui" }, "hello")
+    ).resolves.toEqual({
+      messageId: "tui-1",
+      threadId: "tui:local",
+    });
+
+    expect(responseSink.messages()).toEqual([
+      {
+        messageId: "tui-1",
+        text: "hello",
+        threadId: "tui:local",
+      },
+    ]);
+  });
+
+  it("rejects non-TUI channels", async () => {
+    const responseSink = createTuiResponseMessageSink();
+
+    await expect(
+      responseSink.sink.send({ id: "chat-1", kind: "telegram" }, "hello")
+    ).rejects.toThrow("TUI response sink can only send to tui channels.");
+  });
+});

--- a/apps/worker-agent/src/tui-response-sink.ts
+++ b/apps/worker-agent/src/tui-response-sink.ts
@@ -1,0 +1,44 @@
+import type { WorkerAgentDeliveredMessage } from "./agent-do";
+import type { ChannelMessageSink, ChannelSentMessage } from "./channel";
+import { channelKey } from "./channel";
+
+export interface TuiResponseMessageSink {
+  readonly messages: () => readonly WorkerAgentDeliveredMessage[];
+  readonly sink: ChannelMessageSink;
+}
+
+export class TuiResponseMessageSinkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TuiResponseMessageSinkError";
+  }
+}
+
+export function createTuiResponseMessageSink(): TuiResponseMessageSink {
+  const messages: WorkerAgentDeliveredMessage[] = [];
+
+  return {
+    messages: () => [...messages],
+    sink: {
+      send: (channel, text): Promise<ChannelSentMessage> => {
+        if (channel.kind !== "tui") {
+          return Promise.reject(
+            new TuiResponseMessageSinkError(
+              "TUI response sink can only send to tui channels."
+            )
+          );
+        }
+
+        const sent = {
+          messageId: `tui-${messages.length + 1}`,
+          threadId: channelKey(channel),
+        };
+        messages.push({
+          ...sent,
+          text,
+        });
+        return Promise.resolve(sent);
+      },
+    },
+  };
+}

--- a/apps/worker-agent/src/tui-rpc.ts
+++ b/apps/worker-agent/src/tui-rpc.ts
@@ -1,0 +1,109 @@
+import { initTRPC, TRPCError } from "@trpc/server";
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+
+import { type Env, isDevelopment } from "./env";
+import {
+  TuiInspectInputSchema,
+  TuiInspectOutputSchema,
+  TuiTurnInputSchema,
+  TuiTurnOutputSchema,
+} from "./tui-contract";
+import {
+  dispatchTuiInspect,
+  dispatchTuiTurn,
+  TuiServerBadRequestError,
+  TuiServerUpstreamError,
+} from "./tui-server";
+
+const TUI_RPC_ENDPOINT = "/trpc";
+const UNAUTHORIZED_MESSAGE = "unauthorized";
+
+interface TuiRpcContext {
+  readonly env: Env;
+  readonly request: Request;
+}
+
+const trpc = initTRPC.context<TuiRpcContext>().create({ isDev: false });
+
+const authorizedProcedure = trpc.procedure.use(({ ctx, next }) => {
+  if (!isAuthorizedTuiRequest(ctx.request, ctx.env)) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: UNAUTHORIZED_MESSAGE,
+    });
+  }
+
+  return next();
+});
+
+export const workerAgentRouter = trpc.router({
+  tui: trpc.router({
+    inspect: authorizedProcedure
+      .input(TuiInspectInputSchema)
+      .output(TuiInspectOutputSchema)
+      .query(async ({ ctx, input }) => {
+        try {
+          return await dispatchTuiInspect(input, ctx.env);
+        } catch (error) {
+          if (error instanceof TuiServerBadRequestError) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: error.message,
+            });
+          }
+          if (error instanceof TuiServerUpstreamError) {
+            throw new TRPCError({
+              code: "BAD_GATEWAY",
+              message: error.message,
+            });
+          }
+          throw error;
+        }
+      }),
+    turn: authorizedProcedure
+      .input(TuiTurnInputSchema)
+      .output(TuiTurnOutputSchema)
+      .mutation(async ({ ctx, input }) => {
+        try {
+          return await dispatchTuiTurn(input, ctx.env);
+        } catch (error) {
+          if (error instanceof TuiServerBadRequestError) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: error.message,
+            });
+          }
+          if (error instanceof TuiServerUpstreamError) {
+            throw new TRPCError({
+              code: "BAD_GATEWAY",
+              message: error.message,
+            });
+          }
+          throw error;
+        }
+      }),
+  }),
+});
+
+export type WorkerAgentRouter = typeof workerAgentRouter;
+
+export function handleTuiRpcRequest(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  return fetchRequestHandler({
+    createContext: () => ({ env, request }),
+    endpoint: TUI_RPC_ENDPOINT,
+    req: request,
+    router: workerAgentRouter,
+  });
+}
+
+function isAuthorizedTuiRequest(request: Request, env: Env): boolean {
+  const token = env.WORKER_AGENT_TUI_TOKEN?.trim();
+  if (!token) {
+    return isDevelopment(env);
+  }
+
+  return request.headers.get("authorization") === `Bearer ${token}`;
+}

--- a/apps/worker-agent/src/tui-server.test.ts
+++ b/apps/worker-agent/src/tui-server.test.ts
@@ -1,0 +1,261 @@
+import { createTRPCClient, httpLink } from "@trpc/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { channelKey } from "./channel";
+import { durableObjectName, type Env } from "./env";
+import { handleTuiRpcRequest, type WorkerAgentRouter } from "./tui-rpc";
+
+const durableObjectMock = vi.hoisted(
+  (): {
+    readonly requests: {
+      readonly objectName: string;
+      readonly request: Request;
+    }[];
+    readonly responses: Response[];
+  } => ({
+    requests: [],
+    responses: [],
+  })
+);
+
+vi.mock("@minpeter/pss-runtime/cloudflare", () => ({
+  fetchCloudflareDurableObject: (options: unknown) => {
+    if (
+      !(
+        typeof options === "object" &&
+        options !== null &&
+        "objectName" in options &&
+        typeof options.objectName === "string" &&
+        "request" in options &&
+        options.request instanceof Request
+      )
+    ) {
+      throw new Error("Expected Durable Object fetch options.");
+    }
+    durableObjectMock.requests.push({
+      objectName: options.objectName,
+      request: options.request,
+    });
+    return Promise.resolve(
+      durableObjectMock.responses.shift() ??
+        Response.json({
+          delivered: true,
+          messages: [],
+        })
+    );
+  },
+}));
+
+describe("TUI worker tRPC route", () => {
+  beforeEach(() => {
+    durableObjectMock.requests.length = 0;
+    durableObjectMock.responses.length = 0;
+  });
+
+  it("forwards development TUI turns to the channel Durable Object", async () => {
+    const env = createEnv({ ENVIRONMENT: "development" });
+    durableObjectMock.responses.push(
+      Response.json({
+        delivered: true,
+        messages: [
+          {
+            messageId: "tui-1",
+            text: "visible",
+            threadId: "tui:local",
+          },
+        ],
+      })
+    );
+
+    const client = createTuiRpcTestClient(env);
+
+    await expect(
+      client.tui.turn.mutate({
+        channel: { id: " local ", kind: "tui" },
+        text: " hello ",
+      })
+    ).resolves.toEqual({
+      delivered: true,
+      messages: [
+        {
+          messageId: "tui-1",
+          text: "visible",
+          threadId: "tui:local",
+        },
+      ],
+    });
+
+    const [request] = durableObjectMock.requests;
+    if (!request) {
+      throw new Error("Expected a Durable Object request.");
+    }
+    expect(request.objectName).toBe(
+      durableObjectName(channelKey({ id: "local", kind: "tui" }))
+    );
+    await expect(request.request.json()).resolves.toEqual({
+      channel: { id: "local", kind: "tui" },
+      text: "hello",
+    });
+  });
+
+  it("rejects production TUI turns without the configured token", async () => {
+    const env = createEnv({
+      ENVIRONMENT: "production",
+      WORKER_AGENT_TUI_TOKEN: "secret",
+    });
+
+    const response = await handleTuiRpcRequest(
+      new Request("https://worker.example.com/trpc/tui.turn", {
+        body: JSON.stringify({
+          channel: { id: "local", kind: "tui" },
+          text: "hello",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+      env
+    );
+
+    expect(response.status).toBe(401);
+    expect(durableObjectMock.requests).toEqual([]);
+  });
+
+  it("accepts production TUI turns with the configured token", async () => {
+    const env = createEnv({
+      ENVIRONMENT: "production",
+      WORKER_AGENT_TUI_TOKEN: "secret",
+    });
+
+    const response = await handleTuiRpcRequest(
+      new Request("https://worker.example.com/trpc/tui.turn", {
+        body: JSON.stringify({
+          channel: { id: "local", kind: "tui" },
+          text: "hello",
+        }),
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(durableObjectMock.requests).toHaveLength(1);
+  });
+
+  it("rejects non-TUI channels", async () => {
+    const env = createEnv({ ENVIRONMENT: "development" });
+
+    const response = await handleTuiRpcRequest(
+      new Request("https://worker.example.com/trpc/tui.turn", {
+        body: JSON.stringify({
+          channel: { id: "chat-1", kind: "telegram" },
+          text: "hello",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    expect(durableObjectMock.requests).toEqual([]);
+  });
+
+  it("inspects a known conversation key through the target Durable Object", async () => {
+    const env = createEnv({ ENVIRONMENT: "development" });
+    durableObjectMock.responses.push(
+      Response.json({
+        compactionCount: 0,
+        compactions: [],
+        exists: true,
+        messageCount: 3,
+        summaryBytes: 0,
+        threadKey: "default",
+        version: "v1",
+      })
+    );
+
+    const client = createTuiRpcTestClient(env);
+
+    await expect(
+      client.tui.inspect.query({ conversationKey: "telegram:123" })
+    ).resolves.toEqual({
+      compactionCount: 0,
+      compactions: [],
+      exists: true,
+      messageCount: 3,
+      summaryBytes: 0,
+      threadKey: "telegram:123",
+      version: "v1",
+    });
+
+    const [request] = durableObjectMock.requests;
+    if (!request) {
+      throw new Error("Expected a Durable Object request.");
+    }
+    expect(request.objectName).toBe(durableObjectName("telegram:123"));
+    await expect(request.request.json()).resolves.toEqual({ inspect: true });
+  });
+});
+
+function createTuiRpcTestClient(env: Env) {
+  return createTRPCClient<WorkerAgentRouter>({
+    links: [
+      httpLink({
+        fetch: (input, init) =>
+          handleTuiRpcRequest(new Request(input, init), env),
+        url: "https://worker.example.com/trpc",
+      }),
+    ],
+  });
+}
+
+function createEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    AGENT_DO: createDurableObjectNamespace("agent"),
+    AI_API_KEY: "test-key",
+    ENVIRONMENT: "development",
+    TELEGRAM_BOT_TOKEN: "test-token",
+    TELEGRAM_WEBHOOK_SECRET_TOKEN: "secret",
+    ...overrides,
+  };
+}
+
+function createDurableObjectNamespace(label: string): DurableObjectNamespace {
+  const namespace: DurableObjectNamespace = {
+    get(_id: DurableObjectId) {
+      throw new Error(`${label} namespace should not be fetched`);
+    },
+    getByName(_name: string) {
+      throw new Error(`${label} namespace should not be fetched`);
+    },
+    idFromString(id: string) {
+      return createDurableObjectId(id);
+    },
+    idFromName(name: string) {
+      return createDurableObjectId(name);
+    },
+    jurisdiction() {
+      return namespace;
+    },
+    newUniqueId() {
+      return createDurableObjectId(`${label}-unique`);
+    },
+  };
+  return namespace;
+}
+
+function createDurableObjectId(name: string): DurableObjectId {
+  return {
+    equals(other: DurableObjectId) {
+      return other.toString() === name;
+    },
+    name,
+    toString() {
+      return name;
+    },
+  };
+}

--- a/apps/worker-agent/src/tui-server.ts
+++ b/apps/worker-agent/src/tui-server.ts
@@ -1,0 +1,107 @@
+import { fetchCloudflareDurableObject } from "@minpeter/pss-runtime/cloudflare";
+
+import type { WorkerAgentDeliveryResponse } from "./agent-do";
+import { channelKey } from "./channel";
+import { durableObjectName, type Env } from "./env";
+import {
+  ThreadInspectionSchema,
+  type TuiInspectInput,
+  type TuiInspectOutput,
+  type TuiTurnInput,
+  TuiTurnOutputSchema,
+} from "./tui-contract";
+
+export async function dispatchTuiTurn(
+  input: TuiTurnInput,
+  env: Env
+): Promise<WorkerAgentDeliveryResponse> {
+  const channelId = input.channel.id.trim();
+  const text = input.text.trim();
+  if (!(channelId && text)) {
+    throw new TuiServerBadRequestError("text and tui channel required");
+  }
+
+  switch (input.channel.kind) {
+    case "tui":
+      break;
+    case "telegram":
+      throw new TuiServerBadRequestError("text and tui channel required");
+    default:
+      return assertNever(input.channel.kind);
+  }
+  const payload = {
+    channel: { id: channelId, kind: "tui" },
+    text,
+  } satisfies TuiTurnInput;
+
+  const response = await fetchCloudflareDurableObject({
+    namespace: env.AGENT_DO,
+    objectName: durableObjectName(channelKey(payload.channel)),
+    request: new Request("https://agent.internal/turn", {
+      body: JSON.stringify(payload),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }),
+  });
+
+  if (!response) {
+    throw new TuiServerUpstreamError("agent durable object unavailable");
+  }
+
+  const body: unknown = await response.json();
+  return TuiTurnOutputSchema.parse(body);
+}
+
+export async function dispatchTuiInspect(
+  input: TuiInspectInput,
+  env: Env
+): Promise<TuiInspectOutput> {
+  const conversationKey = input.conversationKey.trim();
+  if (!conversationKey) {
+    throw new TuiServerBadRequestError("conversationKey required");
+  }
+
+  const response = await fetchCloudflareDurableObject({
+    namespace: env.AGENT_DO,
+    objectName: durableObjectName(conversationKey),
+    request: new Request("https://agent.internal/inspect", {
+      body: JSON.stringify({ inspect: true }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }),
+  });
+
+  if (!response) {
+    throw new TuiServerUpstreamError("agent durable object unavailable");
+  }
+
+  const inspection = ThreadInspectionSchema.parse(await response.json());
+  return { ...inspection, threadKey: conversationKey };
+}
+
+function assertNever(value: never): never {
+  throw new TuiServerInvariantError(
+    `Unexpected channel variant: ${String(value)}`
+  );
+}
+
+class TuiServerInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TuiServerInvariantError";
+  }
+}
+
+export class TuiServerBadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TuiServerBadRequestError";
+  }
+}
+
+export class TuiServerUpstreamError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TuiServerUpstreamError";
+  }
+}

--- a/apps/worker-agent/src/tui-sink.test.ts
+++ b/apps/worker-agent/src/tui-sink.test.ts
@@ -1,0 +1,270 @@
+import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
+import { describe, expect, it } from "vitest";
+
+import { SEND_MESSAGE_TOOL_NAME } from "./tools";
+import {
+  createTuiMessageSink,
+  deliverRemoteTuiTurn,
+  deliverTuiTurn,
+  TUI_DEBUG_ASSISTANT_PREFIX,
+  TUI_DEBUG_TOOL_CALL_PREFIX,
+  TUI_DEBUG_TOOL_RESULT_PREFIX,
+  TUI_FAILURE_MESSAGE,
+} from "./tui-sink";
+
+describe("TUI channel sink", () => {
+  it("writes assistant-visible messages only when the channel sink sends", async () => {
+    const lines: string[] = [];
+    const sink = createTuiMessageSink({
+      writeLine: (line) => lines.push(line),
+    });
+
+    await expect(
+      sink.send({ id: "local", kind: "tui" }, "hello")
+    ).resolves.toEqual({
+      messageId: "tui-1",
+      threadId: "tui:local",
+    });
+    expect(lines).toEqual(["apex: hello"]);
+  });
+
+  it("prints assistant-output debug lines after tool delivery", async () => {
+    const lines: string[] = [];
+
+    await expect(
+      deliverTuiTurn({
+        output: { writeLine: (line) => lines.push(line) },
+        text: " hello ",
+        thread: threadWithRun([
+          sendMessageEvent(),
+          { text: "assistant fallback", type: "assistant-output" },
+        ]),
+      })
+    ).resolves.toEqual({ delivered: true });
+    expect(lines).toEqual([
+      "you: hello",
+      `${TUI_DEBUG_TOOL_RESULT_PREFIX} send_message {"delivered":true,"messageId":"msg-1","threadId":"tui:local"}`,
+      `${TUI_DEBUG_ASSISTANT_PREFIX} assistant fallback`,
+    ]);
+  });
+
+  it("prints tool debug lines when the model only calls send_message", async () => {
+    const lines: string[] = [];
+
+    await expect(
+      deliverTuiTurn({
+        output: { writeLine: (line) => lines.push(line) },
+        text: "hello",
+        thread: threadWithRun([
+          toolCallEvent({
+            text: "visible answer",
+          }),
+          sendMessageEvent(),
+        ]),
+      })
+    ).resolves.toEqual({ delivered: true });
+    expect(lines).toEqual([
+      "you: hello",
+      `${TUI_DEBUG_TOOL_CALL_PREFIX} send_message {"text":"visible answer"}`,
+      `${TUI_DEBUG_TOOL_RESULT_PREFIX} send_message {"delivered":true,"messageId":"msg-1","threadId":"tui:local"}`,
+    ]);
+  });
+
+  it("prints labeled assistant-output debug lines", async () => {
+    const lines: string[] = [];
+
+    await expect(
+      deliverTuiTurn({
+        output: { writeLine: (line) => lines.push(line) },
+        text: " hello ",
+        thread: threadWithRun([
+          { text: "thinking out loud", type: "assistant-output" },
+          sendMessageEvent(),
+        ]),
+      })
+    ).resolves.toEqual({ delivered: true });
+    expect(lines).toEqual([
+      "you: hello",
+      `${TUI_DEBUG_ASSISTANT_PREFIX} thinking out loud`,
+      `${TUI_DEBUG_TOOL_RESULT_PREFIX} send_message {"delivered":true,"messageId":"msg-1","threadId":"tui:local"}`,
+    ]);
+  });
+
+  it("prefixes every assistant-output debug line when model output is multiline", async () => {
+    const lines: string[] = [];
+
+    await expect(
+      deliverTuiTurn({
+        output: { writeLine: (line) => lines.push(line) },
+        text: "hello",
+        thread: threadWithRun([
+          { text: "line one\nline two", type: "assistant-output" },
+          sendMessageEvent(),
+        ]),
+      })
+    ).resolves.toEqual({ delivered: true });
+    expect(lines).toEqual([
+      "you: hello",
+      `${TUI_DEBUG_ASSISTANT_PREFIX} line one`,
+      `${TUI_DEBUG_ASSISTANT_PREFIX} line two`,
+      `${TUI_DEBUG_TOOL_RESULT_PREFIX} send_message {"delivered":true,"messageId":"msg-1","threadId":"tui:local"}`,
+    ]);
+  });
+
+  it("assistant-output debug lines do not satisfy delivery without send_message", async () => {
+    const lines: string[] = [];
+
+    await expect(
+      deliverTuiTurn({
+        output: { writeLine: (line) => lines.push(line) },
+        text: "hello",
+        thread: threadWithRuns([
+          [{ text: "first draft", type: "assistant-output" }],
+          [{ text: "second draft", type: "assistant-output" }],
+        ]),
+      })
+    ).resolves.toEqual({
+      delivered: false,
+      error: "missing_send_message",
+    });
+    expect(lines).toEqual([
+      "you: hello",
+      `${TUI_DEBUG_ASSISTANT_PREFIX} first draft`,
+      `${TUI_DEBUG_ASSISTANT_PREFIX} second draft`,
+      TUI_FAILURE_MESSAGE,
+    ]);
+  });
+
+  it("prints a system warning when no send_message result is delivered", async () => {
+    const lines: string[] = [];
+
+    await expect(
+      deliverTuiTurn({
+        output: { writeLine: (line) => lines.push(line) },
+        text: "hello",
+        thread: threadWithRuns([
+          [{ text: "assistant fallback", type: "assistant-output" }],
+          [{ text: "still assistant fallback", type: "assistant-output" }],
+        ]),
+      })
+    ).resolves.toEqual({
+      delivered: false,
+      error: "missing_send_message",
+    });
+    expect(lines).toEqual([
+      "you: hello",
+      `${TUI_DEBUG_ASSISTANT_PREFIX} assistant fallback`,
+      `${TUI_DEBUG_ASSISTANT_PREFIX} still assistant fallback`,
+      TUI_FAILURE_MESSAGE,
+    ]);
+  });
+
+  it("prints remote TUI messages returned from the worker channel response", async () => {
+    const lines: string[] = [];
+
+    await expect(
+      deliverRemoteTuiTurn({
+        client: {
+          deliver: () =>
+            Promise.resolve({
+              delivered: true,
+              messages: [
+                {
+                  messageId: "tui-1",
+                  text: "first",
+                  threadId: "tui:local",
+                },
+                {
+                  messageId: "tui-2",
+                  text: "second",
+                  threadId: "tui:local",
+                },
+              ],
+            }),
+          inspect: () =>
+            Promise.resolve({
+              compactionCount: 0,
+              compactions: [],
+              exists: false,
+              messageCount: 0,
+              summaryBytes: 0,
+              threadKey: "tui:local",
+              version: null,
+            }),
+        },
+        output: { writeLine: (line) => lines.push(line) },
+        text: " hello ",
+      })
+    ).resolves.toEqual({
+      delivered: true,
+      messages: [
+        {
+          messageId: "tui-1",
+          text: "first",
+          threadId: "tui:local",
+        },
+        {
+          messageId: "tui-2",
+          text: "second",
+          threadId: "tui:local",
+        },
+      ],
+    });
+    expect(lines).toEqual(["you: hello", "apex: first", "apex: second"]);
+  });
+});
+
+function threadWithRun(events: readonly AgentEvent[]) {
+  return threadWithRuns([events]);
+}
+
+function threadWithRuns(runs: readonly (readonly AgentEvent[])[]) {
+  let nextRunIndex = 0;
+  return {
+    send: () => {
+      const events = runs[nextRunIndex];
+      nextRunIndex += 1;
+      if (!events) {
+        throw new Error("No test run queued.");
+      }
+      return Promise.resolve(runWithEvents(events));
+    },
+  };
+}
+
+function sendMessageEvent(): AgentEvent {
+  return {
+    output: {
+      type: "json",
+      value: {
+        delivered: true,
+        messageId: "msg-1",
+        threadId: "tui:local",
+      },
+    },
+    toolCallId: "call-1",
+    toolName: SEND_MESSAGE_TOOL_NAME,
+    type: "tool-result",
+  };
+}
+
+function toolCallEvent(input: unknown): AgentEvent {
+  return {
+    input,
+    toolCallId: "call-1",
+    toolName: SEND_MESSAGE_TOOL_NAME,
+    type: "tool-call",
+  };
+}
+
+function runWithEvents(events: readonly AgentEvent[]): AgentTurn {
+  return {
+    events: () => eventStream(events),
+  };
+}
+
+async function* eventStream(
+  events: readonly AgentEvent[]
+): AsyncIterable<AgentEvent> {
+  yield* events;
+}

--- a/apps/worker-agent/src/tui-sink.ts
+++ b/apps/worker-agent/src/tui-sink.ts
@@ -1,0 +1,185 @@
+import type { AgentEvent } from "@minpeter/pss-runtime";
+
+import type {
+  WorkerAgentDeliveryResponse,
+  WorkerAgentThreadSender,
+} from "./agent-do";
+import { deliverToolOnlyTurn } from "./agent-do";
+import type {
+  ChannelAddress,
+  ChannelMessageSink,
+  ChannelSentMessage,
+} from "./channel";
+import { channelKey } from "./channel";
+import type { RemoteTuiDeliveryClient } from "./tui-remote";
+
+export const WORKER_AGENT_TUI_CHANNEL: ChannelAddress = {
+  id: "local",
+  kind: "tui",
+};
+export const TUI_FAILURE_MESSAGE =
+  "system: send_message was not called; no assistant text was shown.";
+export const TUI_DEBUG_ASSISTANT_PREFIX = "debug assistant:";
+export const TUI_DEBUG_REASONING_PREFIX = "debug reasoning:";
+export const TUI_DEBUG_TOOL_CALL_PREFIX = "debug tool-call:";
+export const TUI_DEBUG_TOOL_RESULT_PREFIX = "debug tool-result:";
+const ASSISTANT_OUTPUT_LINE_SEPARATOR = /\r\n|\n|\r/u;
+
+export interface TuiOutput {
+  writeLine(line: string): void;
+}
+
+export interface DeliverTuiTurnOptions {
+  readonly output: TuiOutput;
+  readonly text: string;
+  readonly thread: WorkerAgentThreadSender;
+}
+
+export interface DeliverRemoteTuiTurnOptions {
+  readonly client: RemoteTuiDeliveryClient;
+  readonly output: TuiOutput;
+  readonly text: string;
+}
+
+export class TuiMessageSinkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TuiMessageSinkError";
+  }
+}
+
+export function createTuiMessageSink(output: TuiOutput): ChannelMessageSink {
+  let nextMessageIndex = 0;
+  return {
+    send: (channel, text): Promise<ChannelSentMessage> => {
+      if (channel.kind !== "tui") {
+        return Promise.reject(
+          new TuiMessageSinkError("TUI sink can only send to tui channels.")
+        );
+      }
+
+      nextMessageIndex += 1;
+      output.writeLine(`apex: ${text}`);
+      return Promise.resolve({
+        messageId: `tui-${nextMessageIndex}`,
+        threadId: channelKey(channel),
+      });
+    },
+  };
+}
+
+export async function deliverTuiTurn({
+  output,
+  text,
+  thread,
+}: DeliverTuiTurnOptions): Promise<WorkerAgentDeliveryResponse> {
+  const trimmedText = text.trim();
+  if (!trimmedText) {
+    return { delivered: true };
+  }
+
+  output.writeLine(`you: ${trimmedText}`);
+  const delivery = await deliverToolOnlyTurn(thread, trimmedText, {
+    onEvent: (event) => writeDebugEvent(output, event),
+  });
+  if (!delivery.delivered) {
+    output.writeLine(TUI_FAILURE_MESSAGE);
+  }
+
+  return delivery;
+}
+
+export async function deliverRemoteTuiTurn({
+  client,
+  output,
+  text,
+}: DeliverRemoteTuiTurnOptions): Promise<WorkerAgentDeliveryResponse> {
+  const trimmedText = text.trim();
+  if (!trimmedText) {
+    return { delivered: true };
+  }
+
+  output.writeLine(`you: ${trimmedText}`);
+  const delivery = await client.deliver(trimmedText);
+  if (delivery.delivered) {
+    for (const message of delivery.messages ?? []) {
+      output.writeLine(`apex: ${message.text}`);
+    }
+    return delivery;
+  }
+
+  output.writeLine(TUI_FAILURE_MESSAGE);
+  return delivery;
+}
+
+function writeDebugEvent(output: TuiOutput, event: AgentEvent): void {
+  switch (event.type) {
+    case "assistant-output":
+      writePrefixedLines(output, TUI_DEBUG_ASSISTANT_PREFIX, event.text);
+      return;
+    case "assistant-reasoning":
+      writePrefixedLines(output, TUI_DEBUG_REASONING_PREFIX, event.text);
+      return;
+    case "tool-call":
+      output.writeLine(
+        `${TUI_DEBUG_TOOL_CALL_PREFIX} ${event.toolName} ${stringifyDebugValue(
+          event.input
+        )}`
+      );
+      return;
+    case "tool-result":
+      output.writeLine(
+        `${TUI_DEBUG_TOOL_RESULT_PREFIX} ${event.toolName} ${stringifyDebugValue(
+          event.output
+        )}`
+      );
+      return;
+    case "turn-error":
+      output.writeLine(`debug turn-error: ${event.message}`);
+      return;
+    default:
+      return;
+  }
+}
+
+function writePrefixedLines(
+  output: TuiOutput,
+  prefix: string,
+  text: string
+): void {
+  for (const line of text.split(ASSISTANT_OUTPUT_LINE_SEPARATOR)) {
+    output.writeLine(`${prefix} ${line}`);
+  }
+}
+
+function stringifyDebugValue(value: unknown): string {
+  const normalizedValue = unwrapJsonToolOutput(value);
+  if (typeof normalizedValue === "string") {
+    return normalizedValue;
+  }
+
+  try {
+    return JSON.stringify(normalizedValue);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      return "[unserializable]";
+    }
+    throw error;
+  }
+}
+
+function unwrapJsonToolOutput(value: unknown): unknown {
+  return isJsonToolOutput(value) ? value.value : value;
+}
+
+function isJsonToolOutput(
+  value: unknown
+): value is { readonly type: "json"; readonly value: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "json" &&
+    "value" in value
+  );
+}

--- a/apps/worker-agent/src/tui.test.ts
+++ b/apps/worker-agent/src/tui.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWorkerAgentTuiConfig, WorkerAgentTuiConfigError } from "./tui";
+
+describe("worker-agent TUI config", () => {
+  it("resolves the default TUI channel and storage directory", () => {
+    const config = resolveWorkerAgentTuiConfig({
+      AI_API_KEY: "test-key",
+      WORKER_AGENT_TUI_DIR: "/tmp/worker-agent-tui",
+    });
+
+    expect(config.channel).toEqual({ id: "local", kind: "tui" });
+    expect(config).toMatchObject({
+      directory: "/tmp/worker-agent-tui",
+      mode: "local",
+    });
+  });
+
+  it("resolves remote mode from environment without a local model key", () => {
+    const config = resolveWorkerAgentTuiConfig({
+      WORKER_AGENT_TUI_CHANNEL_ID: "dev-shell",
+      WORKER_AGENT_TUI_ENDPOINT: "http://127.0.0.1:8792/trpc",
+      WORKER_AGENT_TUI_TOKEN: " secret-token ",
+    });
+
+    expect(config).toEqual({
+      channel: { id: "dev-shell", kind: "tui" },
+      endpoint: "http://127.0.0.1:8792/trpc",
+      mode: "remote",
+      token: "secret-token",
+    });
+  });
+
+  it("lets a CLI remote flag override the environment endpoint", () => {
+    const config = resolveWorkerAgentTuiConfig(
+      {
+        WORKER_AGENT_TUI_ENDPOINT: "http://127.0.0.1:8792/trpc",
+      },
+      ["--remote", "https://worker.example.com/trpc"]
+    );
+
+    expect(config).toMatchObject({
+      endpoint: "https://worker.example.com/trpc",
+      mode: "remote",
+    });
+  });
+
+  it("requires a local model key when no remote endpoint is configured", () => {
+    expect(() => resolveWorkerAgentTuiConfig({})).toThrow(
+      WorkerAgentTuiConfigError
+    );
+  });
+});

--- a/apps/worker-agent/src/tui.ts
+++ b/apps/worker-agent/src/tui.ts
@@ -1,0 +1,258 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { argv, env, stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
+import { pathToFileURL } from "node:url";
+import type { AgentHost, ThreadInspection } from "@minpeter/pss-runtime";
+import { createNodeFileThreadHost } from "@minpeter/pss-runtime/node";
+import { z } from "zod";
+
+import { createConfiguredAgent, type WorkerAgentModelEnv } from "./agent";
+import type { WorkerAgentDeliveryResponse } from "./agent-do";
+import { type ChannelAddress, channelKey } from "./channel";
+import { deliverTuiInspect, isTuiInspectCommand } from "./tui-inspect";
+import { createRemoteTuiDeliveryClient } from "./tui-remote";
+import {
+  createTuiMessageSink,
+  deliverRemoteTuiTurn,
+  deliverTuiTurn,
+  type TuiOutput,
+  WORKER_AGENT_TUI_CHANNEL,
+} from "./tui-sink";
+
+const TuiEnvironmentSchema = z
+  .object({
+    AI_API_KEY: z.string().optional(),
+    AI_BASE_URL: z.string().optional(),
+    AI_MODEL: z.string().optional(),
+    WORKER_AGENT_TUI_CHANNEL_ID: z.string().optional(),
+    WORKER_AGENT_TUI_DIR: z.string().optional(),
+    WORKER_AGENT_TUI_ENDPOINT: z.string().url().optional(),
+    WORKER_AGENT_TUI_TOKEN: z.string().optional(),
+  })
+  .passthrough();
+
+export type WorkerAgentTuiConfig =
+  | WorkerAgentLocalTuiConfig
+  | WorkerAgentRemoteTuiConfig;
+
+export interface WorkerAgentLocalTuiConfig {
+  readonly channel: ChannelAddress;
+  readonly directory: string;
+  readonly env: WorkerAgentModelEnv;
+  readonly mode: "local";
+}
+
+export interface WorkerAgentRemoteTuiConfig {
+  readonly channel: ChannelAddress;
+  readonly endpoint: string;
+  readonly mode: "remote";
+  readonly token?: string;
+}
+
+export interface StartWorkerAgentTuiOptions {
+  readonly config?: WorkerAgentTuiConfig;
+  readonly host?: AgentHost;
+  readonly output?: TuiOutput;
+}
+
+export function resolveWorkerAgentTuiConfig(
+  environment: NodeJS.ProcessEnv = env,
+  args: readonly string[] = argv.slice(2)
+): WorkerAgentTuiConfig {
+  const parsed = TuiEnvironmentSchema.parse(environment);
+  const remoteEndpoint = readRemoteEndpoint(
+    parsed.WORKER_AGENT_TUI_ENDPOINT,
+    args
+  );
+  const channel = {
+    id:
+      parsed.WORKER_AGENT_TUI_CHANNEL_ID?.trim() || WORKER_AGENT_TUI_CHANNEL.id,
+    kind: "tui",
+  } satisfies ChannelAddress;
+
+  if (remoteEndpoint) {
+    return {
+      channel,
+      endpoint: remoteEndpoint,
+      mode: "remote",
+      ...(parsed.WORKER_AGENT_TUI_TOKEN?.trim()
+        ? { token: parsed.WORKER_AGENT_TUI_TOKEN.trim() }
+        : {}),
+    };
+  }
+
+  const apiKey = parsed.AI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new WorkerAgentTuiConfigError(
+      "AI_API_KEY is required for local TUI mode. Set WORKER_AGENT_TUI_ENDPOINT or pass --remote for remote mode."
+    );
+  }
+
+  return {
+    channel,
+    directory:
+      parsed.WORKER_AGENT_TUI_DIR?.trim() ||
+      join(homedir(), ".pss-next", "worker-agent-tui"),
+    env: {
+      AI_API_KEY: apiKey,
+      ENVIRONMENT: "development",
+      ...(parsed.AI_BASE_URL?.trim()
+        ? { AI_BASE_URL: parsed.AI_BASE_URL.trim() }
+        : {}),
+      ...(parsed.AI_MODEL?.trim() ? { AI_MODEL: parsed.AI_MODEL.trim() } : {}),
+    },
+    mode: "local",
+  };
+}
+
+export async function startWorkerAgentTui(
+  options: StartWorkerAgentTuiOptions = {}
+): Promise<void> {
+  const config = options.config ?? resolveWorkerAgentTuiConfig();
+  const output =
+    options.output ??
+    ({
+      writeLine: (line) => stdout.write(`${line}\n`),
+    } satisfies TuiOutput);
+
+  const input = createInterface({
+    input: stdin,
+    output: stdout,
+    terminal: true,
+  });
+  let inputClosed = false;
+  input.once("close", () => {
+    inputClosed = true;
+  });
+  const close = await configureTuiTurnDelivery(config, output, options.host);
+
+  output.writeLine("pss worker-agent TUI. Type /exit to quit.");
+  input.setPrompt("> ");
+  input.prompt();
+
+  for await (const line of input) {
+    const text = line.trim();
+    if (text === "/exit" || text === "/quit") {
+      break;
+    }
+
+    if (isTuiInspectCommand(text)) {
+      if (close.inspect) {
+        await deliverTuiInspect({
+          defaultKey: channelKey(config.channel),
+          inspect: close.inspect,
+          output,
+          text,
+        });
+      } else {
+        output.writeLine("inspect is only available in local TUI mode.");
+      }
+      if (!inputClosed) {
+        input.prompt();
+      }
+      continue;
+    }
+
+    await close.deliver(text);
+    if (!inputClosed) {
+      input.prompt();
+    }
+  }
+
+  if (!inputClosed) {
+    input.close();
+  }
+  await close.dispose();
+}
+
+async function configureTuiTurnDelivery(
+  config: WorkerAgentTuiConfig,
+  output: TuiOutput,
+  hostOverride?: AgentHost
+): Promise<{
+  readonly deliver: (text: string) => Promise<WorkerAgentDeliveryResponse>;
+  readonly dispose: () => Promise<void>;
+  readonly inspect?: (key: string) => Promise<ThreadInspection>;
+}> {
+  switch (config.mode) {
+    case "local": {
+      await mkdir(config.directory, { recursive: true });
+      const host =
+        hostOverride ??
+        createNodeFileThreadHost({ directory: config.directory });
+      const agent = createConfiguredAgent(config.env, host, {
+        sendMessage: {
+          channel: () => config.channel,
+          sink: createTuiMessageSink(output),
+        },
+      });
+      const thread = agent.thread(channelKey(config.channel));
+      return {
+        deliver: (text) =>
+          deliverTuiTurn({
+            output,
+            text,
+            thread,
+          }),
+        dispose: () => thread.dispose(),
+        inspect: (key) => agent.inspectThread(key),
+      };
+    }
+    case "remote": {
+      const client = createRemoteTuiDeliveryClient(config);
+      return {
+        deliver: (text) =>
+          deliverRemoteTuiTurn({
+            client,
+            output,
+            text,
+          }),
+        dispose: () => Promise.resolve(),
+        inspect: (key) => client.inspect(key),
+      };
+    }
+    default:
+      return assertNever(config);
+  }
+}
+
+function readRemoteEndpoint(
+  environmentValue: string | undefined,
+  args: readonly string[]
+): string | undefined {
+  const flagValue = args.find((arg) => arg.startsWith("--remote="));
+  if (flagValue) {
+    return flagValue.slice("--remote=".length).trim();
+  }
+
+  const remoteFlagIndex = args.indexOf("--remote");
+  const remoteArgValue =
+    remoteFlagIndex >= 0 ? args[remoteFlagIndex + 1]?.trim() : undefined;
+  return remoteArgValue || environmentValue?.trim();
+}
+
+function isMainModule(moduleUrl: string, argvPath = argv[1]): boolean {
+  return (
+    argvPath !== undefined &&
+    moduleUrl === pathToFileURL(resolve(argvPath)).href
+  );
+}
+
+if (isMainModule(import.meta.url)) {
+  await startWorkerAgentTui();
+}
+
+function assertNever(value: never): never {
+  throw new WorkerAgentTuiConfigError(
+    `Unexpected TUI config variant: ${String(value)}`
+  );
+}
+
+export class WorkerAgentTuiConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerAgentTuiConfigError";
+  }
+}

--- a/apps/worker-agent/tsconfig.json
+++ b/apps/worker-agent/tsconfig.json
@@ -8,6 +8,9 @@
       "@minpeter/pss-runtime/cloudflare": [
         "../../packages/runtime/src/platform/cloudflare/index.ts"
       ],
+      "@minpeter/pss-runtime/node": [
+        "../../packages/runtime/src/platform/node/index.ts"
+      ],
       "chat": ["./node_modules/chat"],
       "chat/*": ["./node_modules/chat/*"]
     }

--- a/apps/worker-agent/vitest.config.ts
+++ b/apps/worker-agent/vitest.config.ts
@@ -19,6 +19,20 @@ export default defineConfig({
           "../../packages/runtime/src/index.ts"
         ),
       },
+      {
+        find: /^@minpeter\/pss-runtime\/node$/,
+        replacement: resolve(
+          import.meta.dirname,
+          "../../packages/runtime/src/platform/node/index.ts"
+        ),
+      },
+      {
+        find: /^cloudflare:workers$/,
+        replacement: resolve(
+          import.meta.dirname,
+          "src/cloudflare-workers-test-shim.ts"
+        ),
+      },
     ],
     conditions: ["@minpeter/pss-source", "import", "module", "default"],
   },

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -21,6 +21,10 @@ import {
   type ThreadHandle,
   type ThreadKey,
 } from "./thread-entry";
+import {
+  inspectStoredThread,
+  type ThreadInspection,
+} from "./thread-inspection";
 
 export type { AgentHost } from "../../execution/host/types";
 export type { ThreadCompactionInput } from "../../thread/handle/thread";
@@ -31,6 +35,10 @@ export type {
   ThreadKey,
   ThreadMetadata,
 } from "./thread-entry";
+export type {
+  ThreadInspection,
+  ThreadInspectionCompaction,
+} from "./thread-inspection";
 
 export class Agent {
   readonly #modelOptions: AgentModelOptions;
@@ -112,6 +120,13 @@ export class Agent {
     return this.#threadEntry(normalizeThreadKey(thread)).publicHandle;
   }
 
+  inspectThread(thread: ThreadKey): Promise<ThreadInspection> {
+    return inspectStoredThread({
+      key: normalizeThreadKey(thread),
+      store: this.#store,
+    });
+  }
+
   #threadEntry(key: string): AgentThreadEntry {
     const existing = this.#threads.get(key);
     if (existing) {
@@ -140,6 +155,7 @@ export class Agent {
         this.#evictThreadHandle(key);
         return Promise.resolve();
       },
+      inspect: () => inspectStoredThread({ key, store: this.#store }),
       interrupt: () => thread.interrupt(),
       overlay: (input) => {
         thread.overlay(input);

--- a/packages/runtime/src/agent/core/thread-entry.ts
+++ b/packages/runtime/src/agent/core/thread-entry.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../thread/handle/thread";
 import type { AgentTurn } from "../../thread/protocol/turn";
 import { namespacePart } from "../identity/namespace";
+import type { ThreadInspection } from "./thread-inspection";
 
 export interface ThreadMetadata {
   readonly [key: string]: unknown;
@@ -23,6 +24,7 @@ export interface ThreadHandle {
   compact(input: ThreadCompactionInput): Promise<void>;
   delete(): Promise<void>;
   dispose(): Promise<void>;
+  inspect(): Promise<ThreadInspection>;
   interrupt(): void;
   overlay(input: AgentInput): ThreadHandle;
   send(input: AgentInput): Promise<AgentTurn>;

--- a/packages/runtime/src/agent/core/thread-inspection.test.ts
+++ b/packages/runtime/src/agent/core/thread-inspection.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { ThreadInspection, ThreadInspectionCompaction } from "../../index";
+import {
+  createMockLanguageModelV4,
+  mockLanguageModelV4Text,
+} from "../../testing/mock-language-model-v4-test-utils";
+import { assistantMessage } from "../../testing/test-fixtures";
+import { SpyStore } from "../../thread/handle/test-support";
+import { encodeThreadSnapshot } from "../../thread/state/snapshot";
+import { Agent } from "./agent";
+import type { ThreadHandle } from "./thread-entry";
+
+const fakeModel = createMockLanguageModelV4([mockLanguageModelV4Text("DONE")]);
+
+describe("thread inspection", () => {
+  it("inspects another known thread key without mutating thread state", async () => {
+    const threadStore = new SpyStore();
+    const summary = assistantMessage("older context summary");
+    const summaryBytes = new TextEncoder().encode(
+      JSON.stringify(summary)
+    ).byteLength;
+    threadStore.threads.set("room:42", {
+      state: encodeThreadSnapshot(
+        [
+          { content: "first", role: "user" },
+          { content: "second", role: "assistant" },
+          { content: "third", role: "user" },
+        ],
+        [
+          {
+            endSeqExclusive: 2,
+            schemaVersion: 1,
+            startSeq: 0,
+            summary,
+          },
+        ]
+      ),
+      version: "7",
+    });
+    const agent = new Agent({
+      host: { kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    await expect(agent.inspectThread("room:42")).resolves.toEqual({
+      compactionCount: 1,
+      compactions: [
+        {
+          endSeqExclusive: 2,
+          startSeq: 0,
+          summaryBytes,
+        },
+      ],
+      exists: true,
+      messageCount: 3,
+      summaryBytes,
+      threadKey: "room:42",
+      version: "7",
+    });
+    expect(threadStore.commits).toEqual([]);
+  });
+
+  it("inspects a thread handle by its canonical scoped key", async () => {
+    const threadStore = new SpyStore();
+    const agent = new Agent({
+      host: { kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    await expect(
+      agent.thread({ key: "room/1", scope: "user:1" }).inspect()
+    ).resolves.toEqual({
+      compactionCount: 0,
+      compactions: [],
+      exists: false,
+      messageCount: 0,
+      summaryBytes: 0,
+      threadKey: "scope:user%3A1:thread:room%2F1",
+      version: null,
+    });
+  });
+
+  it("exports inspect result types from the package root", () => {
+    expectTypeOf<
+      Awaited<ReturnType<ThreadHandle["inspect"]>>
+    >().toEqualTypeOf<ThreadInspection>();
+    expectTypeOf<
+      Awaited<ReturnType<Agent["inspectThread"]>>
+    >().toEqualTypeOf<ThreadInspection>();
+    expectTypeOf<
+      ThreadInspection["compactions"][number]
+    >().toEqualTypeOf<ThreadInspectionCompaction>();
+  });
+});

--- a/packages/runtime/src/agent/core/thread-inspection.ts
+++ b/packages/runtime/src/agent/core/thread-inspection.ts
@@ -1,0 +1,66 @@
+import type { ThreadCompactionRecord } from "../../thread/state/snapshot";
+import { decodeStoredThreadState } from "../../thread/state/snapshot";
+import type { ThreadStore } from "../../thread/store/types";
+
+export interface ThreadInspectionCompaction {
+  readonly endSeqExclusive: number;
+  readonly startSeq: number;
+  readonly summaryBytes: number;
+}
+
+export interface ThreadInspection {
+  readonly compactionCount: number;
+  readonly compactions: readonly ThreadInspectionCompaction[];
+  readonly exists: boolean;
+  readonly messageCount: number;
+  readonly summaryBytes: number;
+  readonly threadKey: string;
+  readonly version: string | null;
+}
+
+export interface ThreadInspectionOptions {
+  readonly key: string;
+  readonly store: ThreadStore;
+}
+
+export async function inspectStoredThread({
+  key,
+  store,
+}: ThreadInspectionOptions): Promise<ThreadInspection> {
+  const stored = await store.load(key);
+  const state = decodeStoredThreadState(stored);
+  const compactions = state.compactions.map(threadCompactionInspection);
+  const summaryBytes = compactions.reduce(
+    (total, record) => total + record.summaryBytes,
+    0
+  );
+
+  return {
+    compactionCount: compactions.length,
+    compactions,
+    exists: stored !== null,
+    messageCount: state.history.length,
+    summaryBytes,
+    threadKey: key,
+    version: stored?.version ?? null,
+  };
+}
+
+function threadCompactionInspection(
+  record: ThreadCompactionRecord
+): ThreadInspectionCompaction {
+  return {
+    endSeqExclusive: record.endSeqExclusive,
+    startSeq: record.startSeq,
+    summaryBytes: jsonByteLength(record.summary),
+  };
+}
+
+function jsonByteLength(value: unknown): number {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) {
+    throw new Error("Thread compaction summary could not be encoded");
+  }
+
+  return new TextEncoder().encode(encoded).byteLength;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5,6 +5,8 @@ export {
   type ThreadAddress,
   type ThreadCompactionInput,
   type ThreadHandle,
+  type ThreadInspection,
+  type ThreadInspectionCompaction,
   type ThreadKey,
   type ThreadMetadata,
 } from "./agent/core/agent";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,12 @@ importers:
       '@minpeter/pss-runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
+      '@trpc/client':
+        specifier: 11.18.0
+        version: 11.18.0(@trpc/server@11.18.0(typescript@6.0.3))(typescript@6.0.3)
+      '@trpc/server':
+        specifier: 11.18.0
+        version: 11.18.0(typescript@6.0.3)
       chat:
         specifier: 4.30.0
         version: 4.30.0(ai@6.0.198(zod@4.4.3))(zod@4.4.3)
@@ -1360,6 +1366,19 @@ packages:
         optional: true
       zod:
         optional: true
+
+  '@trpc/client@11.18.0':
+    resolution: {integrity: sha512-wOqeg3Fvl25V1ZisQhUD3K8G60ZJDlSGJNSyeXrLH24xAo5w6GSR2Kzb1cSNY9Y+IQ2YZvYGZstBU+V/ulo/ow==}
+    hasBin: true
+    peerDependencies:
+      '@trpc/server': 11.18.0
+      typescript: '>=5.7.2'
+
+  '@trpc/server@11.18.0':
+    resolution: {integrity: sha512-JAvXOuNTxgXjIDfQaOvDq1j66LMNfDJUH1IU7Slfn8EvRv2EkH6ehu3A7zpYhjO0syHHiYg77v2lG2JFJgvw7Q==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.7.2'
 
   '@turbo/darwin-64@2.9.18':
     resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
@@ -4393,6 +4412,15 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
       zod: 4.4.3
+
+  '@trpc/client@11.18.0(@trpc/server@11.18.0(typescript@6.0.3))(typescript@6.0.3)':
+    dependencies:
+      '@trpc/server': 11.18.0(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@trpc/server@11.18.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@turbo/darwin-64@2.9.18':
     optional: true


### PR DESCRIPTION
## What

Refactor the worker-agent conversation boundary around a single `channelKey(channel)` abstraction and add read-only runtime thread inspection that can look up a session by a known key.

### Channel abstraction
- `channelKey(channel)` maps a channel address to a conversation key:
  - `channelKey({ kind: "telegram", id: "123" })` -> `telegram:123`
  - `channelKey({ kind: "tui", id: "local" })` -> `tui:local`
- Cloudflare Durable Object routing now uses `durableObjectName(channelKey(channel))`.
- DO-internal runtime thread stays `"default"` (each DO already represents one conversation).

### Runtime thread inspection (known-key, read-only)
- `Agent.inspectThread(threadKey)` and `ThreadHandle.inspect()` return a `ThreadInspection` snapshot (existence, version, message count, compaction stats) without instantiating or mutating thread state.
- Exports `ThreadInspection` / `ThreadInspectionCompaction` types from the package root.

### TUI `/inspect`
- `/inspect` inspects the current TUI channel.
- `/inspect telegram:123` / `/inspect tui:local` inspect any conversation key.
- Local mode calls `agent.inspectThread(key)`; remote mode goes through tRPC `tui.inspect` and routes to the target DO.

## Scope notes
- This is **known-key inspection only**, not global session discovery/listing. No `listThreads()` API was added.
- `.changeset/pre.json` was intentionally left out of this PR (unrelated prerelease metadata churn).

## Verification
```
pnpm lint
pnpm typecheck
pnpm test
pnpm build
pnpm verify:release
pnpm boundaries
git diff --check
```
All passed. runtime: 362 tests, worker-agent: 72 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies conversation routing around a single `channelKey(channel)` and adds read-only runtime thread inspection by known key. Also introduces a TUI `/inspect` command with local and remote (tRPC) support and tool-based delivery for Telegram/TUI.

- **New Features**
  - `channelKey(channel)` maps channels to conversation keys (e.g. `telegram:123`, `tui:local`); Durable Object routing now uses `durableObjectName(channelKey(channel))`.
  - Read-only inspection: `Agent.inspectThread(key)` and `ThreadHandle.inspect()` return a `ThreadInspection` snapshot (existence, version, message count, compaction stats). Types exported from `@minpeter/pss-runtime`.
  - TUI `/inspect` command:
    - Local: inspects the current TUI channel or a provided key.
    - Remote: `/trpc` endpoint with bearer auth; `createRemoteTuiDeliveryClient` added.
  - Tool-driven delivery: `send_message` tool with sinks for Telegram and TUI; TUI shows assistant/tool debug lines. Observability plugin logs non-sensitive turn events.
  - Auto compaction defaults set for the worker agent; added `tui` CLI for local dev.

- **Refactors**
  - Worker DOs represent a single conversation; the internal runtime thread stays `"default"`.
  - Telegram webhook flow delivers via `send_message`; no assistant-output fallback after delivery. Standardized error for missing tool delivery and recovery prompt.
  - Added `@trpc/client` and `@trpc/server` dependencies; new env `WORKER_AGENT_TUI_TOKEN`. Extensive tests across DOs, sinks, TUI, observability, and inspection.

<sup>Written for commit e959d20ae081101d4b812298eeebbddf8c5c4dd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

