### PR TITLE
chore(runtime): remove orphan @deprecated comments

### DIFF
--- a/.tegami/2026-07-19-remove-orphan-deprecated-comments.md
+++ b/.tegami/2026-07-19-remove-orphan-deprecated-comments.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "npm:@minpeter/pss-runtime": patch
+---
+
+## Remove orphan `@deprecated` comments
+
+Delete leftover deprecation comments after `SessionInput` and `FileSessionStore`
+aliases were already removed. No API or behavior change.

--- a/packages/runtime/src/platform/file/storage/file-thread-store.ts
+++ b/packages/runtime/src/platform/file/storage/file-thread-store.ts
@@ -124,8 +124,6 @@ function parseStoredFileThread(value: unknown, file: string): StoredThread {
   });
 }
 
-/** @deprecated Use FileThreadStore. */
-
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }

--- a/packages/runtime/src/thread/input/input.ts
+++ b/packages/runtime/src/thread/input/input.ts
@@ -45,5 +45,3 @@ export type AgentInput =
   | readonly UserMessageContentPart[]
   | string;
 export type ThreadInput = AgentInput;
-
-/** @deprecated Use ThreadInput or AgentInput. */


### PR DESCRIPTION
## Summary
- Remove dead `@deprecated` comments that no longer attach to any symbol after `SessionInput` / `FileSessionStore` aliases were deleted.
- Touches only `thread/input/input.ts` and `platform/file/storage/file-thread-store.ts`.
- No public API or behavior changes.

## Test plan
- [x] `pnpm exec vitest run src/platform/file/storage/file-thread-store.test.ts src/platform/file/storage/file-execution-store-input.test.ts` in `packages/runtime` (15 tests passed)
- [x] `rg '@deprecated' packages/runtime/src` — remaining hits are real aliases (Cloudflare host), not orphan comments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove orphan `@deprecated` comments left after dropping the `SessionInput` and `FileSessionStore` aliases. No API changes; updated thread/input/input.ts, platform/file/storage/file-thread-store.ts, and added a `.tegami` changelog for `npm:@minpeter/pss-runtime`.

<sup>Written for commit fd6fd73985ce003702940b1808cd43d009b6832e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

