### PR TITLE
[codex] Close runtime attachment staging cleanup gaps

### DIFF
--- a/.changeset/runtime-attachment-review-fixes.md
+++ b/.changeset/runtime-attachment-review-fixes.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Tighten runtime attachment ref validation, cleanup staged attachments on rejected durable inputs, and keep host-owned attachment stores authoritative for resumed work.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ await agent.send([
 ]);
 ```
 
+Inline image/file bytes and base64 data URLs are staged into the runtime's
+`attachmentStore` before thread state is committed. Durable events and snapshots
+store only internal `pss-attachment:` refs, and the runtime hydrates those refs
+back into bytes immediately before calling the model. Custom hosts that accept
+byte inputs must provide an `attachmentStore` with `put`, `get`, and `delete`;
+remote `http(s)` media stays as a provider URL/reference and is not fetched by
+the runtime.
+
 Run the TUI:
 
 ```sh

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -107,9 +107,13 @@ await agent.send([
 ]);
 ```
 
-The runtime normalizes and persists these content parts as thread continuation
-state; it does not fetch remote media, decode files, or guarantee provider support
-for every media type.
+Inline bytes and base64 data URLs are runtime-owned attachments. Before the
+input is committed, the runtime writes them to the configured `attachmentStore`
+and persists only internal `pss-attachment:` refs in events, snapshots, queued
+inputs, and notifications. Refs are hydrated back into bytes immediately before
+model generation. Custom hosts that accept byte inputs must provide an
+`attachmentStore` with `put`, `get`, and `delete`; remote `http(s)` media stays
+as a provider URL/reference and is not fetched by the runtime.
 
 The public transcript protocol is `AgentEvent`: live turns emit runtime-defined
 events through `turn.events()`. Provider/model message history is internal
@@ -322,11 +326,13 @@ Each accepted call returns one `AgentTurn`. Drain that turn's `events()` stream 
 observe the turn; each `AgentTurn.events()` stream is single-consumer.
 
 Input APIs accept strings, arrays of strings, or multipart arrays such as
-`[{ type: "text", text: "hello" }, { type: "image", image }]`. The runtime
-normalizes accepted `send` input into `user-input` events. Active steering and
-host resume input emit `runtime-input` events. A `runtime-input` is
-runtime/API-originated input mapped internally to the model's user role. It is
-distinct from human-origin `user-input` events.
+`[{ type: "text", text: "hello" }, { type: "image", image }]`. Inline
+image/file bytes are staged into `attachmentStore` and replaced by
+`pss-attachment:` refs before durable state is written. The runtime normalizes
+accepted `send` input into `user-input` events. Active steering and host resume
+input emit `runtime-input` events. A `runtime-input` is runtime/API-originated
+input mapped internally to the model's user role. It is distinct from
+human-origin `user-input` events.
 
 Runtime input windows are tied to synchronized events:
 

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -46,11 +46,12 @@ export class Agent {
   constructor(options: AgentOptions) {
     assertAgentOptions(options);
 
+    const providedHost = options.host;
     this.namespace = options.namespace;
     this.#ownerNamespace = stableAgentNamespace({
       namespace: options.namespace,
     });
-    this.#host = options.host ?? createInMemoryExecutionHost();
+    this.#host = providedHost ?? createInMemoryExecutionHost();
     this.host = this.#host;
     this.#store = threadStoreForHost(this.#host);
     this.#plugins = options.plugins ?? [];
@@ -59,7 +60,10 @@ export class Agent {
       options.autoCompaction
     );
     this.#modelOptions = {
-      attachmentStore: options.attachmentStore ?? this.#host.attachmentStore,
+      attachmentStore:
+        providedHost?.attachmentStore ??
+        options.attachmentStore ??
+        this.#host.attachmentStore,
       instructions: options.instructions,
       model: options.model,
       toolChoice: options.toolChoice,

--- a/packages/runtime/src/agent/core/host-api.test.ts
+++ b/packages/runtime/src/agent/core/host-api.test.ts
@@ -6,6 +6,7 @@ import type {
   ThreadHost,
 } from "../../execution";
 import { createInMemoryExecutionHost } from "../../platform/memory";
+import { MemoryAttachmentStore } from "../../platform/memory/storage/memory-attachment-store";
 import {
   createMockLanguageModelV4,
   mockLanguageModelV4Text,
@@ -15,6 +16,12 @@ import {
   createCallbackModel,
 } from "../../testing/test-fixtures";
 import { collect, SpyStore } from "../../thread/handle/test-support";
+import type {
+  RuntimeAttachmentBlob,
+  RuntimeAttachmentPutInput,
+  RuntimeAttachmentReference,
+  RuntimeAttachmentStore,
+} from "../../thread/input/attachments";
 import { Agent, type AgentHost, type AgentOptions } from "./agent";
 
 const fakeModel = createMockLanguageModelV4([mockLanguageModelV4Text("DONE")]);
@@ -207,4 +214,76 @@ describe("Agent host public API", () => {
       "scope:user%3A1:thread:room%2F1"
     );
   });
+
+  it("uses a caller-provided host attachment store before an option store", async () => {
+    const baseHost = createInMemoryExecutionHost();
+    const hostAttachmentStore = new TrackingAttachmentStore();
+    const optionAttachmentStore = new TrackingAttachmentStore();
+    const agent = new Agent({
+      attachmentStore: optionAttachmentStore,
+      host: { ...baseHost, attachmentStore: hostAttachmentStore },
+      model: createCallbackModel(() =>
+        Promise.resolve([assistantMessage("DONE")])
+      ),
+    });
+
+    await collect(
+      await agent.send([
+        {
+          data: new Uint8Array([1, 2, 3]),
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    );
+
+    expect(hostAttachmentStore.putCount).toBe(1);
+    expect(optionAttachmentStore.putCount).toBe(0);
+  });
+
+  it("uses an option attachment store when Agent creates the host", async () => {
+    const attachmentStore = new TrackingAttachmentStore();
+    const agent = new Agent({
+      attachmentStore,
+      model: createCallbackModel(() =>
+        Promise.resolve([assistantMessage("DONE")])
+      ),
+    });
+
+    await collect(
+      await agent.send([
+        {
+          data: new Uint8Array([1, 2, 3]),
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    );
+
+    expect(attachmentStore.putCount).toBe(1);
+  });
 });
+
+class TrackingAttachmentStore implements RuntimeAttachmentStore {
+  readonly #store = new MemoryAttachmentStore();
+  #putCount = 0;
+
+  get putCount(): number {
+    return this.#putCount;
+  }
+
+  delete(ref: RuntimeAttachmentReference): Promise<void> {
+    return this.#store.delete(ref);
+  }
+
+  get(ref: RuntimeAttachmentReference): Promise<RuntimeAttachmentBlob | null> {
+    return this.#store.get(ref);
+  }
+
+  async put(
+    input: RuntimeAttachmentPutInput
+  ): Promise<RuntimeAttachmentReference> {
+    this.#putCount += 1;
+    return await this.#store.put(input);
+  }
+}

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { agentNamespace } from "../../agent/identity/namespace";
 import { createInMemoryExecutionHost } from "../../platform/memory";
-import { isRuntimeAttachmentData } from "../../thread/input/attachments";
+import {
+  isRuntimeAttachmentData,
+  type RuntimeAttachmentReference,
+  type RuntimeAttachmentStore,
+} from "../../thread/input/attachments";
 import type { ExecutionHost, TurnRecord, TurnStore } from "../host/types";
 import { dispatchAgentNotification } from "./notification-dispatch";
 
@@ -190,7 +194,99 @@ describe("dispatchAgentNotification", () => {
 
     expect(duplicate).toEqual({ ...first, deduplicated: true });
   });
+
+  it("deletes staged notification attachments when a create race dedupes", async () => {
+    const baseHost = createInMemoryExecutionHost();
+    const deletedRefs: RuntimeAttachmentReference[] = [];
+    const attachmentStore = trackingAttachmentStore(
+      baseHost.attachmentStore,
+      deletedRefs
+    );
+    const host = { ...baseHost, attachmentStore } satisfies ExecutionHost;
+    const first = await dispatchAgentNotification({
+      host,
+      idempotencyKey: "attachment-race",
+      input: { text: "first", type: "user-input" },
+      namespace: "agent-a",
+      threadKey: "room:1:user:2",
+    });
+    const racingHost = hostWithDuplicateRunCreateAfterFirstLookup(host);
+
+    const duplicate = await dispatchAgentNotification({
+      host: racingHost,
+      idempotencyKey: "attachment-race",
+      input: {
+        content: [
+          {
+            data: new Uint8Array([1, 2, 3]),
+            filename: "duplicate.png",
+            mediaType: "image/png",
+            type: "file",
+          },
+        ],
+        type: "user-input",
+      },
+      namespace: "agent-a",
+      threadKey: "room:1:user:2",
+    });
+
+    expect(duplicate).toEqual({ ...first, deduplicated: true });
+    expect(deletedRefs).toHaveLength(1);
+    const deletedRef = deletedRefs[0];
+    if (!deletedRef) {
+      throw new Error("expected deleted staged attachment ref");
+    }
+    await expect(attachmentStore.get(deletedRef)).resolves.toBeNull();
+  });
 });
+
+function trackingAttachmentStore(
+  store: RuntimeAttachmentStore | undefined,
+  deletedRefs: RuntimeAttachmentReference[]
+): RuntimeAttachmentStore {
+  if (!store) {
+    throw new Error("expected base host attachment store");
+  }
+
+  return {
+    delete: async (ref) => {
+      deletedRefs.push(ref);
+      await store.delete(ref);
+    },
+    get: (ref) => store.get(ref),
+    put: (input) => store.put(input),
+  };
+}
+
+function hostWithDuplicateRunCreateAfterFirstLookup(
+  host: ExecutionHost
+): ExecutionHost {
+  let dedupeLookups = 0;
+  const runs = {
+    claim: (runId, options) => host.store.turns.claim(runId, options),
+    create: async (record: TurnRecord) => {
+      const existing = record.dedupeKey
+        ? await host.store.turns.getByDedupeKey(record.dedupeKey)
+        : await host.store.turns.get(record.runId);
+      if (!existing) {
+        throw new Error("Expected pre-existing run for duplicate create race.");
+      }
+      return { ok: false, reason: "duplicate", record: existing } as const;
+    },
+    get: (runId) => host.store.turns.get(runId),
+    getByDedupeKey: async (dedupeKey) => {
+      dedupeLookups += 1;
+      return dedupeLookups === 1
+        ? null
+        : await host.store.turns.getByDedupeKey(dedupeKey);
+    },
+    listByParentRunId: (parentRunId) =>
+      host.store.turns.listByParentRunId(parentRunId),
+    update: (record) => host.store.turns.update(record),
+  } satisfies TurnStore;
+
+  return hostWithRuns(host, runs);
+}
 
 function hostWithDuplicateRunCreate(host: ExecutionHost): ExecutionHost {
   const runs = {
@@ -211,6 +307,10 @@ function hostWithDuplicateRunCreate(host: ExecutionHost): ExecutionHost {
     update: (record) => host.store.turns.update(record),
   } satisfies TurnStore;
 
+  return hostWithRuns(host, runs);
+}
+
+function hostWithRuns(host: ExecutionHost, runs: TurnStore): ExecutionHost {
   return {
     ...host,
     store: {

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.ts
@@ -1,5 +1,7 @@
 import { agentNamespace } from "../../agent/identity/namespace";
 import {
+  cleanupStagedRuntimeAttachments,
+  type RuntimeAttachmentReference,
   stageAgentEventsAttachments,
   stageUserInputAttachments,
 } from "../../thread/input/attachments";
@@ -62,83 +64,99 @@ export async function dispatchAgentNotification(
 
   const runId = crypto.randomUUID();
   const notificationId = crypto.randomUUID();
-  const stagedInput = await stageUserInputAttachments(
-    input.input,
-    input.host.attachmentStore
-  );
-  const stagedOverlays = await stageUserInputs(
-    input.overlays,
-    input.host.attachmentStore
-  );
-  const stagedObserverEvents = await stageAgentEventsAttachments(
-    input.observerEvents ?? [],
-    input.host.attachmentStore
-  );
-  const runRecord = {
-    checkpointVersion: 0,
-    dedupeKey: storageIdempotencyKey,
-    kind: "notification",
-    ownerNamespace,
-    rootRunId: runId,
-    runId,
-    threadKey: input.threadKey,
-    status: "queued",
-  } satisfies TurnRecord;
-  const notificationRecord = {
-    idempotencyKey: storageIdempotencyKey,
-    input: stagedInput,
-    notificationId,
-    observerEvents: stagedObserverEvents,
-    overlays: stagedOverlays,
-    ownerNamespace,
-    runId,
-    threadKey: input.threadKey,
-    status: "pending",
-  } satisfies NotificationRecord;
-
+  const stagedRefs: RuntimeAttachmentReference[] = [];
+  let keepStagedAttachments = false;
   try {
-    await input.host.store.transaction(async (tx) => {
-      const runCreate = await tx.turns.create(runRecord);
-      if (!runCreate.ok) {
-        throw new DuplicateNotificationError();
-      }
-      const writeResult = await tx.notifications.enqueue(notificationRecord);
-      if (!writeResult.ok) {
-        throw new DuplicateNotificationError();
-      }
-    });
-  } catch (error) {
-    if (error instanceof DuplicateNotificationError) {
-      const deduplicated = await queuedNotificationRun({
-        host: input.host,
-        idempotencyKey: input.idempotencyKey,
-        ownerNamespace,
-        threadKey: input.threadKey,
-        storageIdempotencyKey,
-      });
-      if (deduplicated) {
-        await scheduleAgentNotification(input.host, deduplicated);
-        return dispatchedAgentNotification(deduplicated);
-      }
-    }
-    throw error;
-  }
+    const stagedInput = await stageUserInputAttachments(
+      input.input,
+      input.host.attachmentStore,
+      { stagedRefs }
+    );
+    const stagedOverlays = await stageUserInputs(
+      input.overlays,
+      input.host.attachmentStore,
+      { stagedRefs }
+    );
+    const stagedObserverEvents = await stageAgentEventsAttachments(
+      input.observerEvents ?? [],
+      input.host.attachmentStore,
+      { stagedRefs }
+    );
+    const runRecord = {
+      checkpointVersion: 0,
+      dedupeKey: storageIdempotencyKey,
+      kind: "notification",
+      ownerNamespace,
+      rootRunId: runId,
+      runId,
+      threadKey: input.threadKey,
+      status: "queued",
+    } satisfies TurnRecord;
+    const notificationRecord = {
+      idempotencyKey: storageIdempotencyKey,
+      input: stagedInput,
+      notificationId,
+      observerEvents: stagedObserverEvents,
+      overlays: stagedOverlays,
+      ownerNamespace,
+      runId,
+      threadKey: input.threadKey,
+      status: "pending",
+    } satisfies NotificationRecord;
 
-  const created = {
-    deduplicated: false,
-    idempotencyKey: input.idempotencyKey,
-    notificationId,
-    runId,
-    threadKey: input.threadKey,
-    storageIdempotencyKey,
-  } satisfies SchedulableAgentNotification;
-  await scheduleAgentNotification(input.host, created);
-  return dispatchedAgentNotification(created);
+    try {
+      await input.host.store.transaction(async (tx) => {
+        const runCreate = await tx.turns.create(runRecord);
+        if (!runCreate.ok) {
+          throw new DuplicateNotificationError();
+        }
+        const writeResult = await tx.notifications.enqueue(notificationRecord);
+        if (!writeResult.ok) {
+          throw new DuplicateNotificationError();
+        }
+      });
+    } catch (error) {
+      if (error instanceof DuplicateNotificationError) {
+        const deduplicated = await queuedNotificationRun({
+          host: input.host,
+          idempotencyKey: input.idempotencyKey,
+          ownerNamespace,
+          threadKey: input.threadKey,
+          storageIdempotencyKey,
+        });
+        if (deduplicated) {
+          await scheduleAgentNotification(input.host, deduplicated);
+          return dispatchedAgentNotification(deduplicated);
+        }
+      }
+      throw error;
+    }
+
+    keepStagedAttachments = true;
+    const created = {
+      deduplicated: false,
+      idempotencyKey: input.idempotencyKey,
+      notificationId,
+      runId,
+      threadKey: input.threadKey,
+      storageIdempotencyKey,
+    } satisfies SchedulableAgentNotification;
+    await scheduleAgentNotification(input.host, created);
+    return dispatchedAgentNotification(created);
+  } finally {
+    if (!keepStagedAttachments) {
+      await cleanupStagedRuntimeAttachments(
+        input.host.attachmentStore,
+        stagedRefs
+      );
+    }
+  }
 }
 
 async function stageUserInputs(
   inputs: readonly UserInput[] | undefined,
-  attachmentStore: Parameters<typeof stageUserInputAttachments>[1]
+  attachmentStore: Parameters<typeof stageUserInputAttachments>[1],
+  options: Parameters<typeof stageUserInputAttachments>[2]
 ): Promise<readonly UserInput[] | undefined> {
   if (!inputs) {
     return;
@@ -146,7 +164,9 @@ async function stageUserInputs(
 
   const staged: UserInput[] = [];
   for (const input of inputs) {
-    staged.push(await stageUserInputAttachments(input, attachmentStore));
+    staged.push(
+      await stageUserInputAttachments(input, attachmentStore, options)
+    );
   }
   return staged;
 }

--- a/packages/runtime/src/platform/cloudflare/storage/attachment-store.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/attachment-store.test.ts
@@ -20,4 +20,29 @@ describe("CloudflareAttachmentStore", () => {
       ref,
     });
   });
+
+  it("deletes stored attachment records by ref", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage();
+    const store = new CloudflareAttachmentStore({ storage });
+    const ref = await store.put({
+      bytes: new Uint8Array([3, 2, 1]),
+      mediaType: "image/png",
+    });
+
+    await store.delete(ref);
+
+    await expect(store.get(ref)).resolves.toBeNull();
+  });
+
+  it("rejects attachment refs that cannot be store-owned ids", async () => {
+    const storage = new InMemoryCloudflareDurableObjectStorage();
+    const store = new CloudflareAttachmentStore({ storage });
+
+    await expect(
+      store.get({
+        id: "../outside",
+        schemaVersion: 1,
+      })
+    ).rejects.toThrow("Invalid CloudflareAttachmentStore ref id.");
+  });
 });

--- a/packages/runtime/src/platform/cloudflare/storage/attachment-store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/attachment-store.ts
@@ -14,6 +14,16 @@ interface StoredCloudflareAttachment {
   readonly sizeBytes: number;
 }
 
+class CloudflareAttachmentStoreError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CloudflareAttachmentStoreError";
+  }
+}
+
+const attachmentIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export class CloudflareAttachmentStore implements RuntimeAttachmentStore {
   readonly #prefix: string;
   readonly #storage: CloudflareDurableObjectTransactionStorage;
@@ -29,9 +39,15 @@ export class CloudflareAttachmentStore implements RuntimeAttachmentStore {
     this.#storage = storage;
   }
 
+  async delete(ref: RuntimeAttachmentReference): Promise<void> {
+    assertAttachmentId(ref.id);
+    await this.#storage.delete(this.#key(ref.id));
+  }
+
   async get(
     ref: RuntimeAttachmentReference
   ): Promise<RuntimeAttachmentBlob | null> {
+    assertAttachmentId(ref.id);
     const stored = await this.#storage.get<StoredCloudflareAttachment>(
       this.#key(ref.id)
     );
@@ -63,6 +79,14 @@ export class CloudflareAttachmentStore implements RuntimeAttachmentStore {
 
   #key(id: string): string {
     return `${this.#prefix}:attachment:${id}`;
+  }
+}
+
+function assertAttachmentId(id: string): void {
+  if (!attachmentIdPattern.test(id)) {
+    throw new CloudflareAttachmentStoreError(
+      "Invalid CloudflareAttachmentStore ref id."
+    );
   }
 }
 

--- a/packages/runtime/src/platform/file/storage/file-attachment-store.test.ts
+++ b/packages/runtime/src/platform/file/storage/file-attachment-store.test.ts
@@ -23,6 +23,19 @@ describe("FileAttachmentStore", () => {
     });
   });
 
+  it("deletes persisted attachment blobs by ref", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pss-attachments-"));
+    const store = new FileAttachmentStore(directory);
+    const ref = await store.put({
+      bytes: new Uint8Array([4, 5, 6]),
+      mediaType: "image/png",
+    });
+
+    await store.delete(ref);
+
+    await expect(store.get(ref)).resolves.toBeNull();
+  });
+
   it("rejects attachment refs that cannot be store-owned ids", async () => {
     const directory = await mkdtemp(join(tmpdir(), "pss-attachments-"));
     const store = new FileAttachmentStore(directory);

--- a/packages/runtime/src/platform/file/storage/file-attachment-store.ts
+++ b/packages/runtime/src/platform/file/storage/file-attachment-store.ts
@@ -32,6 +32,14 @@ export class FileAttachmentStore implements RuntimeAttachmentStore {
     this.#directory = join(directory, "attachments");
   }
 
+  async delete(ref: RuntimeAttachmentReference): Promise<void> {
+    assertAttachmentId(ref.id);
+    await Promise.all([
+      rm(this.#blobFile(ref.id), { force: true }),
+      rm(this.#metadataFile(ref.id), { force: true }),
+    ]);
+  }
+
   async get(
     ref: RuntimeAttachmentReference
   ): Promise<RuntimeAttachmentBlob | null> {

--- a/packages/runtime/src/platform/memory/storage/memory-attachment-store.test.ts
+++ b/packages/runtime/src/platform/memory/storage/memory-attachment-store.test.ts
@@ -20,4 +20,16 @@ describe("MemoryAttachmentStore", () => {
       ref,
     });
   });
+
+  it("deletes stored attachments by ref", async () => {
+    const store = new MemoryAttachmentStore();
+    const ref = await store.put({
+      bytes: new Uint8Array([9, 8, 7]),
+      mediaType: "image/png",
+    });
+
+    await store.delete(ref);
+
+    await expect(store.get(ref)).resolves.toBeNull();
+  });
 });

--- a/packages/runtime/src/platform/memory/storage/memory-attachment-store.ts
+++ b/packages/runtime/src/platform/memory/storage/memory-attachment-store.ts
@@ -8,6 +8,11 @@ import type {
 export class MemoryAttachmentStore implements RuntimeAttachmentStore {
   readonly #attachments = new Map<string, RuntimeAttachmentBlob>();
 
+  delete(ref: RuntimeAttachmentReference): Promise<void> {
+    this.#attachments.delete(ref.id);
+    return Promise.resolve();
+  }
+
   get(ref: RuntimeAttachmentReference): Promise<RuntimeAttachmentBlob | null> {
     const attachment = this.#attachments.get(ref.id);
     return Promise.resolve(attachment ? cloneAttachment(attachment) : null);

--- a/packages/runtime/src/thread/handle/durable-queue.test.ts
+++ b/packages/runtime/src/thread/handle/durable-queue.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ExecutionHost,
+  ThreadInputInbox,
+  ThreadInputRecord,
+} from "../../execution/host/types";
+import { createInMemoryExecutionHost } from "../../platform/memory";
+import { MemoryAttachmentStore } from "../../platform/memory/storage/memory-attachment-store";
+import type {
+  RuntimeAttachmentBlob,
+  RuntimeAttachmentPutInput,
+  RuntimeAttachmentReference,
+  RuntimeAttachmentStore,
+} from "../input/attachments";
+import type { UserInput } from "../input/input";
+import type { AgentPlugin } from "../plugins/pipeline";
+import { BufferedAgentTurn } from "../protocol/turn";
+import { ThreadEventDispatcher } from "../runtime/events";
+import { createQueuedSendInput } from "./durable-queue";
+
+describe("createQueuedSendInput", () => {
+  it("deletes plugin-transformed attachment bytes when durable admission dedupes", async () => {
+    const attachmentStore = new TrackingAttachmentStore();
+    const events = new ThreadEventDispatcher({
+      attachmentStore,
+      history: () => [],
+      plugins: [transformTextToFileInputPlugin()],
+      signal: () => undefined,
+    });
+
+    const result = await createQueuedSendInput({
+      attachmentStore,
+      awaitBoundaries: false,
+      events,
+      executionHost: duplicateAdmissionHost(),
+      input: "turn text",
+      pendingOverlays: [],
+      pendingRuntimeInputs: [],
+      run: new BufferedAgentTurn(),
+      threadKey: "plugin-duplicate",
+    });
+
+    expect(result.kind).toBe("handled");
+    expect(attachmentStore.putCount).toBe(1);
+    expect(attachmentStore.deletedRefs).toHaveLength(1);
+    const ref = attachmentStore.deletedRefs[0];
+    if (!ref) {
+      throw new Error("expected plugin-transformed attachment ref cleanup");
+    }
+    await expect(attachmentStore.get(ref)).resolves.toBeNull();
+  });
+
+  it("deletes staged attachment bytes dropped by a successful plugin transform", async () => {
+    const attachmentStore = new TrackingAttachmentStore();
+    const events = new ThreadEventDispatcher({
+      attachmentStore,
+      history: () => [],
+      plugins: [transformAnyInputToTextPlugin()],
+      signal: () => undefined,
+    });
+
+    const result = await createQueuedSendInput({
+      attachmentStore,
+      awaitBoundaries: false,
+      events,
+      executionHost: undefined,
+      input: [
+        {
+          data: new Uint8Array([4, 5, 6]),
+          filename: "discarded.png",
+          mediaType: "image/png",
+          type: "file",
+        },
+      ],
+      pendingOverlays: [],
+      pendingRuntimeInputs: [],
+      run: new BufferedAgentTurn(),
+      threadKey: "plugin-dropped",
+    });
+
+    expect(result.kind).toBe("queued");
+    expect(attachmentStore.putCount).toBe(1);
+    expect(attachmentStore.deletedRefs).toHaveLength(1);
+    const ref = attachmentStore.deletedRefs[0];
+    if (!ref) {
+      throw new Error("expected dropped attachment ref cleanup");
+    }
+    await expect(attachmentStore.get(ref)).resolves.toBeNull();
+  });
+});
+
+function transformTextToFileInputPlugin(): AgentPlugin {
+  return {
+    on: ({ event }) => {
+      if (event.type !== "user-input") {
+        return { action: "continue" };
+      }
+
+      return {
+        action: "transform",
+        event: {
+          content: [
+            {
+              data: new Uint8Array([1, 2, 3]),
+              filename: "plugin.png",
+              mediaType: "image/png",
+              type: "file",
+            },
+          ],
+          type: "user-input",
+        },
+      };
+    },
+  };
+}
+
+function transformAnyInputToTextPlugin(): AgentPlugin {
+  return {
+    on: ({ event }) => {
+      if (event.type !== "user-input") {
+        return { action: "continue" };
+      }
+
+      return {
+        action: "transform",
+        event: {
+          text: "plugin replacement",
+          type: "user-input",
+        },
+      };
+    },
+  };
+}
+
+function duplicateAdmissionHost(): ExecutionHost {
+  const base = createInMemoryExecutionHost();
+  return {
+    ...base,
+    store: {
+      ...base.store,
+      inputs: duplicateAdmissionInbox(base.store.inputs),
+    },
+  };
+}
+
+function duplicateAdmissionInbox(base: ThreadInputInbox): ThreadInputInbox {
+  return {
+    ack: (record) => base.ack(record),
+    admit: (input) =>
+      Promise.resolve({
+        duplicate: true,
+        record: threadInputRecord(input.input, input.kind, input.messageId),
+      }),
+    claimNext: (threadKey, boundary, options) =>
+      base.claimNext(threadKey, boundary, options),
+    markPromoted: (record) => base.markPromoted(record),
+    recoverClaims: (threadKey) => base.recoverClaims(threadKey),
+    releaseClaim: (record) => base.releaseClaim(record),
+  };
+}
+
+function threadInputRecord(
+  input: UserInput,
+  kind: ThreadInputRecord["kind"],
+  messageId: string
+): ThreadInputRecord {
+  return {
+    admittedAtMs: 1,
+    admittedSeq: 1,
+    input,
+    kind,
+    messageId,
+    status: "pending",
+    threadKey: "plugin-duplicate",
+  };
+}
+
+class TrackingAttachmentStore implements RuntimeAttachmentStore {
+  readonly #store = new MemoryAttachmentStore();
+  readonly deletedRefs: RuntimeAttachmentReference[] = [];
+  #putCount = 0;
+
+  get putCount(): number {
+    return this.#putCount;
+  }
+
+  async delete(ref: RuntimeAttachmentReference): Promise<void> {
+    this.deletedRefs.push(ref);
+    await this.#store.delete(ref);
+  }
+
+  get(ref: RuntimeAttachmentReference): Promise<RuntimeAttachmentBlob | null> {
+    return this.#store.get(ref);
+  }
+
+  async put(
+    input: RuntimeAttachmentPutInput
+  ): Promise<RuntimeAttachmentReference> {
+    this.#putCount += 1;
+    return await this.#store.put(input);
+  }
+}

--- a/packages/runtime/src/thread/handle/durable-queue.ts
+++ b/packages/runtime/src/thread/handle/durable-queue.ts
@@ -1,5 +1,8 @@
 import type { ExecutionHost } from "../../execution/host/types";
 import {
+  cleanupStagedRuntimeAttachments,
+  cleanupUnreferencedStagedRuntimeAttachments,
+  type RuntimeAttachmentReference,
   type RuntimeAttachmentStore,
   stageUserInputAttachments,
   userInputRequiresAttachmentProcessing,
@@ -134,49 +137,66 @@ export async function createQueuedSendInput({
     normalized.meta === undefined
       ? attachInputMeta(normalized, { source: "send" })
       : normalized;
-  const stagedAcceptedInput = await stageUserInputAttachments(
-    acceptedInput,
-    attachmentStore
-  );
-  const processed = await events.interceptEvent(stagedAcceptedInput);
-  if (processed === "handled") {
-    run.close();
-    return { kind: "handled" };
-  }
+  const stagedRefs: RuntimeAttachmentReference[] = [];
+  let keepStagedAttachments = false;
+  try {
+    const stagedAcceptedInput = await stageUserInputAttachments(
+      acceptedInput,
+      attachmentStore,
+      { stagedRefs }
+    );
+    const processed = await events.interceptEvent(stagedAcceptedInput, {
+      stagedRefs,
+    });
+    if (processed === "handled") {
+      run.close();
+      return { kind: "handled" };
+    }
 
-  const queuedInput = await stageUserInputAttachments(
-    userInputFromEvent(
-      processed.type === "user-input" ? processed : stagedAcceptedInput
-    ),
-    attachmentStore,
-    { trustRuntimeAttachmentRefs: true }
-  );
-  const admission = await admitDurableThreadInput({
-    executionHost,
-    input: queuedInput,
-    kind: "send",
-    threadKey,
-  });
-  if (admission.kind === "admitted" && admission.receipt.duplicate) {
-    run.close();
-    return { kind: "handled" };
-  }
+    const queuedInput = await stageUserInputAttachments(
+      userInputFromEvent(
+        processed.type === "user-input" ? processed : stagedAcceptedInput
+      ),
+      attachmentStore,
+      { stagedRefs, trustRuntimeAttachmentRefs: true }
+    );
+    const admission = await admitDurableThreadInput({
+      executionHost,
+      input: queuedInput,
+      kind: "send",
+      threadKey,
+    });
+    if (admission.kind === "admitted" && admission.receipt.duplicate) {
+      run.close();
+      return { kind: "handled" };
+    }
 
-  const item = {
-    awaitBoundaries,
-    durableInput: admission.kind === "admitted",
-    ...(admission.kind === "admitted"
-      ? { durableMessageId: admission.receipt.record.messageId }
-      : {}),
-    initialEvents: [],
-    ...(admission.kind === "unavailable"
-      ? { input: structuredClone(queuedInput) }
-      : {}),
-    preUserRuntimeInputs: pendingOverlays.splice(0),
-    run,
-    runtimeInput: createRuntimeInputState(pendingRuntimeInputs.splice(0)),
-  } satisfies QueuedInput;
-  return { kind: "queued", item, processed };
+    const item = {
+      awaitBoundaries,
+      durableInput: admission.kind === "admitted",
+      ...(admission.kind === "admitted"
+        ? { durableMessageId: admission.receipt.record.messageId }
+        : {}),
+      initialEvents: [],
+      ...(admission.kind === "unavailable"
+        ? { input: structuredClone(queuedInput) }
+        : {}),
+      preUserRuntimeInputs: pendingOverlays.splice(0),
+      run,
+      runtimeInput: createRuntimeInputState(pendingRuntimeInputs.splice(0)),
+    } satisfies QueuedInput;
+    await cleanupUnreferencedStagedRuntimeAttachments(
+      attachmentStore,
+      stagedRefs,
+      [queuedInput, processed]
+    );
+    keepStagedAttachments = true;
+    return { kind: "queued", item, processed };
+  } finally {
+    if (!keepStagedAttachments) {
+      await cleanupStagedRuntimeAttachments(attachmentStore, stagedRefs);
+    }
+  }
 }
 
 export async function addDurableSteeringInput({
@@ -194,31 +214,43 @@ export async function addDurableSteeringInput({
 }): Promise<void> {
   const placement = currentSteeringPlacement(runtimeInput);
   const next = runtimeInput.pending.then(async () => {
+    const stagedRefs: RuntimeAttachmentReference[] = [];
+    let keepStagedAttachments = false;
     assertRuntimeInputOpen(runtimeInput);
     const acceptedInput = attachInputMeta(normalizeAgentInput(input), {
       source: "steer",
       streaming: "steer",
     });
-    const stagedInput = userInputRequiresAttachmentProcessing(acceptedInput)
-      ? await stageUserInputAttachments(acceptedInput, attachmentStore)
-      : acceptedInput;
-    assertRuntimeInputOpen(runtimeInput);
-    const admission = await admitDurableThreadInput({
-      executionHost,
-      input: stagedInput,
-      kind: "steer",
-      placement,
-      threadKey,
-    });
-    if (admission.kind === "admitted") {
-      return;
-    }
+    try {
+      const stagedInput = userInputRequiresAttachmentProcessing(acceptedInput)
+        ? await stageUserInputAttachments(acceptedInput, attachmentStore, {
+            stagedRefs,
+          })
+        : acceptedInput;
+      assertRuntimeInputOpen(runtimeInput);
+      const admission = await admitDurableThreadInput({
+        executionHost,
+        input: stagedInput,
+        kind: "steer",
+        placement,
+        threadKey,
+      });
+      if (admission.kind === "admitted") {
+        keepStagedAttachments = true;
+        return;
+      }
 
-    assertRuntimeInputOpen(runtimeInput);
-    queueRuntimeInput(runtimeInput, {
-      input: stagedInput,
-      placement,
-    });
+      assertRuntimeInputOpen(runtimeInput);
+      queueRuntimeInput(runtimeInput, {
+        input: stagedInput,
+        placement,
+      });
+      keepStagedAttachments = true;
+    } finally {
+      if (!keepStagedAttachments) {
+        await cleanupStagedRuntimeAttachments(attachmentStore, stagedRefs);
+      }
+    }
   });
   runtimeInput.pending = next.catch(() => undefined);
   await next;

--- a/packages/runtime/src/thread/input/attachment-staging.ts
+++ b/packages/runtime/src/thread/input/attachment-staging.ts
@@ -1,10 +1,12 @@
 import type { AgentEvent, RuntimeInput } from "../protocol/events";
 import { base64ToBytes } from "./attachment-base64";
 import {
+  decodeRuntimeAttachmentData,
   encodeRuntimeAttachmentData,
   isRuntimeAttachmentData,
 } from "./attachment-refs";
 import type {
+  RuntimeAttachmentReference,
   RuntimeAttachmentStagingOptions,
   RuntimeAttachmentStore,
 } from "./attachment-types";
@@ -50,6 +52,35 @@ export async function stageUserInputAttachments(
     ...input,
     content,
   };
+}
+
+export async function cleanupStagedRuntimeAttachments(
+  store: RuntimeAttachmentStore | undefined,
+  refs: readonly RuntimeAttachmentReference[]
+): Promise<void> {
+  if (!store || refs.length === 0) {
+    return;
+  }
+
+  await Promise.allSettled([...refs].reverse().map((ref) => store.delete(ref)));
+}
+
+export async function cleanupUnreferencedStagedRuntimeAttachments(
+  store: RuntimeAttachmentStore | undefined,
+  refs: readonly RuntimeAttachmentReference[],
+  retained: readonly (AgentEvent | UserInput)[]
+): Promise<void> {
+  const retainedRefs = new Set<string>();
+  for (const value of retained) {
+    for (const ref of runtimeAttachmentRefs(value)) {
+      retainedRefs.add(runtimeAttachmentRefKey(ref));
+    }
+  }
+
+  await cleanupStagedRuntimeAttachments(
+    store,
+    refs.filter((ref) => !retainedRefs.has(runtimeAttachmentRefKey(ref)))
+  );
 }
 
 export function userInputRequiresAttachmentStaging(input: UserInput): boolean {
@@ -125,6 +156,43 @@ export async function stageAgentEventsAttachments(
   return staged;
 }
 
+function runtimeAttachmentRefs(
+  value: AgentEvent | UserInput
+): RuntimeAttachmentReference[] {
+  if ("type" in value && value.type === "runtime-input") {
+    return runtimeAttachmentRefsForUserInput(value.input);
+  }
+
+  if ("type" in value && value.type === "user-input") {
+    return runtimeAttachmentRefsForUserInput(value);
+  }
+
+  return [];
+}
+
+function runtimeAttachmentRefsForUserInput(
+  input: UserInput
+): RuntimeAttachmentReference[] {
+  if (!("content" in input)) {
+    return [];
+  }
+
+  const refs: RuntimeAttachmentReference[] = [];
+  for (const part of input.content) {
+    if (part.type === "image" && isRuntimeAttachmentData(part.image)) {
+      refs.push(decodeRuntimeAttachmentData(part.image));
+    }
+
+    if (part.type === "file") {
+      const ref = runtimeAttachmentDataRef(part.data);
+      if (ref) {
+        refs.push(decodeRuntimeAttachmentData(ref));
+      }
+    }
+  }
+  return refs;
+}
+
 async function stageFileData(
   data: UserMessageFileData,
   part: { readonly filename?: string; readonly mediaType: string },
@@ -157,6 +225,7 @@ async function stageFileData(
     filename: part.filename,
     mediaType: part.mediaType,
   });
+  options.stagedRefs?.push(ref);
   return encodeRuntimeAttachmentData(ref);
 }
 
@@ -256,6 +325,10 @@ function runtimeAttachmentDataRef(
     return data.url;
   }
 
+  if (isReferenceFileData(data)) {
+    return Object.values(data.reference).find(isRuntimeAttachmentData);
+  }
+
   return;
 }
 
@@ -272,6 +345,14 @@ function isUrlFileData(
 ): data is Extract<UserMessageFileData, { readonly type: "url" }> {
   return typeof data === "object" && data !== null && "type" in data
     ? data.type === "url"
+    : false;
+}
+
+function isReferenceFileData(
+  data: UserMessageFileData
+): data is Extract<UserMessageFileData, { readonly type: "reference" }> {
+  return typeof data === "object" && data !== null && "type" in data
+    ? data.type === "reference"
     : false;
 }
 
@@ -292,4 +373,8 @@ function base64DataToBytes(data: string): Uint8Array {
 
 function isRemoteUrl(value: string): boolean {
   return value.startsWith("http://") || value.startsWith("https://");
+}
+
+function runtimeAttachmentRefKey(ref: RuntimeAttachmentReference): string {
+  return `${ref.schemaVersion}:${ref.source ?? ""}:${ref.id}`;
 }

--- a/packages/runtime/src/thread/input/attachment-types.ts
+++ b/packages/runtime/src/thread/input/attachment-types.ts
@@ -16,11 +16,13 @@ export interface RuntimeAttachmentBlob extends RuntimeAttachmentPutInput {
 }
 
 export interface RuntimeAttachmentStore {
+  delete(ref: RuntimeAttachmentReference): Promise<void>;
   get(ref: RuntimeAttachmentReference): Promise<RuntimeAttachmentBlob | null>;
   put(input: RuntimeAttachmentPutInput): Promise<RuntimeAttachmentReference>;
 }
 
 export interface RuntimeAttachmentStagingOptions {
+  readonly stagedRefs?: RuntimeAttachmentReference[];
   readonly trustRuntimeAttachmentRefs?: boolean;
 }
 

--- a/packages/runtime/src/thread/input/attachments.ts
+++ b/packages/runtime/src/thread/input/attachments.ts
@@ -7,6 +7,8 @@ export {
   isRuntimeAttachmentData,
 } from "./attachment-refs";
 export {
+  cleanupStagedRuntimeAttachments,
+  cleanupUnreferencedStagedRuntimeAttachments,
   stageAgentEventAttachments,
   stageAgentEventsAttachments,
   stageUserInputAttachments,

--- a/packages/runtime/src/thread/input/runtime-input.test.ts
+++ b/packages/runtime/src/thread/input/runtime-input.test.ts
@@ -25,7 +25,12 @@ describe("runtime input", () => {
     const putResult = new Promise<RuntimeAttachmentReference>((resolve) => {
       resolvePut = resolve;
     });
+    const deletedRefs: RuntimeAttachmentReference[] = [];
     const store: RuntimeAttachmentStore = {
+      delete: (ref) => {
+        deletedRefs.push(ref);
+        return Promise.resolve();
+      },
       get: () => Promise.resolve(null),
       put: () => {
         resolvePutStarted();
@@ -47,11 +52,13 @@ describe("runtime input", () => {
 
     await putStarted;
     closeRuntimeInput(runtimeInput, "test close");
-    resolvePut({ id: "attachment-1", schemaVersion: 1 });
+    const stagedRef = { id: "attachment-1", schemaVersion: 1 } as const;
+    resolvePut(stagedRef);
 
     await expect(pending).rejects.toThrow(
       "thread.steer() cannot be used after test close"
     );
     expect(runtimeInput.queue).toEqual([]);
+    expect(deletedRefs).toEqual([stagedRef]);
   });
 });

--- a/packages/runtime/src/thread/input/runtime-input.ts
+++ b/packages/runtime/src/thread/input/runtime-input.ts
@@ -2,6 +2,8 @@ import type { ClaimedThreadInput } from "../../execution/host/types";
 import type { AgentEvent, RuntimeInput } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
 import {
+  cleanupStagedRuntimeAttachments,
+  type RuntimeAttachmentReference,
   type RuntimeAttachmentStore,
   stageUserInputAttachments,
   userInputRequiresAttachmentProcessing,
@@ -54,20 +56,28 @@ export function addSteeringInput(
 ): Promise<void> {
   const placement = currentSteeringPlacement(runtimeInput);
   const next = runtimeInput.pending.then(async () => {
+    const stagedRefs: RuntimeAttachmentReference[] = [];
     assertRuntimeInputOpen(runtimeInput);
 
     const acceptedInput = attachInputMeta(normalizeAgentInput(input), {
       source: "steer",
       streaming: "steer",
     });
-    const staged = userInputRequiresAttachmentProcessing(acceptedInput)
-      ? await stageUserInputAttachments(acceptedInput, attachmentStore)
-      : acceptedInput;
-    assertRuntimeInputOpen(runtimeInput);
-    queueRuntimeInput(runtimeInput, {
-      input: staged,
-      placement,
-    });
+    try {
+      const staged = userInputRequiresAttachmentProcessing(acceptedInput)
+        ? await stageUserInputAttachments(acceptedInput, attachmentStore, {
+            stagedRefs,
+          })
+        : acceptedInput;
+      assertRuntimeInputOpen(runtimeInput);
+      queueRuntimeInput(runtimeInput, {
+        input: staged,
+        placement,
+      });
+    } catch (error) {
+      await cleanupStagedRuntimeAttachments(attachmentStore, stagedRefs);
+      throw error;
+    }
   });
   runtimeInput.pending = next.catch(() => undefined);
   return next;

--- a/packages/runtime/src/thread/runtime/attachment-staging.test.ts
+++ b/packages/runtime/src/thread/runtime/attachment-staging.test.ts
@@ -224,6 +224,39 @@ describe("runtime attachment staging", () => {
     expect(generateTextMock).not.toHaveBeenCalled();
   });
 
+  it("rejects provider-reference values containing runtime attachment refs before queueing", async () => {
+    const threadStore = new SpyStore();
+    const attachmentStore = new MemoryAttachmentStore();
+    const Agent = await loadAgent();
+    const agent = new Agent({
+      attachmentStore,
+      host: { attachmentStore, kind: "thread", threadStore },
+      model: fakeModel,
+    });
+
+    await expect(
+      agent.send([
+        { text: "spoof", type: "text" },
+        {
+          data: {
+            reference: {
+              provider: "test-provider",
+              uri: encodeRuntimeAttachmentData({
+                id: "attacker-controlled",
+                schemaVersion: 1,
+              }),
+            },
+            type: "reference",
+          },
+          mediaType: "image/png",
+          type: "file",
+        },
+      ])
+    ).rejects.toThrow("External input cannot contain runtime attachment refs.");
+    expect(threadStore.commits).toEqual([]);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
   it("rejects file bytes before queueing when a custom host has no attachment store", async () => {
     const threadStore = new SpyStore();
     const Agent = await loadAgent();

--- a/packages/runtime/src/thread/runtime/events.ts
+++ b/packages/runtime/src/thread/runtime/events.ts
@@ -4,6 +4,7 @@ import type {
   RuntimeToolExecutionDecision,
 } from "../../llm/llm";
 import {
+  type RuntimeAttachmentReference,
   type RuntimeAttachmentStore,
   stageAgentEventAttachments,
 } from "../input/attachments";
@@ -20,6 +21,10 @@ interface ThreadEventDispatcherOptions {
   readonly history: () => readonly ModelMessage[];
   readonly plugins: readonly AgentPlugin[];
   readonly signal: () => AbortSignal | undefined;
+}
+
+interface InterceptEventOptions {
+  readonly stagedRefs?: RuntimeAttachmentReference[];
 }
 
 export class ThreadEventDispatcher {
@@ -131,7 +136,10 @@ export class ThreadEventDispatcher {
       : undefined;
   }
 
-  async interceptEvent(event: AgentEvent): Promise<AgentEvent | "handled"> {
+  async interceptEvent(
+    event: AgentEvent,
+    options: InterceptEventOptions = {}
+  ): Promise<AgentEvent | "handled"> {
     const pipeline = await this.#runInterceptPipeline(event);
     if (pipeline.kind === "handled") {
       return "handled";
@@ -142,6 +150,7 @@ export class ThreadEventDispatcher {
     }
 
     return stageAgentEventAttachments(pipeline.event, this.#attachmentStore, {
+      stagedRefs: options.stagedRefs,
       trustRuntimeAttachmentRefs: true,
     });
   }


### PR DESCRIPTION
## Summary

Follows up the review of #177.

- add `delete(ref)` to runtime attachment stores and implement it for memory, file, and Cloudflare stores
- clean up staged attachment refs when durable input admission, runtime steer, or notification dispatch is handled, deduped, closed, or throws before commit
- clean up staged refs that plugin transforms discard after a successful durable queue path
- reject forged `pss-attachment:` refs nested in provider `reference` file data
- keep caller-provided host attachment stores authoritative over `AgentOptions.attachmentStore`
- document the runtime-owned attachment lifecycle and add a patch changeset for `@minpeter/pss-runtime`

## Validation

- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm -C packages/runtime exec vitest run src/thread/handle/durable-queue.test.ts`
- `pnpm --filter @minpeter/pss-runtime exec vitest run src/thread/handle/durable-queue.test.ts src/thread/input/runtime-input.test.ts src/thread/runtime/attachment-staging.test.ts src/execution/dispatch/notification-dispatch.test.ts src/platform/memory/storage/memory-attachment-store.test.ts src/platform/file/storage/file-attachment-store.test.ts src/platform/cloudflare/storage/attachment-store.test.ts src/agent/core/host-api.test.ts`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm -C packages/runtime exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm changeset status --since origin/main`
- `git diff --check origin/main`
- `pnpm --filter @minpeter/pss-runtime build`

Review-work reruns passed for QA, code quality, security, docs/context, and gate acceptance on the final working tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the runtime attachment lifecycle in `@minpeter/pss-runtime` to prevent leaked blobs and reject forged refs. Adds `delete(ref)` to attachment stores, cleans staged refs on dedupe/error paths, and prefers host-owned stores during resumed work.

- **Bug Fixes**
  - Add `delete(ref)` to memory, file, and Cloudflare stores and clean staged attachments on dedupe/abort for durable input, steer, and notification paths.
  - Clean dropped refs when plugin transforms discard attachments.
  - Reject forged `pss-attachment:` refs nested in provider `reference` file data.
  - Prefer the host’s `attachmentStore` over `AgentOptions.attachmentStore` when both are provided.

- **Migration**
  - Custom hosts must implement `attachmentStore.delete(ref)` alongside `put`/`get`. Ensure you do not accept forged `pss-attachment:` refs; remote `http(s)` media is not fetched by the runtime.

<sup>Written for commit cfb2a0f2ae595d78f097a16b99c6eb4ed31156d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

