### PR TITLE
Lower RFC001-003 runtime changeset to patch

### DIFF
--- a/.changeset/rfc001-003-follow-up.md
+++ b/.changeset/rfc001-003-follow-up.md
@@ -1,5 +1,5 @@
 ---
-"@minpeter/pss-runtime": minor
+"@minpeter/pss-runtime": patch
 ---
 
 Add durable thread event replay via `thread.events({ after, limit })`, pre-provider context budget gating for automatic compaction, and documentation for durable attachment replay behavior.


### PR DESCRIPTION
## Summary
- lower the RFC001-003 runtime changeset from minor to patch after PR #181 changed the release classification
- keep the follow-up scoped to release metadata only

## Verification
- pnpm changeset status --since origin/main
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lower the RFC001–003 follow-up changeset for `@minpeter/pss-runtime` from minor to patch to align with the updated release classification. This PR only updates release metadata; no runtime or API changes.

<sup>Written for commit 2e7a4cd794c634a9d2d558d95ea9947a7204754e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

