### PR TITLE
breaking: drop legacy storage and namespace read-compat

### DIFF
--- a/.tegami/2026-07-19-remove-storage-namespace-read-compat.md
+++ b/.tegami/2026-07-19-remove-storage-namespace-read-compat.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "npm:@minpeter/pss-runtime": minor
+---
+
+## Drop legacy storage and namespace read-compat
+
+Stop hydrating SQLite `legacy-json` thread-message chunk markers and stop
+treating `:session:` owner namespaces as valid for ownership/resume.
+
+Current chunk markers and `:thread:` owner namespaces only.

--- a/apps/worker-agent/src/channel.ts
+++ b/apps/worker-agent/src/channel.ts
@@ -56,10 +56,6 @@ export function durableObjectChannelBinding(
   return bindChannelToThread(channel, CHANNEL_DURABLE_OBJECT_THREAD_KEY);
 }
 
-export function legacyChannelThreadKey(channel: ChannelAddress): string {
-  return channelKey(channel);
-}
-
 function bindChannelToThread(
   channel: ChannelAddress,
   thread: ThreadKey

--- a/apps/worker-agent/src/session-index-sql.test.ts
+++ b/apps/worker-agent/src/session-index-sql.test.ts
@@ -54,7 +54,7 @@ describe("sql session index repository", () => {
     ]);
   });
 
-  it("defaults legacy rows without session_scope_key to their conversation key", async () => {
+  it("leaves null session_scope_key unset instead of defaulting to conversation key", async () => {
     const sql = createNodeTestSqlStorage();
     sql.exec(
       `CREATE TABLE pss_worker_session_index (
@@ -93,6 +93,6 @@ describe("sql session index repository", () => {
     const [record] = await repository.all();
 
     expect(record?.conversationKey).toBe("telegram:legacy");
-    expect(record?.sessionScopeKey).toBe("telegram:legacy");
+    expect(record?.sessionScopeKey).toBeUndefined();
   });
 });

--- a/apps/worker-agent/src/session-index-sql.ts
+++ b/apps/worker-agent/src/session-index-sql.ts
@@ -121,10 +121,11 @@ function toRecord(row: SessionIndexRow): SessionIndexRecord {
     lastSeenAt: Number(row.last_seen_at),
     recentAssistantText: parseStringArray(row.recent_assistant_text),
     recentUserText: parseStringArray(row.recent_user_text),
-    ...(row.session_scope_key ? { sessionScopeKey: row.session_scope_key } : {}),
+    ...(row.session_scope_key
+      ? { sessionScopeKey: row.session_scope_key }
+      : {}),
     threadKey:
-      row.thread_key ??
-      channelKey({ id: channelId, kind: channelKind }),
+      row.thread_key ?? channelKey({ id: channelId, kind: channelKind }),
     turnCount: Number(row.turn_count),
   };
 }

--- a/apps/worker-agent/src/session-index-sql.ts
+++ b/apps/worker-agent/src/session-index-sql.ts
@@ -1,6 +1,6 @@
 import type { SqlStorage } from "@minpeter/pss-runtime/platform/cloudflare";
 
-import { ChannelAddressSchema, legacyChannelThreadKey } from "./channel";
+import { ChannelAddressSchema, channelKey } from "./channel";
 import type {
   SessionIndexRecord,
   SessionIndexRepository,
@@ -96,11 +96,11 @@ export function createSqlSessionIndexRepository(
         record.channelKind,
         record.channelId,
         record.threadKey ??
-          legacyChannelThreadKey({
+          channelKey({
             id: record.channelId,
             kind: record.channelKind,
           }),
-        record.sessionScopeKey ?? record.conversationKey,
+        record.sessionScopeKey ?? null,
         record.lastSeenAt,
         record.turnCount,
         JSON.stringify(record.recentUserText),
@@ -121,10 +121,10 @@ function toRecord(row: SessionIndexRow): SessionIndexRecord {
     lastSeenAt: Number(row.last_seen_at),
     recentAssistantText: parseStringArray(row.recent_assistant_text),
     recentUserText: parseStringArray(row.recent_user_text),
-    sessionScopeKey: row.session_scope_key ?? row.conversation_key,
+    ...(row.session_scope_key ? { sessionScopeKey: row.session_scope_key } : {}),
     threadKey:
       row.thread_key ??
-      legacyChannelThreadKey({ id: channelId, kind: channelKind }),
+      channelKey({ id: channelId, kind: channelKind }),
     turnCount: Number(row.turn_count),
   };
 }

--- a/apps/worker-agent/src/session-index.ts
+++ b/apps/worker-agent/src/session-index.ts
@@ -4,7 +4,6 @@ import {
   type ChannelAddress,
   ChannelAddressSchema,
   channelKey,
-  legacyChannelThreadKey,
 } from "./channel";
 import {
   buildSessionSnippet,
@@ -120,7 +119,7 @@ export function summarizeSessionRecord(
     snippet: buildSessionSnippet(record),
     threadKey:
       record.threadKey ??
-      legacyChannelThreadKey({
+      channelKey({
         id: record.channelId,
         kind: record.channelKind,
       }),
@@ -168,7 +167,7 @@ export function createSessionIndexStore(
       }
       return (
         record.threadKey ??
-        legacyChannelThreadKey({
+        channelKey({
           id: record.channelId,
           kind: record.channelKind,
         })

--- a/packages/runtime/src/agent/identity/namespace.test.ts
+++ b/packages/runtime/src/agent/identity/namespace.test.ts
@@ -16,7 +16,7 @@ describe("agent namespace helpers", () => {
     ).toBe("agent:coordinator:thread:room%2F1:generation:2");
   });
 
-  it("accepts current thread owner namespaces and legacy session owner namespaces", () => {
+  it("accepts current thread owner namespaces only", () => {
     const ownerNamespace = agentNamespace("coordinator");
 
     expect(ownsAgentNamespace(ownerNamespace, ownerNamespace)).toBe(true);
@@ -31,7 +31,7 @@ describe("agent namespace helpers", () => {
         `${ownerNamespace}:session:room%2F1:generation:2`,
         ownerNamespace
       )
-    ).toBe(true);
+    ).toBe(false);
     expect(
       ownsAgentNamespace(
         `${agentNamespace("other")}:thread:room%2F1:generation:2`,

--- a/packages/runtime/src/agent/identity/namespace.ts
+++ b/packages/runtime/src/agent/identity/namespace.ts
@@ -65,8 +65,7 @@ export function ownsAgentNamespace(
 ): boolean {
   return (
     ownerNamespace === agentOwnerNamespace ||
-    ownerNamespace?.startsWith(`${agentOwnerNamespace}:thread:`) === true ||
-    ownerNamespace?.startsWith(`${agentOwnerNamespace}:session:`) === true
+    ownerNamespace?.startsWith(`${agentOwnerNamespace}:thread:`) === true
   );
 }
 

--- a/packages/runtime/src/agent/resume/resume.ts
+++ b/packages/runtime/src/agent/resume/resume.ts
@@ -96,10 +96,7 @@ function canAccessRun(run: TurnRecord, ownerNamespace: string): boolean {
     return ownsAgentNamespace(run.ownerNamespace, ownerNamespace);
   }
 
-  return (
-    run.threadKey.startsWith(`parent:${ownerNamespace}:`) ||
-    run.parentRunId?.startsWith(`${ownerNamespace}:session:`) === true
-  );
+  return run.threadKey.startsWith(`parent:${ownerNamespace}:`);
 }
 
 export async function completeNotificationRun(

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql/keys/types.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql/keys/types.ts
@@ -32,7 +32,6 @@ export interface ThreadMessageChunkRow {
 }
 
 export interface ThreadMessageChunkMarker {
-  readonly kind: "legacy-json" | "raw-prefix";
   readonly n: number;
 }
 

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql/messages/chunks.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql/messages/chunks.ts
@@ -130,9 +130,6 @@ export function reconstructThreadMessagePayload(
   chunks: readonly ThreadMessageChunkRow[]
 ): string {
   if (chunks.length !== marker.n) {
-    if (marker.kind === "legacy-json" && chunks.length === 0) {
-      return row.message;
-    }
     throw new Error(
       `Missing chunked thread message payload for ${key} seq ${row.seq}`
     );
@@ -169,12 +166,10 @@ export function parseThreadMessageChunkMarker(
   message: string
 ): ThreadMessageChunkMarker | null {
   if (!message.startsWith(threadMessageChunkMarkerPrefix)) {
-    return parseLegacyThreadMessageChunkMarker(message);
+    return null;
   }
   const count = Number(message.slice(threadMessageChunkMarkerPrefix.length));
-  return Number.isInteger(count) && count > 0
-    ? { kind: "raw-prefix", n: count }
-    : null;
+  return Number.isInteger(count) && count > 0 ? { n: count } : null;
 }
 
 function avoidTrailingHighSurrogate(value: string, index: number): number {
@@ -197,33 +192,6 @@ function nextCodePointEnd(value: string, index: number): number {
     second <= 0xdf_ff
     ? index + 2
     : index + 1;
-}
-
-function parseLegacyThreadMessageChunkMarker(
-  message: string
-): ThreadMessageChunkMarker | null {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(message);
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      return null;
-    }
-    throw error;
-  }
-  if (
-    typeof parsed !== "object" ||
-    parsed === null ||
-    !("$pss" in parsed) ||
-    !("n" in parsed) ||
-    parsed.$pss !== "chunk" ||
-    typeof parsed.n !== "number"
-  ) {
-    return null;
-  }
-  return Number.isInteger(parsed.n) && parsed.n > 0
-    ? { kind: "legacy-json", n: parsed.n }
-    : null;
 }
 
 function createThreadChunkMarker(

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.test.ts
@@ -306,7 +306,7 @@ describe("DurableObjectSqliteThreadStore", () => {
     });
   });
 
-  it("hydrates existing rows that use the legacy JSON chunk marker", async () => {
+  it("does not treat legacy JSON chunk markers as chunk pointers", async () => {
     const { storage, store } = createStore();
     const threadKey = storeKey(PREFIX, "thread", "legacy");
     const serializedMessage = JSON.stringify({
@@ -344,9 +344,10 @@ describe("DurableObjectSqliteThreadStore", () => {
       serializedMessage.slice(midpoint)
     );
 
+    // Current format only: `$pss:chunk` JSON is ordinary payload, not a marker.
     await expect(store.load("legacy")).resolves.toEqual({
       state: {
-        history: [{ content: "legacy chunked message", role: "user" }],
+        history: [{ $pss: "chunk", n: 2 }],
         schemaVersion: 1,
       },
       version: "1",


### PR DESCRIPTION
## Summary
- Drop SQLite thread-message `legacy-json` chunk marker parse/hydrate; only current `pss-thread-chunk:` prefix markers (U+001E-prefixed) remain.
- Drop owner-namespace `:session:` recognition in `ownsAgentNamespace` and resume `canAccessRun`.
- Stop defaulting null `session_scope_key` rows to `conversationKey` on SQL read/write; leave unset when null.
- Remove `legacyChannelThreadKey` and use `channelKey` for thread-key fallbacks.

## Breaking change
Persisted rows still on legacy chunk markers, `:session:` ownership, or null `session_scope_key` hydrate semantics will not load/authorize as before. Ops migration is out of band.

Unmigrated legacy JSON chunk rows load without error: history may contain `{ $pss: "chunk", n }` payload objects and orphan chunk-table rows are unused. Re-detecting the old format on the hot path is intentionally avoided; backfill/diagnose offline before deploy.

## Pre-merge ops checklist
- [ ] **Legacy JSON chunk markers** (`{ "$pss": "chunk", "n": N }`): confirm none remain in live SQLite thread message rows, or backfill to U+001E-prefixed `pss-thread-chunk:` markers. Unmigrated rows load as ordinary history payloads (silent corruption risk).
- [ ] **`:session:` owner namespaces**: confirm no runs/owners still use `:session:`; ownership/resume will fail. Prefer top-level or `:thread:` ownership.
- [ ] **null `session_scope_key`**: confirm callers do not rely on SQL hydrate → `conversationKey`. Set scope explicitly where list/search/authorize filters depend on it.
- [ ] No hot-path re-detection of removed formats (by design). Diagnostics/backfill stay out of band.

## Intentional leftovers (not this PR)
- **`thread_key` null synthesis via `channelKey({ id, kind })`** (SQL read/write, summarize, resolveThreadKey) stays. That is the **current default model**, not dead-format read-compat. Follow-up may require `thread_key` on write and stop synthesizing on read.
- **`session_scope_key` null** is the opposite: no longer filled from `conversationKey` on SQL hydrate (legacy read-compat removed here).
- **`canAccessRun` without `ownerNamespace`**: still allows `threadKey` prefix `parent:${ownerNamespace}:`. If all new data always sets `ownerNamespace`, a later PR can refuse owner-less runs.

## Test plan
- [x] runtime `thread-store.test.ts` + `namespace.test.ts`
- [x] worker-agent `session-index-sql.test.ts` + `session-index.test.ts`
- [x] typecheck runtime + worker-agent
