### PR TITLE
chore: patch changeset for image storage budget (PR #187 follow-up)

### DIFF
--- a/.changeset/image-storage-budget-240kb.md
+++ b/.changeset/image-storage-budget-240kb.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": patch
+---
+
+Lower the default image attachment storage budget from 1MB to 240KB so multi-image turns stay lighter while typical chat photos remain under budget.


### PR DESCRIPTION
## Summary

- Adds a **patch** changeset for `@minpeter/pss-runtime` covering the default image storage budget drop to **240KB** from PR #187 (`feat/worker-agent-telegram-image-bridge`), which was merged without a changeset.
- `@minpeter/pss-worker-agent` is in the changesets `ignore` list, so only the publishable runtime package is listed.

## Test plan

- [ ] Confirm changeset format is valid (`pnpm changeset status` if available)
- [ ] Release PR / version flow picks up `@minpeter/pss-runtime` as patch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a patch changeset for `@minpeter/pss-runtime` documenting the default image attachment storage budget drop to 240KB, aligning the release with PR #187. Ensures the next release reflects this runtime change.

<sup>Written for commit 7c4bb7e65961f0a1ba0a03cd9318b9234f493627. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-next/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

