### PR TITLE
feat(runtime): allow tool.call.before input transform

### DIFF
--- a/.tegami/2026-07-19-tool-call-before-input-transform.md
+++ b/.tegami/2026-07-19-tool-call-before-input-transform.md
@@ -1,0 +1,16 @@
+---
+packages:
+  "npm:@minpeter/pss-runtime": minor
+---
+
+## Allow explicit tool.call.before input transforms
+
+`tool.call.before` handlers may return
+`{ action: "transform", input }` to replace the arguments passed to tool
+`execute`. Transforms chain in plugin registration order. Each handler still
+receives a structured clone of the current event, so in-place mutation of the
+event object does not affect later plugins or execution.
+
+`continue`, `block`, and `needs-recovery` decisions are unchanged. A transform
+missing `input`, or an input that is not structured-cloneable, fails closed
+with `PluginHookError`.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -328,6 +328,8 @@ Return one of:
 - `{ action: "transform", value: event }` — replace the value for transformable
   input, context, model-step, provider, compaction, tool-result, and turn-start
   requests
+- `{ action: "transform", input }` — replace tool arguments for
+  `tool.call.before` only (not `value`; chained; drives tool `execute`)
 - `{ action: "handled" }` — skip emit; for `thread.send`, close the run without
   starting a turn (`user-input` and `runtime-input` only)
 - `{ action: "cancel" }` — cancel compaction without changing thread state
@@ -355,18 +357,41 @@ const approvalPlugin = definePlugin((pss) =>
     return { action: "continue" };
   })
 );
+
+const pathJailPlugin = definePlugin((pss) =>
+  pss.on("tool.call.before", (event) => {
+    if (event.toolName !== "write_file" || !isWriteInput(event.input)) {
+      return { action: "continue" };
+    }
+    return {
+      action: "transform",
+      input: { ...event.input, path: jailPath(event.input.path) },
+    };
+  })
+);
 ```
 
 `tool.call.before` events carry `toolName`, `toolCallId`, `input`, `policy`,
 `attempt`, and `idempotencyKey`. Plugin handlers also receive current
 model-message `history` and `signal` through `PluginEventContext`. The runtime
-snapshots `tool.call.before` payloads before each plugin runs, so input mutations
-do not affect later plugins or tool execution. Keep tool inputs
-structured-cloneable and reasonably sized, because the runtime clones the input
-once per plugin before tool execution. `transform` and `handled` returns are
-not valid for `tool.call.before`; invalid decisions fail closed.
+snapshots `tool.call.before` payloads before each plugin runs, so **in-place
+mutations of the event object do not affect later plugins or tool execution**.
+To change the input that reaches `execute`, return an explicit decision:
 
-`tool.execution.start` runs only after every `tool.call.before` handler continues.
+- `{ action: "transform", input }` — replace the tool input (chained in
+  registration order; the final value is what `execute` receives)
+- `{ action: "block", reason? }` — skip execution and synthesize a blocked result
+- `{ action: "needs-recovery" }` — stop before real execution for durable recovery
+- `{ action: "continue" }` — leave the current input unchanged (default when omitted)
+
+Keep tool inputs structured-cloneable and reasonably sized: the runtime clones
+the working input once per plugin, and transform inputs must also be
+structured-cloneable. `handled` is not valid for `tool.call.before`; invalid
+decisions (including a transform missing `input`) fail closed with
+`PluginHookError`.
+
+`tool.execution.start` runs only after every `tool.call.before` handler continues
+(and carries the final transformed input when transforms were applied).
 `tool.result` transforms chain in registration order, followed by the
 observe-only `tool.execution.end` event carrying the final result.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -387,8 +387,10 @@ To change the input that reaches `execute`, return an explicit decision:
 Keep tool inputs structured-cloneable and reasonably sized: the runtime clones
 the working input once per plugin, and transform inputs must also be
 structured-cloneable. `handled` is not valid for `tool.call.before`; invalid
-decisions (including a transform missing `input`) fail closed with
-`PluginHookError`.
+decisions fail closed with `PluginHookError`, including a transform missing
+`input`, `input: undefined`, or a non-cloneable `input` (for example a function).
+If an earlier plugin transforms and a later one returns `block` or
+`needs-recovery`, execution and `tool.execution.start` are skipped.
 
 `tool.execution.start` runs only after every `tool.call.before` handler continues
 (and carries the final transformed input when transforms were applied).

--- a/packages/runtime/src/contracts/root-api-events.test.ts
+++ b/packages/runtime/src/contracts/root-api-events.test.ts
@@ -74,11 +74,22 @@ describe("runtime root event API exports", () => {
     const recoveryResult = {
       action: "needs-recovery",
     } satisfies PluginRequestResultMap["tool.call.before"];
+    const transformResult = {
+      action: "transform",
+      input: { path: "docs/README.md" },
+    } satisfies PluginRequestResultMap["tool.call.before"];
+    const blockResult = {
+      action: "block",
+      reason: "path not allowed",
+    } satisfies PluginRequestResultMap["tool.call.before"];
 
     expect(event.toolName).toBe("write_file");
     expect(event.type).toBe("tool.call.before");
     expect(continueResult.action).toBe("continue");
     expect(recoveryResult.action).toBe("needs-recovery");
+    expect(transformResult.action).toBe("transform");
+    expect(transformResult.input).toEqual({ path: "docs/README.md" });
+    expect(blockResult.action).toBe("block");
   });
 
   it("types atomic model step transforms from the package root", () => {

--- a/packages/runtime/src/llm/tool-execution.ts
+++ b/packages/runtime/src/llm/tool-execution.ts
@@ -26,6 +26,7 @@ export type RuntimePersistedToolExecutionCheckpoint =
 
 export type RuntimeToolExecutionDecision =
   | { readonly output: unknown; readonly status: "blocked" }
+  | { readonly input: unknown; readonly status: "continue" }
   | { readonly status: "needs-recovery" }
   | undefined;
 
@@ -148,8 +149,14 @@ function wrapToolExecute(
       if (decision?.status === "blocked") {
         return decision.output;
       }
+      const executeInput =
+        decision?.status === "continue" ? decision.input : input;
+      const executionCheckpoint =
+        decision?.status === "continue"
+          ? { ...checkpoint, input: executeInput }
+          : checkpoint;
 
-      const output = await execute(input, {
+      const output = await execute(executeInput, {
         ...options,
         attempt: checkpoint.attempt,
         idempotencyKey: checkpoint.idempotencyKey,
@@ -160,7 +167,7 @@ function wrapToolExecute(
         toolCallId,
       });
       const transformed = await toolExecution.afterTool?.({
-        ...checkpoint,
+        ...executionCheckpoint,
         output,
       });
       return transformed ? transformed.output : output;

--- a/packages/runtime/src/plugins/api.test.ts
+++ b/packages/runtime/src/plugins/api.test.ts
@@ -506,6 +506,356 @@ describe("factory plugin API", () => {
     await runtime.dispose();
   });
 
+  it("rejects tool.call.before transform when input is undefined", async () => {
+    const beforeEvent = {
+      attempt: 1,
+      idempotencyKey: "run:call_1",
+      input: { path: "a.md" },
+      policy: "idempotent" as const,
+      toolCallId: "call_1",
+      toolName: "write_file",
+      type: "tool.call.before" as const,
+    };
+    const runtime = await PluginRuntime.create(
+      [
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => ({
+            action: "transform",
+            input: undefined,
+          }));
+        }),
+      ],
+      {
+        diagnostics: { report: () => undefined },
+        factoryTimeoutMs: 1000,
+        hookTimeoutMs: 1000,
+      }
+    );
+
+    await expect(
+      runtime.beforeToolExecution("thread", beforeEvent, [])
+    ).rejects.toBeInstanceOf(PluginHookError);
+
+    await runtime.dispose();
+  });
+
+  it("rejects non-cloneable tool.call.before transform input", async () => {
+    const beforeEvent = {
+      attempt: 1,
+      idempotencyKey: "run:call_1",
+      input: { path: "a.md" },
+      policy: "idempotent" as const,
+      toolCallId: "call_1",
+      toolName: "write_file",
+      type: "tool.call.before" as const,
+    };
+    const runtime = await PluginRuntime.create(
+      [
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => ({
+            action: "transform",
+            input: { fn: () => "nope" },
+          }));
+        }),
+      ],
+      {
+        diagnostics: { report: () => undefined },
+        factoryTimeoutMs: 1000,
+        hookTimeoutMs: 1000,
+      }
+    );
+
+    await expect(
+      runtime.beforeToolExecution("thread", beforeEvent, [])
+    ).rejects.toMatchObject({
+      name: "PluginHookError",
+      event: "tool.call.before",
+    });
+
+    await runtime.dispose();
+  });
+
+  it("does not emit tool.execution.start when a later plugin blocks after transform", async () => {
+    const phases: string[] = [];
+    const startInputs: unknown[] = [];
+    const beforeEvent = {
+      attempt: 1,
+      idempotencyKey: "run:call_1",
+      input: { path: "a.md" },
+      policy: "idempotent" as const,
+      toolCallId: "call_1",
+      toolName: "write_file",
+      type: "tool.call.before" as const,
+    };
+    const runtime = await PluginRuntime.create(
+      [
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => ({
+            action: "transform",
+            input: { path: "transformed.md" },
+          }));
+        }),
+        definePlugin((pss) => {
+          pss.on("tool.call.before", (event) => {
+            phases.push(`second:${JSON.stringify(event.input)}`);
+            return { action: "block", reason: "blocked after transform" };
+          });
+          pss.on("tool.execution.start", (event) => {
+            phases.push("tool.execution.start");
+            startInputs.push(structuredClone(event.input));
+          });
+        }),
+      ],
+      {
+        diagnostics: { report: () => undefined },
+        factoryTimeoutMs: 1000,
+        hookTimeoutMs: 1000,
+      }
+    );
+
+    const decision = await runtime.beforeToolExecution(
+      "thread",
+      beforeEvent,
+      []
+    );
+
+    expect(decision).toEqual({
+      output: {
+        blocked: true,
+        reason: "blocked after transform",
+      },
+      status: "blocked",
+    });
+    expect(phases).toEqual(['second:{"path":"transformed.md"}']);
+    expect(startInputs).toEqual([]);
+
+    await runtime.dispose();
+  });
+
+  it("does not emit tool.execution.start when a later plugin requests recovery after transform", async () => {
+    const phases: string[] = [];
+    const beforeEvent = {
+      attempt: 1,
+      idempotencyKey: "run:call_1",
+      input: { path: "a.md" },
+      policy: "manual-recovery" as const,
+      toolCallId: "call_1",
+      toolName: "write_file",
+      type: "tool.call.before" as const,
+    };
+    const runtime = await PluginRuntime.create(
+      [
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => ({
+            action: "transform",
+            input: { path: "transformed.md" },
+          }));
+        }),
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => {
+            phases.push("second:needs-recovery");
+            return { action: "needs-recovery" };
+          });
+          pss.on("tool.execution.start", () => {
+            phases.push("tool.execution.start");
+          });
+        }),
+      ],
+      {
+        diagnostics: { report: () => undefined },
+        factoryTimeoutMs: 1000,
+        hookTimeoutMs: 1000,
+      }
+    );
+
+    await expect(
+      runtime.beforeToolExecution("thread", beforeEvent, [])
+    ).resolves.toEqual({ status: "needs-recovery" });
+    expect(phases).toEqual(["second:needs-recovery"]);
+
+    await runtime.dispose();
+  });
+
+  it("notifies tool.execution.start with the final transformed input", async () => {
+    const startInputs: unknown[] = [];
+    const beforeEvent = {
+      attempt: 1,
+      idempotencyKey: "run:call_1",
+      input: { path: "a.md" },
+      policy: "idempotent" as const,
+      toolCallId: "call_1",
+      toolName: "write_file",
+      type: "tool.call.before" as const,
+    };
+    const runtime = await PluginRuntime.create(
+      [
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => ({
+            action: "transform",
+            input: { path: "first.md" },
+          }));
+        }),
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => ({
+            action: "transform",
+            input: { path: "final.md" },
+          }));
+          pss.on("tool.execution.start", (event) => {
+            startInputs.push(structuredClone(event.input));
+          });
+        }),
+      ],
+      {
+        diagnostics: { report: () => undefined },
+        factoryTimeoutMs: 1000,
+        hookTimeoutMs: 1000,
+      }
+    );
+
+    const decision = await runtime.beforeToolExecution(
+      "thread",
+      beforeEvent,
+      []
+    );
+
+    expect(decision).toEqual({
+      input: { path: "final.md" },
+      status: "continue",
+    });
+    expect(startInputs).toEqual([{ path: "final.md" }]);
+
+    await runtime.dispose();
+  });
+
+  it("notifies tool.execution.start with original input when no transform runs", async () => {
+    const startInputs: unknown[] = [];
+    const beforeEvent = {
+      attempt: 1,
+      idempotencyKey: "run:call_1",
+      input: { path: "original.md" },
+      policy: "idempotent" as const,
+      toolCallId: "call_1",
+      toolName: "write_file",
+      type: "tool.call.before" as const,
+    };
+    const runtime = await PluginRuntime.create(
+      [
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => ({ action: "continue" }));
+          pss.on("tool.execution.start", (event) => {
+            startInputs.push(structuredClone(event.input));
+          });
+        }),
+      ],
+      {
+        diagnostics: { report: () => undefined },
+        factoryTimeoutMs: 1000,
+        hookTimeoutMs: 1000,
+      }
+    );
+
+    const decision = await runtime.beforeToolExecution(
+      "thread",
+      beforeEvent,
+      []
+    );
+
+    expect(decision).toBeUndefined();
+    expect(startInputs).toEqual([{ path: "original.md" }]);
+
+    await runtime.dispose();
+  });
+
+  it("does not execute the tool when transform input is non-cloneable", async () => {
+    const call = toolCallPart("call-nonclone", "rewrite_tool");
+    const model = createScriptedModelOptions([
+      [assistantMessage([call]), toolResultFor(call)],
+    ]);
+    let executions = 0;
+    model.tools = {
+      rewrite_tool: tool({
+        execute: () => {
+          executions += 1;
+          return { ok: true };
+        },
+        inputSchema: jsonSchema({
+          additionalProperties: true,
+          type: "object",
+        }),
+      }),
+    };
+    const plugin = definePlugin((pss) => {
+      pss.on("tool.call.before", () => ({
+        action: "transform",
+        input: { fn: () => "nope" },
+      }));
+    });
+    const agent = await createAgent({ ...model, plugins: [plugin] });
+
+    const events = await collect(await agent.send("rewrite"));
+
+    expect(executions).toBe(0);
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "turn-error" })
+    );
+  });
+
+  it("blocks execute after an earlier plugin transforms input", async () => {
+    const call = toolCallPart("call-transform-then-block", "rewrite_tool");
+    const model = createScriptedModelOptions([
+      [assistantMessage([call]), toolResultFor(call)],
+      [assistantMessage("DONE")],
+    ]);
+    let executions = 0;
+    const phases: string[] = [];
+    model.tools = {
+      rewrite_tool: tool({
+        execute: () => {
+          executions += 1;
+          return { ok: true };
+        },
+        inputSchema: jsonSchema({
+          additionalProperties: true,
+          type: "object",
+        }),
+      }),
+    };
+    const transformThenBlock = [
+      definePlugin((pss) => {
+        pss.on("tool.call.before", () => ({
+          action: "transform",
+          input: { path: "transformed.md" },
+        }));
+      }),
+      definePlugin((pss) => {
+        pss.on("tool.call.before", () => ({
+          action: "block",
+          reason: "nope",
+        }));
+        pss.on("tool.execution.start", () => {
+          phases.push("tool.execution.start");
+        });
+      }),
+    ];
+    const agent = await createAgent({
+      ...model,
+      plugins: transformThenBlock,
+    });
+
+    const events = await collect(await agent.send("rewrite"));
+
+    expect(executions).toBe(0);
+    expect(phases).toEqual([]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        output: expect.objectContaining({
+          value: expect.objectContaining({ blocked: true }),
+        }),
+        type: "tool-result",
+      })
+    );
+  });
+
   it("transforms tool results before they return to the model", async () => {
     const call = toolCallPart("call-transform", "lookup");
     const model = createScriptedModelOptions([

--- a/packages/runtime/src/plugins/api.test.ts
+++ b/packages/runtime/src/plugins/api.test.ts
@@ -417,6 +417,95 @@ describe("factory plugin API", () => {
     );
   });
 
+  it("transforms tool.call.before input for later plugins and execute", async () => {
+    const call = toolCallPart("call-transform-input", "rewrite_tool");
+    const model = createScriptedModelOptions([
+      [assistantMessage([call]), toolResultFor(call)],
+      [assistantMessage("DONE")],
+    ]);
+    let executedInput: unknown;
+    const secondSaw: unknown[] = [];
+    model.tools = {
+      rewrite_tool: tool({
+        execute: (input) => {
+          executedInput = input;
+          return { ok: true };
+        },
+        inputSchema: jsonSchema({
+          additionalProperties: true,
+          properties: {
+            path: { type: "string" },
+          },
+          type: "object",
+        }),
+      }),
+    };
+    const first = definePlugin((pss) => {
+      pss.on("tool.call.before", (event) => ({
+        action: "transform",
+        input: {
+          ...(typeof event.input === "object" && event.input !== null
+            ? event.input
+            : {}),
+          path: "first.md",
+        },
+      }));
+    });
+    const second = definePlugin((pss) => {
+      pss.on("tool.call.before", (event) => {
+        secondSaw.push(structuredClone(event.input));
+        return {
+          action: "transform",
+          input: {
+            ...(typeof event.input === "object" && event.input !== null
+              ? event.input
+              : {}),
+            path: "second.md",
+          },
+        };
+      });
+    });
+    const agent = await createAgent({
+      ...model,
+      plugins: [first, second],
+    });
+
+    await collect(await agent.send("rewrite"));
+
+    expect(secondSaw).toEqual([{ path: "first.md" }]);
+    expect(executedInput).toEqual({ path: "second.md" });
+  });
+
+  it("rejects tool.call.before transform without input", async () => {
+    const beforeEvent = {
+      attempt: 1,
+      idempotencyKey: "run:call_1",
+      input: { path: "a.md" },
+      policy: "idempotent" as const,
+      toolCallId: "call_1",
+      toolName: "write_file",
+      type: "tool.call.before" as const,
+    };
+    const runtime = await PluginRuntime.create(
+      [
+        definePlugin((pss) => {
+          pss.on("tool.call.before", () => ({ action: "transform" }) as never);
+        }),
+      ],
+      {
+        diagnostics: { report: () => undefined },
+        factoryTimeoutMs: 1000,
+        hookTimeoutMs: 1000,
+      }
+    );
+
+    await expect(
+      runtime.beforeToolExecution("thread", beforeEvent, [])
+    ).rejects.toBeInstanceOf(PluginHookError);
+
+    await runtime.dispose();
+  });
+
   it("transforms tool results before they return to the model", async () => {
     const call = toolCallPart("call-transform", "lookup");
     const model = createScriptedModelOptions([

--- a/packages/runtime/src/plugins/api.ts
+++ b/packages/runtime/src/plugins/api.ts
@@ -124,7 +124,8 @@ export interface PluginRequestResultMap {
   readonly "tool.call.before":
     | PluginContinue
     | { readonly action: "block"; readonly reason?: string }
-    | { readonly action: "needs-recovery" };
+    | { readonly action: "needs-recovery" }
+    | { readonly action: "transform"; readonly input: unknown };
   readonly "tool.result":
     | PluginContinue
     | PluginEventTransform<PluginToolResultEvent>;

--- a/packages/runtime/src/plugins/runtime.ts
+++ b/packages/runtime/src/plugins/runtime.ts
@@ -55,6 +55,7 @@ export type PluginInputDecision = InputAcceptEvent | "handled";
 
 export type PluginToolExecutionDecision =
   | { readonly status: "blocked"; readonly output: unknown }
+  | { readonly input: unknown; readonly status: "continue" }
   | { readonly status: "needs-recovery" }
   | undefined;
 
@@ -219,14 +220,20 @@ export class PluginRuntime {
     history: readonly ModelMessage[],
     signal: AbortSignal = this.#abort.signal
   ): Promise<PluginToolExecutionDecision> {
+    let currentInput = structuredClone(event.input);
+    let inputTransformed = false;
     for (const { registered, registration } of this.#handlers(
       "tool.call.before"
     )) {
+      const snapshot: PluginToolCallBeforeEvent = {
+        ...event,
+        input: structuredClone(currentInput),
+      };
       const result = await this.#invoke(
         registration,
         "tool.call.before",
         registered,
-        structuredClone(event),
+        snapshot,
         { history, signal, threadKey }
       );
       const decision = result as
@@ -236,7 +243,7 @@ export class PluginRuntime {
         registration,
         "tool.call.before",
         decision,
-        ["block", "continue", "needs-recovery"]
+        ["block", "continue", "needs-recovery", "transform"]
       );
       if (decision?.action === "needs-recovery") {
         return { status: "needs-recovery" };
@@ -250,13 +257,28 @@ export class PluginRuntime {
           status: "blocked",
         };
       }
+      if (decision?.action === "transform") {
+        try {
+          currentInput = cloneToolCallInput(decision.input);
+        } catch (cause) {
+          await this.#throwHookFailure(registration, "tool.call.before", cause);
+        }
+        inputTransformed = true;
+      }
     }
 
-    await this.#notify("tool.execution.start", event, {
+    const finalEvent: PluginToolCallBeforeEvent = {
+      ...event,
+      input: structuredClone(currentInput),
+    };
+    await this.#notify("tool.execution.start", finalEvent, {
       history,
       signal,
       threadKey,
     });
+    if (inputTransformed) {
+      return { input: currentInput, status: "continue" };
+    }
     return;
   }
 
@@ -781,12 +803,22 @@ export class PluginRuntime {
       typeof result.action === "string" &&
       actions.includes(result.action)
     ) {
-      if (result.action === "transform" && !("value" in result)) {
-        throw await this.#invalidResult(
-          registration,
-          event,
-          `Plugin ${event} transform result is missing value.`
-        );
+      if (result.action === "transform") {
+        if (event === "tool.call.before") {
+          if (!("input" in result)) {
+            throw await this.#invalidResult(
+              registration,
+              event,
+              `Plugin ${event} transform result is missing input.`
+            );
+          }
+        } else if (!("value" in result)) {
+          throw await this.#invalidResult(
+            registration,
+            event,
+            `Plugin ${event} transform result is missing value.`
+          );
+        }
       }
       if (
         result.action === "block" &&
@@ -988,6 +1020,17 @@ function cloneEvent<T>(event: T): T {
     return structuredClone(event);
   } catch {
     return event;
+  }
+}
+
+function cloneToolCallInput(input: unknown): unknown {
+  try {
+    return structuredClone(input);
+  } catch (cause) {
+    throw new TypeError(
+      "Plugin tool.call.before transform input must be structured-cloneable.",
+      { cause }
+    );
   }
 }
 

--- a/packages/runtime/src/plugins/runtime.ts
+++ b/packages/runtime/src/plugins/runtime.ts
@@ -805,7 +805,12 @@ export class PluginRuntime {
     ) {
       if (result.action === "transform") {
         if (event === "tool.call.before") {
-          if (!("input" in result)) {
+          // Require an own/enumerable `input` that is not undefined. `"input" in
+          // result` alone would accept `{ action: "transform", input: undefined }`.
+          if (
+            !("input" in result) ||
+            (result as { readonly input?: unknown }).input === undefined
+          ) {
             throw await this.#invalidResult(
               registration,
               event,

--- a/packages/runtime/src/testing/tool-call-plugin-snapshot-agent.test.ts
+++ b/packages/runtime/src/testing/tool-call-plugin-snapshot-agent.test.ts
@@ -97,6 +97,178 @@ describe("tool-call plugin snapshots through Agent", () => {
     });
   });
 
+  it("applies explicit tool.call.before transform to tool execute input", async () => {
+    const { createAgent } = await import("../agent/core/agent");
+    const { host } = createCheckpointSpyHost();
+    const signal = new AbortController().signal;
+    let executedInput: unknown;
+
+    generateTextMock
+      .mockImplementationOnce(async (options: GenerateTextToolOptions) => {
+        const toolCall = toolCallPart("call_sdk-tool-call-1", "checked_tool");
+        await executableTool(options.tools ?? {}, "checked_tool").execute?.(
+          { payload: { path: "README.md" } },
+          toolOptions("call_sdk-tool-call-1", signal)
+        );
+
+        return {
+          responseMessages: [
+            assistantMessage([toolCall]),
+            toolResultFor(toolCall),
+          ],
+        };
+      })
+      .mockImplementationOnce(async () => ({
+        responseMessages: [assistantMessage("DONE")],
+      }));
+
+    const transformPlugin = definePlugin((pss) => {
+      pss.on("tool.call.before", (event) => {
+        if (!isMutableNestedInput(event.input)) {
+          return { action: "continue" };
+        }
+        return {
+          action: "transform",
+          input: {
+            payload: { path: `jailed/${event.input.payload.path}` },
+          },
+        };
+      });
+    });
+
+    const agent = await createAgent({
+      host,
+      model: fakeModel,
+      plugins: [transformPlugin],
+      tools: {
+        checked_tool: checkpointedTool("idempotent", (input) => {
+          executedInput = input;
+          return { ok: true };
+        }),
+      },
+    });
+
+    await collectRun(await agent.send("use the tool"));
+
+    expect(executedInput).toEqual({
+      payload: { path: "jailed/README.md" },
+    });
+  });
+
+  it("chains tool.call.before transforms across plugins in registration order", async () => {
+    const { createAgent } = await import("../agent/core/agent");
+    const { host } = createCheckpointSpyHost();
+    const signal = new AbortController().signal;
+    let executedInput: unknown;
+    const seenBySecond: unknown[] = [];
+
+    generateTextMock
+      .mockImplementationOnce(async (options: GenerateTextToolOptions) => {
+        const toolCall = toolCallPart("call_sdk-tool-call-1", "checked_tool");
+        await executableTool(options.tools ?? {}, "checked_tool").execute?.(
+          { payload: { path: "README.md" } },
+          toolOptions("call_sdk-tool-call-1", signal)
+        );
+
+        return {
+          responseMessages: [
+            assistantMessage([toolCall]),
+            toolResultFor(toolCall),
+          ],
+        };
+      })
+      .mockImplementationOnce(async () => ({
+        responseMessages: [assistantMessage("DONE")],
+      }));
+
+    const first = definePlugin((pss) => {
+      pss.on("tool.call.before", (event) => {
+        if (!isMutableNestedInput(event.input)) {
+          return { action: "continue" };
+        }
+        return {
+          action: "transform",
+          input: {
+            payload: { path: `first/${event.input.payload.path}` },
+          },
+        };
+      });
+    });
+    const second = definePlugin((pss) => {
+      pss.on("tool.call.before", (event) => {
+        seenBySecond.push(structuredClone(event.input));
+        if (!isMutableNestedInput(event.input)) {
+          return { action: "continue" };
+        }
+        return {
+          action: "transform",
+          input: {
+            payload: { path: `second/${event.input.payload.path}` },
+          },
+        };
+      });
+    });
+
+    const agent = await createAgent({
+      host,
+      model: fakeModel,
+      plugins: [first, second],
+      tools: {
+        checked_tool: checkpointedTool("idempotent", (input) => {
+          executedInput = input;
+          return { ok: true };
+        }),
+      },
+    });
+
+    await collectRun(await agent.send("use the tool"));
+
+    expect(seenBySecond).toEqual([{ payload: { path: "first/README.md" } }]);
+    expect(executedInput).toEqual({
+      payload: { path: "second/first/README.md" },
+    });
+  });
+
+  it("fails closed when tool.call.before transform omits input", async () => {
+    const { createAgent } = await import("../agent/core/agent");
+    const { host } = createCheckpointSpyHost();
+    const signal = new AbortController().signal;
+    let executions = 0;
+
+    generateTextMock.mockImplementationOnce(
+      async (options: GenerateTextToolOptions) => {
+        await executableTool(options.tools ?? {}, "checked_tool").execute?.(
+          { payload: { path: "README.md" } },
+          toolOptions("call_sdk-tool-call-1", signal)
+        );
+        return {
+          responseMessages: [assistantMessage("UNREACHABLE")],
+        };
+      }
+    );
+
+    const badTransform = definePlugin((pss) => {
+      pss.on("tool.call.before", () => ({ action: "transform" }) as never);
+    });
+
+    const agent = await createAgent({
+      host,
+      model: fakeModel,
+      plugins: [badTransform],
+      tools: {
+        checked_tool: checkpointedTool("idempotent", () => {
+          executions += 1;
+          return { ok: true };
+        }),
+      },
+    });
+
+    const events = await collectRun(await agent.send("use the tool"));
+
+    expect(executions).toBe(0);
+    expect(events.some((event) => event.type === "turn-error")).toBe(true);
+  });
+
   it("keeps tool.call.before events out of public turn events", async () => {
     const { createAgent } = await import("../agent/core/agent");
     const { host } = createCheckpointSpyHost();

--- a/packages/runtime/src/testing/tool-checkpointing.test.ts
+++ b/packages/runtime/src/testing/tool-checkpointing.test.ts
@@ -171,4 +171,59 @@ describe("tool checkpointing", () => {
     });
     expect(executions).toBe(0);
   });
+
+  it("passes beforeTool continue input to tool execute", async () => {
+    const runModelStep = await loadModelStepRunner();
+    const signal = new AbortController().signal;
+    let executedInput: unknown;
+
+    generateTextMock.mockImplementationOnce(
+      async (options: GenerateTextToolOptions) => {
+        const toolCall = toolCallPart("call_sdk-tool-call-1", "rewrite_tool");
+        await executableTool(options.tools ?? {}, "rewrite_tool").execute?.(
+          { path: "original.md" },
+          toolOptions("call_sdk-tool-call-1", signal)
+        );
+
+        return {
+          responseMessages: [
+            assistantMessage([toolCall]),
+            toolResultFor(toolCall),
+          ],
+        };
+      }
+    );
+
+    await runModelStep(
+      {
+        model: fakeModel,
+        tools: {
+          rewrite_tool: checkpointedTool("idempotent", (input) => {
+            executedInput = input;
+            return { ok: true };
+          }),
+        },
+      },
+      {
+        history: [],
+        signal,
+        toolExecution: {
+          attempt: 1,
+          beforeTool: async (checkpoint: RuntimeToolExecutionCheckpoint) => ({
+            input: {
+              ...(typeof checkpoint.input === "object" &&
+              checkpoint.input !== null
+                ? checkpoint.input
+                : {}),
+              path: "transformed.md",
+            },
+            status: "continue",
+          }),
+          runId: "run-1",
+        },
+      }
+    );
+
+    expect(executedInput).toEqual({ path: "transformed.md" });
+  });
 });


### PR DESCRIPTION
## Summary

- Allow `tool.call.before` handlers to return `{ action: "transform", input }` so plugin policies can rewrite tool arguments before `execute`.
- Chain transforms in registration order; each handler still receives a structured clone (in-place event mutation does not leak into later plugins or execution).
- Propagate the final input through `RuntimeToolExecutionDecision` (`status: "continue"`) into the tool-execution wrapper.
- Keep `continue` / `block` / `needs-recovery` behavior; missing or non-cloneable transform `input` fails closed with `PluginHookError`.
- Update runtime README, contract type tests, and tegami changelog entry.

## Test plan

- [x] `pnpm --filter @minpeter/pss-runtime exec vitest run` on plugin tool-call suites:
  - `src/plugins/api.test.ts`
  - `src/testing/tool-call-plugin-snapshot-agent.test.ts`
  - `src/testing/tool-checkpointing.test.ts`
  - `src/testing/tool-checkpointing-plugin-recovery-agent.test.ts`
  - `src/contracts/root-api-events.test.ts`
- [x] Agent path covers: explicit transform → execute input, mutation isolation, multi-plugin chain, invalid transform fail-closed, block/needs-recovery unchanged
- [x] Typecheck/lint on touched files

## Notes

Orthogonal to open stacks #206–#208 / #189 (no prepareModelStep or compaction provenance changes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit tool input transforms to `tool.call.before` so plugins can rewrite arguments before a tool runs. Transforms chain in order, are clone-safe, and the final input reaches `tool.execution.start` and `execute`.

- **New Features**
  - `tool.call.before` handlers can return `{ action: "transform", input }`. Each handler sees a structured clone; in-place mutation doesn’t leak. Inputs must be structured‑cloneable and defined; missing/`undefined`/non‑cloneable inputs fail closed with `PluginHookError`.
  - The runtime carries the final input via `RuntimeToolExecutionDecision` (`status: "continue"`) into tool `execute` and checkpoints. `tool.execution.start` runs only if all handlers continue, and receives the final input.
  - Keeps `continue`/`block`/`needs-recovery`; `handled` is not valid here. Updated README, contract types, tests (including transform‑then‑block/recovery cases), and changelog for `npm:@minpeter/pss-runtime`.

<sup>Written for commit 69939f7efc5f59f3179853f3dcc1d8cb79a16e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

