### PR TITLE
feat(runtime): expose ./testing subpath with AgentTurn test helpers

### DIFF
--- a/.tegami/2026-07-19-runtime-testing-subpath.md
+++ b/.tegami/2026-07-19-runtime-testing-subpath.md
@@ -1,0 +1,23 @@
+---
+packages:
+  "npm:@minpeter/pss-runtime": minor
+---
+
+## Expose AgentTurn test helpers via the `./testing` subpath
+
+`@minpeter/pss-runtime/testing` is now a public subpath for downstream tests
+that consume `AgentTurn.events()`:
+
+- `createMockAgentTurn(events)` builds an `AgentTurn` from an `AgentEvent`
+  array or an `AsyncIterable<AgentEvent>`. Like a real turn, `events()` is
+  single-consumption and throws on a second call.
+- `agentEventStream(events)` replays an event array as a deterministic async
+  iterable.
+- `agentEvent` provides typed builders for public event payloads:
+  `assistantOutput`, `assistantReasoning`, `toolCall`, `toolResult`,
+  `stepStart` / `stepEnd`, the `turn-*` lifecycle events, and `userText` /
+  `userMessage`.
+
+Internal fixtures stay unexported; the subpath surface is only the helpers
+above, so downstream mocks no longer drift when event names or turn APIs
+change.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -45,6 +45,11 @@
       "@minpeter/pss-source": "./src/evals/index.ts",
       "types": "./dist/evals/index.d.ts",
       "import": "./dist/evals/index.js"
+    },
+    "./testing": {
+      "@minpeter/pss-source": "./src/testing/index.ts",
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
     }
   },
   "bin": {

--- a/packages/runtime/src/contracts/package-subpaths.test.ts
+++ b/packages/runtime/src/contracts/package-subpaths.test.ts
@@ -76,6 +76,16 @@ describe("runtime package subpaths", () => {
     expect(packageJson.exports["./platform/node"]).toBeUndefined();
     expect(packageJson.exports["./node"]).toBeUndefined();
   });
+
+  it("declares the testing subpath for AgentTurn test helpers", async () => {
+    const packageJson = await readRuntimePackageJson();
+
+    expect(packageJson.exports["./testing"]).toMatchObject({
+      "@minpeter/pss-source": "./src/testing/index.ts",
+      import: "./dist/testing/index.js",
+      types: "./dist/testing/index.d.ts",
+    });
+  });
 });
 
 async function readRuntimePackageJson(): Promise<RuntimePackageJson> {

--- a/packages/runtime/src/testing/agent-event-builders.ts
+++ b/packages/runtime/src/testing/agent-event-builders.ts
@@ -1,0 +1,80 @@
+import type {
+  AgentEvent,
+  AssistantOutput,
+  AssistantReasoning,
+  ToolCall,
+  ToolResult,
+} from "../thread/protocol/events";
+import { userMessage, userText } from "./input-fixtures";
+
+type LifecycleEvent<Type extends AgentEvent["type"]> = Extract<
+  AgentEvent,
+  { type: Type }
+>;
+
+const assistantOutput = (text: string): AssistantOutput => ({
+  text,
+  type: "assistant-output",
+});
+
+const assistantReasoning = (text: string): AssistantReasoning => ({
+  text,
+  type: "assistant-reasoning",
+});
+
+const toolCall = (
+  toolName: string,
+  input: unknown = {},
+  toolCallId = `${toolName}-call`
+): ToolCall => ({
+  input,
+  toolCallId,
+  toolName,
+  type: "tool-call",
+});
+
+const toolResult = (
+  toolName: string,
+  output: unknown = {},
+  toolCallId = `${toolName}-call`
+): ToolResult => ({
+  output,
+  toolCallId,
+  toolName,
+  type: "tool-result",
+});
+
+const stepStart = (): LifecycleEvent<"step-start"> => ({ type: "step-start" });
+
+const stepEnd = (): LifecycleEvent<"step-end"> => ({ type: "step-end" });
+
+const turnStart = (): LifecycleEvent<"turn-start"> => ({ type: "turn-start" });
+
+const turnEnd = (): LifecycleEvent<"turn-end"> => ({ type: "turn-end" });
+
+const turnAbort = (): LifecycleEvent<"turn-abort"> => ({ type: "turn-abort" });
+
+const turnError = (message: string): LifecycleEvent<"turn-error"> => ({
+  message,
+  type: "turn-error",
+});
+
+/**
+ * Typed builders for public `AgentEvent` payloads. Builders stay in sync with
+ * the runtime event union, so downstream mocks do not drift when event names
+ * or shapes change.
+ */
+export const agentEvent = {
+  assistantOutput,
+  assistantReasoning,
+  stepEnd,
+  stepStart,
+  toolCall,
+  toolResult,
+  turnAbort,
+  turnEnd,
+  turnError,
+  turnStart,
+  userMessage,
+  userText,
+} as const;

--- a/packages/runtime/src/testing/agent-event-stream.ts
+++ b/packages/runtime/src/testing/agent-event-stream.ts
@@ -1,0 +1,14 @@
+import type { AgentEvent } from "../thread/protocol/events";
+
+/**
+ * Replays a fixed list of events as an async iterable, in order. Useful for
+ * building deterministic `AgentTurn.events()` sequences in tests.
+ */
+export async function* agentEventStream(
+  events: readonly AgentEvent[]
+): AsyncIterable<AgentEvent> {
+  for (const event of events) {
+    await Promise.resolve();
+    yield event;
+  }
+}

--- a/packages/runtime/src/testing/index.test.ts
+++ b/packages/runtime/src/testing/index.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { AgentEvent } from "../thread/protocol/events";
+import type { AgentTurn } from "../thread/protocol/turn";
+import { agentEvent, agentEventStream, createMockAgentTurn } from "./index";
+
+async function collectEvents(
+  events: AsyncIterable<AgentEvent>
+): Promise<AgentEvent[]> {
+  const collected: AgentEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+describe("agentEvent builders", () => {
+  it("builds assistant output and reasoning events", () => {
+    const events: AgentEvent[] = [
+      agentEvent.assistantOutput("visible text"),
+      agentEvent.assistantReasoning("private chain of thought"),
+    ];
+
+    expect(events).toEqual([
+      { text: "visible text", type: "assistant-output" },
+      { text: "private chain of thought", type: "assistant-reasoning" },
+    ]);
+  });
+
+  it("builds step and turn lifecycle events", () => {
+    const events: AgentEvent[] = [
+      agentEvent.turnStart(),
+      agentEvent.stepStart(),
+      agentEvent.stepEnd(),
+      agentEvent.turnEnd(),
+      agentEvent.turnAbort(),
+      agentEvent.turnError("provider unavailable"),
+    ];
+
+    expect(events).toEqual([
+      { type: "turn-start" },
+      { type: "step-start" },
+      { type: "step-end" },
+      { type: "turn-end" },
+      { type: "turn-abort" },
+      { message: "provider unavailable", type: "turn-error" },
+    ]);
+  });
+
+  it("builds tool call and tool result events with a default id", () => {
+    const events: AgentEvent[] = [
+      agentEvent.toolCall("search", { query: "pss" }),
+      agentEvent.toolResult("search", { hits: 3 }),
+    ];
+
+    expect(events).toEqual([
+      {
+        input: { query: "pss" },
+        toolCallId: "search-call",
+        toolName: "search",
+        type: "tool-call",
+      },
+      {
+        output: { hits: 3 },
+        toolCallId: "search-call",
+        toolName: "search",
+        type: "tool-result",
+      },
+    ]);
+  });
+
+  it("builds tool events with an explicit correlation id", () => {
+    const call: AgentEvent = agentEvent.toolCall(
+      "search",
+      { query: "pss" },
+      "call-42"
+    );
+    const result: AgentEvent = agentEvent.toolResult(
+      "search",
+      { hits: 3 },
+      "call-42"
+    );
+
+    expect(call).toMatchObject({ toolCallId: "call-42", type: "tool-call" });
+    expect(result).toMatchObject({
+      toolCallId: "call-42",
+      type: "tool-result",
+    });
+  });
+
+  it("builds user input events", () => {
+    const events: AgentEvent[] = [
+      agentEvent.userText("hello"),
+      agentEvent.userMessage([{ text: "hello", type: "text" }]),
+    ];
+
+    expect(events).toEqual([
+      { text: "hello", type: "user-input" },
+      { content: [{ text: "hello", type: "text" }], type: "user-input" },
+    ]);
+  });
+});
+
+describe("agentEventStream", () => {
+  it("yields the given events in order", async () => {
+    const events: AgentEvent[] = [
+      agentEvent.turnStart(),
+      agentEvent.stepStart(),
+      agentEvent.assistantOutput("hi"),
+      agentEvent.stepEnd(),
+      agentEvent.turnEnd(),
+    ];
+
+    expect(await collectEvents(agentEventStream(events))).toEqual(events);
+  });
+
+  it("yields nothing for an empty sequence", async () => {
+    expect(await collectEvents(agentEventStream([]))).toEqual([]);
+  });
+});
+
+describe("createMockAgentTurn", () => {
+  it("creates a turn that satisfies the public AgentTurn contract", () => {
+    expectTypeOf(createMockAgentTurn([])).toMatchTypeOf<AgentTurn>();
+  });
+
+  it("replays an array of events through events()", async () => {
+    const events: AgentEvent[] = [
+      agentEvent.turnStart(),
+      agentEvent.assistantOutput("hello"),
+      agentEvent.turnEnd(),
+    ];
+    const turn = createMockAgentTurn(events);
+
+    expect(await collectEvents(turn.events())).toEqual(events);
+  });
+
+  it("replays an async iterable source through events()", async () => {
+    const events: AgentEvent[] = [
+      agentEvent.turnStart(),
+      agentEvent.assistantOutput("streamed"),
+      agentEvent.turnEnd(),
+    ];
+    const turn = createMockAgentTurn(agentEventStream(events));
+
+    expect(await collectEvents(turn.events())).toEqual(events);
+  });
+
+  it("propagates errors thrown by the source iterable", async () => {
+    async function* failing(): AsyncIterable<AgentEvent> {
+      yield agentEvent.turnStart();
+      await Promise.resolve();
+      throw new Error("model exploded");
+    }
+    const turn = createMockAgentTurn(failing());
+
+    await expect(collectEvents(turn.events())).rejects.toThrow(
+      "model exploded"
+    );
+  });
+
+  it("is single-consumption like a real AgentTurn", async () => {
+    const turn = createMockAgentTurn([agentEvent.turnStart()]);
+
+    await collectEvents(turn.events());
+
+    expect(() => turn.events()).toThrow(
+      "AgentTurn.events() can only be consumed once"
+    );
+  });
+
+  it("rejects a second events() call even before the first is consumed", () => {
+    const turn = createMockAgentTurn(agentEventStream([]));
+
+    turn.events();
+
+    expect(() => turn.events()).toThrow(
+      "AgentTurn.events() can only be consumed once"
+    );
+  });
+});

--- a/packages/runtime/src/testing/index.ts
+++ b/packages/runtime/src/testing/index.ts
@@ -1,0 +1,8 @@
+// biome-ignore-all lint/performance/noBarrelFile: Subpath entrypoint re-exports the public testing API; callers import named symbols from it.
+// pss-runtime testing: deterministic AgentTurn mocks and typed AgentEvent
+// builders for downstream tests that consume turn event streams. Only the
+// intentional public helpers live here; internal fixtures stay unexported.
+
+export { agentEvent } from "./agent-event-builders";
+export { agentEventStream } from "./agent-event-stream";
+export { createMockAgentTurn } from "./mock-agent-turn";

--- a/packages/runtime/src/testing/mock-agent-turn.ts
+++ b/packages/runtime/src/testing/mock-agent-turn.ts
@@ -1,0 +1,32 @@
+import type { AgentEvent } from "../thread/protocol/events";
+import type { AgentTurn } from "../thread/protocol/turn";
+import { agentEventStream } from "./agent-event-stream";
+
+/**
+ * Creates an `AgentTurn` that replays the given events. Like a real turn,
+ * `events()` is single-consumption: calling it a second time throws.
+ */
+export function createMockAgentTurn(
+  events: readonly AgentEvent[] | AsyncIterable<AgentEvent>
+): AgentTurn {
+  let eventsStarted = false;
+
+  return {
+    events(): AsyncIterable<AgentEvent> {
+      if (eventsStarted) {
+        throw new Error("AgentTurn.events() can only be consumed once");
+      }
+      eventsStarted = true;
+      return isAsyncIterable(events) ? events : agentEventStream(events);
+    },
+  };
+}
+
+function isAsyncIterable(
+  events: readonly AgentEvent[] | AsyncIterable<AgentEvent>
+): events is AsyncIterable<AgentEvent> {
+  return (
+    typeof (events as AsyncIterable<AgentEvent>)[Symbol.asyncIterator] ===
+    "function"
+  );
+}

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     "src/namespace.ts",
     "src/evals/index.ts",
     "src/evals/cli-bin.ts",
+    "src/testing/index.ts",
   ],
   unbundle: true,
   root: "src",


### PR DESCRIPTION
Closes #51

## Summary

Exposes `@minpeter/pss-runtime/testing` as a public subpath, wired exactly like `./evals` (package.json `exports` + `tsdown.config.ts` entry). The surface is intentionally minimal — three helpers:

- **`createMockAgentTurn(events)`** — builds an `AgentTurn` from an `AgentEvent[]` or `AsyncIterable<AgentEvent>`. Like the real turn, `events()` is single-consumption: a second call throws `AgentTurn.events() can only be consumed once`, and source-iterable errors propagate to the consumer.
- **`agentEventStream(events)`** — async generator that replays an event array as a deterministic `AsyncIterable<AgentEvent>` (same shape as the existing internal `eventStream` test helper).
- **`agentEvent`** — typed builders for public `AgentEvent` payloads: `assistantOutput(text)`, `assistantReasoning(text)`, `stepStart()` / `stepEnd()`, `turnStart()` / `turnEnd()` / `turnAbort()` / `turnError(message)`, `toolCall(toolName, input?, toolCallId?)` / `toolResult(toolName, output?, toolCallId?)` (default id: `<toolName>-call`), plus `userText` / `userMessage` promoted from the existing internal `input-fixtures`.

```ts
import { createMockAgentTurn, agentEvent } from "@minpeter/pss-runtime/testing";
```

Internal-only fixtures (`llm-test-utils`, `model-fixtures`, `mock-language-model-v4-test-utils`, the `test-fixtures` compat barrel, `createScriptedModel`, `eventTypes`) are **not** exported — they are vitest/`ai/test`-bound or driftable one-liners, and the issue scopes this to a small AgentTurn/event helper surface.

Also extends `src/contracts/package-subpaths.test.ts` to assert the `./testing` exports entry, and adds a tegami entry (minor bump for `@minpeter/pss-runtime`).

## Test plan

- [x] `pnpm install` — clean
- [x] `pnpm --filter @minpeter/pss-runtime build` — `dist/testing/` emitted
- [x] `pnpm --filter @minpeter/pss-runtime test` — 111 files, 626 passed, 3 skipped (includes 13 new tests for the public helpers)
- [x] `pnpm typecheck` (repo) — 10/10 turbo tasks + root `tsc --noEmit`
- [x] `pnpm exec ultracite check` on changed files — no findings
- [x] `pnpm build` (repo) then `pnpm verify:release` — "Release artifact verification passed"
- [x] `pnpm boundaries` — no issues
- [x] Node smoke test importing `@minpeter/pss-runtime/testing` through the real exports map — replays events in order; second `events()` call throws the single-consumption error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes `@minpeter/pss-runtime/testing` as a public subpath for deterministic AgentTurn testing. Adds minimal helpers to build event streams and mock turns, and wires the subpath in `exports` and `tsdown.config.ts`.

- **New Features**
  - Public subpath: `@minpeter/pss-runtime/testing`.
  - `createMockAgentTurn(events)`: builds an `AgentTurn` from an array or `AsyncIterable`; `events()` is single-consumption.
  - `agentEventStream(events)`: async generator that replays events in order.
  - `agentEvent`: typed builders (assistant output/reasoning, step start/end, turn start/end/abort/error, tool call/result with default id, user text/message).
  - Internal fixtures remain unexported; tests added to validate the subpath and helper behavior.

<sup>Written for commit 7df1cfde5bbc4bf6f6c1545b4aaff21a9ac7d6af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

