### PR TITLE
fix(ci): restore aged Cloudflare workers types

### DIFF
--- a/apps/worker-agent/package.json
+++ b/apps/worker-agent/package.json
@@ -35,7 +35,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^5.20260704.1",
+    "@cloudflare/workers-types": "^4.20260628.1",
     "@types/node": "^26.0.1",
     "npm-run-all": "^4.1.5",
     "tsx": "^4.22.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^5.20260704.1
-        version: 5.20260704.1
+        specifier: ^4.20260628.1
+        version: 4.20260628.1
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
@@ -136,7 +136,7 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.105.0
-        version: 4.105.0(@cloudflare/workers-types@5.20260704.1)
+        version: 4.105.0(@cloudflare/workers-types@4.20260628.1)
 
   examples/background-subagent:
     dependencies:
@@ -308,7 +308,7 @@ importers:
     devDependencies:
       agents:
         specifier: 0.17.1
-        version: 0.17.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260704.1)(ai@7.0.14(zod@4.4.3))(chat@4.31.0(ai@7.0.14(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(zod@4.4.3)
+        version: 0.17.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@4.20260628.1)(ai@7.0.14(zod@4.4.3))(chat@4.31.0(ai@7.0.14(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(zod@4.4.3)
       tsdown:
         specifier: ^0.22.3
         version: 0.22.3(tsx@4.22.4)(typescript@6.0.3)
@@ -691,8 +691,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@5.20260704.1':
-    resolution: {integrity: sha512-3yhiCWzlWjkwtvZCTrvppLTSTEY+HkaBHJ9EXOEbuA4WQduCbZxgbCnVq/AWyojHrvhYXtKpqWdHA3UIIX3POQ==}
+  '@cloudflare/workers-types@4.20260628.1':
+    resolution: {integrity: sha512-fMy5zBnNl/PxGqDzSOQb1TdqyR1sRT1Z7T4F8/cqtxpZ1w8VkejWi0qUH7GZE0I2gJyapdP0oW4pNZfxUbekmw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4168,7 +4168,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260625.1':
     optional: true
 
-  '@cloudflare/workers-types@5.20260704.1': {}
+  '@cloudflare/workers-types@4.20260628.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4770,7 +4770,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agents@0.17.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260704.1)(ai@7.0.14(zod@4.4.3))(chat@4.31.0(ai@7.0.14(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(zod@4.4.3):
+  agents@0.17.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@4.20260628.1)(ai@7.0.14(zod@4.4.3))(chat@4.31.0(ai@7.0.14(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(zod@4.4.3):
     dependencies:
       '@babel/plugin-proposal-decorators': 8.0.2(@babel/core@8.0.1)
       '@cfworker/json-schema': 4.1.1
@@ -4781,7 +4781,7 @@ snapshots:
       esbuild: 0.28.1
       mimetext: 3.0.28
       nanoid: 5.1.16
-      partyserver: 0.5.8(@cloudflare/workers-types@5.20260704.1)
+      partyserver: 0.5.8(@cloudflare/workers-types@4.20260628.1)
       partysocket: 1.3.0(react@19.2.7)
       react: 19.2.7
       yaml: 2.9.0
@@ -6372,9 +6372,9 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  partyserver@0.5.8(@cloudflare/workers-types@5.20260704.1):
+  partyserver@0.5.8(@cloudflare/workers-types@4.20260628.1):
     dependencies:
-      '@cloudflare/workers-types': 5.20260704.1
+      '@cloudflare/workers-types': 4.20260628.1
       nanoid: 5.1.16
 
   partysocket@1.3.0(react@19.2.7):
@@ -7202,7 +7202,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260625.1
       '@cloudflare/workerd-windows-64': 1.20260625.1
 
-  wrangler@4.105.0(@cloudflare/workers-types@5.20260704.1):
+  wrangler@4.105.0(@cloudflare/workers-types@4.20260628.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260625.1)
@@ -7213,7 +7213,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260625.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260704.1
+      '@cloudflare/workers-types': 4.20260628.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## Summary
- revert the fresh @cloudflare/workers-types bump from PR #152
- restore the lockfile peer resolutions back to 4.20260628.1 so pnpm minimum release age policy passes

## Verification
- pnpm install --frozen-lockfile
- pnpm boundaries
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm verify:release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted `@cloudflare/workers-types` to 4.20260628.1 to meet pnpm’s minimum release age policy and unblock CI. Updated the lockfile so `wrangler`, `agents`, and `partyserver` resolve against the aged types.

<sup>Written for commit b7bc5aa0c042c0a0d10963975c594e1354c54476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

