### PR TITLE
fix(ci): satisfy ultracite/biome lint after host unify merge

### DIFF
--- a/apps/coding-agent/src/thread-inspect.test.ts
+++ b/apps/coding-agent/src/thread-inspect.test.ts
@@ -1,14 +1,12 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   formatThreadInspectionReport,
   inspectCodingAgentThread,
+  storageFileForThread,
 } from "./thread-inspect";
-
-const threadFileName = (key: string): string =>
-  `${Buffer.from(key).toString("base64url")}.json`;
 
 async function tempDir(): Promise<string> {
   return await mkdtemp(join(tmpdir(), "pss-coding-agent-inspect-"));
@@ -20,10 +18,12 @@ describe("thread inspection", () => {
     const key = "inspect:key";
     const summary = { content: "old context summarized", role: "system" };
     const summaryBytes = Buffer.byteLength(JSON.stringify(summary), "utf8");
+    const storageFile = storageFileForThread(directory, key);
 
     try {
+      await mkdir(dirname(storageFile), { recursive: true });
       await writeFile(
-        join(directory, threadFileName(key)),
+        storageFile,
         `${JSON.stringify(
           {
             state: {
@@ -57,7 +57,7 @@ describe("thread inspection", () => {
       });
 
       expect(formatThreadInspectionReport(report)).toBe(`threadKey: inspect:key
-storageFile: ${join(directory, threadFileName(key))}
+storageFile: ${storageFile}
 version: 7
 messageCount: 3
 compactionCount: 1
@@ -82,7 +82,7 @@ autoCompaction: min=12 retain=4`);
       });
 
       expect(formatThreadInspectionReport(report)).toBe(`threadKey: missing:key
-storageFile: ${join(directory, threadFileName(key))}
+storageFile: ${storageFileForThread(directory, key)}
 version: none
 messageCount: 0
 compactionCount: 0

--- a/apps/coding-agent/src/thread-inspect.ts
+++ b/apps/coding-agent/src/thread-inspect.ts
@@ -1,8 +1,8 @@
 import {
-  fileThreadStoragePath,
-  inspectFileThread,
   type FileThreadInspection,
   type FileThreadInspectionCompaction,
+  fileThreadStoragePath,
+  inspectFileThread,
 } from "@minpeter/pss-runtime/platform/file";
 import type { CodingAgentThreadConfig } from "./thread-config";
 

--- a/apps/worker-agent/src/agent-do.test.ts
+++ b/apps/worker-agent/src/agent-do.test.ts
@@ -1,6 +1,6 @@
-import { DurableObject } from "cloudflare:workers";
-import { Agent as CloudflareAgent } from "agents";
+import type { DurableObject } from "cloudflare:workers";
 import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
+import { Agent as CloudflareAgent } from "agents";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { AgentDurableObject } from "./agent-do";
 import {

--- a/apps/worker-agent/src/agent-do.ts
+++ b/apps/worker-agent/src/agent-do.ts
@@ -1,4 +1,3 @@
-import { Agent as CloudflareAgent } from "agents";
 import type { Agent as PssAgent } from "@minpeter/pss-runtime";
 import {
   type CloudflareAgentsFiberRecoveryContext,
@@ -7,6 +6,7 @@ import {
   createCloudflarePlatformContext,
 } from "@minpeter/pss-runtime/platform/cloudflare";
 import { installCloudflareImageCodecs } from "@minpeter/pss-runtime/platform/cloudflare/image-codecs";
+import { Agent as CloudflareAgent } from "agents";
 
 import { createConfiguredAgent } from "./agent";
 import { deliverToolOnlyTurn, withCapturedMessages } from "./agent-do-delivery";
@@ -84,7 +84,7 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
 
   override async onFiberRecovered(
     ctx: CloudflareAgentsFiberRecoveryContext
-  ): Promise<void | CloudflareAgentsFiberRecoveryResult> {
+  ): Promise<undefined | CloudflareAgentsFiberRecoveryResult> {
     const result = await this.#platform.recoverFiber(ctx);
     if (result === false) {
       return;

--- a/apps/worker-agent/src/agents-test-shim.ts
+++ b/apps/worker-agent/src/agents-test-shim.ts
@@ -12,22 +12,22 @@ export class Agent<
 > extends DurableObject<Env> {
   initialState: State = undefined as State;
 
-  async onRequest(_request: Request): Promise<Response> {
-    return new Response("not found", { status: 404 });
+  onRequest(_request: Request): Promise<Response> {
+    return Promise.resolve(new Response("not found", { status: 404 }));
   }
 
   /** PartyServer-compatible entry used by DO stubs and tests. */
-  async fetch(request: Request): Promise<Response> {
-    return await this.onRequest(request);
+  fetch(request: Request): Promise<Response> {
+    return this.onRequest(request);
   }
 
-  async onFiberRecovered(
+  onFiberRecovered(
     _ctx: unknown
-  ): Promise<void | { readonly status: string }> {
-    return;
+  ): Promise<undefined | { readonly status: string }> {
+    return Promise.resolve(undefined);
   }
 
-  async schedule(
+  schedule(
     _when: Date | number | string,
     _callback: string,
     payload: unknown
@@ -39,14 +39,14 @@ export class Agent<
     readonly type: "delayed";
     readonly delayInSeconds: number;
   }> {
-    return {
+    return Promise.resolve({
       callback: String(_callback),
       delayInSeconds: 0,
       id: "test-schedule",
       payload,
       time: Date.now(),
       type: "delayed",
-    };
+    });
   }
 
   async startFiber(

--- a/apps/worker-agent/src/tui.ts
+++ b/apps/worker-agent/src/tui.ts
@@ -94,8 +94,7 @@ async function configureTuiTurnDelivery(
     case "local": {
       await mkdir(config.directory, { recursive: true });
       const host =
-        hostOverride ??
-        createFileHost({ directory: config.directory });
+        hostOverride ?? createFileHost({ directory: config.directory });
       const sessionIndex: SessionIndexStore = createSessionIndexStore(
         createFileSessionIndexRepository(
           join(config.directory, "session-index.json")

--- a/examples/background-subagent/src/background-delegation.ts
+++ b/examples/background-subagent/src/background-delegation.ts
@@ -1,8 +1,5 @@
 import type { AgentInput } from "@minpeter/pss-runtime";
-import type {
-  AgentHost,
-  TurnRecord,
-} from "@minpeter/pss-runtime/execution";
+import type { AgentHost, TurnRecord } from "@minpeter/pss-runtime/execution";
 
 const backgroundDelegationStateKind = "background-delegation" as const;
 

--- a/examples/background-subagent/src/background-output-tool.ts
+++ b/examples/background-subagent/src/background-output-tool.ts
@@ -1,7 +1,4 @@
-import type {
-  AgentHost,
-  TurnStatus,
-} from "@minpeter/pss-runtime/execution";
+import type { AgentHost, TurnStatus } from "@minpeter/pss-runtime/execution";
 import { jsonSchema, tool } from "ai";
 import { readDurableBackgroundDelegationState } from "./background-delegation";
 import { readerChildName } from "./delegate-tool";

--- a/experimental/pss-image-codec-edge-qa/qa-client.ts
+++ b/experimental/pss-image-codec-edge-qa/qa-client.ts
@@ -33,28 +33,28 @@ interface NormalizeResponse {
   readonly ok: boolean;
 }
 
-type ExpectOk = {
-  readonly kind: "ok";
-  readonly name: string;
-  readonly mediaType: string;
+interface ExpectOk {
   readonly bytes: Uint8Array;
-  readonly maxImageBytes?: number;
-  readonly expectMedia: string;
-  readonly expectMagic: "jpeg" | "png" | "unknown";
-  /** Skip ≤1MB check (small passthrough / under-budget alpha / non-image). */
-  readonly skipSizeCap?: boolean;
   /** When true, output bytes must equal input (non-image passthrough). */
   readonly expectByteIdentity?: boolean;
-};
-
-type ExpectFail = {
-  readonly kind: "fail";
-  readonly name: string;
-  readonly mediaType: string;
-  readonly bytes: Uint8Array;
+  readonly expectMagic: "jpeg" | "png" | "unknown";
+  readonly expectMedia: string;
+  readonly kind: "ok";
   readonly maxImageBytes?: number;
+  readonly mediaType: string;
+  readonly name: string;
+  /** Skip ≤1MB check (small passthrough / under-budget alpha / non-image). */
+  readonly skipSizeCap?: boolean;
+}
+
+interface ExpectFail {
+  readonly bytes: Uint8Array;
   readonly errorIncludes?: string;
-};
+  readonly kind: "fail";
+  readonly maxImageBytes?: number;
+  readonly mediaType: string;
+  readonly name: string;
+}
 
 type Case = ExpectOk | ExpectFail;
 
@@ -276,7 +276,11 @@ async function runFunctional(cases: Case[]): Promise<number> {
     );
     if (c.kind === "fail") {
       if (body.ok || status < 400) {
-        console.error(`FAIL ${c.name}: expected error, got ok`, body, `(${ms.toFixed(0)}ms)`);
+        console.error(
+          `FAIL ${c.name}: expected error, got ok`,
+          body,
+          `(${ms.toFixed(0)}ms)`
+        );
         failed += 1;
       } else {
         console.log(
@@ -294,16 +298,17 @@ async function runFunctional(cases: Case[]): Promise<number> {
     const mediaOk = body.mediaType === c.expectMedia;
     const magicOk = body.magic === c.expectMagic;
     const sizeOk =
-      c.skipSizeCap || (body.byteLength ?? Infinity) <= MAX_IMAGE_BYTES;
+      c.skipSizeCap ||
+      (body.byteLength ?? Number.POSITIVE_INFINITY) <= MAX_IMAGE_BYTES;
     const identityOk =
       !c.expectByteIdentity || body.byteLength === c.bytes.byteLength;
-    if (!mediaOk || !magicOk || !sizeOk || !identityOk) {
-      console.error(`FAIL ${c.name}:`, body, `(${ms.toFixed(0)}ms)`);
-      failed += 1;
-    } else {
+    if (mediaOk && magicOk && sizeOk && identityOk) {
       console.log(
         `OK   ${c.name}: ${body.mediaType} magic=${body.magic} in=${body.inputByteLength} out=${body.byteLength} (${ms.toFixed(0)}ms)`
       );
+    } else {
+      console.error(`FAIL ${c.name}:`, body, `(${ms.toFixed(0)}ms)`);
+      failed += 1;
     }
   }
   return failed;
@@ -311,9 +316,21 @@ async function runFunctional(cases: Case[]): Promise<number> {
 
 async function runConcurrent(): Promise<number> {
   const payloads = [
-    { name: "heic", mediaType: "image/heic", bytes: loadFixture("sample.heic") },
-    { name: "avif", mediaType: "image/avif", bytes: loadFixture("sample.avif") },
-    { name: "webp", mediaType: "image/webp", bytes: loadFixture("sample.webp") },
+    {
+      name: "heic",
+      mediaType: "image/heic",
+      bytes: loadFixture("sample.heic"),
+    },
+    {
+      name: "avif",
+      mediaType: "image/avif",
+      bytes: loadFixture("sample.avif"),
+    },
+    {
+      name: "webp",
+      mediaType: "image/webp",
+      bytes: loadFixture("sample.webp"),
+    },
     {
       name: "alpha-webp",
       mediaType: "image/webp",
@@ -337,14 +354,16 @@ async function runConcurrent(): Promise<number> {
   for (let i = 0; i < payloads.length; i += 1) {
     const p = payloads[i];
     const r = results[i];
-    if (!p || !r) {
+    if (!(p && r)) {
       failed += 1;
       continue;
     }
     if (!r.body.ok || r.body.mediaType !== expected[p.name]) {
       console.error(`FAIL concurrent-${p.name}:`, r.body);
       failed += 1;
-    } else if ((r.body.byteLength ?? Infinity) > MAX_IMAGE_BYTES) {
+    } else if (
+      (r.body.byteLength ?? Number.POSITIVE_INFINITY) > MAX_IMAGE_BYTES
+    ) {
       console.error(`FAIL concurrent-${p.name}: oversize`, r.body);
       failed += 1;
     } else {
@@ -353,8 +372,72 @@ async function runConcurrent(): Promise<number> {
       );
     }
   }
-  console.log(`     concurrent wall=${wall.toFixed(0)}ms for ${payloads.length} parallel`);
+  console.log(
+    `     concurrent wall=${wall.toFixed(0)}ms for ${payloads.length} parallel`
+  );
   return failed;
+}
+
+function benchHardCapMs(name: string): number {
+  if (name === "bench-oversize-jpeg") {
+    return 30_000;
+  }
+  if (name === "bench-avif" || name === "bench-heic") {
+    return 15_000;
+  }
+  return 5000;
+}
+
+async function warmupBenchTarget(
+  name: string,
+  mediaType: string,
+  bytes: Uint8Array
+): Promise<boolean> {
+  for (let w = 0; w < 2; w += 1) {
+    const warm = await normalize(mediaType, bytes);
+    if (!warm.body.ok) {
+      console.error(`FAIL ${name} warmup: ${warm.body.error}`);
+      return false;
+    }
+  }
+  return true;
+}
+
+async function sampleBenchTarget(
+  name: string,
+  mediaType: string,
+  bytes: Uint8Array
+): Promise<number[] | undefined> {
+  const samples: number[] = [];
+  for (let i = 0; i < BENCH_RUNS; i += 1) {
+    const r = await normalize(mediaType, bytes);
+    if (!r.body.ok) {
+      console.error(`FAIL ${name} run ${i}: ${r.body.error}`);
+      return;
+    }
+    if (
+      !name.includes("small") &&
+      (r.body.byteLength ?? Number.POSITIVE_INFINITY) > MAX_IMAGE_BYTES
+    ) {
+      console.error(`FAIL ${name} oversize out=${r.body.byteLength}`);
+      return;
+    }
+    samples.push(r.ms);
+  }
+  return samples;
+}
+
+function logBenchStats(name: string, samples: number[]): number {
+  samples.sort((a, b) => a - b);
+  const p50 = percentile(samples, 50);
+  const p95 = percentile(samples, 95);
+  const min = samples[0] ?? 0;
+  const max = samples.at(-1) ?? 0;
+  const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+  console.log(
+    `BENCH ${name}: n=${samples.length} min=${min.toFixed(0)} p50=${p50.toFixed(0)} mean=${mean.toFixed(0)} p95=${p95.toFixed(0)} max=${max.toFixed(0)} ms`
+  );
+  return p95;
 }
 
 async function runBench(): Promise<number> {
@@ -387,66 +470,24 @@ async function runBench(): Promise<number> {
   ] as const;
 
   let failed = 0;
-  console.log(`\n--- Warm latency bench (${BENCH_RUNS} runs after 2 warmup) ---`);
+  console.log(
+    `\n--- Warm latency bench (${BENCH_RUNS} runs after 2 warmup) ---`
+  );
 
   for (const t of targets) {
-    // Warmup (cold isolate amortization for later runs)
-    let warmupFailed = false;
-    for (let w = 0; w < 2; w += 1) {
-      const warm = await normalize(t.mediaType, t.bytes);
-      if (!warm.body.ok) {
-        console.error(`FAIL ${t.name} warmup: ${warm.body.error}`);
-        failed += 1;
-        warmupFailed = true;
-        break;
-      }
-    }
-    if (warmupFailed) {
+    if (!(await warmupBenchTarget(t.name, t.mediaType, t.bytes))) {
+      failed += 1;
       continue;
     }
-
-    const samples: number[] = [];
-    for (let i = 0; i < BENCH_RUNS; i += 1) {
-      const r = await normalize(t.mediaType, t.bytes);
-      if (!r.body.ok) {
-        console.error(`FAIL ${t.name} run ${i}: ${r.body.error}`);
-        failed += 1;
-        break;
-      }
-      if (
-        !t.name.includes("small") &&
-        (r.body.byteLength ?? Infinity) > MAX_IMAGE_BYTES
-      ) {
-        console.error(`FAIL ${t.name} oversize out=${r.body.byteLength}`);
-        failed += 1;
-        break;
-      }
-      samples.push(r.ms);
-    }
-
-    if (samples.length === 0) {
+    const samples = await sampleBenchTarget(t.name, t.mediaType, t.bytes);
+    if (!samples || samples.length === 0) {
+      failed += 1;
       continue;
     }
-    samples.sort((a, b) => a - b);
-    const p50 = percentile(samples, 50);
-    const p95 = percentile(samples, 95);
-    const min = samples[0] ?? 0;
-    const max = samples[samples.length - 1] ?? 0;
-    const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
-    console.log(
-      `BENCH ${t.name}: n=${samples.length} min=${min.toFixed(0)} p50=${p50.toFixed(0)} mean=${mean.toFixed(0)} p95=${p95.toFixed(0)} max=${max.toFixed(0)} ms`
-    );
-
-    // Soft budget guards (network+worker). Fail hard only on extreme regressions.
-    const hardCapMs =
-      t.name === "bench-oversize-jpeg"
-        ? 30_000
-        : t.name === "bench-avif" || t.name === "bench-heic"
-          ? 15_000
-          : 5_000;
-    if (p95 > hardCapMs) {
+    const p95 = logBenchStats(t.name, samples);
+    if (p95 > benchHardCapMs(t.name)) {
       console.error(
-        `FAIL ${t.name}: p95 ${p95.toFixed(0)}ms exceeds hard cap ${hardCapMs}ms`
+        `FAIL ${t.name}: p95 ${p95.toFixed(0)}ms exceeds hard cap ${benchHardCapMs(t.name)}ms`
       );
       failed += 1;
     }

--- a/experimental/pss-image-codec-edge-qa/src/runtime-bridge.ts
+++ b/experimental/pss-image-codec-edge-qa/src/runtime-bridge.ts
@@ -3,8 +3,10 @@
  * Uses public @minpeter/pss-runtime exports only (workspace boundaries).
  */
 
-export { installCloudflareImageCodecs } from "@minpeter/pss-runtime/platform/cloudflare/image-codecs";
+// biome-ignore-all lint/performance/noBarrelFile: Edge QA bridge re-exports public runtime surfaces only.
+
 export {
   DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES,
   prepareAttachmentBytesForStorage,
 } from "@minpeter/pss-runtime";
+export { installCloudflareImageCodecs } from "@minpeter/pss-runtime/platform/cloudflare/image-codecs";

--- a/packages/runtime/scripts/bench-image-compress.ts
+++ b/packages/runtime/scripts/bench-image-compress.ts
@@ -36,7 +36,7 @@ async function bench(
   const p50 = samples[Math.floor(samples.length / 2)] ?? 0;
   const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
   console.log(
-    `${name}: p50=${p50.toFixed(0)} mean=${mean.toFixed(0)} min=${samples[0]?.toFixed(0)} max=${samples[samples.length - 1]?.toFixed(0)}`
+    `${name}: p50=${p50.toFixed(0)} mean=${mean.toFixed(0)} min=${samples[0]?.toFixed(0)} max=${samples.at(-1)?.toFixed(0)}`
   );
 }
 

--- a/packages/runtime/scripts/inspect-storage.ts
+++ b/packages/runtime/scripts/inspect-storage.ts
@@ -1,6 +1,6 @@
 import type {
-  Checkpoint,
   AgentHost,
+  Checkpoint,
   NotificationRecord,
   TurnRecord,
 } from "../src/execution";

--- a/packages/runtime/scripts/probe-image-edge-cases.ts
+++ b/packages/runtime/scripts/probe-image-edge-cases.ts
@@ -40,13 +40,14 @@ async function main(): Promise<void> {
   ] as const) {
     try {
       const b = new Uint8Array(readFileSync(join(fixturesDir, f)));
-      const mt = f.includes("heic")
-        ? "image/heic"
-        : f.includes("webp")
-          ? "image/webp"
-          : f.includes("avif")
-            ? "image/avif"
-            : "image/jpeg";
+      let mt = "image/jpeg";
+      if (f.includes("heic")) {
+        mt = "image/heic";
+      } else if (f.includes("webp")) {
+        mt = "image/webp";
+      } else if (f.includes("avif")) {
+        mt = "image/avif";
+      }
       const out = await prepareAttachmentBytesForStorage({
         bytes: b,
         mediaType: mt,
@@ -93,7 +94,9 @@ async function main(): Promise<void> {
     data[i + 2] = (i * 41) % 256;
     data[i + 3] = 255;
   }
-  const big = new Uint8Array(jpeg.encode({ data, width: w, height: h }, 90).data);
+  const big = new Uint8Array(
+    jpeg.encode({ data, width: w, height: h }, 90).data
+  );
   console.log("extreme in", big.byteLength);
   const t1 = performance.now();
   const re = await prepareAttachmentBytesForStorage({

--- a/packages/runtime/src/agent/core/host-api.test.ts
+++ b/packages/runtime/src/agent/core/host-api.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { solidTestPng } from "../../testing/valid-image-fixture";
 import type { AgentHost } from "../../execution";
 import { createInMemoryHost } from "../../platform/memory";
 import { MemoryAttachmentStore } from "../../platform/memory/storage/memory-attachment-store";
@@ -12,12 +11,13 @@ import {
   assistantMessage,
   createCallbackModel,
 } from "../../testing/test-fixtures";
+import { solidTestPng } from "../../testing/valid-image-fixture";
 import { collect, SpyStore } from "../../thread/handle/test-support";
 import type {
+  HostAttachmentStore,
   RuntimeAttachmentBlob,
   RuntimeAttachmentPutInput,
   RuntimeAttachmentReference,
-  HostAttachmentStore,
 } from "../../thread/input/attachments";
 import { Agent, type AgentOptions } from "./agent";
 
@@ -62,8 +62,7 @@ type AcceptsInMemoryHostAsAgentHost = IsAssignable<
 >;
 
 const acceptsHostOptionAssertion: AcceptsHostOption = true;
-const rejectsRuntimeModelOptionAssertion: AssertFalse<AcceptsRuntimeModelOption> =
-  false;
+const rejectsRuntimeModelOptionAssertion: AssertFalse<AcceptsRuntimeModelOption> = false;
 const llmOptionAssertion: RejectsLlmOptionKey = false;
 const runtimeOptionAssertion: RejectsRuntimeOptionKey = false;
 const sessionsOptionAssertion: RejectsSessionsOptionKey = false;

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -163,9 +163,7 @@ describe("runtime public exports", () => {
       HostAttachmentStore | undefined
     >();
     expectTypeOf<HostStore["turns"]>().toEqualTypeOf<TurnStore>();
-    expectTypeOf<
-      HostStore["checkpoints"]
-    >().toEqualTypeOf<CheckpointStore>();
+    expectTypeOf<HostStore["checkpoints"]>().toEqualTypeOf<CheckpointStore>();
     expectTypeOf<HostStore["events"]>().toEqualTypeOf<EventStore>();
     expectTypeOf<HostStore["threadEvents"]>().toEqualTypeOf<
       ThreadEventLog | undefined
@@ -176,9 +174,7 @@ describe("runtime public exports", () => {
     expectTypeOf<
       Awaited<ReturnType<TurnStore["get"]>>
     >().toEqualTypeOf<TurnRecord | null>();
-    expectTypeOf<
-      HostStoreTransaction["turns"]
-    >().toEqualTypeOf<TurnStore>();
+    expectTypeOf<HostStoreTransaction["turns"]>().toEqualTypeOf<TurnStore>();
     expectTypeOf<
       HostStoreTransaction["notifications"]
     >().toEqualTypeOf<NotificationInbox>();

--- a/packages/runtime/src/contracts/root-host-api.test.ts
+++ b/packages/runtime/src/contracts/root-host-api.test.ts
@@ -25,9 +25,7 @@ describe("runtime host public contracts", () => {
       HostAttachmentStore | undefined
     >();
     expectTypeOf<HostStore["turns"]>().toEqualTypeOf<TurnStore>();
-    expectTypeOf<
-      HostStore["checkpoints"]
-    >().toEqualTypeOf<CheckpointStore>();
+    expectTypeOf<HostStore["checkpoints"]>().toEqualTypeOf<CheckpointStore>();
     expectTypeOf<HostStore["events"]>().toEqualTypeOf<EventStore>();
     expectTypeOf<HostStore["threadEvents"]>().toEqualTypeOf<
       ThreadEventLog | undefined
@@ -38,9 +36,7 @@ describe("runtime host public contracts", () => {
     expectTypeOf<
       Awaited<ReturnType<TurnStore["get"]>>
     >().toEqualTypeOf<TurnRecord | null>();
-    expectTypeOf<
-      HostStoreTransaction["turns"]
-    >().toEqualTypeOf<TurnStore>();
+    expectTypeOf<HostStoreTransaction["turns"]>().toEqualTypeOf<TurnStore>();
     expectTypeOf<
       HostStoreTransaction["notifications"]
     >().toEqualTypeOf<NotificationInbox>();

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { solidTestPng } from "../../testing/valid-image-fixture";
 import { agentNamespace } from "../../agent/identity/namespace";
 import { createInMemoryHost } from "../../platform/memory";
+import { solidTestPng } from "../../testing/valid-image-fixture";
 import {
+  type HostAttachmentStore,
   isRuntimeAttachmentData,
   type RuntimeAttachmentReference,
-  type HostAttachmentStore,
 } from "../../thread/input/attachments";
 import type { AgentHost, TurnRecord, TurnStore } from "../host/types";
 import { dispatchAgentNotification } from "./notification-dispatch";

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.ts
@@ -6,11 +6,7 @@ import {
   stageUserInputAttachments,
 } from "../../thread/input/attachments";
 import type { AgentEvent, UserInput } from "../../thread/protocol/events";
-import type {
-  AgentHost,
-  NotificationRecord,
-  TurnRecord,
-} from "../host/types";
+import type { AgentHost, NotificationRecord, TurnRecord } from "../host/types";
 
 export interface DispatchAgentNotificationInput {
   readonly host: AgentHost;

--- a/packages/runtime/src/execution/index.ts
+++ b/packages/runtime/src/execution/index.ts
@@ -15,9 +15,9 @@ export { threadStoreFromHost } from "./host/host";
 export type { ResumeThreadOptions } from "./host/scheduler-options";
 export { ThreadInputDuplicateConflictError } from "./host/thread-input-conflict";
 export type {
-  AgentHost,
   AdmitReceipt,
   AdmitThreadInput,
+  AgentHost,
   Checkpoint,
   CheckpointPhase,
   CheckpointStore,

--- a/packages/runtime/src/execution/resume/checkpoints.ts
+++ b/packages/runtime/src/execution/resume/checkpoints.ts
@@ -1,7 +1,7 @@
 import type { RuntimeToolExecutionCheckpointMetadata } from "../../llm/llm";
 import { ToolExecutionNeedsRecoveryError } from "../../llm/tool-execution";
 import { createCheckpointId } from "../host/checkpoint-ids";
-import type { Checkpoint, CheckpointPhase, AgentHost } from "../host/types";
+import type { AgentHost, Checkpoint, CheckpointPhase } from "../host/types";
 import type { ResumeRunState } from "./types";
 
 const maxCheckpointWriteAttempts = 5;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -22,17 +22,18 @@ export {
   decodeRuntimeAttachmentData,
   encodeRuntimeAttachmentData,
   getInstalledImageCodecWasm,
+  type HostAttachmentStore,
+  type ImageCodecWasmModules,
   installImageCodecWasm,
   installImageCodecWasmFromNodeModules,
   isCompressibleImageMediaType,
   isRuntimeAttachmentData,
   isStoredImageMediaType,
-  type ImageCodecWasmModules,
   MAX_IMAGE_DECODED_PIXELS,
   MAX_IMAGE_INPUT_BYTES,
   MAX_IMAGE_STORAGE_BUDGET_BYTES,
-  prepareAttachmentBytesForStorage,
   type PreparedAttachmentBytes,
+  prepareAttachmentBytesForStorage,
   type RuntimeAttachmentBlob,
   RuntimeAttachmentHydrationError,
   RuntimeAttachmentImageLimitError,
@@ -42,7 +43,6 @@ export {
   RuntimeAttachmentStagingError,
   STORED_IMAGE_MEDIA_TYPES,
   type StoredImageMediaType,
-  type HostAttachmentStore,
 } from "./thread/input/attachments";
 export { delegateUserInput } from "./thread/input/delegate-input";
 export type { AgentInput, ThreadInput } from "./thread/input/input";

--- a/packages/runtime/src/llm/llm.ts
+++ b/packages/runtime/src/llm/llm.ts
@@ -1,8 +1,8 @@
 import type { LanguageModel, ModelMessage, ToolChoice, ToolSet } from "ai";
 import { generateText } from "ai";
 import {
-  hydrateRuntimeAttachments,
   type HostAttachmentStore,
+  hydrateRuntimeAttachments,
 } from "../thread/input/attachments";
 import { assertNoUnsupportedToolApproval } from "./tool-approval";
 import type { RuntimeToolExecutionContext } from "./tool-execution";

--- a/packages/runtime/src/platform/cloudflare/agents/context.ts
+++ b/packages/runtime/src/platform/cloudflare/agents/context.ts
@@ -1,7 +1,7 @@
 import type { AgentHost } from "../../../execution";
-import { recoverCloudflareAgentsFiber } from "./fiber";
 import type { CloudflareHostAgentsOptions } from "../host/create-cloudflare-host";
 import { createCloudflareHost } from "../host/create-cloudflare-host";
+import { recoverCloudflareAgentsFiber } from "./fiber";
 import { createCloudflareAgentsFiberRetryScheduler } from "./retry-scheduler";
 import { resumeScheduledCloudflareAgentsFiber } from "./scheduled-fiber";
 import type {

--- a/packages/runtime/src/platform/cloudflare/agents/drain-options.ts
+++ b/packages/runtime/src/platform/cloudflare/agents/drain-options.ts
@@ -1,6 +1,6 @@
-import type { CloudflareAgentTurnDrainOptions } from "../turn-drain";
 import { createCloudflareStorageHost } from "../host/durable-object-host";
 import type { CloudflareDurableObjectStorage } from "../storage/durable-object/durable-object-storage";
+import type { CloudflareAgentTurnDrainOptions } from "../turn-drain";
 import {
   assertNeverPayload,
   type CloudflareAgentsFiberPayload,

--- a/packages/runtime/src/platform/cloudflare/agents/fiber-scheduler.test.ts
+++ b/packages/runtime/src/platform/cloudflare/agents/fiber-scheduler.test.ts
@@ -4,8 +4,8 @@ import {
   cloudflareAgentsFiberIdempotencyKey,
   cloudflareAgentsRunPayload,
   cloudflareAgentsThreadPayload,
-  createCloudflareHost,
   createCloudflareAgentsFiberScheduler,
+  createCloudflareHost,
   resumeScheduledCloudflareAgentsFiber,
 } from "./index";
 import { createFakeCloudflareAgent, runWithText } from "./test-support";

--- a/packages/runtime/src/platform/cloudflare/agents/fiber.ts
+++ b/packages/runtime/src/platform/cloudflare/agents/fiber.ts
@@ -1,5 +1,5 @@
-import { drainAgentTurnWithBudget } from "../turn-drain";
 import type { CloudflareDurableObjectStorage } from "../storage/durable-object/durable-object-storage";
+import { drainAgentTurnWithBudget } from "../turn-drain";
 import { cloudflareAgentsDrainOptionsForPayload } from "./drain-options";
 import {
   type CloudflareAgentsFiberPayload,

--- a/packages/runtime/src/platform/cloudflare/agents/index.ts
+++ b/packages/runtime/src/platform/cloudflare/agents/index.ts
@@ -1,12 +1,18 @@
 // biome-ignore-all lint/performance/noBarrelFile: Internal Cloudflare Agents barrel for the canonical Cloudflare adapter.
 
 export {
+  type CloudflareHostAgentsOptions,
+  type CloudflareHostOptions,
+  createCloudflareAgentsHost,
+  createCloudflareHost,
+} from "../host/create-cloudflare-host";
+export {
+  type CloudflareAgentsResumableAgent,
   type CloudflarePlatformContext,
   type CloudflarePlatformContextOptions,
   type CloudflarePlatformFactoryOptions,
   type CloudflarePlatformPrefixGuard,
   type CloudflarePlatformPrefixGuardOptions,
-  type CloudflareAgentsResumableAgent,
   createCloudflarePlatformContext,
 } from "./context";
 export {
@@ -16,12 +22,6 @@ export {
   startCloudflareAgentsResumeFiber,
 } from "./fiber";
 export type { CloudflareAgentsHostOptions } from "./host";
-export {
-  type CloudflareHostAgentsOptions,
-  type CloudflareHostOptions,
-  createCloudflareAgentsHost,
-  createCloudflareHost,
-} from "../host/create-cloudflare-host";
 export {
   ackScheduledCloudflareAgentsRun,
   ackScheduledCloudflareAgentsThreadPrompt,

--- a/packages/runtime/src/platform/cloudflare/agents/operations.ts
+++ b/packages/runtime/src/platform/cloudflare/agents/operations.ts
@@ -1,15 +1,15 @@
 import {
+  type AgentHost,
   type DispatchedAgentNotification,
   dispatchAgentNotification,
-  type AgentHost,
 } from "../../../execution";
 import type { AgentEvent, UserInput } from "../../../thread/protocol/events";
-import type { CloudflareScheduledThreadPrompt } from "../host/scheduled-work-queue";
-import type { CloudflareDurableObjectStorage } from "../storage/durable-object/durable-object-storage";
 import {
   type CloudflareHostOptions,
   createCloudflareHost,
 } from "../host/create-cloudflare-host";
+import type { CloudflareScheduledThreadPrompt } from "../host/scheduled-work-queue";
+import type { CloudflareDurableObjectStorage } from "../storage/durable-object/durable-object-storage";
 import type { CloudflareAgentsHostOptions } from "./host";
 import {
   ackListedCloudflareAgentsScheduledRun,

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
@@ -247,7 +247,7 @@ describe("Cloudflare Durable Object host adapter", () => {
   });
 });
 
-function notificationRunRecord(runId: string, idempotencyKey = runId) {
+function _notificationRunRecord(runId: string, idempotencyKey = runId) {
   return {
     checkpointVersion: 0,
     dedupeKey: idempotencyKey,

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.ts
@@ -154,7 +154,6 @@ export async function claimScheduledCloudflareThreadPrompt(
   );
 }
 
-
 function executionStoreWithThreads(
   store: AgentHost["store"],
   threads: ThreadStore

--- a/packages/runtime/src/platform/cloudflare/image-codecs-edge.ts
+++ b/packages/runtime/src/platform/cloudflare/image-codecs-edge.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../types/wasm.d.ts" />
 /**
  * Cloudflare Workers / edge bootstrap for image attachment codecs.
  *

--- a/packages/runtime/src/platform/cloudflare/index.ts
+++ b/packages/runtime/src/platform/cloudflare/index.ts
@@ -1,12 +1,12 @@
 // biome-ignore-all lint/performance/noBarrelFile: Public package subpath entrypoint required by package exports.
 
 export {
+  type CloudflareAgentsResumableAgent,
   type CloudflarePlatformContext,
   type CloudflarePlatformContextOptions,
   type CloudflarePlatformFactoryOptions,
   type CloudflarePlatformPrefixGuard,
   type CloudflarePlatformPrefixGuardOptions,
-  type CloudflareAgentsResumableAgent,
   createCloudflarePlatformContext,
 } from "./agents/context";
 /** Lazy so Node tests can import the cloudflare entry without loading .wasm. */
@@ -94,12 +94,6 @@ export type {
   CloudflareAgentsTurnDrainOptions,
 } from "./agents/types";
 export type {
-  AgentTurnDrainResult,
-  AgentTurnDrainStopReason,
-  CloudflareAgentTurnDrainOptions,
-} from "./turn-drain";
-export { drainAgentTurn, drainAgentTurnWithBudget } from "./turn-drain";
-export type {
   DispatchCloudflareAgentNotificationInput,
   SourceCloudflareAgentNotificationIdempotencyKeyInput,
 } from "./dispatch/notification-dispatch";
@@ -107,6 +101,12 @@ export {
   dispatchCloudflareAgentNotification,
   sourceCloudflareAgentNotificationIdempotencyKey,
 } from "./dispatch/notification-dispatch";
+export {
+  type CloudflareHostAgentsOptions,
+  type CloudflareHostOptions,
+  createCloudflareAgentsHost,
+  createCloudflareHost,
+} from "./host/create-cloudflare-host";
 export type {
   CloudflareDurableObjectFetchOptions,
   CloudflareDurableObjectStubOptions,
@@ -126,19 +126,13 @@ export type {
 export {
   ackScheduledCloudflareRun,
   ackScheduledCloudflareThreadPrompt,
+  type CloudflareStorageHostOptions,
   createCloudflareScheduledWorkScheduler,
   createCloudflareStorageHost,
-  type CloudflareStorageHostOptions,
   InMemoryCloudflareDurableObjectStorage,
   listScheduledCloudflareRuns,
   listScheduledCloudflareThreadPrompts,
 } from "./host/durable-object-host";
-export {
-  type CloudflareHostAgentsOptions,
-  type CloudflareHostOptions,
-  createCloudflareAgentsHost,
-  createCloudflareHost,
-} from "./host/create-cloudflare-host";
 export type {
   SqlStorage,
   SqlStorageCursorLike,
@@ -165,3 +159,9 @@ export {
 export { DurableObjectSqliteCheckpointStore } from "./storage/sqlite/checkpoint-store";
 export { DurableObjectSqliteEventStore } from "./storage/sqlite/event-store";
 export { DurableObjectSqliteThreadStore } from "./storage/sqlite/thread-store";
+export type {
+  AgentTurnDrainResult,
+  AgentTurnDrainStopReason,
+  CloudflareAgentTurnDrainOptions,
+} from "./turn-drain";
+export { drainAgentTurn, drainAgentTurnWithBudget } from "./turn-drain";

--- a/packages/runtime/src/platform/cloudflare/storage/attachment-store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/attachment-store.ts
@@ -1,8 +1,8 @@
 import type {
+  HostAttachmentStore,
   RuntimeAttachmentBlob,
   RuntimeAttachmentPutInput,
   RuntimeAttachmentReference,
-  HostAttachmentStore,
 } from "../../../thread/input/attachments";
 import type { CloudflareDurableObjectTransactionStorage } from "./durable-object/durable-object-storage";
 

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-contract.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-contract.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { describeExecutionStoreContract } from "../../../../contracts/execution-store/contract";
 import type { NotificationRecord, TurnRecord } from "../../../../execution";
-import { createCloudflareStorageHost } from "../../host/durable-object-host";
-import { InMemoryCloudflareDurableObjectStorage as PublicInMemoryCloudflareDurableObjectStorage } from "../../host/durable-object-host";
+import {
+  createCloudflareStorageHost,
+  InMemoryCloudflareDurableObjectStorage as PublicInMemoryCloudflareDurableObjectStorage,
+} from "../../host/durable-object-host";
 import { InMemorySqlStorage } from "../../sql/node-test/node-sqlite-storage";
 import type {
   SqlStorage,

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-thread-event.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-thread-event.test.ts
@@ -1,7 +1,7 @@
-import { createCloudflareStorageHost } from "../../host/durable-object-host";
 import { expect, it } from "vitest";
 import type { StoredThreadEvent } from "../../../../execution";
 import {
+  createCloudflareStorageHost,
   InMemoryCloudflareDurableObjectStorage,
 } from "../../host/durable-object-host";
 

--- a/packages/runtime/src/platform/file/host/agent-context.ts
+++ b/packages/runtime/src/platform/file/host/agent-context.ts
@@ -1,9 +1,6 @@
 import type { Agent } from "../../../agent/core/agent";
 import type { AgentHost } from "../../../execution";
-import {
-  createFileHost,
-  type FileHostOptions,
-} from "./file-host";
+import { createFileHost, type FileHostOptions } from "./file-host";
 
 export interface NodeFileAgentContextFactoryOptions {
   readonly directory: string;
@@ -27,8 +24,7 @@ export function createNodeFileAgentContext<CreatedAgent extends Agent>({
   createAgent,
   directory,
 }: NodeFileAgentContextOptions<CreatedAgent>): NodeFileAgentContext<CreatedAgent> {
-  const createHost = (options: FileHostOptions) =>
-    createFileHost(options);
+  const createHost = (options: FileHostOptions) => createFileHost(options);
   const createContextHost = () => createHost({ directory });
 
   return {

--- a/packages/runtime/src/platform/file/index.ts
+++ b/packages/runtime/src/platform/file/index.ts
@@ -31,11 +31,11 @@ export type {
 export { FileAttachmentStore } from "./storage/file-attachment-store";
 export { FileExecutionStore } from "./storage/file-execution-store";
 export {
-  fileThreadStorageHint,
-  fileThreadStoragePath,
-  inspectFileThread,
   type FileThreadInspection,
   type FileThreadInspectionCompaction,
   type FileThreadInspectionOptions,
+  fileThreadStorageHint,
+  fileThreadStoragePath,
+  inspectFileThread,
 } from "./storage/file-thread-inspection";
 export { FileThreadStore } from "./storage/file-thread-store";

--- a/packages/runtime/src/platform/file/storage/file-attachment-store.ts
+++ b/packages/runtime/src/platform/file/storage/file-attachment-store.ts
@@ -2,10 +2,10 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
+  HostAttachmentStore,
   RuntimeAttachmentBlob,
   RuntimeAttachmentPutInput,
   RuntimeAttachmentReference,
-  HostAttachmentStore,
 } from "../../../thread/input/attachments";
 
 interface FileAttachmentMetadata {

--- a/packages/runtime/src/platform/memory/execution/execution-host.ts
+++ b/packages/runtime/src/platform/memory/execution/execution-host.ts
@@ -1,8 +1,5 @@
 import type { ResumeThreadOptions } from "../../../execution/host/scheduler-options";
-import type {
-  AgentHost,
-  HostScheduler,
-} from "../../../execution/host/types";
+import type { AgentHost, HostScheduler } from "../../../execution/host/types";
 import {
   applyListLimit,
   type ScheduledThreadPrompt,

--- a/packages/runtime/src/platform/memory/index.ts
+++ b/packages/runtime/src/platform/memory/index.ts
@@ -2,8 +2,8 @@
 
 export {
   createInMemoryHost,
-  type InMemoryHost,
   InMemoryExecutionScheduler,
+  type InMemoryHost,
   type MemoryScheduledThreadPrompt,
   type MemoryScheduledWorkListOptions,
 } from "./execution/execution-host";

--- a/packages/runtime/src/platform/memory/storage/memory-attachment-store.ts
+++ b/packages/runtime/src/platform/memory/storage/memory-attachment-store.ts
@@ -1,8 +1,8 @@
 import type {
+  HostAttachmentStore,
   RuntimeAttachmentBlob,
   RuntimeAttachmentPutInput,
   RuntimeAttachmentReference,
-  HostAttachmentStore,
 } from "../../../thread/input/attachments";
 
 export class MemoryAttachmentStore implements HostAttachmentStore {

--- a/packages/runtime/src/testing/execution-checkpoint-test-support.ts
+++ b/packages/runtime/src/testing/execution-checkpoint-test-support.ts
@@ -1,8 +1,8 @@
 import type { Tool, ToolSet } from "ai";
 import { jsonSchema, tool } from "ai";
 import type {
-  Checkpoint,
   AgentHost,
+  Checkpoint,
   TurnRecord,
 } from "../execution/host/types";
 import { createInMemoryHost } from "../platform/memory";

--- a/packages/runtime/src/testing/llm-test-utils.ts
+++ b/packages/runtime/src/testing/llm-test-utils.ts
@@ -1,6 +1,6 @@
 import type { Tool, ToolSet } from "ai";
 import { jsonSchema, tool } from "ai";
-import { expect, vi } from "vitest";
+import { expect, type Mock, vi } from "vitest";
 import type { ModelGenerationOptions, ModelStepOptions } from "../llm/llm";
 import type { AgentEvent } from "../thread/protocol/events";
 import {
@@ -25,11 +25,11 @@ export const fakeModel = createMockLanguageModelV4([
   mockLanguageModelV4Empty(),
 ]);
 
-export function getGenerateTextMock() {
+export function getGenerateTextMock(): Mock {
   return generateTextMock;
 }
 
-export const createNoopTool = () =>
+export const createNoopTool = (): Tool =>
   tool({
     description: "No-op test tool.",
     execute: () => ({}),

--- a/packages/runtime/src/testing/tool-checkpointing-agent.test.ts
+++ b/packages/runtime/src/testing/tool-checkpointing-agent.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Checkpoint, AgentHost } from "../execution";
+import type { AgentHost, Checkpoint } from "../execution";
 import { InMemorySqlStorage } from "../platform/cloudflare/sql/node-test/node-sqlite-storage";
 import { InMemoryCloudflareDurableObjectStorage } from "../platform/cloudflare/storage/durable-object/durable-object-storage";
 import { DurableObjectExecutionStore } from "../platform/cloudflare/storage/execution/store";

--- a/packages/runtime/src/thread/handle/automatic-compaction-overflow.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction-overflow.test.ts
@@ -1,5 +1,6 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
@@ -12,7 +13,6 @@ import {
   storedAssistantOutput,
 } from "./automatic-compaction.test-support";
 import { collect, SpyStore } from "./test-support";
-import { hostWithThreads } from "../../testing/host-with-threads";
 
 describe("Agent thread automatic compaction overflow recovery", () => {
   it("rejects before provider calls when the context gate overflows with error", async () => {

--- a/packages/runtime/src/thread/handle/automatic-compaction-policy.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Agent } from "../../agent/core/agent";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
@@ -14,7 +15,6 @@ import {
 } from "./automatic-compaction.test-support";
 import { collect, SpyStore } from "./test-support";
 import { AgentThread } from "./thread";
-import { hostWithThreads } from "../../testing/host-with-threads";
 
 const minMessagesError = /autoCompaction\.minMessages/;
 const retainMessagesError = /autoCompaction\.retainMessages/;

--- a/packages/runtime/src/thread/handle/automatic-compaction-resilience.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction-resilience.test.ts
@@ -1,5 +1,6 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
@@ -16,7 +17,6 @@ import {
   storedAssistantOutput,
   waitForModelCalls,
 } from "./automatic-compaction.test-support";
-import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   ConflictOnCommitStore,
   collect,

--- a/packages/runtime/src/thread/handle/automatic-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction.test.ts
@@ -5,6 +5,7 @@ import {
   readCompactionRows,
   readRows,
 } from "../../platform/cloudflare/storage/sqlite/thread-store.test-support";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
@@ -19,7 +20,6 @@ import {
   waitForModelCalls,
 } from "./automatic-compaction.test-support";
 import { collect, SpyStore } from "./test-support";
-import { hostWithThreads } from "../../testing/host-with-threads";
 
 describe("Agent thread automatic compaction", () => {
   it("summarizes old history in the background and uses the summary plus latest tail on the next model call", async () => {

--- a/packages/runtime/src/thread/handle/delete-failure.test.ts
+++ b/packages/runtime/src/thread/handle/delete-failure.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { Agent } from "../../agent/core/agent";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
 } from "../../testing/test-fixtures";
 import { collect, SpyStore } from "./test-support";
-import { hostWithThreads } from "../../testing/host-with-threads";
 
 class RejectingDeleteStore extends SpyStore {
   override delete(_key: string): Promise<void> {

--- a/packages/runtime/src/thread/handle/durable-queue.test.ts
+++ b/packages/runtime/src/thread/handle/durable-queue.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { solidTestPng } from "../../testing/valid-image-fixture";
 import type {
   AgentHost,
   ThreadInputInbox,
@@ -7,11 +6,12 @@ import type {
 } from "../../execution/host/types";
 import { createInMemoryHost } from "../../platform/memory";
 import { MemoryAttachmentStore } from "../../platform/memory/storage/memory-attachment-store";
+import { solidTestPng } from "../../testing/valid-image-fixture";
 import type {
+  HostAttachmentStore,
   RuntimeAttachmentBlob,
   RuntimeAttachmentPutInput,
   RuntimeAttachmentReference,
-  HostAttachmentStore,
 } from "../input/attachments";
 import type { UserInput } from "../input/input";
 import type { AgentPlugin } from "../plugins/pipeline";

--- a/packages/runtime/src/thread/handle/durable-queue.ts
+++ b/packages/runtime/src/thread/handle/durable-queue.ts
@@ -2,8 +2,8 @@ import type { AgentHost } from "../../execution/host/types";
 import {
   cleanupStagedRuntimeAttachments,
   cleanupUnreferencedStagedRuntimeAttachments,
-  type RuntimeAttachmentReference,
   type HostAttachmentStore,
+  type RuntimeAttachmentReference,
   stageUserInputAttachments,
 } from "../input/attachments";
 import type { AgentInput } from "../input/input";

--- a/packages/runtime/src/thread/handle/durable-steering.ts
+++ b/packages/runtime/src/thread/handle/durable-steering.ts
@@ -1,8 +1,8 @@
 import type { AgentHost } from "../../execution/host/types";
 import {
   cleanupStagedRuntimeAttachments,
-  type RuntimeAttachmentReference,
   type HostAttachmentStore,
+  type RuntimeAttachmentReference,
   stageUserInputAttachments,
   userInputRequiresAttachmentProcessing,
 } from "../input/attachments";

--- a/packages/runtime/src/thread/handle/persistence-attachments.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-attachments.test.ts
@@ -2,15 +2,15 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { solidTestPng, solidTestPngBase64 } from "../../testing/valid-image-fixture";
 import { Agent } from "../../agent/core/agent";
 import { FileAttachmentStore, FileThreadStore } from "../../platform/file";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   createMockLanguageModelV4,
   mockLanguageModelV4Text,
 } from "../../testing/mock-language-model-v4-test-utils";
+import { solidTestPngBase64 } from "../../testing/valid-image-fixture";
 import { collect } from "./test-support";
-import { hostWithThreads } from "../../testing/host-with-threads";
 
 describe("Agent thread persistence attachments", () => {
   it("file thread store preserves image file parts across reload", async () => {

--- a/packages/runtime/src/thread/handle/persistence-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-compaction.test.ts
@@ -1,6 +1,7 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { Agent } from "../../agent/core/agent";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
@@ -8,7 +9,6 @@ import {
 } from "../../testing/test-fixtures";
 import { userTextToModelMessage } from "../protocol/mapping";
 import { collect, SpyStore } from "./test-support";
-import { hostWithThreads } from "../../testing/host-with-threads";
 
 const storedAssistantOutput = (text: string): ModelMessage => ({
   content: [{ providerOptions: undefined, text, type: "text" }],

--- a/packages/runtime/src/thread/handle/persistence.test.ts
+++ b/packages/runtime/src/thread/handle/persistence.test.ts
@@ -1,6 +1,7 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { Agent } from "../../agent/core/agent";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
@@ -10,12 +11,7 @@ import {
 } from "../../testing/test-fixtures";
 import type { AgentEvent } from "../protocol/events";
 import { userTextToModelMessage } from "../protocol/mapping";
-import { hostWithThreads } from "../../testing/host-with-threads";
-import {
-  ConflictOnCommitStore,
-  collect,
-  SpyStore,
-} from "./test-support";
+import { ConflictOnCommitStore, collect, SpyStore } from "./test-support";
 
 describe("Agent thread persistence", () => {
   it("emits and propagates runtime input commit conflicts without using the conflicted snapshot", async () => {

--- a/packages/runtime/src/thread/handle/terminal-state.test.ts
+++ b/packages/runtime/src/thread/handle/terminal-state.test.ts
@@ -1,6 +1,7 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { Agent } from "../../agent/core/agent";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
@@ -10,7 +11,6 @@ import {
 } from "../../testing/test-fixtures";
 import { userTextToModelMessage } from "../protocol/mapping";
 import { collect, SpyStore } from "./test-support";
-import { hostWithThreads } from "../../testing/host-with-threads";
 
 const timeoutMarker = Symbol("timeout");
 

--- a/packages/runtime/src/thread/handle/thread-events.test.ts
+++ b/packages/runtime/src/thread/handle/thread-events.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { Agent } from "../../agent/core/agent";
-import {
-  createInMemoryHost,
-  MemoryThreadStore,
-} from "../../platform/memory";
+import { createInMemoryHost, MemoryThreadStore } from "../../platform/memory";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   assistantMessage,
   createCallbackModel,
 } from "../../testing/test-fixtures";
 import { collect } from "./test-support";
 import { ThreadEventReplayUnsupportedError } from "./thread-event-replay";
-import { hostWithThreads } from "../../testing/host-with-threads";
 
 describe("AgentThread durable event replay", () => {
   it("replays committed thread events with cursor pagination", async () => {

--- a/packages/runtime/src/thread/handle/thread.test.ts
+++ b/packages/runtime/src/thread/handle/thread.test.ts
@@ -1,6 +1,5 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
-import { solidTestPng, solidTestPngBase64 } from "../../testing/valid-image-fixture";
 import { Agent } from "../../agent/core/agent";
 import {
   assistantMessage,
@@ -10,6 +9,10 @@ import {
   sentUserText,
   userText,
 } from "../../testing/test-fixtures";
+import {
+  solidTestPng,
+  solidTestPngBase64,
+} from "../../testing/valid-image-fixture";
 import {
   encodeRuntimeAttachmentData,
   isRuntimeAttachmentData,

--- a/packages/runtime/src/thread/input/attachment-image-compress.test.ts
+++ b/packages/runtime/src/thread/input/attachment-image-compress.test.ts
@@ -18,6 +18,10 @@ import { stageUserInputAttachments } from "./attachment-staging";
 import { RuntimeAttachmentStagingError } from "./attachment-types";
 
 const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+const MAX_INPUT_SIZE_ERROR = /max input size/i;
+const MAX_DECODED_PIXELS_ERROR = /max decoded pixel count/i;
+const UNSUPPORTED_GIF_ERROR = /Unsupported image media type|gif/i;
+const UNSUPPORTED_SVG_ERROR = /Unsupported image media type|svg/i;
 
 describe("prepareAttachmentBytesForStorage", () => {
   it("leaves non-image bytes unchanged even when larger than the default cap", async () => {
@@ -52,27 +56,23 @@ describe("prepareAttachmentBytesForStorage", () => {
     expect(prepared.mediaType).toBe("image/png");
   });
 
-  it(
-    "compresses oversized opaque images to image/jpeg under 1MB",
-    async () => {
-      const bytes = encodeNoisyJpeg(1600, 1600, 95);
-      expect(bytes.byteLength).toBeGreaterThan(
-        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "image/jpeg",
-      });
-      expect(prepared.mediaType).toBe("image/jpeg");
-      expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
-        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-      );
-      expect(jpeg.decode(prepared.bytes, { useTArray: true }).width).toBeGreaterThan(
-        0
-      );
-    },
-    20_000
-  );
+  it("compresses oversized opaque images to image/jpeg under 1MB", async () => {
+    const bytes = encodeNoisyJpeg(1600, 1600, 95);
+    expect(bytes.byteLength).toBeGreaterThan(
+      DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "image/jpeg",
+    });
+    expect(prepared.mediaType).toBe("image/jpeg");
+    expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
+      DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
+    );
+    expect(
+      jpeg.decode(prepared.bytes, { useTArray: true }).width
+    ).toBeGreaterThan(0);
+  }, 20_000);
 
   it("keeps transparent PNGs as image/png when under budget", async () => {
     const bytes = encodeSolidPng(64, 64, true);
@@ -84,82 +84,66 @@ describe("prepareAttachmentBytesForStorage", () => {
     expect(prepared.bytes).toBe(bytes);
   });
 
-  it(
-    "encodes transparent oversized frames as PNG (or JPEG fallback)",
-    async () => {
-      const bytes = encodeSolidPng(1800, 1800, true);
-      const maxImageBytes = 50_000;
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        maxImageBytes,
-        mediaType: "image/png",
-      });
-      expect(isStoredImageMediaType(prepared.mediaType)).toBe(true);
-      expect(prepared.bytes.byteLength).toBeLessThanOrEqual(maxImageBytes);
-    },
-    20_000
-  );
+  it("encodes transparent oversized frames as PNG (or JPEG fallback)", async () => {
+    const bytes = encodeSolidPng(1800, 1800, true);
+    const maxImageBytes = 50_000;
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      maxImageBytes,
+      mediaType: "image/png",
+    });
+    expect(isStoredImageMediaType(prepared.mediaType)).toBe(true);
+    expect(prepared.bytes.byteLength).toBeLessThanOrEqual(maxImageBytes);
+  }, 20_000);
 
-  it(
-    "always normalizes HEIC to image/jpeg or image/png (never heic)",
-    async () => {
-      const bytes = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.heic"))
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "image/heic",
-      });
-      expect(isStoredImageMediaType(prepared.mediaType)).toBe(true);
-      expect(prepared.mediaType).not.toBe("image/heic");
-      // fixture is photo-like / opaque → jpeg
-      expect(prepared.mediaType).toBe("image/jpeg");
-      expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
-        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-      );
-    },
-    30_000
-  );
+  it("always normalizes HEIC to image/jpeg or image/png (never heic)", async () => {
+    const bytes = new Uint8Array(
+      readFileSync(join(fixturesDir, "sample.heic"))
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "image/heic",
+    });
+    expect(isStoredImageMediaType(prepared.mediaType)).toBe(true);
+    expect(prepared.mediaType).not.toBe("image/heic");
+    // fixture is photo-like / opaque → jpeg
+    expect(prepared.mediaType).toBe("image/jpeg");
+    expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
+      DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
+    );
+  }, 30_000);
 
-  it(
-    "always normalizes AVIF to image/jpeg or image/png (never avif)",
-    async () => {
-      const bytes = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.avif"))
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "image/avif",
-      });
-      expect(isStoredImageMediaType(prepared.mediaType)).toBe(true);
-      expect(prepared.mediaType).not.toBe("image/avif");
-      expect(prepared.mediaType).toBe("image/jpeg");
-      expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
-        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-      );
-    },
-    30_000
-  );
+  it("always normalizes AVIF to image/jpeg or image/png (never avif)", async () => {
+    const bytes = new Uint8Array(
+      readFileSync(join(fixturesDir, "sample.avif"))
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "image/avif",
+    });
+    expect(isStoredImageMediaType(prepared.mediaType)).toBe(true);
+    expect(prepared.mediaType).not.toBe("image/avif");
+    expect(prepared.mediaType).toBe("image/jpeg");
+    expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
+      DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
+    );
+  }, 30_000);
 
-  it(
-    "always normalizes WebP to image/jpeg or image/png (never webp)",
-    async () => {
-      const bytes = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.webp"))
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "image/webp",
-      });
-      expect(isStoredImageMediaType(prepared.mediaType)).toBe(true);
-      expect(prepared.mediaType).not.toBe("image/webp");
-      expect(prepared.mediaType).toBe("image/jpeg");
-      expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
-        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-      );
-    },
-    30_000
-  );
+  it("always normalizes WebP to image/jpeg or image/png (never webp)", async () => {
+    const bytes = new Uint8Array(
+      readFileSync(join(fixturesDir, "sample.webp"))
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "image/webp",
+    });
+    expect(isStoredImageMediaType(prepared.mediaType)).toBe(true);
+    expect(prepared.mediaType).not.toBe("image/webp");
+    expect(prepared.mediaType).toBe("image/jpeg");
+    expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
+      DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
+    );
+  }, 30_000);
 
   it("throws when maxImageBytes is non-positive", async () => {
     await expect(
@@ -193,14 +177,14 @@ describe("prepareAttachmentBytesForStorage", () => {
         bytes,
         mediaType: "image/jpeg",
       })
-    ).rejects.toThrow(/max input size/i);
+    ).rejects.toThrow(MAX_INPUT_SIZE_ERROR);
   });
 
   it("rejects decoded frames above MAX_IMAGE_DECODED_PIXELS", () => {
     const side = Math.ceil(Math.sqrt(MAX_IMAGE_DECODED_PIXELS)) + 1;
     expect(() =>
       assertDecodedImageWithinLimits({ width: side, height: side })
-    ).toThrow(/max decoded pixel count/i);
+    ).toThrow(MAX_DECODED_PIXELS_ERROR);
     expect(() =>
       assertDecodedImageWithinLimits({ width: 100, height: 100 })
     ).not.toThrow();
@@ -216,20 +200,16 @@ describe("prepareAttachmentBytesForStorage", () => {
     expect(prepared.bytes).toBe(bytes);
   });
 
-  it(
-    "strips MIME parameters for HEIC",
-    async () => {
-      const bytes = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.heic"))
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "image/heic; codecs=hevc",
-      });
-      expect(prepared.mediaType).toBe("image/jpeg");
-    },
-    30_000
-  );
+  it("strips MIME parameters for HEIC", async () => {
+    const bytes = new Uint8Array(
+      readFileSync(join(fixturesDir, "sample.heic"))
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "image/heic; codecs=hevc",
+    });
+    expect(prepared.mediaType).toBe("image/jpeg");
+  }, 30_000);
 
   it("rejects unsupported GIF with a clear error", async () => {
     // Minimal GIF89a header-ish bytes (not a full image; no decoder path).
@@ -242,7 +222,7 @@ describe("prepareAttachmentBytesForStorage", () => {
         bytes,
         mediaType: "image/gif",
       })
-    ).rejects.toThrow(/Unsupported image media type|gif/i);
+    ).rejects.toThrow(UNSUPPORTED_GIF_ERROR);
   });
 
   it("rejects SVG as unsupported for raster normalization", async () => {
@@ -254,7 +234,7 @@ describe("prepareAttachmentBytesForStorage", () => {
         bytes,
         mediaType: "image/svg+xml",
       })
-    ).rejects.toThrow(/Unsupported image media type|svg/i);
+    ).rejects.toThrow(UNSUPPORTED_SVG_ERROR);
   });
 
   it("sniffs JPEG bytes even when mediaType is image/png", async () => {
@@ -266,57 +246,45 @@ describe("prepareAttachmentBytesForStorage", () => {
     expect(prepared.mediaType).toBe("image/jpeg");
   });
 
-  it(
-    "sniffs HEIC bytes even when mediaType lies (image/jpeg)",
-    async () => {
-      const bytes = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.heic"))
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "image/jpeg",
-      });
-      expect(prepared.mediaType).toBe("image/jpeg");
-      expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
-        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-      );
-      expect(prepared.bytes[0]).toBe(0xff);
-      expect(prepared.bytes[1]).toBe(0xd8);
-    },
-    30_000
-  );
+  it("sniffs HEIC bytes even when mediaType lies (image/jpeg)", async () => {
+    const bytes = new Uint8Array(
+      readFileSync(join(fixturesDir, "sample.heic"))
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "image/jpeg",
+    });
+    expect(prepared.mediaType).toBe("image/jpeg");
+    expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
+      DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
+    );
+    expect(prepared.bytes[0]).toBe(0xff);
+    expect(prepared.bytes[1]).toBe(0xd8);
+  }, 30_000);
 
-  it(
-    "sniffs HEIC under application/octet-stream",
-    async () => {
-      const bytes = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.heic"))
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "application/octet-stream",
-      });
-      expect(prepared.mediaType).toBe("image/jpeg");
-    },
-    30_000
-  );
+  it("sniffs HEIC under application/octet-stream", async () => {
+    const bytes = new Uint8Array(
+      readFileSync(join(fixturesDir, "sample.heic"))
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "application/octet-stream",
+    });
+    expect(prepared.mediaType).toBe("image/jpeg");
+  }, 30_000);
 
-  it(
-    "normalizes alpha WebP to image/png (never webp)",
-    async () => {
-      const bytes = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample-alpha.webp"))
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "image/webp",
-      });
-      expect(prepared.mediaType).toBe("image/png");
-      expect(prepared.bytes[0]).toBe(0x89);
-      expect(prepared.bytes[1]).toBe(0x50);
-    },
-    30_000
-  );
+  it("normalizes alpha WebP to image/png (never webp)", async () => {
+    const bytes = new Uint8Array(
+      readFileSync(join(fixturesDir, "sample-alpha.webp"))
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "image/webp",
+    });
+    expect(prepared.mediaType).toBe("image/png");
+    expect(prepared.bytes[0]).toBe(0x89);
+    expect(prepared.bytes[1]).toBe(0x50);
+  }, 30_000);
 
   it("rejects truncated JPEG (no EOI passthrough)", async () => {
     const bytes = new Uint8Array(
@@ -375,72 +343,58 @@ describe("prepareAttachmentBytesForStorage", () => {
     ).rejects.toBeInstanceOf(RuntimeAttachmentStagingError);
   });
 
-  it(
-    "compresses extreme-resolution JPEG under 1MB",
-    async () => {
-      const bytes = encodeNoisyJpeg(2200, 2200, 90);
-      expect(bytes.byteLength).toBeGreaterThan(
-        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-      );
-      const prepared = await prepareAttachmentBytesForStorage({
-        bytes,
-        mediaType: "image/jpeg",
-      });
-      expect(prepared.mediaType).toBe("image/jpeg");
-      expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
-        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-      );
-    },
-    30_000
-  );
+  it("compresses extreme-resolution JPEG under 1MB", async () => {
+    const bytes = encodeNoisyJpeg(2200, 2200, 90);
+    expect(bytes.byteLength).toBeGreaterThan(
+      DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
+    );
+    const prepared = await prepareAttachmentBytesForStorage({
+      bytes,
+      mediaType: "image/jpeg",
+    });
+    expect(prepared.mediaType).toBe("image/jpeg");
+    expect(prepared.bytes.byteLength).toBeLessThanOrEqual(
+      DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
+    );
+  }, 30_000);
 
-  it(
-    "handles concurrent multi-format normalization",
-    async () => {
-      const heic = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.heic"))
+  it("handles concurrent multi-format normalization", async () => {
+    const heic = new Uint8Array(readFileSync(join(fixturesDir, "sample.heic")));
+    const avif = new Uint8Array(readFileSync(join(fixturesDir, "sample.avif")));
+    const webp = new Uint8Array(readFileSync(join(fixturesDir, "sample.webp")));
+    const alpha = new Uint8Array(
+      readFileSync(join(fixturesDir, "sample-alpha.webp"))
+    );
+    const results = await Promise.all([
+      prepareAttachmentBytesForStorage({
+        bytes: heic,
+        mediaType: "image/heic",
+      }),
+      prepareAttachmentBytesForStorage({
+        bytes: avif,
+        mediaType: "image/avif",
+      }),
+      prepareAttachmentBytesForStorage({
+        bytes: webp,
+        mediaType: "image/webp",
+      }),
+      prepareAttachmentBytesForStorage({
+        bytes: alpha,
+        mediaType: "image/webp",
+      }),
+    ]);
+    expect(results.map((r) => r.mediaType)).toEqual([
+      "image/jpeg",
+      "image/jpeg",
+      "image/jpeg",
+      "image/png",
+    ]);
+    for (const r of results) {
+      expect(r.bytes.byteLength).toBeLessThanOrEqual(
+        DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
       );
-      const avif = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.avif"))
-      );
-      const webp = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.webp"))
-      );
-      const alpha = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample-alpha.webp"))
-      );
-      const results = await Promise.all([
-        prepareAttachmentBytesForStorage({
-          bytes: heic,
-          mediaType: "image/heic",
-        }),
-        prepareAttachmentBytesForStorage({
-          bytes: avif,
-          mediaType: "image/avif",
-        }),
-        prepareAttachmentBytesForStorage({
-          bytes: webp,
-          mediaType: "image/webp",
-        }),
-        prepareAttachmentBytesForStorage({
-          bytes: alpha,
-          mediaType: "image/webp",
-        }),
-      ]);
-      expect(results.map((r) => r.mediaType)).toEqual([
-        "image/jpeg",
-        "image/jpeg",
-        "image/jpeg",
-        "image/png",
-      ]);
-      for (const r of results) {
-        expect(r.bytes.byteLength).toBeLessThanOrEqual(
-          DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-        );
-      }
-    },
-    60_000
-  );
+    }
+  }, 60_000);
 });
 
 describe("stageUserInputAttachments image normalization", () => {
@@ -479,108 +433,106 @@ describe("stageUserInputAttachments image normalization", () => {
     });
   });
 
-  it(
-    "stores only jpeg/png media types for image inputs",
-    async () => {
-      const store = new MemoryAttachmentStore();
-      const heic = new Uint8Array(readFileSync(join(fixturesDir, "sample.heic")));
+  it("stores only jpeg/png media types for image inputs", async () => {
+    const store = new MemoryAttachmentStore();
+    const heic = new Uint8Array(readFileSync(join(fixturesDir, "sample.heic")));
 
-      const staged = await stageUserInputAttachments(
-        {
-          type: "user-input",
-          content: [
-            {
-              type: "file",
-              mediaType: "image/heic",
-              filename: "photo.heic",
-              data: heic,
-            },
-          ],
-        },
-        store
-      );
+    const staged = await stageUserInputAttachments(
+      {
+        type: "user-input",
+        content: [
+          {
+            type: "file",
+            mediaType: "image/heic",
+            filename: "photo.heic",
+            data: heic,
+          },
+        ],
+      },
+      store
+    );
 
-      if (!("content" in staged)) {
-        throw new Error("expected multipart user input");
-      }
-      const part = staged.content[0];
+    if (!("content" in staged)) {
+      throw new Error("expected multipart user input");
+    }
+    const part = staged.content[0];
+    if (part?.type !== "file" || typeof part.data !== "string") {
+      throw new Error("expected staged runtime attachment ref string");
+    }
+    const ref = decodeRuntimeAttachmentData(part.data);
+    const blob = await store.get(ref);
+    expect(blob).not.toBeNull();
+    expect(isStoredImageMediaType(blob?.mediaType ?? "")).toBe(true);
+    expect(blob?.mediaType).toBe("image/jpeg");
+  }, 30_000);
+
+  it("stages multi-image user input (heic+avif+webp+alpha) to jpeg/png only", async () => {
+    const store = new MemoryAttachmentStore();
+    const staged = await stageUserInputAttachments(
+      {
+        type: "user-input",
+        content: [
+          {
+            type: "file",
+            mediaType: "image/heic",
+            filename: "a.heic",
+            data: new Uint8Array(
+              readFileSync(join(fixturesDir, "sample.heic"))
+            ),
+          },
+          {
+            type: "file",
+            mediaType: "image/avif",
+            filename: "b.avif",
+            data: new Uint8Array(
+              readFileSync(join(fixturesDir, "sample.avif"))
+            ),
+          },
+          {
+            type: "file",
+            mediaType: "image/webp",
+            filename: "c.webp",
+            data: new Uint8Array(
+              readFileSync(join(fixturesDir, "sample.webp"))
+            ),
+          },
+          {
+            type: "file",
+            mediaType: "image/webp",
+            filename: "d-alpha.webp",
+            data: new Uint8Array(
+              readFileSync(join(fixturesDir, "sample-alpha.webp"))
+            ),
+          },
+        ],
+      },
+      store
+    );
+
+    if (!("content" in staged)) {
+      throw new Error("expected multipart user input");
+    }
+    expect(staged.content).toHaveLength(4);
+    const storedTypes: string[] = [];
+    for (const part of staged.content) {
       if (part?.type !== "file" || typeof part.data !== "string") {
-        throw new Error("expected staged runtime attachment ref string");
+        throw new Error("expected staged ref");
       }
-      const ref = decodeRuntimeAttachmentData(part.data);
-      const blob = await store.get(ref);
+      const blob = await store.get(decodeRuntimeAttachmentData(part.data));
       expect(blob).not.toBeNull();
       expect(isStoredImageMediaType(blob?.mediaType ?? "")).toBe(true);
-      expect(blob?.mediaType).toBe("image/jpeg");
-    },
-    30_000
-  );
-
-  it(
-    "stages multi-image user input (heic+avif+webp+alpha) to jpeg/png only",
-    async () => {
-      const store = new MemoryAttachmentStore();
-      const staged = await stageUserInputAttachments(
-        {
-          type: "user-input",
-          content: [
-            {
-              type: "file",
-              mediaType: "image/heic",
-              filename: "a.heic",
-              data: new Uint8Array(readFileSync(join(fixturesDir, "sample.heic"))),
-            },
-            {
-              type: "file",
-              mediaType: "image/avif",
-              filename: "b.avif",
-              data: new Uint8Array(readFileSync(join(fixturesDir, "sample.avif"))),
-            },
-            {
-              type: "file",
-              mediaType: "image/webp",
-              filename: "c.webp",
-              data: new Uint8Array(readFileSync(join(fixturesDir, "sample.webp"))),
-            },
-            {
-              type: "file",
-              mediaType: "image/webp",
-              filename: "d-alpha.webp",
-              data: new Uint8Array(
-                readFileSync(join(fixturesDir, "sample-alpha.webp"))
-              ),
-            },
-          ],
-        },
-        store
-      );
-
-      if (!("content" in staged)) {
-        throw new Error("expected multipart user input");
-      }
-      expect(staged.content).toHaveLength(4);
-      const storedTypes: string[] = [];
-      for (const part of staged.content) {
-        if (part?.type !== "file" || typeof part.data !== "string") {
-          throw new Error("expected staged ref");
-        }
-        const blob = await store.get(decodeRuntimeAttachmentData(part.data));
-        expect(blob).not.toBeNull();
-        expect(isStoredImageMediaType(blob?.mediaType ?? "")).toBe(true);
-        expect(blob?.bytes.byteLength ?? Infinity).toBeLessThanOrEqual(
-          DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES
-        );
-        storedTypes.push(blob?.mediaType ?? "");
-      }
-      expect(storedTypes).toEqual([
-        "image/jpeg",
-        "image/jpeg",
-        "image/jpeg",
-        "image/png",
-      ]);
-    },
-    60_000
-  );
+      expect(
+        blob?.bytes.byteLength ?? Number.POSITIVE_INFINITY
+      ).toBeLessThanOrEqual(DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES);
+      storedTypes.push(blob?.mediaType ?? "");
+    }
+    expect(storedTypes).toEqual([
+      "image/jpeg",
+      "image/jpeg",
+      "image/jpeg",
+      "image/png",
+    ]);
+  }, 60_000);
 });
 
 function encodeSolidJpeg(

--- a/packages/runtime/src/thread/input/attachment-image-compress.ts
+++ b/packages/runtime/src/thread/input/attachment-image-compress.ts
@@ -1,10 +1,4 @@
-import {
-  assertDecodedImageWithinLimits,
-  DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES,
-  MAX_IMAGE_DECODED_PIXELS,
-  MAX_IMAGE_INPUT_BYTES,
-  MAX_IMAGE_STORAGE_BUDGET_BYTES,
-} from "./attachment-image-limits";
+// biome-ignore-all lint/performance/noBarrelFile: Public compress API re-exports limits/types for stable import surface.
 import {
   decodeImageRgba,
   ensureImageCodecRuntimeReady,
@@ -14,6 +8,13 @@ import {
   encodePngUnderBudget,
   type PreparedAttachmentBytes,
 } from "./attachment-image-encode";
+import {
+  assertDecodedImageWithinLimits,
+  DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES,
+  MAX_IMAGE_INPUT_BYTES,
+  MAX_IMAGE_STORAGE_BUDGET_BYTES,
+} from "./attachment-image-limits";
+import { rgbaHasTransparency } from "./attachment-image-rgba";
 import {
   baseMediaType,
   isImageMediaType,
@@ -25,12 +26,9 @@ import {
   needsWasmImageCodecs,
   sniffImageMediaType,
 } from "./attachment-image-sniff";
-import { rgbaHasTransparency } from "./attachment-image-rgba";
-import {
-  RuntimeAttachmentImageLimitError,
-  RuntimeAttachmentStagingError,
-} from "./attachment-types";
+import { RuntimeAttachmentImageLimitError } from "./attachment-types";
 
+export type { PreparedAttachmentBytes } from "./attachment-image-encode";
 export {
   assertDecodedImageWithinLimits,
   DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES,
@@ -38,7 +36,6 @@ export {
   MAX_IMAGE_INPUT_BYTES,
   MAX_IMAGE_STORAGE_BUDGET_BYTES,
 } from "./attachment-image-limits";
-export type { PreparedAttachmentBytes } from "./attachment-image-encode";
 
 /** Stored image attachments are always one of these MIME types. */
 export const STORED_IMAGE_MEDIA_TYPES = ["image/jpeg", "image/png"] as const;

--- a/packages/runtime/src/thread/input/attachment-image-decode-heic.ts
+++ b/packages/runtime/src/thread/input/attachment-image-decode-heic.ts
@@ -1,8 +1,6 @@
-import {
-  getInstalledImageCodecWasm,
-} from "./attachment-image-codec-registry";
-import { asUint8Array, type RgbaImage } from "./attachment-image-rgba";
+import { getInstalledImageCodecWasm } from "./attachment-image-codec-registry";
 import { ensureImageCodecRuntimeReady } from "./attachment-image-decode-runtime";
+import { asUint8Array, type RgbaImage } from "./attachment-image-rgba";
 
 export async function decodeHeicToRgba(bytes: Uint8Array): Promise<RgbaImage> {
   try {
@@ -25,7 +23,7 @@ export async function decodeHeicToRgba(bytes: Uint8Array): Promise<RgbaImage> {
   }
 }
 
-type LibheifImage = {
+interface LibheifImage {
   display: (
     imageData: {
       data: Uint8ClampedArray;
@@ -33,21 +31,25 @@ type LibheifImage = {
       width: number;
     },
     callback: (
-      displayData: { data: Uint8ClampedArray; height: number; width: number } | null
+      displayData: {
+        data: Uint8ClampedArray;
+        height: number;
+        width: number;
+      } | null
     ) => void
   ) => void;
   free: () => void;
   get_height: () => number;
   get_width: () => number;
-};
+}
 
-type LibheifModule = {
+interface LibheifModule {
   HeifDecoder: new () => {
     decode: (buffer: Uint8Array) => LibheifImage[];
     decoder: { delete: () => void };
   };
   ready: Promise<void>;
-};
+}
 
 /** Cached libheif module — Wasm.Instance is expensive; reuse across HEIC decodes. */
 let libheifModulePromise: Promise<LibheifModule> | undefined;
@@ -179,9 +181,9 @@ async function decodeHeicWithLibheifEsmUnlocked(
   }
 }
 
-let avifInitPromise: Promise<void> | undefined;
-let webpInitPromise: Promise<void> | undefined;
-let runtimeReadyPromise: Promise<void> | undefined;
+let _avifInitPromise: Promise<void> | undefined;
+let _webpInitPromise: Promise<void> | undefined;
+let _runtimeReadyPromise: Promise<void> | undefined;
 
 /** True when AVIF + WebP + HEIF decode wasm modules are installed. */
 function polyfillEmscriptenNodeShims(): void {
@@ -196,4 +198,3 @@ function polyfillEmscriptenNodeShims(): void {
     g.__filename = "/libheif.js";
   }
 }
-

--- a/packages/runtime/src/thread/input/attachment-image-decode-heic.ts
+++ b/packages/runtime/src/thread/input/attachment-image-decode-heic.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../types/heic-decode.d.ts" />
+/// <reference path="../../types/libheif-js.d.ts" />
 import { getInstalledImageCodecWasm } from "./attachment-image-codec-registry";
 import { ensureImageCodecRuntimeReady } from "./attachment-image-decode-runtime";
 import { asUint8Array, type RgbaImage } from "./attachment-image-rgba";

--- a/packages/runtime/src/thread/input/attachment-image-decode-runtime.ts
+++ b/packages/runtime/src/thread/input/attachment-image-decode-runtime.ts
@@ -5,16 +5,18 @@ import {
   hasWebpDecodeWasm,
   installImageCodecWasmFromNodeModules,
 } from "./attachment-image-codec-registry";
-import { asUint8Array, type RgbaImage, toArrayBuffer } from "./attachment-image-rgba";
+import {
+  asUint8Array,
+  type RgbaImage,
+  toArrayBuffer,
+} from "./attachment-image-rgba";
 
 let avifInitPromise: Promise<void> | undefined;
 let webpInitPromise: Promise<void> | undefined;
 let runtimeReadyPromise: Promise<void> | undefined;
 
 function hasAllImageDecodeWasm(): boolean {
-  return (
-    hasAvifDecodeWasm() && hasWebpDecodeWasm() && hasHeifDecodeWasm()
-  );
+  return hasAvifDecodeWasm() && hasWebpDecodeWasm() && hasHeifDecodeWasm();
 }
 
 /**
@@ -41,7 +43,9 @@ export async function ensureImageCodecRuntimeReady(): Promise<void> {
     }
     try {
       // Wrangler follows this static specifier and bundles .wasm imports.
-      const edge = await import("../../platform/cloudflare/image-codecs-edge.js");
+      const edge = await import(
+        "../../platform/cloudflare/image-codecs-edge.js"
+      );
       edge.installCloudflareImageCodecs();
     } catch {
       // Not bundled (e.g. pure Node unit path without edge entry).
@@ -111,4 +115,3 @@ export async function decodeWebpToRgba(bytes: Uint8Array): Promise<RgbaImage> {
     width: decoded.width,
   };
 }
-

--- a/packages/runtime/src/thread/input/attachment-image-decode.ts
+++ b/packages/runtime/src/thread/input/attachment-image-decode.ts
@@ -1,12 +1,12 @@
+// biome-ignore-all lint/performance/noBarrelFile: Re-export wasm bootstrap next to decodeImageRgba public entry.
 import { decode as decodePng } from "fast-png";
 import jpeg from "jpeg-js";
-import { asUint8Array, type RgbaImage } from "./attachment-image-rgba";
 import { decodeHeicToRgba } from "./attachment-image-decode-heic";
 import {
   decodeAvifToRgba,
   decodeWebpToRgba,
-  ensureImageCodecRuntimeReady,
 } from "./attachment-image-decode-runtime";
+import { asUint8Array, type RgbaImage } from "./attachment-image-rgba";
 import {
   baseMediaType,
   isJpegMediaType,
@@ -77,7 +77,7 @@ export async function decodeImageRgba(
 
     throw new Error(
       `Unsupported image media type for normalization: ${normalized}. ` +
-        `Supported: jpeg, png, webp, heic/heif, avif. (gif/bmp/svg/tiff are not decoded.)`
+        "Supported: jpeg, png, webp, heic/heif, avif. (gif/bmp/svg/tiff are not decoded.)"
     );
   } catch (error) {
     if (error instanceof RuntimeAttachmentStagingError) {
@@ -157,4 +157,3 @@ function decodePngToRgba(bytes: Uint8Array): RgbaImage {
     width: decoded.width,
   };
 }
-

--- a/packages/runtime/src/thread/input/attachment-image-encode.ts
+++ b/packages/runtime/src/thread/input/attachment-image-encode.ts
@@ -1,12 +1,12 @@
 import { encode as encodePng } from "fast-png";
 import jpeg from "jpeg-js";
-import { RuntimeAttachmentStagingError } from "./attachment-types";
 import {
+  asUint8Array,
   flattenAlphaOntoWhite,
   type RgbaImage,
   scaleRgbaNearest,
-  asUint8Array,
 } from "./attachment-image-rgba";
+import { RuntimeAttachmentStagingError } from "./attachment-types";
 
 const JPEG_QUALITY_STEPS = [22, 28, 35, 45, 55, 65, 75, 85] as const;
 const FULL_RES_PIXEL_BUDGET = 1_200_000;
@@ -58,7 +58,7 @@ export function encodeJpegMaxQualityUnderBudget(
   let hi = last - 1;
 
   while (lo <= hi) {
-    const mid = (lo + hi) >> 1;
+    const mid = Math.floor((lo + hi) / 2);
     const quality = JPEG_QUALITY_STEPS[mid] ?? 22;
     const encoded = encodeJpeg(frame, quality);
     if (encoded.byteLength < bestAny.byteLength) {
@@ -173,4 +173,3 @@ function encodePngRgba(image: RgbaImage): Uint8Array {
     depth: 8,
   });
 }
-

--- a/packages/runtime/src/thread/input/attachment-image-limits.ts
+++ b/packages/runtime/src/thread/input/attachment-image-limits.ts
@@ -24,8 +24,7 @@ export function assertDecodedImageWithinLimits(decoded: {
   readonly width: number;
 }): void {
   if (
-    !Number.isFinite(decoded.width) ||
-    !Number.isFinite(decoded.height) ||
+    !(Number.isFinite(decoded.width) && Number.isFinite(decoded.height)) ||
     decoded.width <= 0 ||
     decoded.height <= 0
   ) {

--- a/packages/runtime/src/thread/input/attachment-image-sniff.ts
+++ b/packages/runtime/src/thread/input/attachment-image-sniff.ts
@@ -1,5 +1,3 @@
-import { RuntimeAttachmentStagingError } from "./attachment-types";
-
 const HEIC_BRANDS = new Set([
   "heic",
   "heix",
@@ -125,8 +123,8 @@ export function looksLikeCompleteJpeg(bytes: Uint8Array): boolean {
   return (
     looksLikeJpeg(bytes) &&
     bytes.length >= 4 &&
-    bytes[bytes.length - 2] === 0xff &&
-    bytes[bytes.length - 1] === 0xd9
+    bytes.at(-2) === 0xff &&
+    bytes.at(-1) === 0xd9
   );
 }
 
@@ -180,7 +178,9 @@ export function looksLikeWebp(bytes: Uint8Array): boolean {
 
 export function looksLikeHeic(bytes: Uint8Array): boolean {
   // Prefer AVIF when both brand families appear (common with `mif1` + `avif`).
-  return isIsoBmffBrand(bytes, HEIC_BRANDS) && !isIsoBmffBrand(bytes, AVIF_BRANDS);
+  return (
+    isIsoBmffBrand(bytes, HEIC_BRANDS) && !isIsoBmffBrand(bytes, AVIF_BRANDS)
+  );
 }
 
 export function looksLikeAvif(bytes: Uint8Array): boolean {
@@ -209,7 +209,11 @@ export function isIsoBmffBrand(
   if (brands.has(major)) {
     return true;
   }
-  for (let offset = 16; offset + 4 <= bytes.length && offset < 64; offset += 4) {
+  for (
+    let offset = 16;
+    offset + 4 <= bytes.length && offset < 64;
+    offset += 4
+  ) {
     if (brands.has(fourCc(bytes, offset))) {
       return true;
     }
@@ -227,4 +231,3 @@ export function fourCc(bytes: Uint8Array, offset: number): string {
     .replaceAll("\0", " ")
     .trim();
 }
-

--- a/packages/runtime/src/thread/input/attachment-pipeline.test.ts
+++ b/packages/runtime/src/thread/input/attachment-pipeline.test.ts
@@ -8,22 +8,22 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it } from "vitest";
 import { MemoryAttachmentStore } from "../../platform/memory";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
+  collectRun,
   fakeModel,
   getGenerateTextMock,
   loadAgent,
   loadModelStepRunner,
-  collectRun,
 } from "../../testing/llm-test-utils";
-import { hostWithThreads } from "../../testing/host-with-threads";
 import { assistantMessage } from "../../testing/test-fixtures";
 import { SpyStore } from "../handle/test-support";
 import { hydrateRuntimeAttachments } from "./attachment-hydration";
+import { isStoredImageMediaType } from "./attachment-image-compress";
 import {
   decodeRuntimeAttachmentData,
   isRuntimeAttachmentData,
 } from "./attachment-refs";
-import { isStoredImageMediaType } from "./attachment-image-compress";
 import { stageUserInputAttachments } from "./attachment-staging";
 
 const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
@@ -37,160 +37,148 @@ describe("attachment pipeline", () => {
     });
   });
 
-  it(
-    "stages HEIC to jpeg ref, then hydrates jpeg bytes for the model",
-    async () => {
-      const store = new MemoryAttachmentStore();
-      const heic = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.heic"))
-      );
+  it("stages HEIC to jpeg ref, then hydrates jpeg bytes for the model", async () => {
+    const store = new MemoryAttachmentStore();
+    const heic = new Uint8Array(readFileSync(join(fixturesDir, "sample.heic")));
 
-      const staged = await stageUserInputAttachments(
-        {
-          type: "user-input",
-          content: [
-            { type: "text", text: "what is this?" },
-            {
-              type: "file",
-              mediaType: "image/heic",
-              filename: "photo.heic",
-              data: heic,
-            },
-          ],
-        },
-        store
-      );
-
-      if (!("content" in staged)) {
-        throw new Error("expected multipart user input");
-      }
-      const filePart = staged.content[1];
-      if (filePart?.type !== "file" || typeof filePart.data !== "string") {
-        throw new Error("expected staged file ref string");
-      }
-      expect(isRuntimeAttachmentData(filePart.data)).toBe(true);
-      // History keeps the staged mediaType from prepare (jpeg after normalize).
-      expect(filePart.mediaType).toBe("image/jpeg");
-
-      const ref = decodeRuntimeAttachmentData(filePart.data);
-      const blob = await store.get(ref);
-      expect(blob).not.toBeNull();
-      expect(blob?.mediaType).toBe("image/jpeg");
-      expect(isStoredImageMediaType(blob?.mediaType ?? "")).toBe(true);
-      expect(blob?.bytes[0]).toBe(0xff);
-      expect(blob?.bytes[1]).toBe(0xd8);
-
-      const history = [
-        {
-          role: "user" as const,
-          content: [
-            { type: "text" as const, text: "what is this?" },
-            {
-              type: "file" as const,
-              data: filePart.data,
-              mediaType: filePart.mediaType,
-              filename: filePart.filename,
-            },
-          ],
-        },
-      ];
-
-      const hydrated = await hydrateRuntimeAttachments(history, store);
-      const hydratedFile = hydrated[0]?.content;
-      if (!Array.isArray(hydratedFile)) {
-        throw new Error("expected multipart hydrated content");
-      }
-      const modelFile = hydratedFile.find((p) => p.type === "file");
-      if (!modelFile || modelFile.type !== "file") {
-        throw new Error("expected hydrated file part");
-      }
-      expect(modelFile.mediaType).toBe("image/jpeg");
-      expect(modelFile.data).toBeInstanceOf(Uint8Array);
-      const modelBytes = modelFile.data as Uint8Array;
-      expect(modelBytes[0]).toBe(0xff);
-      expect(modelBytes[1]).toBe(0xd8);
-      // History ref string must not be mutated by hydrate.
-      expect(history[0]?.content[1]).toMatchObject({
-        data: filePart.data,
-        type: "file",
-      });
-
-      const runModelStep = await loadModelStepRunner();
-      await runModelStep(
-        { attachmentStore: store, model: fakeModel },
-        { history, signal: new AbortController().signal }
-      );
-      const messages = generateTextMock.mock.calls.at(-1)?.[0].messages;
-      const sent = messages?.[0]?.content?.find(
-        (p: { type: string }) => p.type === "file"
-      );
-      expect(sent?.mediaType).toBe("image/jpeg");
-      expect(sent?.data).toBeInstanceOf(Uint8Array);
-      expect(sent?.data[0]).toBe(0xff);
-      expect(sent?.data[1]).toBe(0xd8);
-    },
-    45_000
-  );
-
-  it(
-    "Agent.send HEIC: commits pss-attachment ref and sends jpeg bytes to the model",
-    async () => {
-      const threadStore = new SpyStore();
-      const attachmentStore = new MemoryAttachmentStore();
-      const heic = new Uint8Array(
-        readFileSync(join(fixturesDir, "sample.heic"))
-      );
-      const Agent = await loadAgent();
-      const agent = new Agent({
-        attachmentStore,
-        host: hostWithThreads(threadStore, attachmentStore),
-        model: fakeModel,
-      });
-
-      const events = await collectRun(
-        await agent.send([
-          { text: "describe", type: "text" },
+    const staged = await stageUserInputAttachments(
+      {
+        type: "user-input",
+        content: [
+          { type: "text", text: "what is this?" },
           {
-            data: heic,
-            filename: "photo.heic",
-            mediaType: "image/heic",
             type: "file",
+            mediaType: "image/heic",
+            filename: "photo.heic",
+            data: heic,
           },
-        ])
-      );
-      expect(events.filter((e) => e.type === "turn-error")).toEqual([]);
+        ],
+      },
+      store
+    );
 
-      const accepted = events[0];
-      if (accepted?.type !== "user-input" || !("content" in accepted)) {
-        throw new Error("expected staged user-input");
-      }
-      const part = accepted.content.find((p) => p.type === "file");
-      if (!part || part.type !== "file" || typeof part.data !== "string") {
-        throw new Error("expected file ref on accepted input");
-      }
-      expect(isRuntimeAttachmentData(part.data)).toBe(true);
-      expect(part.mediaType).toBe("image/jpeg");
+    if (!("content" in staged)) {
+      throw new Error("expected multipart user input");
+    }
+    const filePart = staged.content[1];
+    if (filePart?.type !== "file" || typeof filePart.data !== "string") {
+      throw new Error("expected staged file ref string");
+    }
+    expect(isRuntimeAttachmentData(filePart.data)).toBe(true);
+    // History keeps the staged mediaType from prepare (jpeg after normalize).
+    expect(filePart.mediaType).toBe("image/jpeg");
 
-      const committedJson = JSON.stringify(threadStore.commits.at(0)?.next.state);
-      expect(committedJson).toContain("pss-attachment:");
-      // Original HEIC media type should not linger as stored media type for the part.
-      expect(committedJson).not.toContain("image/heic");
+    const ref = decodeRuntimeAttachmentData(filePart.data);
+    const blob = await store.get(ref);
+    expect(blob).not.toBeNull();
+    expect(blob?.mediaType).toBe("image/jpeg");
+    expect(isStoredImageMediaType(blob?.mediaType ?? "")).toBe(true);
+    expect(blob?.bytes[0]).toBe(0xff);
+    expect(blob?.bytes[1]).toBe(0xd8);
 
-      const blob = await attachmentStore.get(
-        decodeRuntimeAttachmentData(part.data)
-      );
-      expect(blob?.mediaType).toBe("image/jpeg");
-      expect(blob?.bytes[0]).toBe(0xff);
+    const history = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "what is this?" },
+          {
+            type: "file" as const,
+            data: filePart.data,
+            mediaType: filePart.mediaType,
+            filename: filePart.filename,
+          },
+        ],
+      },
+    ];
 
-      const generateTextInput = generateTextMock.mock.calls.at(-1)?.[0];
-      const modelFile = generateTextInput?.messages?.[0]?.content?.find(
-        (p: { type: string }) => p.type === "file"
-      );
-      expect(modelFile?.mediaType).toBe("image/jpeg");
-      expect(modelFile?.data).toBeInstanceOf(Uint8Array);
-      expect(modelFile?.data[0]).toBe(0xff);
-      expect(modelFile?.data[1]).toBe(0xd8);
-    },
-    45_000
-  );
+    const hydrated = await hydrateRuntimeAttachments(history, store);
+    const hydratedFile = hydrated[0]?.content;
+    if (!Array.isArray(hydratedFile)) {
+      throw new Error("expected multipart hydrated content");
+    }
+    const modelFile = hydratedFile.find((p) => p.type === "file");
+    if (modelFile?.type !== "file") {
+      throw new Error("expected hydrated file part");
+    }
+    expect(modelFile.mediaType).toBe("image/jpeg");
+    expect(modelFile.data).toBeInstanceOf(Uint8Array);
+    const modelBytes = modelFile.data as Uint8Array;
+    expect(modelBytes[0]).toBe(0xff);
+    expect(modelBytes[1]).toBe(0xd8);
+    // History ref string must not be mutated by hydrate.
+    expect(history[0]?.content[1]).toMatchObject({
+      data: filePart.data,
+      type: "file",
+    });
+
+    const runModelStep = await loadModelStepRunner();
+    await runModelStep(
+      { attachmentStore: store, model: fakeModel },
+      { history, signal: new AbortController().signal }
+    );
+    const messages = generateTextMock.mock.calls.at(-1)?.[0].messages;
+    const sent = messages?.[0]?.content?.find(
+      (p: { type: string }) => p.type === "file"
+    );
+    expect(sent?.mediaType).toBe("image/jpeg");
+    expect(sent?.data).toBeInstanceOf(Uint8Array);
+    expect(sent?.data[0]).toBe(0xff);
+    expect(sent?.data[1]).toBe(0xd8);
+  }, 45_000);
+
+  it("Agent.send HEIC: commits pss-attachment ref and sends jpeg bytes to the model", async () => {
+    const threadStore = new SpyStore();
+    const attachmentStore = new MemoryAttachmentStore();
+    const heic = new Uint8Array(readFileSync(join(fixturesDir, "sample.heic")));
+    const Agent = await loadAgent();
+    const agent = new Agent({
+      attachmentStore,
+      host: hostWithThreads(threadStore, attachmentStore),
+      model: fakeModel,
+    });
+
+    const events = await collectRun(
+      await agent.send([
+        { text: "describe", type: "text" },
+        {
+          data: heic,
+          filename: "photo.heic",
+          mediaType: "image/heic",
+          type: "file",
+        },
+      ])
+    );
+    expect(events.filter((e) => e.type === "turn-error")).toEqual([]);
+
+    const accepted = events[0];
+    if (accepted?.type !== "user-input" || !("content" in accepted)) {
+      throw new Error("expected staged user-input");
+    }
+    const part = accepted.content.find((p) => p.type === "file");
+    if (part?.type !== "file" || typeof part.data !== "string") {
+      throw new Error("expected file ref on accepted input");
+    }
+    expect(isRuntimeAttachmentData(part.data)).toBe(true);
+    expect(part.mediaType).toBe("image/jpeg");
+
+    const committedJson = JSON.stringify(threadStore.commits.at(0)?.next.state);
+    expect(committedJson).toContain("pss-attachment:");
+    // Original HEIC media type should not linger as stored media type for the part.
+    expect(committedJson).not.toContain("image/heic");
+
+    const blob = await attachmentStore.get(
+      decodeRuntimeAttachmentData(part.data)
+    );
+    expect(blob?.mediaType).toBe("image/jpeg");
+    expect(blob?.bytes[0]).toBe(0xff);
+
+    const generateTextInput = generateTextMock.mock.calls.at(-1)?.[0];
+    const modelFile = generateTextInput?.messages?.[0]?.content?.find(
+      (p: { type: string }) => p.type === "file"
+    );
+    expect(modelFile?.mediaType).toBe("image/jpeg");
+    expect(modelFile?.data).toBeInstanceOf(Uint8Array);
+    expect(modelFile?.data[0]).toBe(0xff);
+    expect(modelFile?.data[1]).toBe(0xd8);
+  }, 45_000);
 });

--- a/packages/runtime/src/thread/input/attachment-refs.test.ts
+++ b/packages/runtime/src/thread/input/attachment-refs.test.ts
@@ -7,6 +7,11 @@ import {
 } from "./attachment-refs";
 import { RuntimeAttachmentHydrationError } from "./attachment-types";
 
+const EXPECTED_RUNTIME_ATTACHMENT_DATA = /Expected runtime attachment data/;
+const UNSUPPORTED_ATTACHMENT_VERSION =
+  /Unsupported runtime attachment data version/;
+const MISSING_PAYLOAD = /missing a payload/;
+
 describe("runtime attachment refs", () => {
   it("round-trips a full reference through encode/decode", () => {
     const ref = {
@@ -26,9 +31,9 @@ describe("runtime attachment refs", () => {
       id: "min-id",
       schemaVersion: 1 as const,
     };
-    expect(decodeRuntimeAttachmentData(encodeRuntimeAttachmentData(ref))).toEqual(
-      ref
-    );
+    expect(
+      decodeRuntimeAttachmentData(encodeRuntimeAttachmentData(ref))
+    ).toEqual(ref);
   });
 
   it("isRuntimeAttachmentData only accepts the pss-attachment prefix", () => {
@@ -46,24 +51,22 @@ describe("runtime attachment refs", () => {
       RuntimeAttachmentHydrationError
     );
     expect(() => decodeRuntimeAttachmentData("not-a-ref")).toThrow(
-      /Expected runtime attachment data/
+      EXPECTED_RUNTIME_ATTACHMENT_DATA
     );
   });
 
   it("rejects unsupported schema versions", () => {
     const payload = bytesToBase64Url(
-      new TextEncoder().encode(
-        JSON.stringify({ id: "x", schemaVersion: 1 })
-      )
+      new TextEncoder().encode(JSON.stringify({ id: "x", schemaVersion: 1 }))
     );
     expect(() =>
       decodeRuntimeAttachmentData(`pss-attachment:?v=2&p=${payload}`)
-    ).toThrow(/Unsupported runtime attachment data version/);
+    ).toThrow(UNSUPPORTED_ATTACHMENT_VERSION);
   });
 
   it("rejects missing payload parameter", () => {
     expect(() => decodeRuntimeAttachmentData("pss-attachment:?v=1")).toThrow(
-      /missing a payload/
+      MISSING_PAYLOAD
     );
   });
 

--- a/packages/runtime/src/thread/input/attachment-staging.ts
+++ b/packages/runtime/src/thread/input/attachment-staging.ts
@@ -1,15 +1,15 @@
 import type { AgentEvent, RuntimeInput } from "../protocol/events";
 import { base64ToBytes } from "./attachment-base64";
+import { prepareAttachmentBytesForStorage } from "./attachment-image-compress";
 import {
   decodeRuntimeAttachmentData,
   encodeRuntimeAttachmentData,
   isRuntimeAttachmentData,
 } from "./attachment-refs";
-import { prepareAttachmentBytesForStorage } from "./attachment-image-compress";
 import type {
+  HostAttachmentStore,
   RuntimeAttachmentReference,
   RuntimeAttachmentStagingOptions,
-  HostAttachmentStore,
 } from "./attachment-types";
 import {
   RuntimeAttachmentImageLimitError,
@@ -234,18 +234,29 @@ function imageLimitOmittedTextPart(
   error: RuntimeAttachmentImageLimitError
 ): UserMessageTextPart {
   const label = filename?.trim() || "image";
-  const reason =
-    error.limit === "input_bytes"
-      ? "file too large to process safely"
-      : error.limit === "decoded_pixels"
-        ? "resolution too high to process safely"
-        : error.limit === "storage_budget"
-          ? "storage budget invalid or too high"
-          : "invalid image dimensions";
   return {
     type: "text",
-    text: `[Attachment omitted: ${label} (${reason})]`,
+    text: `[Attachment omitted: ${label} (${imageLimitReason(error.limit)})]`,
   };
+}
+
+function imageLimitReason(
+  limit: RuntimeAttachmentImageLimitError["limit"]
+): string {
+  switch (limit) {
+    case "input_bytes":
+      return "file too large to process safely";
+    case "decoded_pixels":
+      return "resolution too high to process safely";
+    case "storage_budget":
+      return "storage budget invalid or too high";
+    case "invalid_dimensions":
+      return "invalid image dimensions";
+    default: {
+      const _exhaustive: never = limit;
+      return _exhaustive;
+    }
+  }
 }
 
 function fileDataBytes(data: UserMessageFileData): Uint8Array | undefined {

--- a/packages/runtime/src/thread/input/attachments.ts
+++ b/packages/runtime/src/thread/input/attachments.ts
@@ -3,9 +3,9 @@
 export { hydrateRuntimeAttachments } from "./attachment-hydration";
 export {
   getInstalledImageCodecWasm,
+  type ImageCodecWasmModules,
   installImageCodecWasm,
   installImageCodecWasmFromNodeModules,
-  type ImageCodecWasmModules,
 } from "./attachment-image-codec-registry";
 export {
   DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES,
@@ -14,8 +14,8 @@ export {
   MAX_IMAGE_DECODED_PIXELS,
   MAX_IMAGE_INPUT_BYTES,
   MAX_IMAGE_STORAGE_BUDGET_BYTES,
-  prepareAttachmentBytesForStorage,
   type PreparedAttachmentBytes,
+  prepareAttachmentBytesForStorage,
   STORED_IMAGE_MEDIA_TYPES,
   type StoredImageMediaType,
 } from "./attachment-image-compress";
@@ -35,6 +35,7 @@ export {
   userInputRequiresAttachmentStaging,
 } from "./attachment-staging";
 export {
+  type HostAttachmentStore,
   type RuntimeAttachmentBlob,
   RuntimeAttachmentHydrationError,
   RuntimeAttachmentImageLimitError,
@@ -43,5 +44,4 @@ export {
   RuntimeAttachmentSecurityError,
   RuntimeAttachmentStagingError,
   type RuntimeAttachmentStagingOptions,
-  type HostAttachmentStore,
 } from "./attachment-types";

--- a/packages/runtime/src/thread/input/runtime-input.test.ts
+++ b/packages/runtime/src/thread/input/runtime-input.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { solidTestPng, solidTestPngBase64 } from "../../testing/valid-image-fixture";
+import { solidTestPng } from "../../testing/valid-image-fixture";
 import type {
-  RuntimeAttachmentReference,
   HostAttachmentStore,
+  RuntimeAttachmentReference,
 } from "./attachments";
 import {
   addSteeringInput,

--- a/packages/runtime/src/thread/input/runtime-input.ts
+++ b/packages/runtime/src/thread/input/runtime-input.ts
@@ -3,8 +3,8 @@ import type { AgentEvent, RuntimeInput } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
 import {
   cleanupStagedRuntimeAttachments,
-  type RuntimeAttachmentReference,
   type HostAttachmentStore,
+  type RuntimeAttachmentReference,
   stageUserInputAttachments,
   userInputRequiresAttachmentProcessing,
 } from "./attachments";

--- a/packages/runtime/src/thread/runtime/attachment-staging.test.ts
+++ b/packages/runtime/src/thread/runtime/attachment-staging.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest";
 import { encode as encodePng } from "fast-png";
+import { beforeEach, describe, expect, it } from "vitest";
 import { MemoryAttachmentStore } from "../../platform/memory";
+import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   collectRun,
   fakeModel,
@@ -9,7 +10,6 @@ import {
 } from "../../testing/llm-test-utils";
 import { assistantMessage } from "../../testing/test-fixtures";
 import { SpyStore } from "../handle/test-support";
-import { hostWithThreads } from "../../testing/host-with-threads";
 import {
   encodeRuntimeAttachmentData,
   isRuntimeAttachmentData,
@@ -76,7 +76,9 @@ describe("runtime attachment staging", () => {
     const committedJson = JSON.stringify(committedState);
     expect(committedJson).toContain("pss-attachment:");
     // Raw pixel/png payload must not be embedded in thread JSON.
-    expect(committedJson).not.toContain(Buffer.from(imageBytes).toString("base64"));
+    expect(committedJson).not.toContain(
+      Buffer.from(imageBytes).toString("base64")
+    );
 
     const committedPart = filePartFromStoredState(committedState);
     expect(isRuntimeAttachmentData(committedPart.data)).toBe(true);

--- a/packages/runtime/src/thread/runtime/continuation.test.ts
+++ b/packages/runtime/src/thread/runtime/continuation.test.ts
@@ -1,6 +1,5 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
-import { solidTestPng, solidTestPngBase64 } from "../../testing/valid-image-fixture";
 import { Agent } from "../../agent/core/agent";
 import {
   assistantMessage,
@@ -9,6 +8,10 @@ import {
   steerRuntimeInput,
   userText,
 } from "../../testing/test-fixtures";
+import {
+  solidTestPng,
+  solidTestPngBase64,
+} from "../../testing/valid-image-fixture";
 import { isRuntimeAttachmentData } from "../input/attachments";
 import type { AgentEvent } from "../protocol/events";
 import { userTextToModelMessage } from "../protocol/mapping";

--- a/packages/runtime/src/thread/runtime/durable-inputs.ts
+++ b/packages/runtime/src/thread/runtime/durable-inputs.ts
@@ -1,7 +1,7 @@
 import type {
   AdmitReceipt,
-  ClaimedThreadInput,
   AgentHost,
+  ClaimedThreadInput,
   RecoverThreadInputClaimsResult,
   ThreadInputBoundary,
   ThreadInputKind,

--- a/packages/runtime/src/thread/runtime/events.ts
+++ b/packages/runtime/src/thread/runtime/events.ts
@@ -4,8 +4,8 @@ import type {
   RuntimeToolExecutionDecision,
 } from "../../llm/llm";
 import {
-  type RuntimeAttachmentReference,
   type HostAttachmentStore,
+  type RuntimeAttachmentReference,
   stageAgentEventAttachments,
 } from "../input/attachments";
 import {

--- a/packages/runtime/src/thread/runtime/execution-checkpoints.ts
+++ b/packages/runtime/src/thread/runtime/execution-checkpoints.ts
@@ -1,8 +1,5 @@
 import { createCheckpointId } from "../../execution/host/checkpoint-ids";
-import type {
-  CheckpointPhase,
-  AgentHost,
-} from "../../execution/host/types";
+import type { AgentHost, CheckpointPhase } from "../../execution/host/types";
 import type {
   RuntimeToolExecutionCheckpoint,
   RuntimeToolExecutionContext,

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/scripts/cloudflare-example.test.mjs
+++ b/scripts/cloudflare-example.test.mjs
@@ -31,7 +31,9 @@ describe("cloudflare durable object adapter", () => {
     expect(hostSource).toContain("createCloudflareScheduledWorkScheduler");
     expect(hostSource).not.toContain("setAlarm");
     expect(platformHostSource).toContain("createCloudflareHost");
-    expect(platformHostSource).toContain("createCloudflareAgentsFiberScheduler");
+    expect(platformHostSource).toContain(
+      "createCloudflareAgentsFiberScheduler"
+    );
     expect(platformContextSource).toContain("createCloudflarePlatformContext");
     expect(storeSource).toContain("DurableObjectExecutionStore");
     expect(storeSource).toContain("DurableObjectSqliteThreadStore");
@@ -76,15 +78,15 @@ describe("cloudflare durable object adapter", () => {
     await expect(listScheduledCloudflareRuns(storage)).resolves.toEqual([
       runId,
     ]);
-    await expect(listScheduledCloudflareThreadPrompts(storage)).resolves.toEqual(
-      [
-        {
-          idempotencyKey,
-          runId: notificationRunId,
-          threadKey: "example",
-        },
-      ]
-    );
+    await expect(
+      listScheduledCloudflareThreadPrompts(storage)
+    ).resolves.toEqual([
+      {
+        idempotencyKey,
+        runId: notificationRunId,
+        threadKey: "example",
+      },
+    ]);
 
     await ackScheduledCloudflareRun(storage, runId);
     await ackScheduledCloudflareThreadPrompt(storage, {

--- a/scripts/verify-release-artifacts/runtime-public-surface.mjs
+++ b/scripts/verify-release-artifacts/runtime-public-surface.mjs
@@ -179,7 +179,9 @@ export const FORBIDDEN_RUNTIME_ROOT_NAMES = [
     ].flatMap((names) => names.split(" ")),
     // Every platform-subpath export is forbidden on the root surface; spread
     // the required lists so the two can never drift apart.
-    ...REQUIRED_RUNTIME_EXECUTION_EXPORTS.filter((name) => name !== "AgentHost"),
+    ...REQUIRED_RUNTIME_EXECUTION_EXPORTS.filter(
+      (name) => name !== "AgentHost"
+    ),
     ...REQUIRED_RUNTIME_CLOUDFLARE_AGENTS_EXPORTS,
     ...REQUIRED_RUNTIME_CLOUDFLARE_WORKER_EXPORTS,
     ...REQUIRED_RUNTIME_FILE_EXPORTS,


### PR DESCRIPTION
## Summary
- Fix CI lint failures after #183 merge (Biome format, import order, nested ternaries, barrel files, test regex hoisting, worker-agent useAwait).
- Keep runtime/worker tests and boundaries green.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm boundaries`
- [x] `pnpm --filter @minpeter/pss-runtime test`
- [x] `pnpm --filter @minpeter/pss-worker-agent test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI lint and typecheck after the host unify merge by aligning with `ultracite/biome`, tightening TypeScript surfaces around image codecs, and correcting coding-agent thread inspection to match file-host storage paths. No runtime behavior changes; all runtime/worker tests and boundaries stay green.

- **Refactors**
  - Normalized import/export order and type-only imports across `@minpeter/pss-runtime` packages; avoided barrel-file lint issues by reshuffling re-exports (no public surface change).
  - Simplified conditionals and utilities (removed nested ternaries, used `Number.POSITIVE_INFINITY`, `.at(-1)`, and `Math.floor`), and hoisted shared regex/constants in tests.
  - Updated worker-agent test shim and Cloudflare agent types to avoid unnecessary async/await and to return `Promise<undefined | …>` where required.
  - Image codec QA client: extracted warmup/bench helpers, added clearer guards/logging, and kept existing budgets and behavior.

- **Bug Fixes**
  - Fixed monorepo typecheck for image codecs and TS 7: added ambient `*.d.ts` refs for wasm/HEIC paths, included runtime `*.d.ts` in `tsconfig`, and annotated test helpers (Vitest `Mock`).
  - Ensured edge codec bootstrap compiles cleanly by adding Wasm reference directives and safe dynamic imports.
  - Coding agent inspection now writes/reads thread files via `storageFileForThread` under `generations/main/threads/` to match `createFileHost` storage layout.

<sup>Written for commit 2447e11e69c478232117876b68e3eb79d9598199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

