### PR TITLE
breaking: stop inventing thread keys and owner-less resume

### DIFF
--- a/.tegami/2026-07-19-shrink-leftover-read-compat.md
+++ b/.tegami/2026-07-19-shrink-leftover-read-compat.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "npm:@minpeter/pss-runtime": minor
+---
+
+## Shrink leftover read-compat defaults
+
+Stop inventing session-index `thread_key` values from channel identity when
+stored keys are missing, and stop granting resume access to owner-less runs
+based only on a `parent:${owner}:` thread-key prefix.
+
+Resume requires a present `ownerNamespace` accepted by `ownsAgentNamespace`.
+Session-index write paths already pass explicit `threadKey` values.

--- a/.tegami/2026-07-19-shrink-leftover-read-compat.md
+++ b/.tegami/2026-07-19-shrink-leftover-read-compat.md
@@ -11,3 +11,4 @@ based only on a `parent:${owner}:` thread-key prefix.
 
 Resume requires a present `ownerNamespace` accepted by `ownsAgentNamespace`.
 Session-index write paths already pass explicit `threadKey` values.
+`canRead` / list / search share the same rule: missing `threadKey` is not readable.

--- a/apps/worker-agent/src/session-index-record.ts
+++ b/apps/worker-agent/src/session-index-record.ts
@@ -44,6 +44,9 @@ export function isSessionRecordVisible(
   record: SessionIndexRecord,
   options: SessionRecordFilterOptions = {}
 ): boolean {
+  if (!record.threadKey) {
+    return false;
+  }
   if (record.conversationKey === options.excludeKey) {
     return false;
   }

--- a/apps/worker-agent/src/session-index-sql.test.ts
+++ b/apps/worker-agent/src/session-index-sql.test.ts
@@ -54,6 +54,24 @@ describe("sql session index repository", () => {
     ]);
   });
 
+  it("leaves null thread_key unset instead of synthesizing a channel key", async () => {
+    const sql = createNodeTestSqlStorage();
+    const repository = createSqlSessionIndexRepository(sql);
+    await repository.put({
+      channelId: "missing-thread",
+      channelKind: "telegram",
+      conversationKey: "telegram:missing-thread",
+      lastSeenAt: 5,
+      recentAssistantText: [],
+      recentUserText: ["no key"],
+      turnCount: 1,
+    });
+
+    const record = await repository.get("telegram:missing-thread");
+    expect(record?.threadKey).toBeUndefined();
+    expect(record?.conversationKey).toBe("telegram:missing-thread");
+  });
+
   it("leaves null session_scope_key unset instead of defaulting to conversation key", async () => {
     const sql = createNodeTestSqlStorage();
     sql.exec(

--- a/apps/worker-agent/src/session-index-sql.ts
+++ b/apps/worker-agent/src/session-index-sql.ts
@@ -1,6 +1,6 @@
 import type { SqlStorage } from "@minpeter/pss-runtime/platform/cloudflare";
 
-import { ChannelAddressSchema, channelKey } from "./channel";
+import { ChannelAddressSchema } from "./channel";
 import type {
   SessionIndexRecord,
   SessionIndexRepository,
@@ -95,11 +95,7 @@ export function createSqlSessionIndexRepository(
         record.conversationKey,
         record.channelKind,
         record.channelId,
-        record.threadKey ??
-          channelKey({
-            id: record.channelId,
-            kind: record.channelKind,
-          }),
+        record.threadKey ?? null,
         record.sessionScopeKey ?? null,
         record.lastSeenAt,
         record.turnCount,
@@ -124,8 +120,7 @@ function toRecord(row: SessionIndexRow): SessionIndexRecord {
     ...(row.session_scope_key
       ? { sessionScopeKey: row.session_scope_key }
       : {}),
-    threadKey:
-      row.thread_key ?? channelKey({ id: channelId, kind: channelKind }),
+    ...(row.thread_key ? { threadKey: row.thread_key } : {}),
     turnCount: Number(row.turn_count),
   };
 }

--- a/apps/worker-agent/src/session-index.test.ts
+++ b/apps/worker-agent/src/session-index.test.ts
@@ -135,9 +135,23 @@ describe("summarizeSessionRecord", () => {
       turnCount: 2,
     });
 
-    expect(summary.snippet).toBe("latest user line");
-    expect(summary.channel).toEqual({ id: "123", kind: "telegram" });
-    expect(summary.threadKey).toBe("thread:telegram:123");
+    expect(summary?.snippet).toBe("latest user line");
+    expect(summary?.channel).toEqual({ id: "123", kind: "telegram" });
+    expect(summary?.threadKey).toBe("thread:telegram:123");
+  });
+
+  it("does not invent a thread key from channel identity", () => {
+    expect(
+      summarizeSessionRecord({
+        channelId: "123",
+        channelKind: "telegram",
+        conversationKey: "telegram:123",
+        lastSeenAt: 1,
+        recentAssistantText: [],
+        recentUserText: ["hi"],
+        turnCount: 1,
+      })
+    ).toBeNull();
   });
 });
 
@@ -248,5 +262,22 @@ describe("session index store", () => {
     const store = createSessionIndexStore(createMemorySessionIndexRepository());
 
     expect(await store.resolveThreadKey("tui:missing")).toBeUndefined();
+  });
+
+  it("does not synthesize thread keys for records that omit them", async () => {
+    const repository = createMemorySessionIndexRepository();
+    await repository.put({
+      channelId: "orphan",
+      channelKind: "telegram",
+      conversationKey: "telegram:orphan",
+      lastSeenAt: 1,
+      recentAssistantText: [],
+      recentUserText: ["no thread key"],
+      turnCount: 1,
+    });
+    const store = createSessionIndexStore(repository);
+
+    expect(await store.resolveThreadKey("telegram:orphan")).toBeUndefined();
+    expect(await store.list()).toEqual([]);
   });
 });

--- a/apps/worker-agent/src/session-index.test.ts
+++ b/apps/worker-agent/src/session-index.test.ts
@@ -279,5 +279,7 @@ describe("session index store", () => {
 
     expect(await store.resolveThreadKey("telegram:orphan")).toBeUndefined();
     expect(await store.list()).toEqual([]);
+    expect(await store.search("thread")).toEqual([]);
+    await expect(store.canRead("telegram:orphan")).resolves.toBe(false);
   });
 });

--- a/apps/worker-agent/src/session-index.ts
+++ b/apps/worker-agent/src/session-index.ts
@@ -111,18 +111,16 @@ export interface SessionIndexRepository {
 
 export function summarizeSessionRecord(
   record: SessionIndexRecord
-): SessionSummary {
+): SessionSummary | null {
+  if (!record.threadKey) {
+    return null;
+  }
   return {
     channel: { id: record.channelId, kind: record.channelKind },
     conversationKey: record.conversationKey,
     lastSeenAt: record.lastSeenAt,
     snippet: buildSessionSnippet(record),
-    threadKey:
-      record.threadKey ??
-      channelKey({
-        id: record.channelId,
-        kind: record.channelKind,
-      }),
+    threadKey: record.threadKey,
     turnCount: record.turnCount,
   };
 }
@@ -157,21 +155,15 @@ export function createSessionIndexStore(
       return records
         .slice()
         .sort(byRecency)
-        .slice(0, clampSessionLimit(options.limit, DEFAULT_SESSION_LIST_LIMIT))
-        .map(summarizeSessionRecord);
+        .flatMap((record) => {
+          const summary = summarizeSessionRecord(record);
+          return summary ? [summary] : [];
+        })
+        .slice(0, clampSessionLimit(options.limit, DEFAULT_SESSION_LIST_LIMIT));
     },
     resolveThreadKey: async (conversationKey) => {
       const record = await repository.get(conversationKey);
-      if (!record) {
-        return;
-      }
-      return (
-        record.threadKey ??
-        channelKey({
-          id: record.channelId,
-          kind: record.channelKind,
-        })
-      );
+      return record?.threadKey;
     },
     search: async (query, options = {}) => {
       const normalizedQuery = normalizeSearchText(query);
@@ -187,14 +179,14 @@ export function createSessionIndexStore(
         }))
         .filter((entry) => entry.score > 0)
         .sort(byScoreThenRecency)
+        .flatMap((entry) => {
+          const summary = summarizeSessionRecord(entry.record);
+          return summary ? [{ ...summary, score: entry.score }] : [];
+        })
         .slice(
           0,
           clampSessionLimit(options.limit, DEFAULT_SESSION_SEARCH_LIMIT)
-        )
-        .map((entry) => ({
-          ...summarizeSessionRecord(entry.record),
-          score: entry.score,
-        }));
+        );
     },
     upsert: async (update) => {
       const conversationKey = channelKey(update.channel);

--- a/packages/runtime/src/agent/resume/resume-access.test.ts
+++ b/packages/runtime/src/agent/resume/resume-access.test.ts
@@ -11,9 +11,13 @@ describe("resumeAgentTurn access control", () => {
     const host = createInMemoryHost();
     const ownerNamespace = agentNamespace("coordinator");
     const runId = "orphan-run";
+    const dedupeKey = "orphan-dedupe";
+    // Run has no ownerNamespace but a parent-prefixed threadKey that the old
+    // canAccessRun would accept. Notification owner is valid so claim would
+    // succeed if access were wrongly granted — then resumeNotification throws.
     const run: TurnRecord = {
       checkpointVersion: 0,
-      dedupeKey: "orphan-dedupe",
+      dedupeKey,
       kind: "notification",
       rootRunId: runId,
       runId,
@@ -21,6 +25,15 @@ describe("resumeAgentTurn access control", () => {
       threadKey: `parent:${ownerNamespace}:subagent:child`,
     };
     await host.store.turns.create(run);
+    await host.store.notifications.enqueue({
+      idempotencyKey: dedupeKey,
+      input: userText("orphan ready"),
+      notificationId: "n-orphan",
+      ownerNamespace,
+      runId,
+      status: "pending",
+      threadKey: run.threadKey,
+    });
 
     await expect(
       resumeAgentTurn({

--- a/packages/runtime/src/agent/resume/resume-access.test.ts
+++ b/packages/runtime/src/agent/resume/resume-access.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { TurnRecord } from "../../execution/host/types";
+import { createInMemoryHost } from "../../platform/memory";
+import { userText } from "../../testing/test-fixtures";
+import { BufferedAgentTurn } from "../../thread/protocol/turn";
+import { agentNamespace } from "../identity/namespace";
+import { resumeAgentTurn } from "./resume";
+
+describe("resumeAgentTurn access control", () => {
+  it("denies runs that lack ownerNamespace even with parent-prefixed thread keys", async () => {
+    const host = createInMemoryHost();
+    const ownerNamespace = agentNamespace("coordinator");
+    const runId = "orphan-run";
+    const run: TurnRecord = {
+      checkpointVersion: 0,
+      dedupeKey: "orphan-dedupe",
+      kind: "notification",
+      rootRunId: runId,
+      runId,
+      status: "queued",
+      threadKey: `parent:${ownerNamespace}:subagent:child`,
+    };
+    await host.store.turns.create(run);
+
+    await expect(
+      resumeAgentTurn({
+        host,
+        ownerNamespace,
+        resumeNotification: () => {
+          throw new Error(
+            "resumeNotification must not run without owner access"
+          );
+        },
+        runId,
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("allows runs whose ownerNamespace is owned by the resumer", async () => {
+    const host = createInMemoryHost();
+    const ownerNamespace = agentNamespace("coordinator");
+    const runId = "owned-run";
+    const childOwner = `${ownerNamespace}:thread:room%2F1:generation:1`;
+    const run: TurnRecord = {
+      checkpointVersion: 0,
+      dedupeKey: "owned-dedupe",
+      kind: "notification",
+      ownerNamespace: childOwner,
+      rootRunId: runId,
+      runId,
+      status: "queued",
+      threadKey: "default",
+    };
+    await host.store.turns.create(run);
+    await host.store.notifications.enqueue({
+      idempotencyKey: "owned-dedupe",
+      input: userText("ready"),
+      notificationId: "n1",
+      ownerNamespace: childOwner,
+      runId,
+      status: "pending",
+      threadKey: "default",
+    });
+
+    let resumed = false;
+    const turn = new BufferedAgentTurn();
+    turn.close();
+    const result = await resumeAgentTurn({
+      host,
+      ownerNamespace,
+      resumeNotification: () => {
+        resumed = true;
+        return Promise.resolve(turn);
+      },
+      runId,
+    });
+
+    expect(resumed).toBe(true);
+    expect(result).toBe(turn);
+  });
+});

--- a/packages/runtime/src/agent/resume/resume.ts
+++ b/packages/runtime/src/agent/resume/resume.ts
@@ -92,11 +92,10 @@ async function claimNotificationForRun({
 }
 
 function canAccessRun(run: TurnRecord, ownerNamespace: string): boolean {
-  if (run.ownerNamespace) {
-    return ownsAgentNamespace(run.ownerNamespace, ownerNamespace);
+  if (!run.ownerNamespace) {
+    return false;
   }
-
-  return run.threadKey.startsWith(`parent:${ownerNamespace}:`);
+  return ownsAgentNamespace(run.ownerNamespace, ownerNamespace);
 }
 
 export async function completeNotificationRun(

--- a/packages/runtime/src/agent/resume/resume.ts
+++ b/packages/runtime/src/agent/resume/resume.ts
@@ -92,9 +92,8 @@ async function claimNotificationForRun({
 }
 
 function canAccessRun(run: TurnRecord, ownerNamespace: string): boolean {
-  if (!run.ownerNamespace) {
-    return false;
-  }
+  // Owner-less runs are denied: ownsAgentNamespace(undefined, …) is false,
+  // and there is no parent-threadKey fallback.
   return ownsAgentNamespace(run.ownerNamespace, ownerNamespace);
 }
 


### PR DESCRIPTION
## Summary
- Session-index no longer synthesizes `thread_key` from `channelKey` on SQL read/write, `summarizeSessionRecord`, or `resolveThreadKey`. Missing keys stay missing; list/search omit records without a stored key.
- Resume `canAccessRun` no longer grants access for owner-less runs via `parent:${owner}:` threadKey prefix. Access requires a present `ownerNamespace` accepted by `ownsAgentNamespace`.

## Breaking change
Records without stored `thread_key` no longer appear with invented keys. Historical runs without `ownerNamespace` cannot be resumed via parent-threadKey prefix alone.

## Test plan
- [x] worker-agent `session-index.test.ts` + `session-index-sql.test.ts`
- [x] runtime `resume-access.test.ts` (deny without owner; allow with owned namespace)
- [x] typecheck runtime + worker-agent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop synthesizing session `thread_key` and require `ownerNamespace` for resume access. All reads (`canRead`, list, search, resolve) ignore records without a stored thread key; owner-less runs can’t be resumed.

- **Migration**
  - Ensure all write paths persist `threadKey` for sessions.
  - Backfill `thread_key` for historical records if you need them to be readable or show up in list/search.
  - Include `ownerNamespace` on runs and verify it passes `ownsAgentNamespace`; remove reliance on `parent:${owner}:` thread-key prefixes.

<sup>Written for commit 45acae7fd2747f8aeefad4c254fd6f6620b25aba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

