### PR TITLE
[codex] Runtime-owned multimodal attachment refs

### DIFF
--- a/.changeset/runtime-owned-attachments.md
+++ b/.changeset/runtime-owned-attachments.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Add runtime-owned attachment staging, durable attachment refs, and provider-time hydration for multimodal file inputs.

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -59,6 +59,7 @@ export class Agent {
       options.autoCompaction
     );
     this.#modelOptions = {
+      attachmentStore: options.attachmentStore ?? this.#host.attachmentStore,
       instructions: options.instructions,
       model: options.model,
       toolChoice: options.toolChoice,

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -1,6 +1,7 @@
 import type { LanguageModel, ToolSet } from "ai";
 import type { AgentHost } from "../../execution/host/types";
 import type { AgentToolChoice } from "../../llm/llm";
+import type { RuntimeAttachmentStore } from "../../thread/input/attachments";
 import type { AgentInput, UserInput } from "../../thread/input/input";
 import type { AgentPlugin } from "../../thread/plugins/pipeline";
 
@@ -10,6 +11,7 @@ export interface AgentAutoCompactionOptions {
 }
 
 export interface AgentOptions {
+  readonly attachmentStore?: RuntimeAttachmentStore;
   readonly autoCompaction?: AgentAutoCompactionOptions | false;
   readonly host?: AgentHost;
   readonly instructions?: string;
@@ -23,7 +25,7 @@ export interface AgentOptions {
 
 export type AgentModelOptions = Pick<
   AgentOptions,
-  "instructions" | "model" | "toolChoice" | "tools"
+  "attachmentStore" | "instructions" | "model" | "toolChoice" | "tools"
 >;
 
 export function assertAgentOptions(

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -18,6 +18,7 @@ import type {
   AgentHost,
   AgentInput,
   AgentOptions,
+  RuntimeAttachmentStore,
   ThreadCompactionInput,
   ThreadHandle,
 } from "../index";
@@ -100,7 +101,9 @@ describe("runtime public exports", () => {
       retainMessages: 4,
     } satisfies AgentAutoCompactionOptions;
     const model = {} as AgentOptions["model"];
+    const attachmentStore = {} as RuntimeAttachmentStore;
     const enabledOptions = {
+      attachmentStore,
       autoCompaction,
       model,
       notificationOverlays: ["runtime context"],
@@ -129,6 +132,7 @@ describe("runtime public exports", () => {
       ReturnType<typeof runtimeThreadStoreKey>
     >().toEqualTypeOf<string>();
     expect(enabledOptions.autoCompaction).toEqual(autoCompaction);
+    expect(enabledOptions.attachmentStore).toBe(attachmentStore);
     expect(enabledOptions.notificationOverlays).toEqual(["runtime context"]);
     expect(disabledOptions.autoCompaction).toBe(false);
     expect(compaction.startSeq).toBe(0);
@@ -161,6 +165,7 @@ describe("runtime public exports", () => {
       ExecutionStoreTransaction["notifications"]
     >().toEqualTypeOf<NotificationInbox>();
     const threadHost = {
+      attachmentStore: {} as RuntimeAttachmentStore,
       kind: "thread",
       threadStore: {} as ThreadHost["threadStore"],
     } satisfies ThreadHost;
@@ -182,6 +187,15 @@ describe("runtime public exports", () => {
     >().toEqualTypeOf<ExecutionScheduler>();
     expectTypeOf<DurableBackgroundHost["transaction"]>().toEqualTypeOf<
       ExecutionStore["transaction"]
+    >();
+    expectTypeOf<ThreadHost["attachmentStore"]>().toEqualTypeOf<
+      RuntimeAttachmentStore | undefined
+    >();
+    expectTypeOf<ExecutionHost["attachmentStore"]>().toEqualTypeOf<
+      RuntimeAttachmentStore | undefined
+    >();
+    expectTypeOf<DurableBackgroundHost["attachmentStore"]>().toEqualTypeOf<
+      RuntimeAttachmentStore | undefined
     >();
     expect(agentHost.kind).toBe("thread");
   });

--- a/packages/runtime/src/contracts/root-host-api.test.ts
+++ b/packages/runtime/src/contracts/root-host-api.test.ts
@@ -13,7 +13,7 @@ import type {
   TurnRecord,
   TurnStore,
 } from "../execution";
-import type { AgentHost } from "../index";
+import type { AgentHost, RuntimeAttachmentStore } from "../index";
 
 describe("runtime host public contracts", () => {
   it("types advanced host contracts", () => {
@@ -25,6 +25,9 @@ describe("runtime host public contracts", () => {
       ExecutionStore["notifications"]
     >().toEqualTypeOf<NotificationInbox>();
     expectTypeOf<ExecutionHost["kind"]>().toEqualTypeOf<"execution">();
+    expectTypeOf<ExecutionHost["attachmentStore"]>().toEqualTypeOf<
+      RuntimeAttachmentStore | undefined
+    >();
     expectTypeOf<ExecutionStore["turns"]>().toEqualTypeOf<TurnStore>();
     expectTypeOf<
       ExecutionStore["checkpoints"]
@@ -43,10 +46,14 @@ describe("runtime host public contracts", () => {
       ExecutionStoreTransaction["notifications"]
     >().toEqualTypeOf<NotificationInbox>();
     const threadHost = {
+      attachmentStore: {} as RuntimeAttachmentStore,
       kind: "thread",
       threadStore: {} as ThreadHost["threadStore"],
     } satisfies ThreadHost;
     const agentHost = threadHost satisfies AgentHost;
+    expectTypeOf<ThreadHost["attachmentStore"]>().toEqualTypeOf<
+      RuntimeAttachmentStore | undefined
+    >();
     expectTypeOf<
       DurableBackgroundHost["turnStore"]
     >().toEqualTypeOf<TurnStore>();
@@ -64,6 +71,9 @@ describe("runtime host public contracts", () => {
     >().toEqualTypeOf<ExecutionScheduler>();
     expectTypeOf<DurableBackgroundHost["transaction"]>().toEqualTypeOf<
       ExecutionStore["transaction"]
+    >();
+    expectTypeOf<DurableBackgroundHost["attachmentStore"]>().toEqualTypeOf<
+      RuntimeAttachmentStore | undefined
     >();
     expect(agentHost.kind).toBe("thread");
   });

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { agentNamespace } from "../../agent/identity/namespace";
 import { createInMemoryExecutionHost } from "../../platform/memory";
+import { isRuntimeAttachmentData } from "../../thread/input/attachments";
 import type { ExecutionHost, TurnRecord, TurnStore } from "../host/types";
 import { dispatchAgentNotification } from "./notification-dispatch";
 
@@ -85,6 +86,87 @@ describe("dispatchAgentNotification", () => {
       ownerNamespace: agentNamespace("agent-b"),
       threadKey: "room:1:user:2",
     });
+  });
+
+  it("stages notification file bytes before durable enqueue", async () => {
+    const host = createInMemoryExecutionHost();
+    const dispatched = await dispatchAgentNotification({
+      host,
+      idempotencyKey: "attachment:1",
+      input: {
+        content: [
+          { text: "look", type: "text" },
+          {
+            data: new Uint8Array([1, 2, 3]),
+            filename: "photo.png",
+            mediaType: "image/png",
+            type: "file",
+          },
+        ],
+        type: "user-input",
+      },
+      namespace: "agent-a",
+      threadKey: "room:1:user:2",
+    });
+
+    const run = await host.store.turns.get(dispatched.runId);
+    const notification = await host.store.notifications.getByIdempotencyKey(
+      run?.dedupeKey ?? ""
+    );
+
+    expect(JSON.stringify(notification)).toContain("pss-attachment:");
+    expect(JSON.stringify(notification)).not.toContain('"0":1');
+    if (!(notification && "content" in notification.input)) {
+      throw new Error("expected multipart notification input");
+    }
+    const filePart = notification.input.content[1];
+    expect(filePart?.type).toBe("file");
+    if (filePart?.type !== "file") {
+      throw new Error("expected staged file part");
+    }
+    expect(isRuntimeAttachmentData(filePart.data)).toBe(true);
+  });
+
+  it("stages notification observer event file bytes before durable enqueue", async () => {
+    const host = createInMemoryExecutionHost();
+    const dispatched = await dispatchAgentNotification({
+      host,
+      idempotencyKey: "attachment-observer:1",
+      input: { text: "wake", type: "user-input" },
+      namespace: "agent-a",
+      observerEvents: [
+        {
+          content: [
+            {
+              data: new Uint8Array([7, 8, 9]),
+              filename: "context.png",
+              mediaType: "image/png",
+              type: "file",
+            },
+          ],
+          type: "user-input",
+        },
+      ],
+      threadKey: "room:1:user:2",
+    });
+
+    const run = await host.store.turns.get(dispatched.runId);
+    const notification = await host.store.notifications.getByIdempotencyKey(
+      run?.dedupeKey ?? ""
+    );
+
+    expect(JSON.stringify(notification)).toContain("pss-attachment:");
+    expect(JSON.stringify(notification)).not.toContain('"0":7');
+    const observerEvent = notification?.observerEvents?.[0];
+    if (observerEvent?.type !== "user-input" || !("content" in observerEvent)) {
+      throw new Error("expected staged multipart observer event");
+    }
+    const filePart = observerEvent.content[0];
+    expect(filePart?.type).toBe("file");
+    if (filePart?.type !== "file") {
+      throw new Error("expected staged observer file part");
+    }
+    expect(isRuntimeAttachmentData(filePart.data)).toBe(true);
   });
 
   it("returns the existing notification when run dedupe wins a create race", async () => {

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.ts
@@ -1,4 +1,8 @@
 import { agentNamespace } from "../../agent/identity/namespace";
+import {
+  stageAgentEventsAttachments,
+  stageUserInputAttachments,
+} from "../../thread/input/attachments";
 import type { AgentEvent, UserInput } from "../../thread/protocol/events";
 import type {
   ExecutionHost,
@@ -58,6 +62,18 @@ export async function dispatchAgentNotification(
 
   const runId = crypto.randomUUID();
   const notificationId = crypto.randomUUID();
+  const stagedInput = await stageUserInputAttachments(
+    input.input,
+    input.host.attachmentStore
+  );
+  const stagedOverlays = await stageUserInputs(
+    input.overlays,
+    input.host.attachmentStore
+  );
+  const stagedObserverEvents = await stageAgentEventsAttachments(
+    input.observerEvents ?? [],
+    input.host.attachmentStore
+  );
   const runRecord = {
     checkpointVersion: 0,
     dedupeKey: storageIdempotencyKey,
@@ -70,10 +86,10 @@ export async function dispatchAgentNotification(
   } satisfies TurnRecord;
   const notificationRecord = {
     idempotencyKey: storageIdempotencyKey,
-    input: input.input,
+    input: stagedInput,
     notificationId,
-    observerEvents: input.observerEvents,
-    overlays: input.overlays,
+    observerEvents: stagedObserverEvents,
+    overlays: stagedOverlays,
     ownerNamespace,
     runId,
     threadKey: input.threadKey,
@@ -118,6 +134,21 @@ export async function dispatchAgentNotification(
   } satisfies SchedulableAgentNotification;
   await scheduleAgentNotification(input.host, created);
   return dispatchedAgentNotification(created);
+}
+
+async function stageUserInputs(
+  inputs: readonly UserInput[] | undefined,
+  attachmentStore: Parameters<typeof stageUserInputAttachments>[1]
+): Promise<readonly UserInput[] | undefined> {
+  if (!inputs) {
+    return;
+  }
+
+  const staged: UserInput[] = [];
+  for (const input of inputs) {
+    staged.push(await stageUserInputAttachments(input, attachmentStore));
+  }
+  return staged;
 }
 
 async function queuedNotificationRun({

--- a/packages/runtime/src/execution/host/capabilities.ts
+++ b/packages/runtime/src/execution/host/capabilities.ts
@@ -1,3 +1,4 @@
+import type { RuntimeAttachmentStore } from "../../thread/input/attachments";
 import type { ThreadStore } from "../../thread/store/types";
 import type {
   CheckpointStore,
@@ -9,6 +10,7 @@ import type {
 } from "./types";
 
 export interface ThreadHost {
+  readonly attachmentStore?: RuntimeAttachmentStore;
   readonly kind: "thread";
   readonly threadStore: ThreadStore;
 }
@@ -47,5 +49,6 @@ export type DurableBackgroundHost = BackgroundSchedulerHost &
   NotificationHost &
   CheckpointHost &
   ThreadStoreHost & {
+    readonly attachmentStore?: RuntimeAttachmentStore;
     readonly kind: "durable-background";
   } & TurnHost;

--- a/packages/runtime/src/execution/host/host.ts
+++ b/packages/runtime/src/execution/host/host.ts
@@ -9,9 +9,14 @@ export function threadHost(host: AgentHost): ThreadHost {
     case "thread":
       return host;
     case "durable-background":
-      return { kind: "thread", threadStore: host.threadStore };
+      return {
+        attachmentStore: host.attachmentStore,
+        kind: "thread",
+        threadStore: host.threadStore,
+      };
     case "execution":
       return {
+        attachmentStore: host.attachmentStore,
         kind: "thread",
         threadStore: threadStoreFromExecutionStore(host.store),
       };
@@ -50,6 +55,7 @@ function durableBackgroundHostFromExecutionHost(
   host: ExecutionHost
 ): DurableBackgroundHost {
   return {
+    attachmentStore: host.attachmentStore,
     backgroundScheduler: host.scheduler,
     checkpointStore: host.store.checkpoints,
     eventStore: host.store.events,
@@ -66,6 +72,7 @@ function executionHostFromDurableBackgroundHost(
 ): ExecutionHost {
   const threadStore = host.threadStore;
   return {
+    attachmentStore: host.attachmentStore,
     kind: "execution",
     scheduler: host.backgroundScheduler,
     store: {

--- a/packages/runtime/src/execution/host/types.ts
+++ b/packages/runtime/src/execution/host/types.ts
@@ -1,3 +1,4 @@
+import type { RuntimeAttachmentStore } from "../../thread/input/attachments";
 import type { AgentEvent, UserInput } from "../../thread/protocol/events";
 import type { ThreadStore } from "../../thread/store/types";
 import type { DurableBackgroundHost, ThreadHost } from "./capabilities";
@@ -5,6 +6,7 @@ import type { DurableBackgroundHost, ThreadHost } from "./capabilities";
 export type AgentHost = DurableBackgroundHost | ExecutionHost | ThreadHost;
 
 export interface ExecutionHost {
+  readonly attachmentStore?: RuntimeAttachmentStore;
   readonly kind: "execution";
   readonly scheduler: ExecutionScheduler;
   readonly store: ExecutionStore;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -11,6 +11,18 @@ export {
 export { threadStoreKey } from "./agent/core/thread-entry";
 export type { AgentHost } from "./execution/host/types";
 export type { AgentToolChoice } from "./llm/llm";
+export {
+  decodeRuntimeAttachmentData,
+  encodeRuntimeAttachmentData,
+  isRuntimeAttachmentData,
+  type RuntimeAttachmentBlob,
+  RuntimeAttachmentHydrationError,
+  type RuntimeAttachmentPutInput,
+  type RuntimeAttachmentReference,
+  RuntimeAttachmentSecurityError,
+  RuntimeAttachmentStagingError,
+  type RuntimeAttachmentStore,
+} from "./thread/input/attachments";
 export { delegateUserInput } from "./thread/input/delegate-input";
 export type { AgentInput, ThreadInput } from "./thread/input/input";
 export {

--- a/packages/runtime/src/llm/attachment-hydration.test.ts
+++ b/packages/runtime/src/llm/attachment-hydration.test.ts
@@ -1,0 +1,103 @@
+import type { ModelMessage } from "ai";
+import { beforeEach, describe, expect, it } from "vitest";
+import { MemoryAttachmentStore } from "../platform/memory";
+import {
+  fakeModel,
+  getGenerateTextMock,
+  loadModelStepRunner,
+} from "../testing/llm-test-utils";
+import { assistantMessage } from "../testing/test-fixtures";
+import {
+  encodeRuntimeAttachmentData,
+  RuntimeAttachmentHydrationError,
+} from "../thread/input/attachments";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("model attachment hydration", () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  it("hydrates internal attachment refs into transient file bytes before generateText", async () => {
+    const attachmentStore = new MemoryAttachmentStore();
+    const bytes = new Uint8Array([1, 3, 5, 7]);
+    const ref = await attachmentStore.put({
+      bytes,
+      filename: "photo.png",
+      mediaType: "image/png",
+    });
+    const history = userHistoryWithAttachment(encodeRuntimeAttachmentData(ref));
+    const runModelStep = await loadModelStepRunner();
+
+    await runModelStep(
+      { attachmentStore, model: fakeModel },
+      { history, signal: new AbortController().signal }
+    );
+
+    expect(generateTextMock.mock.calls.at(-1)?.[0].messages).toEqual([
+      {
+        content: [
+          { text: "describe", type: "text" },
+          {
+            data: bytes,
+            filename: "photo.png",
+            mediaType: "image/png",
+            type: "file",
+          },
+        ],
+        role: "user",
+      },
+    ]);
+    expect(history[0]?.content).toEqual([
+      { text: "describe", type: "text" },
+      {
+        data: encodeRuntimeAttachmentData(ref),
+        filename: "photo.png",
+        mediaType: "image/png",
+        type: "file",
+      },
+    ]);
+  });
+
+  it("fails before provider calls when history contains refs without an attachment store", async () => {
+    const attachmentStore = new MemoryAttachmentStore();
+    const ref = await attachmentStore.put({
+      bytes: new Uint8Array([2, 4, 6, 8]),
+      filename: "photo.png",
+      mediaType: "image/png",
+    });
+    const runModelStep = await loadModelStepRunner();
+
+    await expect(
+      runModelStep(
+        { model: fakeModel },
+        {
+          history: userHistoryWithAttachment(encodeRuntimeAttachmentData(ref)),
+          signal: new AbortController().signal,
+        }
+      )
+    ).rejects.toBeInstanceOf(RuntimeAttachmentHydrationError);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+});
+
+function userHistoryWithAttachment(data: string): ModelMessage[] {
+  return [
+    {
+      content: [
+        { text: "describe", type: "text" },
+        {
+          data,
+          filename: "photo.png",
+          mediaType: "image/png",
+          type: "file",
+        },
+      ],
+      role: "user",
+    },
+  ];
+}

--- a/packages/runtime/src/llm/llm.ts
+++ b/packages/runtime/src/llm/llm.ts
@@ -1,5 +1,9 @@
 import type { LanguageModel, ModelMessage, ToolChoice, ToolSet } from "ai";
 import { generateText } from "ai";
+import {
+  hydrateRuntimeAttachments,
+  type RuntimeAttachmentStore,
+} from "../thread/input/attachments";
 import type { RuntimeToolExecutionContext } from "./tool-execution";
 import {
   normalizeToolCallIds,
@@ -22,6 +26,7 @@ export type ModelStepOutput = Awaited<
 export type ModelStepOutputPart = ModelStepOutput[number];
 
 export interface ModelGenerationOptions {
+  attachmentStore?: RuntimeAttachmentStore;
   instructions?: string;
   model: LanguageModel;
   toolChoice?: AgentToolChoice;
@@ -35,6 +40,7 @@ export interface ModelStepOptions extends ModelGenerationOptions {
 }
 
 export async function generateModelStep({
+  attachmentStore,
   history,
   model,
   instructions,
@@ -45,10 +51,14 @@ export async function generateModelStep({
 }: ModelStepOptions): Promise<ModelStepOutput> {
   const toolCallIds = new Map<string, string>();
   const prompt = promptForModel({ history, instructions });
+  const messages = await hydrateRuntimeAttachments(
+    prompt.messages,
+    attachmentStore
+  );
   const { responseMessages } = await generateText({
     abortSignal: signal,
     instructions: prompt.instructions,
-    messages: prompt.messages,
+    messages,
     model,
     toolChoice,
     tools: normalizeToolCallIds(tools, toolCallIds, toolExecution),

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.ts
@@ -1,5 +1,6 @@
 import type { ExecutionHost, ExecutionScheduler } from "../../../execution";
 import type { ThreadStore } from "../../../index";
+import { CloudflareAttachmentStore } from "../storage/attachment-store";
 import {
   InMemoryCloudflareDurableObjectStorage as BaseInMemoryCloudflareDurableObjectStorage,
   type CloudflareDurableObjectStorage as DurableObjectStoragePort,
@@ -62,6 +63,7 @@ export function createCloudflareDurableObjectHost({
     storage,
   });
   return {
+    attachmentStore: new CloudflareAttachmentStore({ prefix, storage }),
     kind: "execution",
     scheduler,
     store: threadStore ? executionStoreWithThreads(store, threadStore) : store,

--- a/packages/runtime/src/platform/cloudflare/index.ts
+++ b/packages/runtime/src/platform/cloudflare/index.ts
@@ -157,6 +157,7 @@ export type {
   SqlStorage,
   SqlStorageCursorLike,
 } from "./sql/ports/storage-port";
+export { CloudflareAttachmentStore } from "./storage/attachment-store";
 export type {
   ResolvedStoragePayloadPolicy,
   StorageCompactionMode,

--- a/packages/runtime/src/platform/cloudflare/storage/attachment-store.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/attachment-store.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { CloudflareAttachmentStore } from "./attachment-store";
+import { InMemoryCloudflareDurableObjectStorage } from "./durable-object/durable-object-storage";
+
+describe("CloudflareAttachmentStore", () => {
+  it("stores attachment bytes outside SQLite thread rows", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage();
+    const store = new CloudflareAttachmentStore({ storage });
+
+    const ref = await store.put({
+      bytes: new Uint8Array([3, 2, 1]),
+      filename: "photo.png",
+      mediaType: "image/png",
+    });
+
+    await expect(store.get(ref)).resolves.toEqual({
+      bytes: new Uint8Array([3, 2, 1]),
+      filename: "photo.png",
+      mediaType: "image/png",
+      ref,
+    });
+  });
+});

--- a/packages/runtime/src/platform/cloudflare/storage/attachment-store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/attachment-store.ts
@@ -1,0 +1,78 @@
+import type {
+  RuntimeAttachmentBlob,
+  RuntimeAttachmentPutInput,
+  RuntimeAttachmentReference,
+  RuntimeAttachmentStore,
+} from "../../../thread/input/attachments";
+import type { CloudflareDurableObjectTransactionStorage } from "./durable-object/durable-object-storage";
+
+interface StoredCloudflareAttachment {
+  readonly bytes: Uint8Array;
+  readonly filename?: string;
+  readonly id: string;
+  readonly mediaType: string;
+  readonly sizeBytes: number;
+}
+
+export class CloudflareAttachmentStore implements RuntimeAttachmentStore {
+  readonly #prefix: string;
+  readonly #storage: CloudflareDurableObjectTransactionStorage;
+
+  constructor({
+    prefix = "pss-runtime",
+    storage,
+  }: {
+    readonly prefix?: string;
+    readonly storage: CloudflareDurableObjectTransactionStorage;
+  }) {
+    this.#prefix = prefix;
+    this.#storage = storage;
+  }
+
+  async get(
+    ref: RuntimeAttachmentReference
+  ): Promise<RuntimeAttachmentBlob | null> {
+    const stored = await this.#storage.get<StoredCloudflareAttachment>(
+      this.#key(ref.id)
+    );
+    if (!stored) {
+      return null;
+    }
+
+    return {
+      bytes: new Uint8Array(stored.bytes),
+      filename: stored.filename,
+      mediaType: stored.mediaType,
+      ref: cloudflareReference(stored),
+    };
+  }
+
+  async put(
+    input: RuntimeAttachmentPutInput
+  ): Promise<RuntimeAttachmentReference> {
+    const stored: StoredCloudflareAttachment = {
+      bytes: new Uint8Array(input.bytes),
+      filename: input.filename,
+      id: crypto.randomUUID(),
+      mediaType: input.mediaType,
+      sizeBytes: input.bytes.byteLength,
+    };
+    await this.#storage.put(this.#key(stored.id), stored);
+    return cloudflareReference(stored);
+  }
+
+  #key(id: string): string {
+    return `${this.#prefix}:attachment:${id}`;
+  }
+}
+
+function cloudflareReference(
+  stored: StoredCloudflareAttachment
+): RuntimeAttachmentReference {
+  return {
+    id: stored.id,
+    schemaVersion: 1,
+    sizeBytes: stored.sizeBytes,
+    source: "cloudflare",
+  };
+}

--- a/packages/runtime/src/platform/file/host/file-execution-host.ts
+++ b/packages/runtime/src/platform/file/host/file-execution-host.ts
@@ -1,4 +1,5 @@
 import type { ExecutionHost, ExecutionScheduler } from "../../../execution";
+import { FileAttachmentStore } from "../storage/file-attachment-store";
 import { FileExecutionStore } from "../storage/file-execution-store";
 import {
   appendScheduledNodeRun,
@@ -13,6 +14,7 @@ export function createNodeFileExecutionHost({
   directory,
 }: NodeFileExecutionHostOptions): ExecutionHost {
   return {
+    attachmentStore: new FileAttachmentStore(directory),
     kind: "execution",
     scheduler: createNodeFileScheduler({ directory }),
     store: new FileExecutionStore(directory),

--- a/packages/runtime/src/platform/file/host/file-thread-host.ts
+++ b/packages/runtime/src/platform/file/host/file-thread-host.ts
@@ -1,4 +1,5 @@
 import type { ThreadHost } from "../../../execution";
+import { FileAttachmentStore } from "../storage/file-attachment-store";
 import { FileThreadStore } from "../storage/file-thread-store";
 
 export interface NodeFileThreadHostOptions {
@@ -9,6 +10,7 @@ export function createNodeFileThreadHost({
   directory,
 }: NodeFileThreadHostOptions): ThreadHost {
   return {
+    attachmentStore: new FileAttachmentStore(directory),
     kind: "thread",
     threadStore: new FileThreadStore(directory),
   };

--- a/packages/runtime/src/platform/file/index.ts
+++ b/packages/runtime/src/platform/file/index.ts
@@ -32,6 +32,7 @@ export type {
   NodeScheduledWorkListOptions,
   NodeScheduledWorkRunContext,
 } from "./host/scheduled-work-types";
+export { FileAttachmentStore } from "./storage/file-attachment-store";
 export { FileExecutionStore } from "./storage/file-execution-store";
 export {
   inspectNodeFileThread,

--- a/packages/runtime/src/platform/file/storage/file-attachment-store.test.ts
+++ b/packages/runtime/src/platform/file/storage/file-attachment-store.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { FileAttachmentStore } from "./file-attachment-store";
+
+describe("FileAttachmentStore", () => {
+  it("persists attachment bytes separately from thread JSON", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pss-attachments-"));
+    const store = new FileAttachmentStore(directory);
+
+    const ref = await store.put({
+      bytes: new Uint8Array([4, 5, 6]),
+      filename: "photo.png",
+      mediaType: "image/png",
+    });
+
+    await expect(store.get(ref)).resolves.toEqual({
+      bytes: new Uint8Array([4, 5, 6]),
+      filename: "photo.png",
+      mediaType: "image/png",
+      ref,
+    });
+  });
+
+  it("rejects attachment refs that cannot be store-owned ids", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pss-attachments-"));
+    const store = new FileAttachmentStore(directory);
+
+    await expect(
+      store.get({
+        id: "../outside",
+        schemaVersion: 1,
+      })
+    ).rejects.toThrow("Invalid FileAttachmentStore ref id.");
+  });
+});

--- a/packages/runtime/src/platform/file/storage/file-attachment-store.ts
+++ b/packages/runtime/src/platform/file/storage/file-attachment-store.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type {
+  RuntimeAttachmentBlob,
+  RuntimeAttachmentPutInput,
+  RuntimeAttachmentReference,
+  RuntimeAttachmentStore,
+} from "../../../thread/input/attachments";
+
+interface FileAttachmentMetadata {
+  readonly filename?: string;
+  readonly id: string;
+  readonly mediaType: string;
+  readonly sizeBytes: number;
+}
+
+class FileAttachmentStoreError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FileAttachmentStoreError";
+  }
+}
+
+const attachmentIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export class FileAttachmentStore implements RuntimeAttachmentStore {
+  readonly #directory: string;
+
+  constructor(directory: string) {
+    this.#directory = join(directory, "attachments");
+  }
+
+  async get(
+    ref: RuntimeAttachmentReference
+  ): Promise<RuntimeAttachmentBlob | null> {
+    assertAttachmentId(ref.id);
+    try {
+      const metadata = parseFileAttachmentMetadata(
+        JSON.parse(await readFile(this.#metadataFile(ref.id), "utf8"))
+      );
+      if (metadata.id !== ref.id) {
+        throw new FileAttachmentStoreError(
+          "FileAttachmentStore metadata id does not match the requested ref."
+        );
+      }
+      const bytes = new Uint8Array(await readFile(this.#blobFile(ref.id)));
+      return {
+        bytes,
+        filename: metadata.filename,
+        mediaType: metadata.mediaType,
+        ref: fileReference(metadata),
+      };
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async put(
+    input: RuntimeAttachmentPutInput
+  ): Promise<RuntimeAttachmentReference> {
+    const metadata: FileAttachmentMetadata = {
+      filename: input.filename,
+      id: randomUUID(),
+      mediaType: input.mediaType,
+      sizeBytes: input.bytes.byteLength,
+    };
+    await mkdir(this.#directory, { recursive: true });
+    try {
+      await writeFile(this.#blobFile(metadata.id), input.bytes);
+      await writeFile(
+        this.#metadataFile(metadata.id),
+        `${JSON.stringify(metadata, null, 2)}\n`,
+        "utf8"
+      );
+    } catch (error) {
+      await Promise.allSettled([
+        rm(this.#blobFile(metadata.id), { force: true }),
+        rm(this.#metadataFile(metadata.id), { force: true }),
+      ]);
+      throw error;
+    }
+    return fileReference(metadata);
+  }
+
+  #blobFile(id: string): string {
+    return join(this.#directory, `${id}.bin`);
+  }
+
+  #metadataFile(id: string): string {
+    return join(this.#directory, `${id}.json`);
+  }
+}
+
+function fileReference(
+  metadata: FileAttachmentMetadata
+): RuntimeAttachmentReference {
+  return {
+    id: metadata.id,
+    schemaVersion: 1,
+    sizeBytes: metadata.sizeBytes,
+    source: "file",
+  };
+}
+
+function parseFileAttachmentMetadata(value: unknown): FileAttachmentMetadata {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    !("id" in value) ||
+    typeof value.id !== "string" ||
+    !("mediaType" in value) ||
+    typeof value.mediaType !== "string" ||
+    !("sizeBytes" in value) ||
+    typeof value.sizeBytes !== "number"
+  ) {
+    throw new FileAttachmentStoreError("Invalid FileAttachmentStore metadata.");
+  }
+
+  assertAttachmentId(value.id);
+  if (value.sizeBytes < 0 || !Number.isSafeInteger(value.sizeBytes)) {
+    throw new FileAttachmentStoreError(
+      "Invalid FileAttachmentStore attachment size."
+    );
+  }
+
+  return {
+    filename:
+      "filename" in value && typeof value.filename === "string"
+        ? value.filename
+        : undefined,
+    id: value.id,
+    mediaType: value.mediaType,
+    sizeBytes: value.sizeBytes,
+  };
+}
+
+function assertAttachmentId(id: string): void {
+  if (!attachmentIdPattern.test(id)) {
+    throw new FileAttachmentStoreError("Invalid FileAttachmentStore ref id.");
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/runtime/src/platform/memory/execution/execution-host.ts
+++ b/packages/runtime/src/platform/memory/execution/execution-host.ts
@@ -8,6 +8,7 @@ import {
   type ScheduledThreadPrompt,
   threadPromptScheduledWorkId,
 } from "../../../execution/scheduled-work";
+import { MemoryAttachmentStore } from "../storage/memory-attachment-store";
 import { InMemoryExecutionStore } from "./store";
 
 export type MemoryScheduledThreadPrompt = ScheduledThreadPrompt;
@@ -23,6 +24,7 @@ export interface InMemoryExecutionHost extends ExecutionHost {
 
 export function createInMemoryExecutionHost(): InMemoryExecutionHost {
   return {
+    attachmentStore: new MemoryAttachmentStore(),
     kind: "execution",
     store: new InMemoryExecutionStore(),
     scheduler: new InMemoryExecutionScheduler(),

--- a/packages/runtime/src/platform/memory/index.ts
+++ b/packages/runtime/src/platform/memory/index.ts
@@ -7,4 +7,5 @@ export {
   type MemoryScheduledThreadPrompt,
   type MemoryScheduledWorkListOptions,
 } from "./execution/execution-host";
+export { MemoryAttachmentStore } from "./storage/memory-attachment-store";
 export { MemoryThreadStore } from "./storage/memory-thread-store";

--- a/packages/runtime/src/platform/memory/storage/memory-attachment-store.test.ts
+++ b/packages/runtime/src/platform/memory/storage/memory-attachment-store.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { MemoryAttachmentStore } from "./memory-attachment-store";
+
+describe("MemoryAttachmentStore", () => {
+  it("round-trips attachment bytes and metadata by ref", async () => {
+    const store = new MemoryAttachmentStore();
+    const bytes = new Uint8Array([9, 8, 7]);
+
+    const ref = await store.put({
+      bytes,
+      filename: "photo.png",
+      mediaType: "image/png",
+    });
+    bytes[0] = 1;
+
+    await expect(store.get(ref)).resolves.toEqual({
+      bytes: new Uint8Array([9, 8, 7]),
+      filename: "photo.png",
+      mediaType: "image/png",
+      ref,
+    });
+  });
+});

--- a/packages/runtime/src/platform/memory/storage/memory-attachment-store.ts
+++ b/packages/runtime/src/platform/memory/storage/memory-attachment-store.ts
@@ -1,0 +1,38 @@
+import type {
+  RuntimeAttachmentBlob,
+  RuntimeAttachmentPutInput,
+  RuntimeAttachmentReference,
+  RuntimeAttachmentStore,
+} from "../../../thread/input/attachments";
+
+export class MemoryAttachmentStore implements RuntimeAttachmentStore {
+  readonly #attachments = new Map<string, RuntimeAttachmentBlob>();
+
+  get(ref: RuntimeAttachmentReference): Promise<RuntimeAttachmentBlob | null> {
+    const attachment = this.#attachments.get(ref.id);
+    return Promise.resolve(attachment ? cloneAttachment(attachment) : null);
+  }
+
+  put(input: RuntimeAttachmentPutInput): Promise<RuntimeAttachmentReference> {
+    const id = crypto.randomUUID();
+    const ref: RuntimeAttachmentReference = {
+      id,
+      schemaVersion: 1,
+      sizeBytes: input.bytes.byteLength,
+      source: "memory",
+    };
+    this.#attachments.set(id, cloneAttachment({ ...input, ref }));
+    return Promise.resolve(ref);
+  }
+}
+
+function cloneAttachment(
+  attachment: RuntimeAttachmentBlob
+): RuntimeAttachmentBlob {
+  return {
+    bytes: new Uint8Array(attachment.bytes),
+    filename: attachment.filename,
+    mediaType: attachment.mediaType,
+    ref: { ...attachment.ref },
+  };
+}

--- a/packages/runtime/src/thread/handle/durable-queue.ts
+++ b/packages/runtime/src/thread/handle/durable-queue.ts
@@ -1,4 +1,9 @@
 import type { ExecutionHost } from "../../execution/host/types";
+import {
+  type RuntimeAttachmentStore,
+  stageUserInputAttachments,
+  userInputRequiresAttachmentProcessing,
+} from "../input/attachments";
 import type { AgentInput } from "../input/input";
 import { attachInputMeta, userInputFromEvent } from "../input/input-meta";
 import { normalizeAgentInput } from "../input/input-normalization";
@@ -27,6 +32,7 @@ export class DurableInputRecoveryState {
 
 export async function admitThreadSendInput({
   awaitBoundaries,
+  attachmentStore,
   drain,
   events,
   executionHost,
@@ -38,6 +44,7 @@ export async function admitThreadSendInput({
   threadKey,
 }: {
   readonly awaitBoundaries: boolean;
+  readonly attachmentStore: RuntimeAttachmentStore | undefined;
   readonly drain: () => Promise<void>;
   readonly events: ThreadEventDispatcher;
   readonly executionHost: ExecutionHost | undefined;
@@ -50,6 +57,7 @@ export async function admitThreadSendInput({
 }): Promise<void> {
   const queued = await createQueuedSendInput({
     awaitBoundaries,
+    attachmentStore,
     events,
     executionHost,
     input,
@@ -102,6 +110,7 @@ type QueuedSendInputResult =
 
 export async function createQueuedSendInput({
   awaitBoundaries,
+  attachmentStore,
   events,
   executionHost,
   input,
@@ -111,6 +120,7 @@ export async function createQueuedSendInput({
   threadKey,
 }: {
   readonly awaitBoundaries: boolean;
+  readonly attachmentStore: RuntimeAttachmentStore | undefined;
   readonly events: ThreadEventDispatcher;
   readonly executionHost: ExecutionHost | undefined;
   readonly input: AgentInput;
@@ -124,14 +134,22 @@ export async function createQueuedSendInput({
     normalized.meta === undefined
       ? attachInputMeta(normalized, { source: "send" })
       : normalized;
-  const processed = await events.interceptEvent(acceptedInput);
+  const stagedAcceptedInput = await stageUserInputAttachments(
+    acceptedInput,
+    attachmentStore
+  );
+  const processed = await events.interceptEvent(stagedAcceptedInput);
   if (processed === "handled") {
     run.close();
     return { kind: "handled" };
   }
 
-  const queuedInput = userInputFromEvent(
-    processed.type === "user-input" ? processed : acceptedInput
+  const queuedInput = await stageUserInputAttachments(
+    userInputFromEvent(
+      processed.type === "user-input" ? processed : stagedAcceptedInput
+    ),
+    attachmentStore,
+    { trustRuntimeAttachmentRefs: true }
   );
   const admission = await admitDurableThreadInput({
     executionHost,
@@ -162,26 +180,32 @@ export async function createQueuedSendInput({
 }
 
 export async function addDurableSteeringInput({
+  attachmentStore,
   executionHost,
   input,
   runtimeInput,
   threadKey,
 }: {
+  readonly attachmentStore: RuntimeAttachmentStore | undefined;
   readonly executionHost: ExecutionHost | undefined;
   readonly input: AgentInput;
   readonly runtimeInput: RuntimeInputState;
   readonly threadKey: string;
 }): Promise<void> {
+  const placement = currentSteeringPlacement(runtimeInput);
   const next = runtimeInput.pending.then(async () => {
     assertRuntimeInputOpen(runtimeInput);
     const acceptedInput = attachInputMeta(normalizeAgentInput(input), {
       source: "steer",
       streaming: "steer",
     });
-    const placement = currentSteeringPlacement(runtimeInput);
+    const stagedInput = userInputRequiresAttachmentProcessing(acceptedInput)
+      ? await stageUserInputAttachments(acceptedInput, attachmentStore)
+      : acceptedInput;
+    assertRuntimeInputOpen(runtimeInput);
     const admission = await admitDurableThreadInput({
       executionHost,
-      input: acceptedInput,
+      input: stagedInput,
       kind: "steer",
       placement,
       threadKey,
@@ -190,8 +214,9 @@ export async function addDurableSteeringInput({
       return;
     }
 
+    assertRuntimeInputOpen(runtimeInput);
     queueRuntimeInput(runtimeInput, {
-      input: acceptedInput,
+      input: stagedInput,
       placement,
     });
   });

--- a/packages/runtime/src/thread/handle/persistence-attachments.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-attachments.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { Agent } from "../../agent/core/agent";
+import { FileAttachmentStore, FileThreadStore } from "../../platform/file";
+import {
+  createMockLanguageModelV4,
+  mockLanguageModelV4Text,
+} from "../../testing/mock-language-model-v4-test-utils";
+import { collect } from "./test-support";
+
+describe("Agent thread persistence attachments", () => {
+  it("file thread store preserves image content parts across reload", async () => {
+    const input = [
+      { text: "remember this image", type: "text" },
+      {
+        image: "data:image/png;base64,ZmFrZQ==",
+        mediaType: "image/png",
+        type: "image",
+      },
+      {
+        data: { text: "inline note", type: "text" },
+        filename: "note.txt",
+        mediaType: "text/plain",
+        type: "file",
+      },
+    ] as const;
+    const directory = await mkdtemp(join(tmpdir(), "pss-runtime-image-store-"));
+    const store = new FileThreadStore(directory);
+
+    const first = new Agent({
+      host: {
+        attachmentStore: new FileAttachmentStore(directory),
+        kind: "thread",
+        threadStore: store,
+      },
+      model: createMockLanguageModelV4([mockLanguageModelV4Text("stored")]),
+    });
+    await collect(await first.thread("images").send(input));
+
+    const secondModel = createMockLanguageModelV4([
+      mockLanguageModelV4Text("DONE"),
+    ]);
+    const second = new Agent({
+      host: {
+        attachmentStore: new FileAttachmentStore(directory),
+        kind: "thread",
+        threadStore: store,
+      },
+      model: secondModel,
+    });
+
+    await collect(await second.thread("images").send("next"));
+
+    expect(JSON.stringify(secondModel.doGenerateCalls[0]?.prompt)).toContain(
+      "remember this image"
+    );
+    expect(JSON.stringify(secondModel.doGenerateCalls[0]?.prompt)).toContain(
+      "next"
+    );
+  });
+});

--- a/packages/runtime/src/thread/handle/persistence-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-compaction.test.ts
@@ -1,0 +1,62 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { Agent } from "../../agent/core/agent";
+import {
+  assistantMessage,
+  createCallbackModel,
+  userText,
+} from "../../testing/test-fixtures";
+import { userTextToModelMessage } from "../protocol/mapping";
+import { collect, SpyStore } from "./test-support";
+
+const storedAssistantOutput = (text: string): ModelMessage => ({
+  content: [{ providerOptions: undefined, text, type: "text" }],
+  role: "assistant",
+});
+
+describe("Agent thread persistence compaction", () => {
+  it("compacts model context without dropping full stored history", async () => {
+    const store = new SpyStore();
+    const seenHistory: ModelMessage[][] = [];
+    const agent = new Agent({
+      host: { kind: "thread", threadStore: store },
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([
+          assistantMessage(`DONE ${seenHistory.length}`),
+        ]);
+      }),
+    });
+    const thread = agent.thread("compact");
+
+    await collect(await thread.send("old"));
+    await thread.compact({
+      endSeqExclusive: 2,
+      startSeq: 0,
+      summary: "old exchange summarized",
+    });
+    await collect(await thread.send("tail"));
+
+    expect(seenHistory[1]).toEqual([
+      { content: "old exchange summarized", role: "system" },
+      userTextToModelMessage(userText("tail")),
+    ]);
+    expect(store.threads.get("compact")?.state).toEqual({
+      compactions: [
+        {
+          endSeqExclusive: 2,
+          schemaVersion: 1,
+          startSeq: 0,
+          summary: { content: "old exchange summarized", role: "system" },
+        },
+      ],
+      history: [
+        userTextToModelMessage(userText("old")),
+        storedAssistantOutput("DONE 1"),
+        userTextToModelMessage(userText("tail")),
+        storedAssistantOutput("DONE 2"),
+      ],
+      schemaVersion: 2,
+    });
+  });
+});

--- a/packages/runtime/src/thread/handle/persistence.test.ts
+++ b/packages/runtime/src/thread/handle/persistence.test.ts
@@ -1,14 +1,6 @@
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { Agent } from "../../agent/core/agent";
-import { FileThreadStore } from "../../platform/file";
-import {
-  createMockLanguageModelV4,
-  mockLanguageModelV4Text,
-} from "../../testing/mock-language-model-v4-test-utils";
 import {
   assistantMessage,
   createCallbackModel,
@@ -25,54 +17,7 @@ import {
   SpyStore,
 } from "./test-support";
 
-const storedAssistantOutput = (text: string): ModelMessage => ({
-  content: [{ providerOptions: undefined, text, type: "text" }],
-  role: "assistant",
-});
-
 describe("Agent thread persistence", () => {
-  it("file thread store preserves image content parts across reload", async () => {
-    const input = [
-      { type: "text", text: "remember this image" },
-      {
-        type: "image",
-        image: "data:image/png;base64,ZmFrZQ==",
-        mediaType: "image/png",
-      },
-      {
-        type: "file",
-        data: { type: "text", text: "inline note" },
-        filename: "note.txt",
-        mediaType: "text/plain",
-      },
-    ] as const;
-    const directory = await mkdtemp(join(tmpdir(), "pss-runtime-image-store-"));
-    const store = new FileThreadStore(directory);
-
-    const first = new Agent({
-      host: { kind: "thread", threadStore: store },
-      model: createMockLanguageModelV4([mockLanguageModelV4Text("stored")]),
-    });
-    await collect(await first.thread("images").send(input));
-
-    const secondModel = createMockLanguageModelV4([
-      mockLanguageModelV4Text("DONE"),
-    ]);
-    const second = new Agent({
-      host: { kind: "thread", threadStore: store },
-      model: secondModel,
-    });
-
-    await collect(await second.thread("images").send("next"));
-
-    expect(JSON.stringify(secondModel.doGenerateCalls[0]?.prompt)).toContain(
-      "remember this image"
-    );
-    expect(JSON.stringify(secondModel.doGenerateCalls[0]?.prompt)).toContain(
-      "next"
-    );
-  });
-
   it("emits and propagates runtime input commit conflicts without using the conflicted snapshot", async () => {
     const store = new ConflictOnCommitStore();
     store.conflictOnCommit = 2;
@@ -268,51 +213,6 @@ describe("Agent thread persistence", () => {
     expect(finalCommit?.next.state).not.toBeInstanceOf(Array);
     expect(finalCommit?.next).not.toHaveProperty("version");
     expect(store.commits[0]?.expectedVersion).toBeNull();
-  });
-
-  it("compacts model context without dropping full stored history", async () => {
-    const store = new SpyStore();
-    const seenHistory: ModelMessage[][] = [];
-    const agent = new Agent({
-      host: { kind: "thread", threadStore: store },
-      model: createCallbackModel(({ history }) => {
-        seenHistory.push([...history]);
-        return Promise.resolve([
-          assistantMessage(`DONE ${seenHistory.length}`),
-        ]);
-      }),
-    });
-    const thread = agent.thread("compact");
-
-    await collect(await thread.send("old"));
-    await thread.compact({
-      endSeqExclusive: 2,
-      startSeq: 0,
-      summary: "old exchange summarized",
-    });
-    await collect(await thread.send("tail"));
-
-    expect(seenHistory[1]).toEqual([
-      { content: "old exchange summarized", role: "system" },
-      userTextToModelMessage(userText("tail")),
-    ]);
-    expect(store.threads.get("compact")?.state).toEqual({
-      compactions: [
-        {
-          endSeqExclusive: 2,
-          schemaVersion: 1,
-          startSeq: 0,
-          summary: { content: "old exchange summarized", role: "system" },
-        },
-      ],
-      history: [
-        userTextToModelMessage(userText("old")),
-        storedAssistantOutput("DONE 1"),
-        userTextToModelMessage(userText("tail")),
-        storedAssistantOutput("DONE 2"),
-      ],
-      schemaVersion: 2,
-    });
   });
 
   it("refreshes stored state after commit conflicts so the handle can recover", async () => {

--- a/packages/runtime/src/thread/handle/thread.test.ts
+++ b/packages/runtime/src/thread/handle/thread.test.ts
@@ -6,10 +6,13 @@ import {
   createCallbackModel,
   eventTypes,
   overlayRuntimeInput,
-  sentUserMessage,
   sentUserText,
   userText,
 } from "../../testing/test-fixtures";
+import {
+  encodeRuntimeAttachmentData,
+  isRuntimeAttachmentData,
+} from "../input/attachments";
 import { userTextToModelMessage } from "../protocol/mapping";
 import { collect } from "./test-support";
 
@@ -78,21 +81,44 @@ describe("Agent thread API", () => {
     expect(seenHistory).toEqual([
       [
         {
-          role: "user",
           content: [
-            { type: "text", text: "describe this" },
-            { type: "file", data: "iVBORw0KGgo=", mediaType: "image/png" },
             {
+              providerOptions: undefined,
+              text: "describe this",
+              type: "text",
+            },
+            {
+              data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
+              filename: undefined,
+              mediaType: "image/png",
+              providerOptions: undefined,
               type: "file",
+            },
+            {
               data: { type: "text", text: "inline document" },
               filename: "note.txt",
               mediaType: "text/plain",
+              providerOptions: undefined,
+              type: "file",
             },
           ],
+          providerOptions: undefined,
+          role: "user",
         },
       ],
     ]);
-    expect(events[0]).toEqual(sentUserMessage(input));
+    const acceptedInput = events[0];
+    expect(acceptedInput?.type).toBe("user-input");
+    if (acceptedInput?.type !== "user-input" || !("content" in acceptedInput)) {
+      throw new Error("expected multipart user-input event");
+    }
+    const imagePart = acceptedInput.content[1];
+    expect(imagePart?.type).toBe("file");
+    if (imagePart?.type !== "file") {
+      throw new Error("expected staged image file part");
+    }
+    expect(isRuntimeAttachmentData(imagePart.data)).toBe(true);
+    expect(acceptedInput.content[2]).toEqual(input[2]);
   });
 
   it("rejects malformed multipart input before queueing", async () => {
@@ -172,17 +198,22 @@ describe("Agent thread API", () => {
     expect(seenHistory).toEqual([
       [
         {
-          role: "user",
           content: [
-            { type: "text", text: "summarize" },
             {
-              type: "file",
-              data: "iVBORw0KGgo=",
+              providerOptions: undefined,
+              text: "summarize",
+              type: "text",
+            },
+            {
+              data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
               filename: undefined,
               mediaType: "image/png",
               providerOptions: undefined,
+              type: "file",
             },
           ],
+          providerOptions: undefined,
+          role: "user",
         },
       ],
     ]);
@@ -241,5 +272,31 @@ describe("Agent thread API", () => {
         userTextToModelMessage(userText("hello")),
       ],
     ]);
+  });
+
+  it("thread.overlay rejects externally supplied runtime attachment refs", () => {
+    const seenHistory: ModelMessage[][] = [];
+    const agent = new Agent({
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        return Promise.resolve([assistantMessage("DONE")]);
+      }),
+    });
+    const ref = encodeRuntimeAttachmentData({
+      id: "attacker-controlled",
+      schemaVersion: 1,
+    });
+
+    expect(() =>
+      agent.overlay([
+        { text: "context", type: "text" },
+        {
+          data: ref,
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    ).toThrow("External input cannot contain runtime attachment refs.");
+    expect(seenHistory).toEqual([]);
   });
 });

--- a/packages/runtime/src/thread/handle/thread.ts
+++ b/packages/runtime/src/thread/handle/thread.ts
@@ -1,4 +1,10 @@
 import type { ModelGenerationOptions } from "../../llm/llm";
+import {
+  RuntimeAttachmentSecurityError,
+  RuntimeAttachmentStagingError,
+  userInputContainsRuntimeAttachmentRefs,
+  userInputRequiresAttachmentStaging,
+} from "../input/attachments";
 import type { AgentInput, UserInput } from "../input/input";
 import { attachInputMeta } from "../input/input-meta";
 import { normalizeAgentInput } from "../input/input-normalization";
@@ -67,6 +73,7 @@ export class AgentThread {
     this.#threadKey = persistence.key;
     this.#state = new ThreadState(persistence);
     this.#events = new ThreadEventDispatcher({
+      attachmentStore: model.attachmentStore,
       history: () => this.#state.modelSnapshot(),
       plugins,
       signal: () => this.#activeAbort?.signal,
@@ -97,6 +104,7 @@ export class AgentThread {
       drain: () => this.#drainInputQueue(),
       events: this.#events,
       executionHost: this.#execution.executionHost,
+      attachmentStore: this.#model.attachmentStore,
       input,
       inputQueue: this.#inputQueue,
       pendingOverlays: this.#pendingOverlays,
@@ -109,11 +117,23 @@ export class AgentThread {
   overlay(input: AgentInput): this {
     this.#assertOpen();
 
+    const normalized = attachInputMeta(normalizeAgentInput(input), {
+      source: "overlay",
+    });
+    if (userInputContainsRuntimeAttachmentRefs(normalized)) {
+      throw new RuntimeAttachmentSecurityError(
+        "External input cannot contain runtime attachment refs."
+      );
+    }
+    if (userInputRequiresAttachmentStaging(normalized)) {
+      throw new RuntimeAttachmentStagingError(
+        "thread.overlay() cannot accept inline file bytes because overlay() is synchronous."
+      );
+    }
+
     this.#pendingOverlays.push({
       canonical: false,
-      input: attachInputMeta(normalizeAgentInput(input), {
-        source: "overlay",
-      }),
+      input: normalized,
       placement: "turn-start",
     });
     return this;
@@ -133,6 +153,7 @@ export class AgentThread {
     return queueThreadNotification(input, options, {
       activeRun: this.#activeRun,
       activeRuntimeInput: this.#activeRuntimeInput,
+      attachmentStore: this.#model.attachmentStore,
       drain: () => this.#drainInputQueue(),
       emitObserverEvent: (run, event) =>
         this.#events.emitObserverEvent(run, event),
@@ -152,6 +173,7 @@ export class AgentThread {
 
     await addDurableSteeringInput({
       executionHost: this.#execution.executionHost,
+      attachmentStore: this.#model.attachmentStore,
       input,
       runtimeInput,
       threadKey: this.#threadKey,

--- a/packages/runtime/src/thread/input/attachment-base64.ts
+++ b/packages/runtime/src/thread/input/attachment-base64.ts
@@ -1,0 +1,88 @@
+const base64Alphabet =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const base64UrlAlphabet =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  return encodeBase64(bytes, base64UrlAlphabet, false);
+}
+
+export function base64UrlToBytes(value: string): Uint8Array {
+  return decodeBase64(value, true);
+}
+
+export function base64ToBytes(value: string): Uint8Array {
+  return decodeBase64(value, false);
+}
+
+function encodeBase64(
+  bytes: Uint8Array,
+  alphabet: string,
+  padded: boolean
+): string {
+  let output = "";
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index] ?? 0;
+    const second = bytes[index + 1] ?? 0;
+    const third = bytes[index + 2] ?? 0;
+    const chunk = first * 65_536 + second * 256 + third;
+    output += alphabet[Math.floor(chunk / 262_144) % 64] ?? "";
+    output += alphabet[Math.floor(chunk / 4096) % 64] ?? "";
+    output +=
+      index + 1 < bytes.length
+        ? (alphabet[Math.floor(chunk / 64) % 64] ?? "")
+        : "";
+    output += index + 2 < bytes.length ? (alphabet[chunk % 64] ?? "") : "";
+  }
+
+  if (!padded) {
+    return output;
+  }
+
+  const padding = (3 - (bytes.length % 3)) % 3;
+  return `${output}${"=".repeat(padding)}`;
+}
+
+function decodeBase64(value: string, urlSafe: boolean): Uint8Array {
+  const normalized = normalizeBase64(value, urlSafe);
+  const bytes: number[] = [];
+
+  for (let index = 0; index < normalized.length; index += 4) {
+    const first = base64Value(normalized[index]);
+    const second = base64Value(normalized[index + 1]);
+    const third = base64Value(normalized[index + 2]);
+    const fourth = base64Value(normalized[index + 3]);
+    const chunk = first * 262_144 + second * 4096 + third * 64 + fourth;
+
+    bytes.push(Math.floor(chunk / 65_536) % 256);
+    if (normalized[index + 2] !== "=") {
+      bytes.push(Math.floor(chunk / 256) % 256);
+    }
+    if (normalized[index + 3] !== "=") {
+      bytes.push(chunk % 256);
+    }
+  }
+
+  return new Uint8Array(bytes);
+}
+
+function normalizeBase64(value: string, urlSafe: boolean): string {
+  const compact = value.replace(/\s/g, "");
+  const standard = urlSafe
+    ? compact.replace(/-/g, "+").replace(/_/g, "/")
+    : compact;
+  const padding = (4 - (standard.length % 4)) % 4;
+  return `${standard}${"=".repeat(padding)}`;
+}
+
+function base64Value(value: string | undefined): number {
+  if (value === undefined || value === "=") {
+    return 0;
+  }
+
+  const index = base64Alphabet.indexOf(value);
+  if (index === -1) {
+    throw new Error("Invalid base64 payload.");
+  }
+  return index;
+}

--- a/packages/runtime/src/thread/input/attachment-hydration.ts
+++ b/packages/runtime/src/thread/input/attachment-hydration.ts
@@ -1,0 +1,53 @@
+import type { ModelMessage } from "ai";
+import {
+  decodeRuntimeAttachmentData,
+  isRuntimeAttachmentData,
+} from "./attachment-refs";
+import type { RuntimeAttachmentStore } from "./attachment-types";
+import { RuntimeAttachmentHydrationError } from "./attachment-types";
+
+export async function hydrateRuntimeAttachments(
+  history: readonly ModelMessage[],
+  store: RuntimeAttachmentStore | undefined
+): Promise<ModelMessage[]> {
+  const hydrated: ModelMessage[] = [];
+  for (const message of history) {
+    if (message.role !== "user" || typeof message.content === "string") {
+      hydrated.push(structuredClone(message));
+      continue;
+    }
+
+    const content: typeof message.content = [];
+    for (const part of message.content) {
+      if (part.type !== "file" || !isRuntimeAttachmentData(part.data)) {
+        content.push(structuredClone(part));
+        continue;
+      }
+
+      if (!store) {
+        throw new RuntimeAttachmentHydrationError(
+          "Runtime attachment hydration requires an attachment store."
+        );
+      }
+
+      const ref = decodeRuntimeAttachmentData(part.data);
+      const blob = await store.get(ref);
+      if (!blob) {
+        throw new RuntimeAttachmentHydrationError(
+          `Runtime attachment ${JSON.stringify(ref.id)} was not found.`
+        );
+      }
+
+      content.push({
+        ...part,
+        data: blob.bytes,
+        filename: part.filename ?? blob.filename,
+        mediaType: blob.mediaType,
+      });
+    }
+
+    hydrated.push({ ...message, content });
+  }
+
+  return hydrated;
+}

--- a/packages/runtime/src/thread/input/attachment-refs.ts
+++ b/packages/runtime/src/thread/input/attachment-refs.ts
@@ -1,0 +1,77 @@
+import { base64UrlToBytes, bytesToBase64Url } from "./attachment-base64";
+import type { RuntimeAttachmentReference } from "./attachment-types";
+import { RuntimeAttachmentHydrationError } from "./attachment-types";
+
+const attachmentDataPrefix = "pss-attachment:";
+
+export function encodeRuntimeAttachmentData(
+  ref: RuntimeAttachmentReference
+): string {
+  return `${attachmentDataPrefix}?v=1&p=${base64UrlEncodeJson(ref)}`;
+}
+
+export function isRuntimeAttachmentData(data: unknown): data is string {
+  return typeof data === "string" && data.startsWith(attachmentDataPrefix);
+}
+
+export function decodeRuntimeAttachmentData(
+  data: string
+): RuntimeAttachmentReference {
+  if (!isRuntimeAttachmentData(data)) {
+    throw new RuntimeAttachmentHydrationError(
+      "Expected runtime attachment data."
+    );
+  }
+
+  const url = new URL(data);
+  if (url.searchParams.get("v") !== "1") {
+    throw new RuntimeAttachmentHydrationError(
+      "Unsupported runtime attachment data version."
+    );
+  }
+
+  const payload = url.searchParams.get("p");
+  if (!payload) {
+    throw new RuntimeAttachmentHydrationError(
+      "Runtime attachment data is missing a payload."
+    );
+  }
+
+  return parseRuntimeAttachmentReference(base64UrlDecodeJson(payload));
+}
+
+function parseRuntimeAttachmentReference(
+  value: unknown
+): RuntimeAttachmentReference {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    !("schemaVersion" in value) ||
+    value.schemaVersion !== 1 ||
+    !("id" in value) ||
+    typeof value.id !== "string"
+  ) {
+    throw new RuntimeAttachmentHydrationError(
+      "Invalid runtime attachment reference payload."
+    );
+  }
+
+  return {
+    id: value.id,
+    schemaVersion: 1,
+    ...("sizeBytes" in value && typeof value.sizeBytes === "number"
+      ? { sizeBytes: value.sizeBytes }
+      : {}),
+    ...("source" in value && typeof value.source === "string"
+      ? { source: value.source }
+      : {}),
+  };
+}
+
+function base64UrlEncodeJson(value: unknown): string {
+  return bytesToBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function base64UrlDecodeJson(value: string): unknown {
+  return JSON.parse(new TextDecoder().decode(base64UrlToBytes(value)));
+}

--- a/packages/runtime/src/thread/input/attachment-staging.ts
+++ b/packages/runtime/src/thread/input/attachment-staging.ts
@@ -1,0 +1,295 @@
+import type { AgentEvent, RuntimeInput } from "../protocol/events";
+import { base64ToBytes } from "./attachment-base64";
+import {
+  encodeRuntimeAttachmentData,
+  isRuntimeAttachmentData,
+} from "./attachment-refs";
+import type {
+  RuntimeAttachmentStagingOptions,
+  RuntimeAttachmentStore,
+} from "./attachment-types";
+import {
+  RuntimeAttachmentSecurityError,
+  RuntimeAttachmentStagingError,
+} from "./attachment-types";
+import type {
+  UserInput,
+  UserMessageContentPart,
+  UserMessageFileData,
+  UserMessageFilePart,
+} from "./input";
+
+export async function stageUserInputAttachments(
+  input: UserInput,
+  store: RuntimeAttachmentStore | undefined,
+  options: RuntimeAttachmentStagingOptions = {}
+): Promise<UserInput> {
+  if (!("content" in input)) {
+    return structuredClone(input);
+  }
+
+  const content: UserMessageContentPart[] = [];
+  for (const part of input.content) {
+    if (part.type === "text") {
+      content.push(structuredClone(part));
+      continue;
+    }
+
+    if (part.type === "image") {
+      content.push(await stageImagePart(part, store, options));
+      continue;
+    }
+
+    content.push({
+      ...part,
+      data: await stageFileData(part.data, part, store, options),
+    });
+  }
+
+  return {
+    ...input,
+    content,
+  };
+}
+
+export function userInputRequiresAttachmentStaging(input: UserInput): boolean {
+  if (!("content" in input)) {
+    return false;
+  }
+
+  return input.content.some((part) => {
+    if (part.type === "file") {
+      return fileDataRequiresStaging(part.data);
+    }
+
+    return part.type === "image" && !isRemoteUrl(part.image);
+  });
+}
+
+export function userInputRequiresAttachmentProcessing(
+  input: UserInput
+): boolean {
+  if (!("content" in input)) {
+    return false;
+  }
+
+  return input.content.some((part) => part.type !== "text");
+}
+
+export function userInputContainsRuntimeAttachmentRefs(
+  input: UserInput
+): boolean {
+  if (!("content" in input)) {
+    return false;
+  }
+
+  return input.content.some((part) => {
+    if (part.type === "image") {
+      return isRuntimeAttachmentData(part.image);
+    }
+
+    return (
+      part.type === "file" && runtimeAttachmentDataRef(part.data) !== undefined
+    );
+  });
+}
+
+export async function stageAgentEventAttachments(
+  event: AgentEvent,
+  store: RuntimeAttachmentStore | undefined,
+  options: RuntimeAttachmentStagingOptions = {}
+): Promise<AgentEvent> {
+  if (event.type === "user-input") {
+    return stageUserInputAttachments(event, store, options);
+  }
+
+  if (event.type === "runtime-input") {
+    return {
+      ...event,
+      input: await stageUserInputAttachments(event.input, store, options),
+    } satisfies RuntimeInput;
+  }
+
+  return structuredClone(event);
+}
+
+export async function stageAgentEventsAttachments(
+  events: readonly AgentEvent[],
+  store: RuntimeAttachmentStore | undefined,
+  options: RuntimeAttachmentStagingOptions = {}
+): Promise<AgentEvent[]> {
+  const staged: AgentEvent[] = [];
+  for (const event of events) {
+    staged.push(await stageAgentEventAttachments(event, store, options));
+  }
+  return staged;
+}
+
+async function stageFileData(
+  data: UserMessageFileData,
+  part: { readonly filename?: string; readonly mediaType: string },
+  store: RuntimeAttachmentStore | undefined,
+  options: RuntimeAttachmentStagingOptions
+): Promise<UserMessageFileData> {
+  const runtimeRef = runtimeAttachmentDataRef(data);
+  if (runtimeRef !== undefined) {
+    if (options.trustRuntimeAttachmentRefs === true) {
+      return runtimeRef;
+    }
+    throw new RuntimeAttachmentSecurityError(
+      "External input cannot contain runtime attachment refs."
+    );
+  }
+
+  const bytes = fileDataBytes(data);
+  if (!bytes) {
+    return structuredClone(data);
+  }
+
+  if (!store) {
+    throw new RuntimeAttachmentStagingError(
+      "File byte inputs require an attachment store."
+    );
+  }
+
+  const ref = await store.put({
+    bytes,
+    filename: part.filename,
+    mediaType: part.mediaType,
+  });
+  return encodeRuntimeAttachmentData(ref);
+}
+
+async function stageImagePart(
+  part: {
+    readonly image: string;
+    readonly mediaType?: string;
+    readonly type: "image";
+  },
+  store: RuntimeAttachmentStore | undefined,
+  options: RuntimeAttachmentStagingOptions
+): Promise<UserMessageFilePart> {
+  if (isRuntimeAttachmentData(part.image)) {
+    if (options.trustRuntimeAttachmentRefs === true) {
+      return {
+        data: part.image,
+        mediaType: part.mediaType ?? "image",
+        type: "file",
+      };
+    }
+    throw new RuntimeAttachmentSecurityError(
+      "External input cannot contain runtime attachment refs."
+    );
+  }
+
+  const mediaType = part.mediaType ?? "image";
+  if (isRemoteUrl(part.image)) {
+    return {
+      data: part.image,
+      mediaType,
+      type: "file",
+    };
+  }
+
+  return {
+    data: await stageFileData(
+      { data: part.image, type: "data" },
+      { mediaType },
+      store,
+      options
+    ),
+    mediaType,
+    type: "file",
+  };
+}
+
+function fileDataBytes(data: UserMessageFileData): Uint8Array | undefined {
+  if (typeof data === "string") {
+    return isRemoteUrl(data) ? undefined : base64DataToBytes(data);
+  }
+
+  if (isBytes(data)) {
+    return bytesFromBinary(data);
+  }
+
+  if (isDataFileData(data)) {
+    return typeof data.data === "string"
+      ? base64DataToBytes(data.data)
+      : bytesFromBinary(data.data);
+  }
+
+  return;
+}
+
+function fileDataRequiresStaging(data: UserMessageFileData): boolean {
+  if (isRuntimeAttachmentData(data)) {
+    return false;
+  }
+  if (typeof data === "string") {
+    return !isRemoteUrl(data);
+  }
+  if (isBytes(data)) {
+    return true;
+  }
+  if (isDataFileData(data)) {
+    return true;
+  }
+  return false;
+}
+
+function runtimeAttachmentDataRef(
+  data: UserMessageFileData
+): string | undefined {
+  if (isRuntimeAttachmentData(data)) {
+    return data;
+  }
+
+  if (
+    isDataFileData(data) &&
+    typeof data.data === "string" &&
+    isRuntimeAttachmentData(data.data)
+  ) {
+    return data.data;
+  }
+
+  if (isUrlFileData(data) && isRuntimeAttachmentData(data.url)) {
+    return data.url;
+  }
+
+  return;
+}
+
+function isDataFileData(
+  data: UserMessageFileData
+): data is Extract<UserMessageFileData, { readonly type: "data" }> {
+  return typeof data === "object" && data !== null && "type" in data
+    ? data.type === "data"
+    : false;
+}
+
+function isUrlFileData(
+  data: UserMessageFileData
+): data is Extract<UserMessageFileData, { readonly type: "url" }> {
+  return typeof data === "object" && data !== null && "type" in data
+    ? data.type === "url"
+    : false;
+}
+
+function isBytes(data: unknown): data is ArrayBuffer | Uint8Array {
+  return data instanceof ArrayBuffer || data instanceof Uint8Array;
+}
+
+function bytesFromBinary(data: ArrayBuffer | Uint8Array): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+function base64DataToBytes(data: string): Uint8Array {
+  const payload = data.startsWith("data:")
+    ? (data.split(",", 2)[1] ?? "")
+    : data;
+  return base64ToBytes(payload);
+}
+
+function isRemoteUrl(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://");
+}

--- a/packages/runtime/src/thread/input/attachment-types.ts
+++ b/packages/runtime/src/thread/input/attachment-types.ts
@@ -1,0 +1,46 @@
+export interface RuntimeAttachmentReference {
+  readonly id: string;
+  readonly schemaVersion: 1;
+  readonly sizeBytes?: number;
+  readonly source?: string;
+}
+
+export interface RuntimeAttachmentPutInput {
+  readonly bytes: Uint8Array;
+  readonly filename?: string;
+  readonly mediaType: string;
+}
+
+export interface RuntimeAttachmentBlob extends RuntimeAttachmentPutInput {
+  readonly ref: RuntimeAttachmentReference;
+}
+
+export interface RuntimeAttachmentStore {
+  get(ref: RuntimeAttachmentReference): Promise<RuntimeAttachmentBlob | null>;
+  put(input: RuntimeAttachmentPutInput): Promise<RuntimeAttachmentReference>;
+}
+
+export interface RuntimeAttachmentStagingOptions {
+  readonly trustRuntimeAttachmentRefs?: boolean;
+}
+
+export class RuntimeAttachmentStagingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeAttachmentStagingError";
+  }
+}
+
+export class RuntimeAttachmentHydrationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeAttachmentHydrationError";
+  }
+}
+
+export class RuntimeAttachmentSecurityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeAttachmentSecurityError";
+  }
+}

--- a/packages/runtime/src/thread/input/attachments.ts
+++ b/packages/runtime/src/thread/input/attachments.ts
@@ -1,0 +1,26 @@
+// biome-ignore-all lint/performance/noBarrelFile: Stable internal import surface for attachment helpers split by responsibility.
+
+export { hydrateRuntimeAttachments } from "./attachment-hydration";
+export {
+  decodeRuntimeAttachmentData,
+  encodeRuntimeAttachmentData,
+  isRuntimeAttachmentData,
+} from "./attachment-refs";
+export {
+  stageAgentEventAttachments,
+  stageAgentEventsAttachments,
+  stageUserInputAttachments,
+  userInputContainsRuntimeAttachmentRefs,
+  userInputRequiresAttachmentProcessing,
+  userInputRequiresAttachmentStaging,
+} from "./attachment-staging";
+export {
+  type RuntimeAttachmentBlob,
+  RuntimeAttachmentHydrationError,
+  type RuntimeAttachmentPutInput,
+  type RuntimeAttachmentReference,
+  RuntimeAttachmentSecurityError,
+  RuntimeAttachmentStagingError,
+  type RuntimeAttachmentStagingOptions,
+  type RuntimeAttachmentStore,
+} from "./attachment-types";

--- a/packages/runtime/src/thread/input/input-normalization.ts
+++ b/packages/runtime/src/thread/input/input-normalization.ts
@@ -127,12 +127,19 @@ function isUserMessageFileData(data: unknown): boolean {
     return true;
   }
 
+  if (isBinaryFileData(data)) {
+    return true;
+  }
+
   if (data === null || typeof data !== "object" || !("type" in data)) {
     return false;
   }
 
   if (data.type === "data") {
-    return "data" in data && typeof data.data === "string";
+    return (
+      "data" in data &&
+      (typeof data.data === "string" || isBinaryFileData(data.data))
+    );
   }
 
   if (data.type === "reference") {
@@ -153,6 +160,10 @@ function isUserMessageFileData(data: unknown): boolean {
   }
 
   return false;
+}
+
+function isBinaryFileData(data: unknown): data is ArrayBuffer | Uint8Array {
+  return data instanceof ArrayBuffer || data instanceof Uint8Array;
 }
 
 function hasDenseItems<T>(

--- a/packages/runtime/src/thread/input/input.ts
+++ b/packages/runtime/src/thread/input/input.ts
@@ -20,8 +20,10 @@ export interface UserMessageImagePart {
 }
 
 export type UserMessageFileData =
+  | ArrayBuffer
   | string
-  | { data: string; type: "data" }
+  | Uint8Array
+  | { data: ArrayBuffer | string | Uint8Array; type: "data" }
   | { reference: Record<string, string>; type: "reference" }
   | { text: string; type: "text" }
   | { type: "url"; url: string };

--- a/packages/runtime/src/thread/input/runtime-input-emit.ts
+++ b/packages/runtime/src/thread/input/runtime-input-emit.ts
@@ -2,6 +2,10 @@ import type { AgentEvent, RuntimeInput } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
 import type { ThreadEventDispatcher } from "../runtime/events";
 import type { ThreadState } from "../state/thread-state";
+import {
+  type RuntimeAttachmentStore,
+  stageUserInputAttachments,
+} from "./attachments";
 import type { UserInput } from "./input";
 import { stripInputMeta } from "./input-meta";
 import type { QueuedRuntimeInput } from "./runtime-input";
@@ -20,7 +24,8 @@ export function runtimeInputEventFromQueued(
 export async function commitPreUserRuntimeInputs(
   events: ThreadEventDispatcher,
   state: ThreadState,
-  runtimeInputs: readonly QueuedRuntimeInput[]
+  runtimeInputs: readonly QueuedRuntimeInput[],
+  attachmentStore: RuntimeAttachmentStore | undefined
 ): Promise<readonly AgentEvent[]> {
   const committed: AgentEvent[] = [];
   for (const queued of runtimeInputs) {
@@ -32,7 +37,11 @@ export async function commitPreUserRuntimeInputs(
     }
 
     committed.push(processed);
-    const input = runtimeInputHistoryFromEvent(processed, queued);
+    const input = await stageUserInputAttachments(
+      runtimeInputHistoryFromEvent(processed, queued),
+      attachmentStore,
+      { trustRuntimeAttachmentRefs: true }
+    );
     if (queued.canonical === false) {
       state.appendTransientUserInput(input);
     } else {
@@ -60,6 +69,7 @@ export async function emitRuntimeInputEvent(
   state: ThreadState,
   queued: QueuedRuntimeInput,
   options: {
+    readonly attachmentStore?: RuntimeAttachmentStore;
     readonly commit?: () => Promise<void>;
     readonly onHandled?: () => Promise<void>;
   } = {}
@@ -73,7 +83,13 @@ export async function emitRuntimeInputEvent(
   }
 
   events.emitProcessedEvent(run, processed);
-  state.appendUserInput(runtimeInputHistoryFromEvent(processed, queued));
+  state.appendUserInput(
+    await stageUserInputAttachments(
+      runtimeInputHistoryFromEvent(processed, queued),
+      options.attachmentStore,
+      { trustRuntimeAttachmentRefs: true }
+    )
+  );
   await (options.commit ?? (() => state.commit()))();
   return true;
 }

--- a/packages/runtime/src/thread/input/runtime-input.test.ts
+++ b/packages/runtime/src/thread/input/runtime-input.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type {
+  RuntimeAttachmentReference,
+  RuntimeAttachmentStore,
+} from "./attachments";
+import {
+  addSteeringInput,
+  closeRuntimeInput,
+  createRuntimeInputState,
+} from "./runtime-input";
+
+describe("runtime input", () => {
+  it("rejects staged steering input if the run closes before queueing", async () => {
+    let resolvePutStarted: () => void = () => {
+      throw new Error("put-started resolver was not initialized");
+    };
+    const putStarted = new Promise<void>((resolve) => {
+      resolvePutStarted = resolve;
+    });
+    let resolvePut: (ref: RuntimeAttachmentReference) => void = (
+      _ref: RuntimeAttachmentReference
+    ) => {
+      throw new Error("put-result resolver was not initialized");
+    };
+    const putResult = new Promise<RuntimeAttachmentReference>((resolve) => {
+      resolvePut = resolve;
+    });
+    const store: RuntimeAttachmentStore = {
+      get: () => Promise.resolve(null),
+      put: () => {
+        resolvePutStarted();
+        return putResult;
+      },
+    };
+    const runtimeInput = createRuntimeInputState([]);
+    const pending = addSteeringInput(
+      runtimeInput,
+      [
+        {
+          data: new Uint8Array([1, 2, 3]),
+          mediaType: "image/png",
+          type: "file",
+        },
+      ],
+      store
+    );
+
+    await putStarted;
+    closeRuntimeInput(runtimeInput, "test close");
+    resolvePut({ id: "attachment-1", schemaVersion: 1 });
+
+    await expect(pending).rejects.toThrow(
+      "thread.steer() cannot be used after test close"
+    );
+    expect(runtimeInput.queue).toEqual([]);
+  });
+});

--- a/packages/runtime/src/thread/input/runtime-input.ts
+++ b/packages/runtime/src/thread/input/runtime-input.ts
@@ -1,6 +1,11 @@
 import type { ClaimedThreadInput } from "../../execution/host/types";
 import type { AgentEvent, RuntimeInput } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
+import {
+  type RuntimeAttachmentStore,
+  stageUserInputAttachments,
+  userInputRequiresAttachmentProcessing,
+} from "./attachments";
 import type { AgentInput, UserInput } from "./input";
 import { attachInputMeta } from "./input-meta";
 import { normalizeAgentInput } from "./input-normalization";
@@ -44,17 +49,24 @@ export function createRuntimeInputState(
 
 export function addSteeringInput(
   runtimeInput: RuntimeInputState,
-  input: AgentInput
+  input: AgentInput,
+  attachmentStore: RuntimeAttachmentStore | undefined
 ): Promise<void> {
-  const next = runtimeInput.pending.then(() => {
+  const placement = currentSteeringPlacement(runtimeInput);
+  const next = runtimeInput.pending.then(async () => {
     assertRuntimeInputOpen(runtimeInput);
 
+    const acceptedInput = attachInputMeta(normalizeAgentInput(input), {
+      source: "steer",
+      streaming: "steer",
+    });
+    const staged = userInputRequiresAttachmentProcessing(acceptedInput)
+      ? await stageUserInputAttachments(acceptedInput, attachmentStore)
+      : acceptedInput;
+    assertRuntimeInputOpen(runtimeInput);
     queueRuntimeInput(runtimeInput, {
-      input: attachInputMeta(normalizeAgentInput(input), {
-        source: "steer",
-        streaming: "steer",
-      }),
-      placement: currentSteeringPlacement(runtimeInput),
+      input: staged,
+      placement,
     });
   });
   runtimeInput.pending = next.catch(() => undefined);

--- a/packages/runtime/src/thread/protocol/mapping.ts
+++ b/packages/runtime/src/thread/protocol/mapping.ts
@@ -96,6 +96,10 @@ function userMessageFileDataToFileData(
     return data;
   }
 
+  if (data instanceof ArrayBuffer || data instanceof Uint8Array) {
+    return data;
+  }
+
   if (data.type === "url") {
     return data.url;
   }

--- a/packages/runtime/src/thread/runtime/attachment-staging.test.ts
+++ b/packages/runtime/src/thread/runtime/attachment-staging.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { MemoryAttachmentStore } from "../../platform/memory";
+import {
+  collectRun,
+  fakeModel,
+  getGenerateTextMock,
+  loadAgent,
+} from "../../testing/llm-test-utils";
+import { assistantMessage } from "../../testing/test-fixtures";
+import { SpyStore } from "../handle/test-support";
+import {
+  encodeRuntimeAttachmentData,
+  isRuntimeAttachmentData,
+} from "../input/attachments";
+
+const generateTextMock = getGenerateTextMock();
+
+describe("runtime attachment staging", () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("DONE")],
+    });
+  });
+
+  it("stores file bytes as an internal ref before committing user history", async () => {
+    const threadStore = new SpyStore();
+    const attachmentStore = new MemoryAttachmentStore();
+    const imageBytes = new Uint8Array([11, 22, 33, 44]);
+    const Agent = await loadAgent();
+    const agent = new Agent({
+      attachmentStore,
+      host: { attachmentStore, kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    const events = await collectRun(
+      await agent.send([
+        { text: "describe", type: "text" },
+        {
+          data: imageBytes,
+          filename: "photo.png",
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    );
+    expect(events.filter((event) => event.type === "turn-error")).toEqual([]);
+    const acceptedInput = events[0];
+    if (acceptedInput?.type !== "user-input" || !("content" in acceptedInput)) {
+      throw new Error("expected staged multipart user-input event");
+    }
+    const acceptedFilePart = acceptedInput.content[1];
+    expect(acceptedFilePart?.type).toBe("file");
+    if (acceptedFilePart?.type !== "file") {
+      throw new Error("expected staged event file part");
+    }
+    expect(isRuntimeAttachmentData(acceptedFilePart.data)).toBe(true);
+
+    const committedState = threadStore.commits.at(0)?.next.state;
+    const committedJson = JSON.stringify(committedState);
+    expect(committedJson).toContain("pss-attachment:");
+    expect(committedJson).not.toContain('"0":11');
+    expect(committedJson).not.toContain('"1":22');
+
+    const committedPart = filePartFromStoredState(committedState);
+    expect(isRuntimeAttachmentData(committedPart.data)).toBe(true);
+
+    const generateTextInput = generateTextMock.mock.calls.at(-1)?.[0];
+    expect(generateTextInput?.messages).toEqual([
+      {
+        content: [
+          { text: "describe", type: "text" },
+          {
+            data: imageBytes,
+            filename: "photo.png",
+            mediaType: "image/png",
+            type: "file",
+          },
+        ],
+        role: "user",
+      },
+    ]);
+  });
+
+  it("stores base64 file strings as an internal ref before committing user history", async () => {
+    const threadStore = new SpyStore();
+    const attachmentStore = new MemoryAttachmentStore();
+    const Agent = await loadAgent();
+    const agent = new Agent({
+      attachmentStore,
+      host: { attachmentStore, kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    const events = await collectRun(
+      await agent.send([
+        { text: "describe", type: "text" },
+        {
+          data: "AQIDBA==",
+          filename: "photo.png",
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    );
+    const acceptedInput = events[0];
+    if (acceptedInput?.type !== "user-input" || !("content" in acceptedInput)) {
+      throw new Error("expected staged multipart user-input event");
+    }
+    const acceptedFilePart = acceptedInput.content[1];
+    expect(acceptedFilePart?.type).toBe("file");
+    if (acceptedFilePart?.type !== "file") {
+      throw new Error("expected staged event file part");
+    }
+    expect(isRuntimeAttachmentData(acceptedFilePart.data)).toBe(true);
+
+    const committedPart = filePartFromStoredState(
+      threadStore.commits.at(0)?.next.state
+    );
+    expect(isRuntimeAttachmentData(committedPart.data)).toBe(true);
+
+    const generateTextInput = generateTextMock.mock.calls.at(-1)?.[0];
+    expect(generateTextInput?.messages).toEqual([
+      {
+        content: [
+          { text: "describe", type: "text" },
+          {
+            data: new Uint8Array([1, 2, 3, 4]),
+            filename: "photo.png",
+            mediaType: "image/png",
+            type: "file",
+          },
+        ],
+        role: "user",
+      },
+    ]);
+  });
+
+  it("rejects externally supplied runtime attachment refs before queueing", async () => {
+    const threadStore = new SpyStore();
+    const attachmentStore = new MemoryAttachmentStore();
+    const Agent = await loadAgent();
+    const agent = new Agent({
+      attachmentStore,
+      host: { attachmentStore, kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    await expect(
+      agent.send([
+        { text: "spoof", type: "text" },
+        {
+          data: encodeRuntimeAttachmentData({
+            id: "attacker-controlled",
+            schemaVersion: 1,
+          }),
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    ).rejects.toThrow("External input cannot contain runtime attachment refs.");
+    expect(threadStore.commits).toEqual([]);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects nested externally supplied runtime attachment refs before queueing", async () => {
+    const threadStore = new SpyStore();
+    const attachmentStore = new MemoryAttachmentStore();
+    const Agent = await loadAgent();
+    const agent = new Agent({
+      attachmentStore,
+      host: { attachmentStore, kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    await expect(
+      agent.send([
+        { text: "spoof", type: "text" },
+        {
+          data: {
+            data: encodeRuntimeAttachmentData({
+              id: "attacker-controlled",
+              schemaVersion: 1,
+            }),
+            type: "data",
+          },
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    ).rejects.toThrow("External input cannot contain runtime attachment refs.");
+    expect(threadStore.commits).toEqual([]);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects url-wrapped externally supplied runtime attachment refs before queueing", async () => {
+    const threadStore = new SpyStore();
+    const attachmentStore = new MemoryAttachmentStore();
+    const Agent = await loadAgent();
+    const agent = new Agent({
+      attachmentStore,
+      host: { attachmentStore, kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    await expect(
+      agent.send([
+        { text: "spoof", type: "text" },
+        {
+          data: {
+            type: "url",
+            url: encodeRuntimeAttachmentData({
+              id: "attacker-controlled",
+              schemaVersion: 1,
+            }),
+          },
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    ).rejects.toThrow("External input cannot contain runtime attachment refs.");
+    expect(threadStore.commits).toEqual([]);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects file bytes before queueing when a custom host has no attachment store", async () => {
+    const threadStore = new SpyStore();
+    const Agent = await loadAgent();
+    const agent = new Agent({
+      host: { kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    await expect(
+      agent.send([
+        { text: "describe", type: "text" },
+        {
+          data: new Uint8Array([1, 2, 3]),
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    ).rejects.toThrow("File byte inputs require an attachment store.");
+    expect(threadStore.commits).toEqual([]);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+});
+
+function filePartFromStoredState(state: unknown): {
+  readonly data: unknown;
+  readonly type: "file";
+} {
+  if (
+    state === null ||
+    typeof state !== "object" ||
+    !("history" in state) ||
+    !Array.isArray(state.history)
+  ) {
+    throw new Error("expected stored thread state with history");
+  }
+
+  const history: readonly unknown[] = state.history;
+  const [message] = history;
+  if (
+    message === null ||
+    typeof message !== "object" ||
+    !("content" in message) ||
+    !Array.isArray(message.content)
+  ) {
+    throw new Error("expected stored user message content");
+  }
+
+  const content: readonly unknown[] = message.content;
+  const part = content.find(isStoredFilePart);
+  if (part === undefined) {
+    throw new Error("expected stored file part");
+  }
+
+  return part;
+}
+
+function isStoredFilePart(
+  value: unknown
+): value is { readonly data: unknown; readonly type: "file" } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "data" in value &&
+    "type" in value &&
+    value.type === "file"
+  );
+}

--- a/packages/runtime/src/thread/runtime/auto-compaction.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction.ts
@@ -167,6 +167,7 @@ async function summarizeCompactionRange({
   readonly model: ModelGenerationOptions;
 }): Promise<string> {
   const output = await generateModelStep({
+    attachmentStore: model.attachmentStore,
     history: [
       {
         content:

--- a/packages/runtime/src/thread/runtime/continuation.test.ts
+++ b/packages/runtime/src/thread/runtime/continuation.test.ts
@@ -6,9 +6,9 @@ import {
   createCallbackModel,
   sentUserText,
   steerRuntimeInput,
-  steerRuntimeInputMessage,
   userText,
 } from "../../testing/test-fixtures";
+import { isRuntimeAttachmentData } from "../input/attachments";
 import type { AgentEvent } from "../protocol/events";
 import { userTextToModelMessage } from "../protocol/mapping";
 
@@ -93,24 +93,55 @@ describe("Agent thread runtime input continuation", () => {
       }
     }
 
-    expect(runtimeInputs).toEqual([
-      steerRuntimeInputMessage(input, "step-start"),
-    ]);
+    const runtimeInput = runtimeInputs[0];
+    if (runtimeInput?.type !== "runtime-input") {
+      throw new Error("expected runtime input event");
+    }
+    expect(runtimeInput.placement).toBe("step-start");
+    expect(runtimeInput.meta).toEqual({
+      source: "steer",
+      streaming: "steer",
+    });
+    if (!("content" in runtimeInput.input)) {
+      throw new Error("expected multipart runtime input");
+    }
+    expect(runtimeInput.input.content[0]).toEqual({
+      text: "describe this",
+      type: "text",
+    });
+    const runtimeImagePart = runtimeInput.input.content[1];
+    expect(runtimeImagePart?.type).toBe("file");
+    if (runtimeImagePart?.type !== "file") {
+      throw new Error("expected staged file part");
+    }
+    expect(isRuntimeAttachmentData(runtimeImagePart.data)).toBe(true);
     expect(seenHistory).toEqual([
       [
         userTextToModelMessage(userText("initial")),
         {
-          role: "user",
           content: [
-            { type: "text", text: "describe this" },
-            { type: "file", data: "iVBORw0KGgo=", mediaType: "image/png" },
             {
+              providerOptions: undefined,
+              text: "describe this",
+              type: "text",
+            },
+            {
+              data: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
+              filename: undefined,
+              mediaType: "image/png",
+              providerOptions: undefined,
               type: "file",
+            },
+            {
               data: { type: "text", text: "inline document" },
               filename: "note.txt",
               mediaType: "text/plain",
+              providerOptions: undefined,
+              type: "file",
             },
           ],
+          providerOptions: undefined,
+          role: "user",
         },
       ],
     ]);

--- a/packages/runtime/src/thread/runtime/drain.ts
+++ b/packages/runtime/src/thread/runtime/drain.ts
@@ -1,4 +1,5 @@
 import type { ExecutionHost } from "../../execution/host/types";
+import type { RuntimeAttachmentStore } from "../input/attachments";
 import {
   type RuntimeInputPlacement,
   type RuntimeInputState,
@@ -23,7 +24,9 @@ export async function drainRuntimeInput({
   runtimeInput,
   state,
   threadKey,
+  attachmentStore,
 }: {
+  readonly attachmentStore: RuntimeAttachmentStore | undefined;
   readonly events: ThreadEventDispatcher;
   readonly executionHost?: ExecutionHost;
   readonly placement: RuntimeInputPlacement;
@@ -35,7 +38,9 @@ export async function drainRuntimeInput({
   let added = false;
   let next = shiftRuntimeInput(runtimeInput, placement);
   while (next) {
-    if (await emitRuntimeInputEvent(events, run, state, next)) {
+    if (
+      await emitRuntimeInputEvent(events, run, state, next, { attachmentStore })
+    ) {
       added = true;
     }
     next = shiftRuntimeInput(runtimeInput, placement);
@@ -45,6 +50,7 @@ export async function drainRuntimeInput({
     (await drainDurableRuntimeInput({
       events,
       executionHost,
+      attachmentStore,
       placement,
       run,
       state,
@@ -56,6 +62,7 @@ export async function drainRuntimeInput({
 async function drainDurableRuntimeInput({
   events,
   executionHost,
+  attachmentStore,
   placement,
   run,
   state,
@@ -63,6 +70,7 @@ async function drainDurableRuntimeInput({
 }: {
   readonly events: ThreadEventDispatcher;
   readonly executionHost?: ExecutionHost;
+  readonly attachmentStore: RuntimeAttachmentStore | undefined;
   readonly placement: RuntimeInputPlacement;
   readonly run: BufferedAgentTurn;
   readonly state: ThreadState;
@@ -90,6 +98,7 @@ async function drainDurableRuntimeInput({
           placement,
         },
         {
+          attachmentStore,
           commit: () =>
             commitAndAckDurableThreadInput({
               executionHost,

--- a/packages/runtime/src/thread/runtime/events.test.ts
+++ b/packages/runtime/src/thread/runtime/events.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { MemoryAttachmentStore } from "../../platform/memory";
+import {
+  decodeRuntimeAttachmentData,
+  isRuntimeAttachmentData,
+} from "../input/attachments";
 import type { AgentPlugin } from "../plugins/pipeline";
 import { BufferedAgentTurn } from "../protocol/turn";
 import { ThreadEventDispatcher } from "./events";
 
 function createDispatcher(
-  plugins: readonly AgentPlugin[]
+  plugins: readonly AgentPlugin[],
+  attachmentStore?: MemoryAttachmentStore
 ): ThreadEventDispatcher {
   return new ThreadEventDispatcher({
+    attachmentStore,
     history: () => [],
     plugins,
     signal: () => undefined,
@@ -45,6 +52,110 @@ describe("ThreadEventDispatcher.emitRunEvent", () => {
       text: "TAG:hello",
     });
     await iterator.return?.();
+  });
+
+  it("stages plugin-transformed file bytes before emitting user-input", async () => {
+    const attachmentStore = new MemoryAttachmentStore();
+    const transformPlugin: AgentPlugin = {
+      on: ({ event }) => {
+        if (event.type !== "user-input") {
+          return;
+        }
+        return {
+          action: "transform",
+          event: {
+            content: [
+              {
+                data: new Uint8Array([1, 2, 3]),
+                mediaType: "application/octet-stream",
+                type: "file",
+              },
+            ],
+            type: "user-input",
+          },
+        };
+      },
+    };
+    const dispatcher = createDispatcher([transformPlugin], attachmentStore);
+    const run = new BufferedAgentTurn();
+
+    const emitted = await dispatcher.emitRunEvent(run, {
+      type: "user-input",
+      text: "hello",
+    });
+
+    if (emitted === "handled" || !("content" in emitted)) {
+      throw new Error("expected emitted multipart user-input");
+    }
+    const part = emitted.content[0];
+    expect(part?.type).toBe("file");
+    if (part?.type !== "file") {
+      throw new Error("expected emitted file part");
+    }
+    const ref = part.data;
+    if (!isRuntimeAttachmentData(ref)) {
+      throw new Error("expected runtime attachment data");
+    }
+    const blob = await attachmentStore.get(decodeRuntimeAttachmentData(ref));
+    expect(blob?.bytes).toEqual(new Uint8Array([1, 2, 3]));
+
+    const iterator = run.events()[Symbol.asyncIterator]();
+    expect((await iterator.next()).value).toEqual(emitted);
+    await iterator.return?.();
+  });
+
+  it("stages plugin-transformed file bytes before returning runtime-input", async () => {
+    const attachmentStore = new MemoryAttachmentStore();
+    const transformPlugin: AgentPlugin = {
+      on: ({ event }) => {
+        if (event.type !== "runtime-input") {
+          return;
+        }
+        return {
+          action: "transform",
+          event: {
+            input: {
+              content: [
+                {
+                  data: new Uint8Array([4, 5, 6]),
+                  mediaType: "application/octet-stream",
+                  type: "file",
+                },
+              ],
+              type: "user-input",
+            },
+            placement: event.placement,
+            type: "runtime-input",
+          },
+        };
+      },
+    };
+    const dispatcher = createDispatcher([transformPlugin], attachmentStore);
+
+    const emitted = await dispatcher.interceptEvent({
+      input: { text: "hint", type: "user-input" },
+      placement: "step-start",
+      type: "runtime-input",
+    });
+
+    if (
+      emitted === "handled" ||
+      emitted.type !== "runtime-input" ||
+      !("content" in emitted.input)
+    ) {
+      throw new Error("expected emitted multipart runtime-input");
+    }
+    const part = emitted.input.content[0];
+    expect(part?.type).toBe("file");
+    if (part?.type !== "file") {
+      throw new Error("expected emitted runtime-input file part");
+    }
+    const ref = part.data;
+    if (!isRuntimeAttachmentData(ref)) {
+      throw new Error("expected runtime attachment data");
+    }
+    const blob = await attachmentStore.get(decodeRuntimeAttachmentData(ref));
+    expect(blob?.bytes).toEqual(new Uint8Array([4, 5, 6]));
   });
 
   it("returns handled without emitting user-input to the run", async () => {

--- a/packages/runtime/src/thread/runtime/events.ts
+++ b/packages/runtime/src/thread/runtime/events.ts
@@ -4,6 +4,10 @@ import type {
   RuntimeToolExecutionDecision,
 } from "../../llm/llm";
 import {
+  type RuntimeAttachmentStore,
+  stageAgentEventAttachments,
+} from "../input/attachments";
+import {
   type AgentPlugin,
   type PluginPipelineResult,
   runPluginsForEvent,
@@ -12,18 +16,21 @@ import type { AgentEvent, BeforeToolCall } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
 
 interface ThreadEventDispatcherOptions {
+  readonly attachmentStore?: RuntimeAttachmentStore;
   readonly history: () => readonly ModelMessage[];
   readonly plugins: readonly AgentPlugin[];
   readonly signal: () => AbortSignal | undefined;
 }
 
 export class ThreadEventDispatcher {
+  readonly #attachmentStore: RuntimeAttachmentStore | undefined;
   readonly #history: () => readonly ModelMessage[];
   #observerEventBuffer?: AgentEvent[];
   readonly #plugins: readonly AgentPlugin[];
   readonly #signal: () => AbortSignal | undefined;
 
   constructor(options: ThreadEventDispatcherOptions) {
+    this.#attachmentStore = options.attachmentStore;
     this.#history = options.history;
     this.#plugins = options.plugins;
     this.#signal = options.signal;
@@ -134,7 +141,9 @@ export class ThreadEventDispatcher {
       return event;
     }
 
-    return pipeline.event;
+    return stageAgentEventAttachments(pipeline.event, this.#attachmentStore, {
+      trustRuntimeAttachmentRefs: true,
+    });
   }
 
   emitProcessedEvent(run: BufferedAgentTurn, event: AgentEvent): void {

--- a/packages/runtime/src/thread/runtime/notification.ts
+++ b/packages/runtime/src/thread/runtime/notification.ts
@@ -1,3 +1,8 @@
+import {
+  type RuntimeAttachmentStore,
+  stageAgentEventsAttachments,
+  stageUserInputAttachments,
+} from "../input/attachments";
 import type { AgentInput, UserInput } from "../input/input";
 import { attachInputMeta } from "../input/input-meta";
 import { normalizeInternalAgentInput } from "../input/input-normalization";
@@ -21,6 +26,7 @@ export interface NotifyOptions {
 interface QueueThreadNotificationOptions {
   readonly activeRun: BufferedAgentTurn | undefined;
   readonly activeRuntimeInput: RuntimeInputState | undefined;
+  readonly attachmentStore: RuntimeAttachmentStore | undefined;
   readonly drain: () => Promise<void>;
   emitObserverEvent(
     run: BufferedAgentTurn | undefined,
@@ -35,14 +41,26 @@ export async function queueThreadNotification(
   options: NotifyOptions,
   state: QueueThreadNotificationOptions
 ): Promise<AgentTurn> {
+  const attachmentStore = state.attachmentStore;
   const queuedRuntimeInput: QueuedRuntimeInput = {
-    input: attachInputMeta(normalizeInternalAgentInput(input), {
-      source: "notify",
-    }),
+    input: await stageUserInputAttachments(
+      attachInputMeta(normalizeInternalAgentInput(input), {
+        source: "notify",
+      }),
+      attachmentStore,
+      { trustRuntimeAttachmentRefs: true }
+    ),
     placement: "turn-start",
   };
-  const queuedOverlays = createNotificationOverlays(options.overlays ?? []);
-  const observerEvents = cloneObserverEvents(options.observerEvents ?? []);
+  const queuedOverlays = await createNotificationOverlays(
+    options.overlays ?? [],
+    attachmentStore
+  );
+  const observerEvents = await stageAgentEventsAttachments(
+    options.observerEvents ?? [],
+    attachmentStore,
+    { trustRuntimeAttachmentRefs: true }
+  );
   const queuedTurn = state.inputQueue[0];
   if (queuedTurn) {
     queuedTurn.initialEvents.push(...observerEvents);
@@ -95,18 +113,23 @@ export function startThreadQueueDrain(
   });
 }
 
-function cloneObserverEvents(events: readonly AgentEvent[]): AgentEvent[] {
-  return events.map((event) => structuredClone(event));
-}
-
-function createNotificationOverlays(
-  overlays: readonly (AgentInput | UserInput)[]
-): QueuedRuntimeInput[] {
-  return overlays.map((input) => ({
-    canonical: false,
-    input: attachInputMeta(normalizeInternalAgentInput(input), {
-      source: "overlay",
-    }),
-    placement: "turn-start",
-  }));
+async function createNotificationOverlays(
+  overlays: readonly (AgentInput | UserInput)[],
+  attachmentStore: RuntimeAttachmentStore | undefined
+): Promise<QueuedRuntimeInput[]> {
+  const queued: QueuedRuntimeInput[] = [];
+  for (const input of overlays) {
+    queued.push({
+      canonical: false,
+      input: await stageUserInputAttachments(
+        attachInputMeta(normalizeInternalAgentInput(input), {
+          source: "overlay",
+        }),
+        attachmentStore,
+        { trustRuntimeAttachmentRefs: true }
+      ),
+      placement: "turn-start" as const,
+    });
+  }
+  return queued;
 }

--- a/packages/runtime/src/thread/runtime/turn-events.ts
+++ b/packages/runtime/src/thread/runtime/turn-events.ts
@@ -1,4 +1,5 @@
 import type { ExecutionHost } from "../../execution/host/types";
+import type { RuntimeAttachmentStore } from "../input/attachments";
 import {
   type RuntimeInputState,
   withRuntimeInputWindow,
@@ -13,6 +14,7 @@ export async function emitTurnEvent({
   event,
   events,
   executionHost,
+  attachmentStore,
   awaitBoundaries,
   run,
   runtimeInput,
@@ -20,6 +22,7 @@ export async function emitTurnEvent({
   threadKey,
 }: {
   readonly event: AgentEvent;
+  readonly attachmentStore: RuntimeAttachmentStore | undefined;
   readonly awaitBoundaries: boolean;
   readonly events: ThreadEventDispatcher;
   readonly executionHost: ExecutionHost | undefined;
@@ -39,6 +42,7 @@ export async function emitTurnEvent({
     });
   });
   const runtimeInputAdded = await drainRuntimeInput({
+    attachmentStore,
     events,
     executionHost,
     placement: event.type,

--- a/packages/runtime/src/thread/runtime/turn-processor.ts
+++ b/packages/runtime/src/thread/runtime/turn-processor.ts
@@ -1,6 +1,7 @@
 import { runAgentLoop } from "../../agent/loop/loop";
 import type { ModelGenerationOptions } from "../../llm/llm";
 import { ToolExecutionNeedsRecoveryError } from "../../llm/tool-execution";
+import { stageUserInputAttachments } from "../input/attachments";
 import {
   closeRuntimeInput,
   type QueuedInput,
@@ -98,10 +99,15 @@ export async function processQueuedInput({
     const committedPreUser = await commitPreUserRuntimeInputs(
       events,
       state,
-      preUserRuntimeInputs
+      preUserRuntimeInputs,
+      model.attachmentStore
     );
     if (input) {
-      state.appendUserInput(input);
+      state.appendUserInput(
+        await stageUserInputAttachments(input, model.attachmentStore, {
+          trustRuntimeAttachmentRefs: true,
+        })
+      );
       if (pendingDurableInputClaim) {
         await commitAndAckDurableThreadInput({
           executionHost: execution.executionHost,
@@ -122,6 +128,7 @@ export async function processQueuedInput({
     });
     await emitCommittedRuntimeInputs(events, run, committedPreUser);
     await drainRuntimeInput({
+      attachmentStore: model.attachmentStore,
       events,
       executionHost: execution.executionHost,
       placement: "turn-start",
@@ -138,6 +145,7 @@ export async function processQueuedInput({
         runAgentLoop({
           emit: async (event) =>
             emitTurnEvent({
+              attachmentStore: model.attachmentStore,
               event,
               events,
               executionHost: execution.executionHost,


### PR DESCRIPTION
## Summary
- Add runtime-owned attachment staging for file/bytes/base64 inputs into durable `pss-attachment:` refs.
- Add memory, file, and Cloudflare attachment stores, with model-call-time hydration.
- Harden external ref injection, overlay inputs, plugin-transform output, and steer close-race boundaries.

Fixes #173

## Release
- Patch changeset for `@minpeter/pss-runtime`.

## Validation
- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm -C packages/runtime exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm -C packages/runtime exec vitest run src/thread/runtime/windows.test.ts src/thread/input/runtime-input.test.ts src/thread/runtime/attachment-staging.test.ts src/llm/attachment-hydration.test.ts`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm changeset status --since origin/main`
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime-owned multimodal attachment staging and durable `pss-attachment:` refs, with Memory/File/Cloudflare stores and provider-time hydration. This shrinks stored JSON, enables safe durable notifications, and hardens input handling (no external refs; `overlay()` can’t carry inline bytes).

- **New Features**
  - Stages file/bytes/base64 inputs into durable refs across `send()`, `steer()`, notifications, observer events, plugin transforms, and the durable queue.
  - Introduces `RuntimeAttachmentStore` plus `MemoryAttachmentStore`, `FileAttachmentStore`, and `CloudflareAttachmentStore`.
  - Hydrates refs into transient bytes before model calls; fails fast if refs exist without a store.
  - Hosts now expose `attachmentStore`; `AgentOptions` accepts `attachmentStore`. Public exports include ref encode/decode helpers.
  - Tightens security: rejects external runtime refs and stages overlays/observer events before enqueue.

- **Migration**
  - Provide an `attachmentStore` (via `AgentOptions.attachmentStore` or on the host) when sending file bytes or base64 data.
  - `thread.overlay()` no longer accepts inline file bytes or runtime refs; use text/remote URLs, or move file context to `thread.send()` or `notify(..., { overlays })` with a store.
  - Custom hosts should implement the optional `attachmentStore` on `ExecutionHost`/`ThreadHost`/`DurableBackgroundHost`.

<sup>Written for commit d84ebb3cf1a927f61697e8174eb8fa137f8ac414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

