### PR TITLE
docs: align guides with factory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Small agent runtime workspace.
 
-- `@minpeter/pss-runtime`: runtime, sessions, model loop.
-- `@minpeter/pss-coding-agent`: model wiring and the `pss` TUI. It ships no
-  built-in tools; pass your own tool set when needed.
+- `@minpeter/pss-runtime`: runtime, threads, model loop, and plugin kernel.
+- `@minpeter/pss-coding-agent`: model wiring and the `pss` TUI, with
+  OpenSearch-backed `web_search` and `web_fetch` tools enabled by default.
 
 ## Use
 
 ```ts
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import { Agent } from "@minpeter/pss-runtime";
+import { createAgent } from "@minpeter/pss-runtime";
 import { createEnv } from "@t3-oss/env-core";
 import { config as loadEnv } from "dotenv";
 import { z } from "zod";
@@ -31,31 +31,33 @@ const provider = createOpenAICompatible({
   baseURL: env.AI_BASE_URL,
 });
 
-const agent = new Agent({
+const agent = await createAgent({
   instructions: "Keep every answer under 3 lines.",
   model: provider(env.AI_MODEL),
 });
-const run = await agent.send("Hello");
-for await (const event of run.events()) {
+const turn = await agent.send("Hello");
+for await (const event of turn.events()) {
   console.dir(event, { depth: null });
 }
 ```
 
-`run.events()` is synchronized and drives the run. Consume it to let the runtime
-cross lifecycle boundaries such as `turn-start`, `step-start`, and `step-end`.
-Use `session.send(input)` for a new user turn. If a run is already active, the
-turn is queued until the active run finishes. Use `session.steer(input)` when the
-input should steer the active run; if no run is active, it starts a normal run.
+`turn.events()` is synchronized and drives the turn. Consume it to let the
+runtime cross lifecycle boundaries such as `turn-start`, `step-start`, and
+`step-end`.
+Use `thread.send(input)` for a new user turn. If a turn is already active, the
+new turn is queued until the active turn finishes. Use `thread.steer(input)` when
+the input should steer the active turn; if no turn is active, it starts a normal
+turn.
 
 ```ts
-const session = agent.session("default");
-const run = await session.send("Write a two sentence summary.");
+const thread = agent.thread("default");
+const turn = await thread.send("Write a two sentence summary.");
 let addedConstraint = false;
 
-for await (const event of run.events()) {
+for await (const event of turn.events()) {
   if (event.type === "step-end" && !addedConstraint) {
     addedConstraint = true;
-    await session.steer("Keep the second sentence under 10 words.");
+    await thread.steer("Keep the second sentence under 10 words.");
   }
 }
 ```
@@ -65,8 +67,36 @@ current turn before the next model snapshot, even after final-looking assistant
 text. Adding input on every `step-end` can keep a turn running indefinitely.
 
 Steering additions appear as `runtime-input` events: runtime/API-originated input
-mapped internally to the model's user role, separate from human `user-text` and
-`user-message` events.
+mapped internally to the model's user role, separate from human `user-input`
+events.
+
+## Plugins
+
+Plugins are async factories. Register typed lifecycle handlers with `on()` and
+capabilities such as tools with `provide()`:
+
+```ts
+import {
+  createAgent,
+  definePlugin,
+  registerTool,
+} from "@minpeter/pss-runtime";
+
+const appPlugin = definePlugin((pss) => {
+  pss.on("turn.end", (event) => {
+    console.log(event.type);
+  });
+  pss.provide(registerTool({ name: "weather", tool: weatherTool }));
+});
+
+const agent = await createAgent({ model, plugins: [appPlugin] });
+```
+
+Plugin factories initialize sequentially before `createAgent()` resolves.
+`Agent` remains available as a type, but agent creation must go through the async
+factory. Factory and hook failures fail closed. See
+[`packages/runtime/README.md`](packages/runtime/README.md#plugins) for lifecycle
+hooks, request decisions, thread-scoped state, and host integrations.
 
 The runtime `send` API also accepts JSON-serializable multimodal content parts
 for model providers that support them:
@@ -131,9 +161,10 @@ The `pss` TUI enables OpenSearch-backed `web_search` and `web_fetch` tools by
 default. Applications can still provide their own tools explicitly to the runtime
 or TUI entrypoint.
 
-The `pss` TUI stores sessions in `~/.pss/sessions` by default. Override with
-`PSS_SESSION_DIR` and `PSS_SESSION_KEY` when you want repo-local storage or a
-shared conversation key.
+The `pss` TUI stores threads in `~/.pss/threads` by default. Override with
+`PSS_THREAD_DIR` and `PSS_THREAD_KEY` when you want repo-local storage or a
+shared conversation key. `PSS_SESSION_DIR` and `PSS_SESSION_KEY` remain accepted
+as legacy aliases.
 
 ## Release
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -548,7 +548,7 @@ console.log(report.messageCount, report.compactionCount, report.storageFile);
 ```
 
 There is a single host contract: `AgentHost` (`HostStore` + `HostScheduler` + optional
-`HostAttachmentStore`). When `host` is omitted, `Agent` defaults to
+`HostAttachmentStore`). When `host` is omitted, `createAgent()` defaults to
 `createInMemoryHost()`. Platform factories (`createInMemoryHost`,
 `createFileHost`, `createCloudflareHost`) all return that same shape.
 `createCloudflareHost` is the Cloudflare Agents SDK path (fibers + schedule).
@@ -576,7 +576,7 @@ const agent = await createAgent({
 retries once. Provider-thrown context-window errors still use the same blocking
 compaction fallback.
 
-Hosts that need durable runs pass `host:` into `Agent`. The execution subpath
+Hosts that need durable runs pass `host:` into `createAgent()`. The execution subpath
 exports the same `AgentHost` contract used by platform factories:
 
 ```ts
@@ -617,8 +617,8 @@ const agent = await createAgent({
 App-owned background work still needs its own durable task/output storage if it
 must survive process restarts.
 
-Cloudflare Durable Objects and similar edge hosts should reconstruct `Agent`
-objects per turn and persist opaque thread state through a durable `threadStore`.
+Cloudflare Durable Objects and similar edge hosts should call `createAgent()` per
+turn and persist opaque thread state through a durable `threadStore`.
 Use `@minpeter/pss-runtime/platform/cloudflare` for the packaged Cloudflare Durable
 Object adapter. See the sync example package for blocking app-owned delegation
 and the background example package for durable background delegation in a local
@@ -702,7 +702,7 @@ child link is committed, and when a run suspends. If a process is killed inside 
 provider call or unsafe tool execution, resume rolls back to the last committed
 checkpoint and may re-enter the operation.
 
-When `Agent` receives an `AgentHost`, high-level model turns create a
+When `createAgent()` receives an `AgentHost`, high-level model turns create a
 `user-turn` run record and thread tool execution context into managed model
 calls. Tools are checkpointed before and after execution and receive stable
 `attempt`, `idempotencyKey`, `retryPolicy`, `signal`, and public `toolCallId`

--- a/scripts/runtime-docs.test.mjs
+++ b/scripts/runtime-docs.test.mjs
@@ -10,6 +10,24 @@ function readRepoFile(path) {
 }
 
 describe("runtime docs", () => {
+  it("keeps the root quick start on the public factory and thread APIs", () => {
+    const readme = readRepoFile("README.md");
+
+    expect(readme).toContain(
+      'import { createAgent } from "@minpeter/pss-runtime"'
+    );
+    expect(readme).toContain("const agent = await createAgent({");
+    expect(readme).toContain('const thread = agent.thread("default")');
+    expect(readme).toContain("PSS_THREAD_DIR");
+    expect(readme).toContain("PSS_THREAD_KEY");
+    expect(readme).not.toContain(
+      'import { Agent } from "@minpeter/pss-runtime"'
+    );
+    expect(readme).not.toContain("new Agent({");
+    expect(readme).not.toContain("agent.session(");
+    expect(readme).not.toContain("~/.pss/sessions");
+  });
+
   it("keeps raw turn.events as the public control loop", () => {
     const readme = readRepoFile("packages/runtime/README.md");
     const changelog = readRepoFile("packages/runtime/CHANGELOG.md");


### PR DESCRIPTION
## Summary

- update the root quick start from the removed public `Agent` constructor to `await createAgent()`
- replace stale session/run terminology and storage settings with the current thread/turn APIs
- document the factory-based plugin kernel and `registerTool()`
- clarify `createAgent()` usage in the runtime host documentation
- add a regression test that rejects the stale public constructor and session examples

## Why

The factory-based plugin runtime and version packages changes landed in #204, but the root README still showed the pre-0.3 constructor, session API, event names, and storage path. The package-specific docs and examples had already been migrated, leaving the repository entrypoint inconsistent with the published API.

## Impact

Users following the repository README now get examples that match the 0.3 prerelease API and current TUI thread storage settings. This is documentation and test coverage only; runtime behavior is unchanged.

## Validation

- `pnpm exec vitest run scripts/runtime-docs.test.mjs scripts/examples.test.mjs`
- `pnpm lint`
- stale public API pattern scan across Markdown files
- `git diff --check`

Note: validation ran on Node.js 22.23.1, so pnpm reported the repository's Node.js >=24 engine warning. The selected documentation and lint checks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns guides with the async `createAgent()` and thread/turn APIs, and documents the plugin kernel (`registerTool()`). Adds a regression test to block the old constructor/session examples; runtime behavior is unchanged.

- **Migration**
  - Replace `new Agent({...})` with `await createAgent({...})`.
  - Use `agent.thread(id).send()/steer()` and `turn.events()` (not sessions/runs).
  - Pass hosts into `createAgent()` (not an `Agent` constructor).
  - For the TUI, prefer `PSS_THREAD_DIR` and `PSS_THREAD_KEY` (legacy `PSS_SESSION_*` still accepted).

<sup>Written for commit f684d8ecaf39ad73df3c7486ed91d10b84a7d67a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

