### PR TITLE
feat(runtime): add opt-in stream-collect llm transport

### DIFF
--- a/.changeset/stream-collect-transport.md
+++ b/.changeset/stream-collect-transport.md
@@ -1,0 +1,5 @@
+---
+"@minpeter/pss-runtime": minor
+---
+
+Add an opt-in `llmTransport: "stream-collect"` agent option that routes every model step (turn steps and auto-compaction summaries) through `streamText` with identical parameters, awaited to completion. The default (`"generate"`) keeps the existing non-streaming `generateText` behavior unchanged. Model errors reported through the stream are captured and rethrown as-is, so both transports surface identical failures.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -463,6 +463,20 @@ const agent = new Agent({
 retries once. Provider-thrown context-window errors still use the same blocking
 compaction fallback.
 
+Model steps default to non-streaming `generateText`. When a provider or
+gateway route only behaves well for streaming requests, opt into the
+stream-and-collect transport. Every model step the agent issues (turn steps
+and auto-compaction summaries) is then sent as a `streamText` call with the
+same parameters and awaited to completion before the step returns — no
+behavior, output shape, or error change is observable to callers:
+
+```ts
+const agent = new Agent({
+  llmTransport: "stream-collect",
+  model,
+});
+```
+
 Hosts that need durable runs pass `host:` into `Agent`. The execution subpath
 exports the same `AgentHost` contract used by platform factories:
 

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -68,6 +68,7 @@ export class Agent {
       model: options.model,
       toolChoice: options.toolChoice,
       tools: options.tools,
+      transport: options.llmTransport,
     };
   }
 

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -1,6 +1,10 @@
 import type { LanguageModel, ToolSet } from "ai";
 import type { AgentHost } from "../../execution/host/types";
-import type { AgentToolChoice, ModelContextGateOptions } from "../../llm/llm";
+import type {
+  AgentToolChoice,
+  ModelContextGateOptions,
+  ModelStepTransport,
+} from "../../llm/llm";
 import { assertNoUnsupportedToolApproval } from "../../llm/tool-approval";
 import type { HostAttachmentStore } from "../../thread/input/attachments";
 import type { AgentInput, UserInput } from "../../thread/input/input";
@@ -20,6 +24,14 @@ export interface AgentOptions {
   readonly autoCompaction?: AgentAutoCompactionOptions | false;
   readonly host?: AgentHost;
   readonly instructions?: string;
+  /**
+   * How model steps reach the provider. Defaults to `"generate"`
+   * (non-streaming `generateText`, the existing behavior).
+   * `"stream-collect"` routes the same request through `streamText` and
+   * awaits the full result before the step returns; it applies to every
+   * model step this agent issues, including auto-compaction summaries.
+   */
+  readonly llmTransport?: ModelStepTransport;
   readonly model: LanguageModel;
   readonly namespace?: string;
   readonly notificationOverlays?: readonly (AgentInput | UserInput)[];
@@ -33,6 +45,7 @@ export type AgentModelOptions = Pick<
   "attachmentStore" | "instructions" | "model" | "toolChoice" | "tools"
 > & {
   readonly contextGate?: false | AgentContextGateOptions;
+  readonly transport?: ModelStepTransport;
 };
 
 export function assertAgentOptions(
@@ -54,10 +67,26 @@ export function assertAgentOptions(
 
   const candidate = options as {
     readonly autoCompaction?: AgentOptions["autoCompaction"];
+    readonly llmTransport?: AgentOptions["llmTransport"];
     readonly tools?: AgentOptions["tools"];
   };
   assertNoUnsupportedToolApproval(candidate.tools);
   normalizeAgentAutoCompactionOptions(candidate.autoCompaction);
+  assertAgentLlmTransport(candidate.llmTransport);
+}
+
+function assertAgentLlmTransport(
+  value: AgentOptions["llmTransport"]
+): asserts value is ModelStepTransport | undefined {
+  if (
+    value !== undefined &&
+    value !== "generate" &&
+    value !== "stream-collect"
+  ) {
+    throw new TypeError(
+      "Agent: options.llmTransport must be 'generate' or 'stream-collect'."
+    );
+  }
 }
 
 export function normalizeAgentAutoCompactionOptions(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -15,7 +15,7 @@ export type {
   ThreadEventCursor,
   ThreadEventReadOptions,
 } from "./execution/host/types";
-export type { AgentToolChoice } from "./llm/llm";
+export type { AgentToolChoice, ModelStepTransport } from "./llm/llm";
 export { ThreadEventReplayUnsupportedError } from "./thread/handle/thread-event-replay";
 export {
   DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES,

--- a/packages/runtime/src/llm/llm-stream-collect.test.ts
+++ b/packages/runtime/src/llm/llm-stream-collect.test.ts
@@ -1,0 +1,118 @@
+import type { ToolSet } from "ai";
+import { jsonSchema, tool } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  createMockLanguageModelV4,
+  createStreamingMockLanguageModelV4,
+  mockLanguageModelV4StreamError,
+  mockLanguageModelV4StreamText,
+  mockLanguageModelV4StreamToolCall,
+  mockLanguageModelV4Text,
+  mockLanguageModelV4ToolCall,
+} from "../testing/mock-language-model-v4-test-utils";
+import { generateModelStep } from "./llm";
+
+const echoToolCall = {
+  input: { city: "Seoul" },
+  toolCallId: "call_echo_1",
+  toolName: "echo",
+} as const;
+
+const echoTools = {
+  echo: tool({
+    description: "Echo test tool.",
+    execute: (input) => ({ echoed: input }),
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: { city: { type: "string" } },
+      additionalProperties: false,
+    }),
+  }),
+} satisfies ToolSet;
+
+describe("generateModelStep stream-collect transport (real streamText)", () => {
+  it("collects streamed text into the same output as the generate transport", async () => {
+    const generated = await generateModelStep({
+      history: [{ role: "user", content: "hello" }],
+      model: createMockLanguageModelV4([mockLanguageModelV4Text("done")]),
+      signal: new AbortController().signal,
+    });
+
+    const streamed = await generateModelStep({
+      history: [{ role: "user", content: "hello" }],
+      model: createStreamingMockLanguageModelV4([
+        mockLanguageModelV4StreamText("done"),
+      ]),
+      signal: new AbortController().signal,
+      transport: "stream-collect",
+    });
+
+    expect(streamed).toEqual(generated);
+  });
+
+  it("collects streamed tool calls and executed tool results like the generate transport", async () => {
+    const generated = await generateModelStep({
+      history: [{ role: "user", content: "call the tool" }],
+      model: createMockLanguageModelV4([
+        mockLanguageModelV4ToolCall(echoToolCall),
+      ]),
+      signal: new AbortController().signal,
+      tools: echoTools,
+    });
+
+    const streamed = await generateModelStep({
+      history: [{ role: "user", content: "call the tool" }],
+      model: createStreamingMockLanguageModelV4([
+        mockLanguageModelV4StreamToolCall(echoToolCall),
+      ]),
+      signal: new AbortController().signal,
+      tools: echoTools,
+      transport: "stream-collect",
+    });
+
+    expect(streamed).toEqual(generated);
+    const assistant = streamed.find((message) => message.role === "assistant");
+    expect(assistant?.content).toEqual([
+      expect.objectContaining({
+        input: echoToolCall.input,
+        toolCallId: echoToolCall.toolCallId,
+        toolName: echoToolCall.toolName,
+        type: "tool-call",
+      }),
+    ]);
+    const toolMessage = streamed.find((message) => message.role === "tool");
+    expect(toolMessage?.content).toEqual([
+      expect.objectContaining({
+        output: { type: "json", value: { echoed: echoToolCall.input } },
+        toolCallId: echoToolCall.toolCallId,
+        type: "tool-result",
+      }),
+    ]);
+  });
+
+  it("surfaces the original model error exactly like the generate transport", async () => {
+    const streamedFailure = new Error("gateway timed out");
+    const generatedFailure = new Error("gateway timed out");
+
+    await expect(
+      generateModelStep({
+        history: [{ role: "user", content: "hello" }],
+        model: createStreamingMockLanguageModelV4([
+          mockLanguageModelV4StreamError(streamedFailure),
+        ]),
+        signal: new AbortController().signal,
+        transport: "stream-collect",
+      })
+    ).rejects.toBe(streamedFailure);
+
+    await expect(
+      generateModelStep({
+        history: [{ role: "user", content: "hello" }],
+        model: createMockLanguageModelV4(() => {
+          throw generatedFailure;
+        }),
+        signal: new AbortController().signal,
+      })
+    ).rejects.toBe(generatedFailure);
+  });
+});

--- a/packages/runtime/src/llm/llm-transport.test.ts
+++ b/packages/runtime/src/llm/llm-transport.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  drainRun,
+  fakeModel,
+  getGenerateTextMock,
+  getStreamTextMock,
+  loadAgent,
+  loadModelStepRunner,
+} from "../testing/llm-test-utils";
+import { assistantMessage } from "../testing/test-fixtures";
+
+const generateTextMock = getGenerateTextMock();
+const streamTextMock = getStreamTextMock();
+const invalidTransportPattern =
+  /llmTransport must be 'generate' or 'stream-collect'/;
+
+function mockStreamedResponse(messages: unknown[]): void {
+  streamTextMock.mockReturnValue({
+    responseMessages: Promise.resolve(messages),
+  });
+}
+
+function mockStreamedError({
+  maskedError,
+  originalError,
+}: {
+  readonly maskedError: Error;
+  readonly originalError: unknown;
+}): void {
+  streamTextMock.mockImplementation(
+    ({ onError }: { onError: (event: { error: unknown }) => void }) => {
+      onError({ error: originalError });
+      return {
+        responseMessages: Promise.reject(maskedError),
+      };
+    }
+  );
+}
+
+describe("generateModelStep transport", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    streamTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("GENERATED")],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses generateText by default and never touches streamText", async () => {
+    const runModelStep = await loadModelStepRunner();
+    const signal = new AbortController().signal;
+
+    await expect(
+      runModelStep(
+        { model: fakeModel },
+        { history: [{ role: "user", content: "hello" }], signal }
+      )
+    ).resolves.toEqual([assistantMessage("GENERATED")]);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it("uses generateText for the explicit 'generate' transport", async () => {
+    const runModelStep = await loadModelStepRunner();
+    const signal = new AbortController().signal;
+
+    await expect(
+      runModelStep(
+        { model: fakeModel, transport: "generate" },
+        { history: [{ role: "user", content: "hello" }], signal }
+      )
+    ).resolves.toEqual([assistantMessage("GENERATED")]);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it("routes the 'stream-collect' transport through streamText with the same request", async () => {
+    const runModelStep = await loadModelStepRunner();
+    mockStreamedResponse([assistantMessage("STREAMED")]);
+    const signal = new AbortController().signal;
+    const history = [{ role: "user" as const, content: "hello" }];
+
+    await expect(
+      runModelStep(
+        {
+          instructions: "test instructions",
+          model: fakeModel,
+          toolChoice: "auto",
+          transport: "stream-collect",
+        },
+        { history, signal }
+      )
+    ).resolves.toEqual([assistantMessage("STREAMED")]);
+
+    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(streamTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: signal,
+        instructions: "test instructions",
+        messages: history,
+        model: fakeModel,
+        onError: expect.any(Function),
+        toolChoice: "auto",
+      })
+    );
+  });
+
+  it("rethrows the original model error instead of streamText's masked rejection", async () => {
+    const runModelStep = await loadModelStepRunner();
+    const originalError = new Error("upstream provider exploded");
+    mockStreamedError({
+      maskedError: new Error(
+        "No output generated. Check the stream for errors."
+      ),
+      originalError,
+    });
+
+    await expect(
+      runModelStep(
+        { model: fakeModel, transport: "stream-collect" },
+        {
+          history: [{ role: "user", content: "hello" }],
+          signal: new AbortController().signal,
+        }
+      )
+    ).rejects.toBe(originalError);
+  });
+
+  it("surfaces a captured stream error even when responseMessages resolves", async () => {
+    const runModelStep = await loadModelStepRunner();
+    const originalError = new Error("late stream error");
+    streamTextMock.mockImplementation(
+      ({ onError }: { onError: (event: { error: unknown }) => void }) => {
+        onError({ error: originalError });
+        return {
+          responseMessages: Promise.resolve([assistantMessage("partial")]),
+        };
+      }
+    );
+
+    await expect(
+      runModelStep(
+        { model: fakeModel, transport: "stream-collect" },
+        {
+          history: [{ role: "user", content: "hello" }],
+          signal: new AbortController().signal,
+        }
+      )
+    ).rejects.toBe(originalError);
+  });
+
+  it("propagates streamText rejections as-is when no stream error was reported", async () => {
+    const runModelStep = await loadModelStepRunner();
+    const abortError = new Error("aborted");
+    streamTextMock.mockReturnValue({
+      responseMessages: Promise.reject(abortError),
+    });
+
+    await expect(
+      runModelStep(
+        { model: fakeModel, transport: "stream-collect" },
+        {
+          history: [{ role: "user", content: "hello" }],
+          signal: new AbortController().signal,
+        }
+      )
+    ).rejects.toBe(abortError);
+  });
+});
+
+describe("Agent llmTransport wiring", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    generateTextMock.mockReset();
+    streamTextMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      responseMessages: [assistantMessage("GENERATED")],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps generateText for agents without llmTransport", async () => {
+    const Agent = await loadAgent();
+    const agent = new Agent({ model: fakeModel });
+
+    await drainRun(await agent.send("default transport"));
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it("routes agent turns through streamText for llmTransport 'stream-collect'", async () => {
+    const Agent = await loadAgent();
+    mockStreamedResponse([assistantMessage("STREAMED")]);
+    const agent = new Agent({
+      llmTransport: "stream-collect",
+      model: fakeModel,
+    });
+
+    await drainRun(await agent.send("streamed transport"));
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid llmTransport values", async () => {
+    const Agent = await loadAgent();
+
+    expect(
+      () =>
+        new Agent({
+          llmTransport: "collect" as never,
+          model: fakeModel,
+        })
+    ).toThrow(invalidTransportPattern);
+  });
+});

--- a/packages/runtime/src/llm/llm.ts
+++ b/packages/runtime/src/llm/llm.ts
@@ -1,5 +1,5 @@
 import type { LanguageModel, ModelMessage, ToolChoice, ToolSet } from "ai";
-import { generateText } from "ai";
+import { generateText, streamText } from "ai";
 import {
   type HostAttachmentStore,
   hydrateRuntimeAttachments,
@@ -25,6 +25,19 @@ export type ModelStepOutput = Awaited<
   ReturnType<typeof generateText>
 >["responseMessages"];
 export type ModelStepOutputPart = ModelStepOutput[number];
+
+/**
+ * How a single model step reaches the provider.
+ *
+ * - `"generate"` (default): one non-streaming `generateText` call. This is the
+ *   existing behavior and stays byte-identical.
+ * - `"stream-collect"`: a `streamText` call with the same parameters that is
+ *   fully awaited before the step returns. No partial output is exposed; the
+ *   step resolves to the same response messages the `"generate"` path
+ *   produces. Useful when a provider or gateway route only behaves well for
+ *   streaming requests.
+ */
+export type ModelStepTransport = "generate" | "stream-collect";
 
 export interface ModelContextTokenEstimateInput {
   readonly instructions?: string;
@@ -73,6 +86,7 @@ export interface ModelGenerationOptions {
   model: LanguageModel;
   toolChoice?: AgentToolChoice;
   tools?: ToolSet;
+  transport?: ModelStepTransport;
 }
 
 export interface ModelStepOptions extends ModelGenerationOptions {
@@ -91,6 +105,7 @@ export async function generateModelStep({
   toolChoice,
   toolExecution,
   tools,
+  transport,
 }: ModelStepOptions): Promise<ModelStepOutput> {
   const toolCallIds = new Map<string, string>();
   const prompt = promptForModel({ history, instructions });
@@ -104,18 +119,61 @@ export async function generateModelStep({
     messages,
   });
   assertNoUnsupportedToolApproval(tools);
-  const { responseMessages } = await generateText({
+  const request = {
     abortSignal: signal,
     instructions: prompt.instructions,
     messages,
     model,
     toolChoice,
     tools: normalizeToolCallIds(tools, toolCallIds, toolExecution),
-  });
+  };
+  const responseMessages =
+    transport === "stream-collect"
+      ? await collectStreamedResponseMessages(request)
+      : (await generateText(request)).responseMessages;
 
   return responseMessages.map((message) =>
     rewriteMessageToolCallIds(message, toolCallIds)
   );
+}
+
+interface ModelStepRequest {
+  readonly abortSignal: AbortSignal;
+  readonly instructions?: string;
+  readonly messages: ModelMessage[];
+  readonly model: LanguageModel;
+  readonly toolChoice?: AgentToolChoice;
+  readonly tools?: ToolSet;
+}
+
+async function collectStreamedResponseMessages(
+  request: ModelStepRequest
+): Promise<ModelStepOutput> {
+  // streamText reports model errors through `onError` (default: console.error)
+  // and rejects its awaited promises with NoOutputGeneratedError instead of
+  // the original failure. Capture the first original error and rethrow it so
+  // callers observe the exact same failures as the generateText transport.
+  let streamedError: unknown;
+  let hasStreamedError = false;
+  const result = streamText({
+    ...request,
+    onError: ({ error }) => {
+      if (!hasStreamedError) {
+        hasStreamedError = true;
+        streamedError = error;
+      }
+    },
+  });
+
+  try {
+    const responseMessages = await result.responseMessages;
+    if (hasStreamedError) {
+      throw streamedError;
+    }
+    return responseMessages;
+  } catch (error) {
+    throw hasStreamedError ? streamedError : error;
+  }
 }
 
 function enforceContextGate({

--- a/packages/runtime/src/testing/llm-test-utils.ts
+++ b/packages/runtime/src/testing/llm-test-utils.ts
@@ -8,8 +8,9 @@ import {
   mockLanguageModelV4Empty,
 } from "./mock-language-model-v4-test-utils";
 
-const { generateTextMock } = vi.hoisted(() => ({
+const { generateTextMock, streamTextMock } = vi.hoisted(() => ({
   generateTextMock: vi.fn(),
+  streamTextMock: vi.fn(),
 }));
 
 vi.mock("ai", async (importOriginal) => {
@@ -18,6 +19,7 @@ vi.mock("ai", async (importOriginal) => {
   return {
     ...actual,
     generateText: generateTextMock,
+    streamText: streamTextMock,
   };
 });
 
@@ -27,6 +29,10 @@ export const fakeModel = createMockLanguageModelV4([
 
 export function getGenerateTextMock(): Mock {
   return generateTextMock;
+}
+
+export function getStreamTextMock(): Mock {
+  return streamTextMock;
 }
 
 export const createNoopTool = (): Tool =>

--- a/packages/runtime/src/testing/mock-language-model-v4-test-utils.ts
+++ b/packages/runtime/src/testing/mock-language-model-v4-test-utils.ts
@@ -1,3 +1,4 @@
+import { simulateReadableStream } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
 
 type MockLanguageModelV4Options = NonNullable<
@@ -20,6 +21,21 @@ export type MockLanguageModelV4GenerateFunction = Extract<
 >;
 export type MockLanguageModelV4CallOptions =
   Parameters<MockLanguageModelV4GenerateFunction>[0];
+type MockLanguageModelV4Stream = NonNullable<
+  MockLanguageModelV4Options["doStream"]
+>;
+type MockLanguageModelV4StreamValue = Exclude<
+  MockLanguageModelV4Stream,
+  (...args: never[]) => unknown
+>;
+export type MockLanguageModelV4StreamResult = Extract<
+  MockLanguageModelV4StreamValue,
+  { readonly stream: unknown }
+>;
+export type MockLanguageModelV4StreamPart =
+  MockLanguageModelV4StreamResult["stream"] extends ReadableStream<infer Part>
+    ? Part
+    : never;
 
 const emptyUsage = {
   inputTokens: {
@@ -86,5 +102,78 @@ export function mockLanguageModelV4Empty(): MockLanguageModelV4GenerateResult {
     finishReason: { raw: "stop", unified: "stop" },
     usage: emptyUsage,
     warnings: [],
+  };
+}
+
+export function createStreamingMockLanguageModelV4(
+  results:
+    | readonly (readonly MockLanguageModelV4StreamPart[])[]
+    | ((
+        options: MockLanguageModelV4CallOptions
+      ) => readonly MockLanguageModelV4StreamPart[])
+): MockLanguageModelV4 {
+  const streamResult = (
+    parts: readonly MockLanguageModelV4StreamPart[]
+  ): MockLanguageModelV4StreamResult => ({
+    stream: simulateReadableStream({ chunks: [...parts] }),
+  });
+  return new MockLanguageModelV4({
+    doStream:
+      typeof results === "function"
+        ? (options) => Promise.resolve(streamResult(results(options)))
+        : results.map(streamResult),
+  });
+}
+
+export function mockLanguageModelV4StreamText(
+  text: string,
+  { id = "text-1" }: { readonly id?: string } = {}
+): MockLanguageModelV4StreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { id, type: "text-start" },
+    { delta: text, id, type: "text-delta" },
+    { id, type: "text-end" },
+    mockLanguageModelV4StreamFinish("stop"),
+  ];
+}
+
+export function mockLanguageModelV4StreamToolCall({
+  input,
+  toolCallId,
+  toolName,
+}: {
+  input: unknown;
+  toolCallId: string;
+  toolName: string;
+}): MockLanguageModelV4StreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    {
+      input: JSON.stringify(input),
+      toolCallId,
+      toolName,
+      type: "tool-call",
+    },
+    mockLanguageModelV4StreamFinish("tool-calls"),
+  ];
+}
+
+export function mockLanguageModelV4StreamError(
+  error: unknown
+): MockLanguageModelV4StreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    { error, type: "error" },
+  ];
+}
+
+function mockLanguageModelV4StreamFinish(
+  finishReason: "stop" | "tool-calls"
+): MockLanguageModelV4StreamPart {
+  return {
+    finishReason: { raw: finishReason, unified: finishReason },
+    type: "finish",
+    usage: emptyUsage,
   };
 }

--- a/packages/runtime/src/thread/handle/automatic-compaction-transport.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction-transport.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "../../agent/core/agent";
+import {
+  createStreamingMockLanguageModelV4,
+  mockLanguageModelV4StreamText,
+} from "../../testing/mock-language-model-v4-test-utils";
+import { waitForModelCalls } from "./automatic-compaction.test-support";
+import { collect } from "./test-support";
+
+describe("Agent automatic compaction llmTransport", () => {
+  it("summarizes over stream-collect when the agent opts into it", async () => {
+    let calls = 0;
+    const model = createStreamingMockLanguageModelV4(() => {
+      calls += 1;
+      if (calls === 1) {
+        return mockLanguageModelV4StreamText("old done");
+      }
+      if (calls === 2) {
+        return mockLanguageModelV4StreamText("tail done");
+      }
+      return mockLanguageModelV4StreamText("old exchange summarized");
+    });
+    const agent = new Agent({
+      autoCompaction: { minMessages: 4, retainMessages: 2 },
+      llmTransport: "stream-collect",
+      model,
+    });
+    const thread = agent.thread("stream-auto");
+
+    await collect(await thread.send("old"));
+    await collect(await thread.send("tail"));
+    await waitForModelCalls(() => calls, 3);
+
+    // Turn steps and the background compaction summary all went through
+    // streamText; the generate transport was never used.
+    expect(model.doStreamCalls.length).toBeGreaterThanOrEqual(3);
+    expect(model.doGenerateCalls).toHaveLength(0);
+  });
+});

--- a/packages/runtime/src/thread/runtime/auto-compaction.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction.ts
@@ -187,6 +187,7 @@ async function summarizeCompactionRange({
     instructions: model.instructions,
     model: model.model,
     signal: new AbortController().signal,
+    transport: model.transport,
   });
   return output
     .flatMap((message) =>


### PR DESCRIPTION
## Summary

Adds an **opt-in** `llmTransport: "generate" | "stream-collect"` option to `Agent`. The default (`"generate"`) keeps today's non-streaming `generateText` model step byte-identical. `"stream-collect"` sends the **same request** through `streamText`, awaits full completion, and returns the exact same output shape — no partial output is exposed and no behavior change is observable to callers.

## Why

The runtime has exactly one model step (`generateModelStep` in `packages/runtime/src/llm/llm.ts`, calling `generateText`), so every consumer turn — agent loop steps and auto-compaction summaries — is non-streamed. A downstream consumer (bori) measured that the Cloudflare AI Gateway `compat` route **deterministically 504s (~55s)** on a reproducible **~8–12% subset of non-streaming requests** (grok-4.5; reproduces with zero tools and no system prompt; retries and `cf-aig-request-timeout` are ineffective), while the **identical requests complete in 1.5–2.5s with `stream: true`**. Evidence: clawroid/bori#1083 (measurement), clawroid/bori#1066 research note ⑥, clawroid/bori#1087 (interim model-layer middleware).

Because the runtime forces non-streaming, this failure mode forced a same-day model-promotion rollback downstream (clawroid/bori#1022 → clawroid/bori#1036). An interim fix exists as model-middleware in the host app, but the clean fix belongs here:

- **Runtime-level beats model-middleware**: middleware must re-simulate `generateText`'s result shape from a stream per host app, and every consumer has to re-discover the error-masking pitfall below. The runtime already owns the single step and can guarantee parity once, with tests.
- A transport seam also opens the door to real streaming UX later without touching call sites.

## Design

- `llmTransport` is validated at `Agent` construction and threads through `ModelGenerationOptions.transport`, so **all** model steps follow it: agent loop steps, durable resume steps, and auto-compaction summaries (compaction intentionally follows the same transport — it hits the same provider route).
- `stream-collect` calls `streamText` with the identical request (`abortSignal`/`instructions`/`messages`/`model`/`toolChoice`/`tools`) and awaits `result.responseMessages`, which is the same accumulated `ResponseMessage[]` the `generateText` path consumes (verified against the installed `ai@7.0.16`).
- **Error parity**: `streamText` reports model errors through `onError` (default: `console.error`) and rejects its awaited promises with `NoOutputGeneratedError`, masking the original failure. The stream-collect path captures the first original error via `onError` and rethrows it, so callers (including the runtime's own context-overflow compaction fallback, which sniffs provider error text) observe identical failures on both transports. Abort behavior is unchanged: with no captured stream error, rejections (e.g. abort reasons) propagate as-is.
- Exported `ModelStepTransport` from the package root; documented in the README; changeset included (`minor`).

## Tests

- Transport default parity: default and explicit `"generate"` use `generateText` and never touch `streamText` (`src/llm/llm-transport.test.ts`).
- `stream-collect` request parity (same params + `onError`) via the existing mocked-`ai` harness.
- Error passthrough parity: original model error surfaces identically on both transports — masked-rejection rethrow, captured-error-despite-resolution, and no-captured-error passthrough cases.
- Real `streamText` integration with a fake streaming model (`MockLanguageModelV4` `doStream`): text parts and tool-call parts (including tool execution) produce output deep-equal to the `generate` transport; error part surfaces the original error (`src/llm/llm-stream-collect.test.ts`).
- Auto-compaction honors the transport: turn steps and the background summary all go through `doStream`, `doGenerate` never called (`src/thread/handle/automatic-compaction-transport.test.ts`).

Full package suite: 586 passed / 3 skipped (baseline 573 / 3); repo-wide `turbo typecheck`, `test`, and `ultracite check` all green.

## bori adoption plan

Once released, bori would set `llmTransport: "stream-collect"` on its `Agent` construction and drop the interim model-layer stream-and-collect middleware from clawroid/bori#1087, unblocking the model promotion that was rolled back in clawroid/bori#1036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in LLM transport to `Agent` so model steps can use streaming under the hood without changing outputs. Default stays non-streaming; `"stream-collect"` sends the same request via `streamText`, waits for completion, and returns the same `responseMessages`.

- **New Features**
  - New `llmTransport: "generate" | "stream-collect"` option on `Agent`, applied to all model steps (turns, durable resume, auto-compaction).
  - `"stream-collect"` mirrors the `"generate"` request and collects the stream; no partials, same output shape.
  - Error parity: original model errors are captured via `onError` and rethrown; aborts propagate unchanged.
  - Exported `ModelStepTransport` from `@minpeter/pss-runtime`; README updated; tests cover transport, parity, and compaction.

- **Migration**
  - No change by default. To opt in, set `llmTransport: "stream-collect"` when creating your `Agent`. Remove any app-side stream-and-collect middleware if present.

<sup>Written for commit 55896661d53dc63a2885b8844067128ba8dac4e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

