### PR TITLE
Lower RFC0001 runtime changeset to patch

### DIFF
--- a/.changeset/rfc0001-durable-input-inbox.md
+++ b/.changeset/rfc0001-durable-input-inbox.md
@@ -1,5 +1,5 @@
 ---
-"@minpeter/pss-runtime": minor
+"@minpeter/pss-runtime": patch
 ---
 
 Add a durable `ThreadInputInbox` execution-store port with memory, file, and Cloudflare storage implementations, and wire runtime send/steer admission through durable input claim, promote, ack, release, recovery, and context-overflow compaction boundaries.


### PR DESCRIPTION
## Summary\n- lower the RFC0001 runtime changeset from minor to patch\n\n## Verification\n- pnpm changeset status --since origin/main\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the RFC0001 changeset for `@minpeter/pss-runtime` from minor to patch. This sets the next release to a patch and reflects no public API or code changes.

<sup>Written for commit d11de3fa97f02621df19f8c0470651609b8dd6ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

