### PR TITLE
Align runtime inputs with AI SDK file parts

### DIFF
--- a/.changeset/rfc001-003-follow-up.md
+++ b/.changeset/rfc001-003-follow-up.md
@@ -1,5 +1,7 @@
 ---
-"@minpeter/pss-runtime": patch
+"@minpeter/pss-runtime": minor
 ---
 
 Add durable thread event replay via `thread.events({ after, limit })`, pre-provider context budget gating for automatic compaction, and documentation for durable attachment replay behavior.
+
+Align public multimodal input with AI SDK 7 by removing the deprecated `UserMessageImagePart` / `{ type: "image" }` path. Use `{ type: "file", mediaType: "image" | "image/png", data }` for image inputs.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ for model providers that support them:
 ```ts
 await agent.send([
   { type: "text", text: "What changed in this screenshot?" },
-  { type: "image", image: "data:image/png;base64,...", mediaType: "image/png" },
+  { type: "file", data: "data:image/png;base64,...", mediaType: "image/png" },
 ]);
 ```
 

--- a/apps/coding-agent/src/tui-runner.ts
+++ b/apps/coding-agent/src/tui-runner.ts
@@ -185,8 +185,6 @@ function formatUserMessagePart(part: UserMessageContentPart): string {
   switch (part.type) {
     case "text":
       return part.text;
-    case "image":
-      return `[image ${part.mediaType ?? "unknown"}]`;
     case "file":
       return `[file ${part.filename ?? part.mediaType}]`;
     default:

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -91,8 +91,8 @@ shortcuts for text-only turns.
 const turn = await agent.send([
   { type: "text", text: "Describe this UI screenshot." },
   {
-    type: "image",
-    image: "data:image/png;base64,iVBORw0KGgo...",
+    type: "file",
+    data: "data:image/png;base64,iVBORw0KGgo...",
     mediaType: "image/png",
   },
 ]);
@@ -332,7 +332,7 @@ Each accepted call returns one `AgentTurn`. Drain that turn's `events()` stream 
 observe the turn; each `AgentTurn.events()` stream is single-consumer.
 
 Input APIs accept strings, arrays of strings, or multipart arrays such as
-`[{ type: "text", text: "hello" }, { type: "image", image }]`. Inline
+`[{ type: "text", text: "hello" }, { type: "file", data: imageBytes, mediaType: "image/png" }]`. Inline
 image/file bytes are staged into `attachmentStore` and replaced by
 `pss-attachment:` refs before durable state is written. The runtime normalizes
 accepted `send` input into `user-input` events. Active steering and host resume

--- a/packages/runtime/src/agent/core/agent.test.ts
+++ b/packages/runtime/src/agent/core/agent.test.ts
@@ -13,6 +13,7 @@ const functionModel = () => Promise.resolve([]);
 const invalidModelPattern = /invalid options\.model/;
 const missingModelPattern = /missing options\.model/;
 const missingOptionsPattern = /Agent options are required/;
+const unsupportedApprovalPattern = /needsApproval.*not supported/;
 const agentOptionsSourceUrl = new URL("./options.ts", import.meta.url);
 const agentSourceUrl = new URL("./agent.ts", import.meta.url);
 const forbiddenAgentSubagentSurface = [
@@ -176,12 +177,13 @@ describe("Agent", () => {
       },
     } satisfies NonNullable<AgentOptions["tools"]>;
 
-    expect(() =>
-      new Agent({
-        model: fakeModel,
-        tools,
-      })
-    ).toThrow(/needsApproval.*not supported/);
+    expect(
+      () =>
+        new Agent({
+          model: fakeModel,
+          tools,
+        })
+    ).toThrow(unsupportedApprovalPattern);
   });
 
   it("does not implement legacy llm configuration", () => {

--- a/packages/runtime/src/agent/core/agent.test.ts
+++ b/packages/runtime/src/agent/core/agent.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
+import { createNoopTool } from "../../testing/llm-test-utils";
 import {
   createMockLanguageModelV4,
   mockLanguageModelV4Text,
@@ -165,6 +166,22 @@ describe("Agent", () => {
     expect(() => Reflect.construct(Agent, [{ model: "not-a-model" }])).toThrow(
       invalidModelPattern
     );
+  });
+
+  it("rejects tools using AI SDK tool approval", () => {
+    const tools = {
+      risky: {
+        ...createNoopTool(),
+        needsApproval: true,
+      },
+    } satisfies NonNullable<AgentOptions["tools"]>;
+
+    expect(() =>
+      new Agent({
+        model: fakeModel,
+        tools,
+      })
+    ).toThrow(/needsApproval.*not supported/);
   });
 
   it("does not implement legacy llm configuration", () => {

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -1,6 +1,7 @@
 import type { LanguageModel, ToolSet } from "ai";
 import type { AgentHost } from "../../execution/host/types";
 import type { AgentToolChoice, ModelContextGateOptions } from "../../llm/llm";
+import { assertNoUnsupportedToolApproval } from "../../llm/tool-approval";
 import type { RuntimeAttachmentStore } from "../../thread/input/attachments";
 import type { AgentInput, UserInput } from "../../thread/input/input";
 import type { AgentPlugin } from "../../thread/plugins/pipeline";
@@ -53,7 +54,9 @@ export function assertAgentOptions(
 
   const candidate = options as {
     readonly autoCompaction?: AgentOptions["autoCompaction"];
+    readonly tools?: AgentOptions["tools"];
   };
+  assertNoUnsupportedToolApproval(candidate.tools);
   normalizeAgentAutoCompactionOptions(candidate.autoCompaction);
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -67,7 +67,6 @@ export type {
   UserMessageContentPart,
   UserMessageFileData,
   UserMessageFilePart,
-  UserMessageImagePart,
   UserMessageTextPart,
   UserText,
   UserTextContent,

--- a/packages/runtime/src/llm/llm.test.ts
+++ b/packages/runtime/src/llm/llm.test.ts
@@ -130,6 +130,29 @@ describe("generateModelStep", () => {
       })
     );
   });
+
+  it("rejects tools using AI SDK tool approval before generateText", async () => {
+    const runModelStep = await loadModelStepRunner();
+    const signal = new AbortController().signal;
+    const history = [{ role: "user" as const, content: "hello" }];
+    const tools = {
+      risky: {
+        ...createNoopTool(),
+        needsApproval: true,
+      },
+    } satisfies ToolSet;
+
+    await expect(
+      runModelStep(
+        {
+          model: fakeModel,
+          tools,
+        },
+        { history, signal }
+      )
+    ).rejects.toThrow(/needsApproval.*not supported/);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("Agent tool wiring", () => {

--- a/packages/runtime/src/llm/llm.test.ts
+++ b/packages/runtime/src/llm/llm.test.ts
@@ -11,6 +11,7 @@ import {
 import { assistantMessage } from "../testing/test-fixtures";
 
 const generateTextMock = getGenerateTextMock();
+const unsupportedApprovalPattern = /needsApproval.*not supported/;
 
 describe("generateModelStep", () => {
   beforeEach(() => {
@@ -150,7 +151,7 @@ describe("generateModelStep", () => {
         },
         { history, signal }
       )
-    ).rejects.toThrow(/needsApproval.*not supported/);
+    ).rejects.toThrow(unsupportedApprovalPattern);
     expect(generateTextMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/runtime/src/llm/llm.ts
+++ b/packages/runtime/src/llm/llm.ts
@@ -4,12 +4,12 @@ import {
   hydrateRuntimeAttachments,
   type RuntimeAttachmentStore,
 } from "../thread/input/attachments";
+import { assertNoUnsupportedToolApproval } from "./tool-approval";
 import type { RuntimeToolExecutionContext } from "./tool-execution";
 import {
   normalizeToolCallIds,
   rewriteMessageToolCallIds,
 } from "./tool-execution";
-import { assertNoUnsupportedToolApproval } from "./tool-approval";
 
 export type {
   RuntimePersistedToolExecutionCheckpoint,

--- a/packages/runtime/src/llm/llm.ts
+++ b/packages/runtime/src/llm/llm.ts
@@ -9,6 +9,7 @@ import {
   normalizeToolCallIds,
   rewriteMessageToolCallIds,
 } from "./tool-execution";
+import { assertNoUnsupportedToolApproval } from "./tool-approval";
 
 export type {
   RuntimePersistedToolExecutionCheckpoint,
@@ -102,6 +103,7 @@ export async function generateModelStep({
     instructions: prompt.instructions,
     messages,
   });
+  assertNoUnsupportedToolApproval(tools);
   const { responseMessages } = await generateText({
     abortSignal: signal,
     instructions: prompt.instructions,

--- a/packages/runtime/src/llm/tool-approval.ts
+++ b/packages/runtime/src/llm/tool-approval.ts
@@ -1,0 +1,23 @@
+import type { ToolSet } from "ai";
+
+export function assertNoUnsupportedToolApproval(
+  tools: ToolSet | undefined
+): void {
+  if (!tools) {
+    return;
+  }
+
+  for (const [toolName, toolDefinition] of Object.entries(tools)) {
+    if (
+      (typeof toolDefinition === "object" ||
+        typeof toolDefinition === "function") &&
+      toolDefinition !== null &&
+      "needsApproval" in toolDefinition
+    ) {
+      throw new TypeError(
+        `Agent tools.${toolName}.needsApproval is not supported. ` +
+          "Use pss before-tool-call checkpoint recovery instead of AI SDK tool approval."
+      );
+    }
+  }
+}

--- a/packages/runtime/src/platform/cloudflare/storage/execution/input-record-parser.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/input-record-parser.ts
@@ -98,12 +98,6 @@ function isUserMessageContentPart(
   if (value.type === "text") {
     return typeof value.text === "string";
   }
-  if (value.type === "image") {
-    return (
-      typeof value.image === "string" &&
-      (value.mediaType === undefined || typeof value.mediaType === "string")
-    );
-  }
   return (
     value.type === "file" &&
     isUserMessageFileData(value.data) &&

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/event-store-roundtrip.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/event-store-roundtrip.test.ts
@@ -32,9 +32,9 @@ function agentEventVariants(): readonly AgentEvent[] {
       content: [
         { text: "multipart text", type: "text" },
         {
-          image: "data:image/png;base64,AAAA",
+          data: "data:image/png;base64,AAAA",
           mediaType: "image/png",
-          type: "image",
+          type: "file",
         },
         {
           data: {

--- a/packages/runtime/src/platform/file/storage/file-execution-store/thread-input-schema.ts
+++ b/packages/runtime/src/platform/file/storage/file-execution-store/thread-input-schema.ts
@@ -106,12 +106,6 @@ function isUserMessageContentPart(
   if (value.type === "text") {
     return typeof value.text === "string";
   }
-  if (value.type === "image") {
-    return (
-      typeof value.image === "string" &&
-      (value.mediaType === undefined || typeof value.mediaType === "string")
-    );
-  }
   return (
     value.type === "file" &&
     isUserMessageFileData(value.data) &&

--- a/packages/runtime/src/thread/handle/persistence-attachments.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-attachments.test.ts
@@ -11,13 +11,13 @@ import {
 import { collect } from "./test-support";
 
 describe("Agent thread persistence attachments", () => {
-  it("file thread store preserves image content parts across reload", async () => {
+  it("file thread store preserves image file parts across reload", async () => {
     const input = [
       { text: "remember this image", type: "text" },
       {
-        image: "data:image/png;base64,ZmFrZQ==",
+        data: "data:image/png;base64,ZmFrZQ==",
         mediaType: "image/png",
-        type: "image",
+        type: "file",
       },
       {
         data: { text: "inline note", type: "text" },

--- a/packages/runtime/src/thread/handle/thread.test.ts
+++ b/packages/runtime/src/thread/handle/thread.test.ts
@@ -68,7 +68,7 @@ describe("Agent thread API", () => {
 
     const input = [
       { type: "text", text: "describe this" },
-      { type: "image", image: "iVBORw0KGgo=", mediaType: "image/png" },
+      { type: "file", data: "iVBORw0KGgo=", mediaType: "image/png" },
       {
         type: "file",
         data: { type: "text", text: "inline document" },
@@ -112,12 +112,12 @@ describe("Agent thread API", () => {
     if (acceptedInput?.type !== "user-input" || !("content" in acceptedInput)) {
       throw new Error("expected multipart user-input event");
     }
-    const imagePart = acceptedInput.content[1];
-    expect(imagePart?.type).toBe("file");
-    if (imagePart?.type !== "file") {
+    const imageFilePart = acceptedInput.content[1];
+    expect(imageFilePart?.type).toBe("file");
+    if (imageFilePart?.type !== "file") {
       throw new Error("expected staged image file part");
     }
-    expect(isRuntimeAttachmentData(imagePart.data)).toBe(true);
+    expect(isRuntimeAttachmentData(imageFilePart.data)).toBe(true);
     expect(acceptedInput.content[2]).toEqual(input[2]);
   });
 
@@ -131,7 +131,7 @@ describe("Agent thread API", () => {
     await expect(
       agent.send([{ type: "image", mediaType: "image/png" }] as never)
     ).rejects.toThrow(
-      'Agent input content parts must be { type: "text", text }, { type: "image", image }, or { type: "file", data, mediaType }.'
+      'Agent input content parts must be { type: "text", text } or { type: "file", data, mediaType }.'
     );
   });
 
@@ -144,7 +144,7 @@ describe("Agent thread API", () => {
     });
 
     await expect(agent.send(sparseInput)).rejects.toThrow(
-      'Agent input content parts must be { type: "text", text }, { type: "image", image }, or { type: "file", data, mediaType }.'
+      'Agent input content parts must be { type: "text", text } or { type: "file", data, mediaType }.'
     );
   });
 
@@ -158,7 +158,7 @@ describe("Agent thread API", () => {
     await expect(
       agent.send([{ type: "file", data: "abc" }] as never)
     ).rejects.toThrow(
-      'Agent input content parts must be { type: "text", text }, { type: "image", image }, or { type: "file", data, mediaType }.'
+      'Agent input content parts must be { type: "text", text } or { type: "file", data, mediaType }.'
     );
   });
 
@@ -191,7 +191,7 @@ describe("Agent thread API", () => {
     await collect(
       await agent.thread("custom").send([
         { type: "text", text: "summarize" },
-        { type: "image", image: "iVBORw0KGgo=" },
+        { type: "file", data: "iVBORw0KGgo=", mediaType: "image/png" },
       ])
     );
 

--- a/packages/runtime/src/thread/input/attachment-staging.ts
+++ b/packages/runtime/src/thread/input/attachment-staging.ts
@@ -104,11 +104,10 @@ export function userInputContainsRuntimeAttachmentRefs(
     return false;
   }
 
-  return input.content.some((part) => {
-    return (
+  return input.content.some(
+    (part) =>
       part.type === "file" && runtimeAttachmentDataRef(part.data) !== undefined
-    );
-  });
+  );
 }
 
 export async function stageAgentEventAttachments(

--- a/packages/runtime/src/thread/input/attachment-staging.ts
+++ b/packages/runtime/src/thread/input/attachment-staging.ts
@@ -18,7 +18,6 @@ import type {
   UserInput,
   UserMessageContentPart,
   UserMessageFileData,
-  UserMessageFilePart,
 } from "./input";
 
 export async function stageUserInputAttachments(
@@ -34,11 +33,6 @@ export async function stageUserInputAttachments(
   for (const part of input.content) {
     if (part.type === "text") {
       content.push(structuredClone(part));
-      continue;
-    }
-
-    if (part.type === "image") {
-      content.push(await stageImagePart(part, store, options));
       continue;
     }
 
@@ -88,13 +82,9 @@ export function userInputRequiresAttachmentStaging(input: UserInput): boolean {
     return false;
   }
 
-  return input.content.some((part) => {
-    if (part.type === "file") {
-      return fileDataRequiresStaging(part.data);
-    }
-
-    return part.type === "image" && !isRemoteUrl(part.image);
-  });
+  return input.content.some(
+    (part) => part.type === "file" && fileDataRequiresStaging(part.data)
+  );
 }
 
 export function userInputRequiresAttachmentProcessing(
@@ -115,10 +105,6 @@ export function userInputContainsRuntimeAttachmentRefs(
   }
 
   return input.content.some((part) => {
-    if (part.type === "image") {
-      return isRuntimeAttachmentData(part.image);
-    }
-
     return (
       part.type === "file" && runtimeAttachmentDataRef(part.data) !== undefined
     );
@@ -179,10 +165,6 @@ function runtimeAttachmentRefsForUserInput(
 
   const refs: RuntimeAttachmentReference[] = [];
   for (const part of input.content) {
-    if (part.type === "image" && isRuntimeAttachmentData(part.image)) {
-      refs.push(decodeRuntimeAttachmentData(part.image));
-    }
-
     if (part.type === "file") {
       const ref = runtimeAttachmentDataRef(part.data);
       if (ref) {
@@ -227,49 +209,6 @@ async function stageFileData(
   });
   options.stagedRefs?.push(ref);
   return encodeRuntimeAttachmentData(ref);
-}
-
-async function stageImagePart(
-  part: {
-    readonly image: string;
-    readonly mediaType?: string;
-    readonly type: "image";
-  },
-  store: RuntimeAttachmentStore | undefined,
-  options: RuntimeAttachmentStagingOptions
-): Promise<UserMessageFilePart> {
-  if (isRuntimeAttachmentData(part.image)) {
-    if (options.trustRuntimeAttachmentRefs === true) {
-      return {
-        data: part.image,
-        mediaType: part.mediaType ?? "image",
-        type: "file",
-      };
-    }
-    throw new RuntimeAttachmentSecurityError(
-      "External input cannot contain runtime attachment refs."
-    );
-  }
-
-  const mediaType = part.mediaType ?? "image";
-  if (isRemoteUrl(part.image)) {
-    return {
-      data: part.image,
-      mediaType,
-      type: "file",
-    };
-  }
-
-  return {
-    data: await stageFileData(
-      { data: part.image, type: "data" },
-      { mediaType },
-      store,
-      options
-    ),
-    mediaType,
-    type: "file",
-  };
 }
 
 function fileDataBytes(data: UserMessageFileData): Uint8Array | undefined {

--- a/packages/runtime/src/thread/input/input-normalization.ts
+++ b/packages/runtime/src/thread/input/input-normalization.ts
@@ -84,7 +84,7 @@ function assertUserMessageContent(
   for (const part of input) {
     if (!isUserMessageContentPart(part)) {
       throw new TypeError(
-        'Agent input content parts must be { type: "text", text }, { type: "image", image }, or { type: "file", data, mediaType }.'
+        'Agent input content parts must be { type: "text", text } or { type: "file", data, mediaType }.'
       );
     }
   }
@@ -99,14 +99,6 @@ function isUserMessageContentPart(
 
   if (part.type === "text") {
     return "text" in part && typeof part.text === "string";
-  }
-
-  if (part.type === "image") {
-    return (
-      "image" in part &&
-      typeof part.image === "string" &&
-      (!("mediaType" in part) || typeof part.mediaType === "string")
-    );
   }
 
   if (part.type === "file") {

--- a/packages/runtime/src/thread/input/input.ts
+++ b/packages/runtime/src/thread/input/input.ts
@@ -29,9 +29,7 @@ export interface UserMessageFilePart {
   type: "file";
 }
 
-export type UserMessageContentPart =
-  | UserMessageFilePart
-  | UserMessageTextPart;
+export type UserMessageContentPart = UserMessageFilePart | UserMessageTextPart;
 
 export type UserMessageContent = readonly UserMessageContentPart[];
 

--- a/packages/runtime/src/thread/input/input.ts
+++ b/packages/runtime/src/thread/input/input.ts
@@ -13,12 +13,6 @@ export interface UserMessageTextPart {
   type: "text";
 }
 
-export interface UserMessageImagePart {
-  image: string;
-  mediaType?: string;
-  type: "image";
-}
-
 export type UserMessageFileData =
   | ArrayBuffer
   | string
@@ -37,7 +31,6 @@ export interface UserMessageFilePart {
 
 export type UserMessageContentPart =
   | UserMessageFilePart
-  | UserMessageImagePart
   | UserMessageTextPart;
 
 export type UserMessageContent = readonly UserMessageContentPart[];

--- a/packages/runtime/src/thread/protocol/events.ts
+++ b/packages/runtime/src/thread/protocol/events.ts
@@ -8,7 +8,6 @@ export type {
   UserMessageContentPart,
   UserMessageFileData,
   UserMessageFilePart,
-  UserMessageImagePart,
   UserMessageTextPart,
   UserText,
   UserTextContent,

--- a/packages/runtime/src/thread/protocol/mapping.test.ts
+++ b/packages/runtime/src/thread/protocol/mapping.test.ts
@@ -55,14 +55,14 @@ describe("thread mapping", () => {
     });
   });
 
-  it("maps user image input to a serializable AI SDK file part", () => {
+  it("maps user image file input to a serializable AI SDK file part", () => {
     expect(
       userMessageToModelMessage(
         userMessage([
           { type: "text", text: "describe this" },
           {
-            type: "image",
-            image: "iVBORw0KGgo=",
+            type: "file",
+            data: "iVBORw0KGgo=",
             mediaType: "image/png",
           },
         ])

--- a/packages/runtime/src/thread/protocol/mapping.ts
+++ b/packages/runtime/src/thread/protocol/mapping.ts
@@ -70,14 +70,6 @@ function userMessageContentPartToUserContentPart(
     return { type: "text", text: part.text };
   }
 
-  if (part.type === "image") {
-    return {
-      type: "file",
-      data: part.image,
-      mediaType: part.mediaType ?? "image",
-    };
-  }
-
   return {
     type: "file",
     data: userMessageFileDataToFileData(part.data),

--- a/packages/runtime/src/thread/runtime/continuation.test.ts
+++ b/packages/runtime/src/thread/runtime/continuation.test.ts
@@ -60,7 +60,7 @@ describe("Agent thread runtime input continuation", () => {
     ]);
   });
 
-  it("normalizes multipart image and file thread.steer input like thread.send", async () => {
+  it("normalizes multipart image file thread.steer input like thread.send", async () => {
     const seenHistory: ModelMessage[][] = [];
     const agent = new Agent({
       model: createCallbackModel(({ history }) => {
@@ -70,7 +70,7 @@ describe("Agent thread runtime input continuation", () => {
     });
     const input = [
       { type: "text", text: "describe this" },
-      { type: "image", image: "iVBORw0KGgo=", mediaType: "image/png" },
+      { type: "file", data: "iVBORw0KGgo=", mediaType: "image/png" },
       {
         type: "file",
         data: { type: "text", text: "inline document" },
@@ -109,12 +109,12 @@ describe("Agent thread runtime input continuation", () => {
       text: "describe this",
       type: "text",
     });
-    const runtimeImagePart = runtimeInput.input.content[1];
-    expect(runtimeImagePart?.type).toBe("file");
-    if (runtimeImagePart?.type !== "file") {
+    const runtimeImageFilePart = runtimeInput.input.content[1];
+    expect(runtimeImageFilePart?.type).toBe("file");
+    if (runtimeImageFilePart?.type !== "file") {
       throw new Error("expected staged file part");
     }
-    expect(isRuntimeAttachmentData(runtimeImagePart.data)).toBe(true);
+    expect(isRuntimeAttachmentData(runtimeImageFilePart.data)).toBe(true);
     expect(seenHistory).toEqual([
       [
         userTextToModelMessage(userText("initial")),


### PR DESCRIPTION
## Summary
- remove the deprecated public `{ type: "image" }` input path and route image bytes through AI SDK-aligned `{ type: "file", data, mediaType }` parts
- update runtime docs, persistence parsers, mapping, staging, and tests to use file parts for image content
- reject AI SDK tools that declare `needsApproval` at Agent option validation and model-step boundaries, since pss does not implement AI SDK tool approval

Refs #171
Refs #173

## Verification
- `pnpm --filter @minpeter/pss-runtime exec vitest run src/agent/core/agent.test.ts src/llm/llm.test.ts src/llm/tool-call-id.test.ts src/thread/handle/thread.test.ts`
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `rg -n "type: \\\"image\\\"|type: 'image'" README.md packages/runtime/README.md` exits 1 with no output
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns multimodal inputs with AI SDK 7 by replacing deprecated `{ type: "image" }` with `{ type: "file", data, mediaType }`. Also rejects tools that use `needsApproval` and removes legacy image handling in the TUI. Refs #171, #173.

- **New Features**
  - Standardizes image inputs as file parts across normalization, staging, persistence, mapping, and docs.
  - Throws if a tool has `needsApproval` during agent option validation and before model execution.
  - Removes stale image input handling in `apps/coding-agent` TUI.

- **Migration**
  - Replace `{ type: "image", image, mediaType }` with `{ type: "file", data: image, mediaType }` in all inputs.
  - The `UserMessageImagePart` type is removed and no longer exported.

<sup>Written for commit 719a1cbc5804ecd31279711f5d23f8dc7258790d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

