### PR TITLE
feat(runtime): add minimal channel adapter contract subpath

### DIFF
--- a/.tegami/2026-07-19-channel-adapter-contract.md
+++ b/.tegami/2026-07-19-channel-adapter-contract.md
@@ -1,0 +1,15 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: minor
+---
+
+## Add the app-owned channel adapter contract
+
+Expose `@minpeter/pss-runtime/channel` with typed inbound channel messages and
+assistant text deliveries. Apps retain ownership of provider mapping, the
+`Agent -> Thread -> Turn -> events()` control flow, and outbound delivery.
+
+`projectChannelAssistantDelivery(event)` projects only non-empty
+`assistant-output` events. The runtime does not add provider adapters or own a
+channel loop.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -366,6 +366,66 @@ for await (const event of turn.events()) {
 
 `agent.send(...)` is shorthand for `agent.thread("default").send(...)`.
 
+## Channel adapters
+
+`@minpeter/pss-runtime/channel` is a minimal boundary for app-owned channel
+integrations. It exports only the `ChannelInboundMessage`,
+`ChannelAssistantTextDelivery`, and `ChannelAssistantDelivery` types plus
+`projectChannelAssistantDelivery(event)`. Apps map provider-specific inbound
+data to the runtime contract and own delivery back to the provider:
+
+```ts
+import type { Agent } from "@minpeter/pss-runtime";
+import {
+  projectChannelAssistantDelivery,
+  type ChannelAssistantDelivery,
+  type ChannelInboundMessage,
+} from "@minpeter/pss-runtime/channel";
+
+interface ChatMessage {
+  readonly roomId: string;
+  readonly text: string;
+  readonly userId: string;
+}
+
+function toChannelInbound(message: ChatMessage): ChannelInboundMessage {
+  return {
+    input: message.text,
+    threadKey: { key: message.userId, scope: message.roomId },
+  };
+}
+
+async function handleChannelMessage(
+  agent: Agent,
+  message: ChatMessage
+): Promise<void> {
+  const inbound = toChannelInbound(message);
+  const turn = await agent.thread(inbound.threadKey).send(inbound.input);
+
+  for await (const event of turn.events()) {
+    const delivery = projectChannelAssistantDelivery(event);
+    if (delivery !== undefined) {
+      await deliverToChannel(message.roomId, delivery);
+    }
+  }
+}
+
+async function deliverToChannel(
+  roomId: string,
+  delivery: ChannelAssistantDelivery
+): Promise<void> {
+  // App-owned provider call.
+  await chatClient.post(roomId, delivery.text);
+}
+```
+
+The projector emits a delivery only for an `assistant-output` event containing
+non-whitespace text, and it preserves the original text. Other visible,
+lifecycle, tool, telemetry, and control events remain available through
+`turn.events()` but are not delivered by default. The runtime provides no
+provider adapters and never owns a channel loop; control flow remains
+`Agent -> Thread -> Turn -> events()`.
+
 ## Plugins
 
 Plugins are async factories. The public plugin kernel stays fixed at `on()` for

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -46,6 +46,11 @@
       "types": "./dist/evals/index.d.ts",
       "import": "./dist/evals/index.js"
     },
+    "./channel": {
+      "@minpeter/pss-source": "./src/channel/index.ts",
+      "types": "./dist/channel/index.d.ts",
+      "import": "./dist/channel/index.js"
+    },
     "./testing": {
       "@minpeter/pss-source": "./src/testing/index.ts",
       "types": "./dist/testing/index.d.ts",

--- a/packages/runtime/src/channel/index.ts
+++ b/packages/runtime/src/channel/index.ts
@@ -1,0 +1,24 @@
+// biome-ignore-all lint/performance/noBarrelFile: Public package subpath entrypoint required by package exports.
+import type { AgentEvent, AgentInput, ThreadKey } from "../index";
+
+export interface ChannelInboundMessage {
+  readonly input: AgentInput;
+  readonly threadKey: ThreadKey;
+}
+
+export interface ChannelAssistantTextDelivery {
+  readonly text: string;
+  readonly type: "assistant-text";
+}
+
+export type ChannelAssistantDelivery = ChannelAssistantTextDelivery;
+
+export function projectChannelAssistantDelivery(
+  event: AgentEvent
+): ChannelAssistantDelivery | undefined {
+  if (event.type !== "assistant-output" || event.text.trim().length === 0) {
+    return;
+  }
+
+  return { text: event.text, type: "assistant-text" };
+}

--- a/packages/runtime/src/contracts/channel-api.test.ts
+++ b/packages/runtime/src/contracts/channel-api.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  type ChannelAssistantDelivery,
+  type ChannelAssistantTextDelivery,
+  type ChannelInboundMessage,
+  projectChannelAssistantDelivery,
+} from "../channel";
+import type { AgentEvent, AgentInput, ThreadKey } from "../index";
+
+describe("runtime channel subpath", () => {
+  it("exports only the channel delivery projector at runtime", async () => {
+    const channel = await import("../channel");
+
+    expect(Object.keys(channel)).toEqual(["projectChannelAssistantDelivery"]);
+  });
+
+  it("types the app-owned inbound and delivery contracts", () => {
+    expectTypeOf<ChannelInboundMessage>().toEqualTypeOf<{
+      readonly input: AgentInput;
+      readonly threadKey: ThreadKey;
+    }>();
+    expectTypeOf<ChannelAssistantTextDelivery>().toEqualTypeOf<{
+      readonly text: string;
+      readonly type: "assistant-text";
+    }>();
+    expectTypeOf<ChannelAssistantDelivery>().toEqualTypeOf<ChannelAssistantTextDelivery>();
+    expectTypeOf<
+      Parameters<typeof projectChannelAssistantDelivery>[0]
+    >().toEqualTypeOf<AgentEvent>();
+    expectTypeOf<
+      ReturnType<typeof projectChannelAssistantDelivery>
+    >().toEqualTypeOf<ChannelAssistantDelivery | undefined>();
+  });
+
+  it("projects non-empty assistant output without changing its text", () => {
+    expect(
+      projectChannelAssistantDelivery({
+        text: " visible reply ",
+        type: "assistant-output",
+      })
+    ).toEqual({ text: " visible reply ", type: "assistant-text" });
+  });
+
+  it("ignores empty assistant output and every non-output event", () => {
+    const ignoredEvents = [
+      { type: "turn-start" },
+      { type: "step-start" },
+      { attemptId: "attempt-1", type: "model-usage" },
+      { text: "thinking", type: "assistant-reasoning" },
+      { text: "user said hi", type: "user-input" },
+      {
+        input: { text: "runtime says continue", type: "user-input" },
+        placement: "turn-start",
+        type: "runtime-input",
+      },
+      {
+        input: { city: "Seoul" },
+        toolCallId: "call-1",
+        toolName: "weather",
+        type: "tool-call",
+      },
+      {
+        output: { ok: true },
+        toolCallId: "call-1",
+        toolName: "weather",
+        type: "tool-result",
+      },
+      { type: "step-end" },
+      { message: "failed", type: "turn-error" },
+      { type: "turn-abort" },
+      { type: "turn-end" },
+      { text: "", type: "assistant-output" },
+      { text: "   ", type: "assistant-output" },
+    ] satisfies readonly AgentEvent[];
+
+    expect(ignoredEvents.map(projectChannelAssistantDelivery)).toEqual(
+      ignoredEvents.map(() => undefined)
+    );
+  });
+});

--- a/packages/runtime/src/contracts/package-subpaths.test.ts
+++ b/packages/runtime/src/contracts/package-subpaths.test.ts
@@ -77,6 +77,16 @@ describe("runtime package subpaths", () => {
     expect(packageJson.exports["./node"]).toBeUndefined();
   });
 
+  it("declares the channel adapter contract subpath", async () => {
+    const packageJson = await readRuntimePackageJson();
+
+    expect(packageJson.exports["./channel"]).toMatchObject({
+      "@minpeter/pss-source": "./src/channel/index.ts",
+      import: "./dist/channel/index.js",
+      types: "./dist/channel/index.d.ts",
+    });
+  });
+
   it("declares the testing subpath for AgentTurn test helpers", async () => {
     const packageJson = await readRuntimePackageJson();
 

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -58,6 +58,12 @@ const forbiddenModelAdapterRootExports = [
   ["Runtime", "Llm", "Output", "Part"].join(""),
   ["create", "Llm"].join(""),
 ] as const;
+const forbiddenChannelRootExports = [
+  ["Channel", "Inbound", "Message"].join(""),
+  ["Channel", "Assistant", "Text", "Delivery"].join(""),
+  ["Channel", "Assistant", "Delivery"].join(""),
+  ["project", "Channel", "Assistant", "Delivery"].join(""),
+] as const;
 
 describe("runtime public exports", () => {
   it("does not expose internal agent loop runner from package root", async () => {
@@ -124,6 +130,14 @@ describe("runtime public exports", () => {
     const runtime = await import("../index");
 
     for (const forbiddenName of forbiddenModelAdapterRootExports) {
+      expect(runtime).not.toHaveProperty(forbiddenName);
+    }
+  });
+
+  it("keeps channel adapter contracts off the package root", async () => {
+    const runtime = await import("../index");
+
+    for (const forbiddenName of forbiddenChannelRootExports) {
       expect(runtime).not.toHaveProperty(forbiddenName);
     }
   });

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     "src/namespace.ts",
     "src/evals/index.ts",
     "src/evals/cli-bin.ts",
+    "src/channel/index.ts",
     "src/testing/index.ts",
   ],
   unbundle: true,

--- a/scripts/verify-release-artifacts-runtime-subpaths.test.mjs
+++ b/scripts/verify-release-artifacts-runtime-subpaths.test.mjs
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { verifyReleaseArtifacts } from "./verify-release-artifacts/core.mjs";
 import {
+  REQUIRED_RUNTIME_CHANNEL_EXPORTS,
   REQUIRED_RUNTIME_CLOUDFLARE_AGENTS_EXPORTS,
   REQUIRED_RUNTIME_CLOUDFLARE_WORKER_EXPORTS,
   REQUIRED_RUNTIME_EXECUTION_EXPORTS,
@@ -20,6 +21,27 @@ function runtimeDistDeclaration(cwd, ...segments) {
 }
 
 describe("verifyReleaseArtifacts runtime subpath checks", () => {
+  it("requires the runtime channel declaration entrypoint", () => {
+    const cwd = createFixture();
+    rmSync(runtimeDistDeclaration(cwd, "channel"));
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
+      "packages/runtime/dist/channel/index.d.ts: missing channel runtime declaration",
+    ]);
+  });
+
+  it("checks the channel contract on its declaration subpath", () => {
+    const cwd = createFixture();
+    writeFileSync(runtimeDistDeclaration(cwd, "channel"), "export {};\n");
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual(
+      REQUIRED_RUNTIME_CHANNEL_EXPORTS.map(
+        (name) =>
+          `packages/runtime/dist/channel/index.d.ts: missing explicit channel runtime export ${name}`
+      )
+    );
+  });
+
   it("requires the runtime execution declaration entrypoint", () => {
     const cwd = createFixture();
     rmSync(join(cwd, "packages", "runtime", "dist", "execution", "index.d.ts"));

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -10,6 +10,11 @@ export const runtimeRootDeclaration = [
   'export type { AgentTurn, RuntimeInput } from "./thread";',
   "",
 ].join("\n");
+export const runtimeChannelDeclaration = [
+  'export type { ChannelInboundMessage, ChannelAssistantTextDelivery, ChannelAssistantDelivery } from "./index";',
+  'export { projectChannelAssistantDelivery } from "./index";',
+  "",
+].join("\n");
 export const runtimeExecutionDeclaration = [
   'export type { AdmitReceipt, AdmitThreadInput, CheckpointStore, ClaimedThreadInput, ClaimThreadInputOptions, EventStore, AgentHost, HostScheduler, HostStore, HostStoreTransaction, NotificationInbox, NotificationRecord, RecoverThreadInputClaimsResult, ThreadInputBoundary, ThreadInputInbox, ThreadInputKind, ThreadInputPlacement, ThreadInputRecord, ThreadInputStatus, TurnRecord, TurnStatus, TurnStore } from "./types";',
   'export { threadStoreFromHost } from "./host";',
@@ -120,6 +125,13 @@ function writePackageDeclarationFixtures(cwd, packageName, packageRoot) {
 }
 
 function writeRuntimeDeclarationFixtures(cwd, packageName) {
+  mkdirSync(join(cwd, "packages", packageName, "dist", "channel"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(cwd, "packages", packageName, "dist", "channel", "index.d.ts"),
+    runtimeChannelDeclaration
+  );
   mkdirSync(join(cwd, "packages", packageName, "dist", "execution"), {
     recursive: true,
   });

--- a/scripts/verify-release-artifacts/runtime-checks.mjs
+++ b/scripts/verify-release-artifacts/runtime-checks.mjs
@@ -5,6 +5,7 @@ import {
   FORBIDDEN_RUNTIME_PUBLIC_PATTERNS,
   FORBIDDEN_RUNTIME_ROOT_NAMES,
   FORBIDDEN_RUNTIME_SUBAGENT_NAMES,
+  REQUIRED_RUNTIME_CHANNEL_EXPORTS,
   REQUIRED_RUNTIME_CLOUDFLARE_EXPORTS,
   REQUIRED_RUNTIME_EXECUTION_EXPORTS,
   REQUIRED_RUNTIME_FILE_EXPORTS,
@@ -26,6 +27,12 @@ export function findRuntimeDeclarationLeaks({ cwd, packages }) {
       file: join(packageDistPath(cwd, "runtime"), "index.d.ts"),
       requiredExports: REQUIRED_RUNTIME_ROOT_EXPORTS,
       surface: "root",
+    }),
+    ...findRuntimeDeclarationExportLeaks({
+      cwd,
+      file: join(packageDistPath(cwd, "runtime"), "channel", "index.d.ts"),
+      requiredExports: REQUIRED_RUNTIME_CHANNEL_EXPORTS,
+      surface: "channel",
     }),
     ...findRuntimeDeclarationExportLeaks({
       cwd,

--- a/scripts/verify-release-artifacts/runtime-public-surface.mjs
+++ b/scripts/verify-release-artifacts/runtime-public-surface.mjs
@@ -4,6 +4,13 @@ export const REQUIRED_RUNTIME_ROOT_EXPORTS = [
   "RuntimeInput",
 ];
 
+export const REQUIRED_RUNTIME_CHANNEL_EXPORTS = [
+  "ChannelInboundMessage",
+  "ChannelAssistantTextDelivery",
+  "ChannelAssistantDelivery",
+  "projectChannelAssistantDelivery",
+];
+
 export const REQUIRED_RUNTIME_EXECUTION_EXPORTS = [
   "AdmitReceipt",
   "AdmitThreadInput",
@@ -185,6 +192,7 @@ export const FORBIDDEN_RUNTIME_ROOT_NAMES = [
     ...REQUIRED_RUNTIME_CLOUDFLARE_WORKER_EXPORTS,
     ...REQUIRED_RUNTIME_FILE_EXPORTS,
     ...REQUIRED_RUNTIME_MEMORY_EXPORTS,
+    ...REQUIRED_RUNTIME_CHANNEL_EXPORTS,
     ["create", "Llm"].join(""),
     ["Runtime", "Create", "Llm", "Options"].join(""),
     ["Runtime", "Llm"].join(""),


### PR DESCRIPTION
## Summary

- add the new `@minpeter/pss-runtime/channel` subpath
- expose only `ChannelInboundMessage`, `ChannelAssistantTextDelivery`, `ChannelAssistantDelivery`, and `projectChannelAssistantDelivery(event)`
- project non-whitespace `assistant-output` text while leaving provider mapping, `Agent -> Thread -> Turn -> events()` control flow, and outbound delivery app-owned
- verify the source, package export, built declaration surface, package-root exclusion, and release artifacts

## RED -> GREEN evidence

Before production code, the focused contract run failed as intended:

- `src/contracts/channel-api.test.ts`: `Cannot find module '../channel'`
- `src/contracts/package-subpaths.test.ts`: expected `./channel`, received `undefined`
- result: 2 failed files, 1 failed test, 16 passed tests

After the minimal implementation and export wiring:

- focused contracts: 3 passed files, 21 passed tests
- full runtime suite: 114 passed files, 726 passed tests, 3 skipped

## Test plan

- [x] `pnpm install`
- [x] `pnpm --filter @minpeter/pss-runtime build`
- [x] `pnpm --filter @minpeter/pss-runtime test`
- [x] `pnpm typecheck`
- [x] `pnpm exec ultracite check` on all changed files
- [x] `pnpm exec vitest run scripts/runtime-docs.test.mjs scripts/tegami-config.test.mjs scripts/verify-release-artifacts-runtime-subpaths.test.mjs`
- [x] `pnpm --filter @minpeter/pss-coding-agent build` (fresh-worktree prerequisite for the repository release verifier)
- [x] `node scripts/verify-release-artifacts.mjs`

Closes #160


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@minpeter/pss-runtime/channel`, a minimal channel adapter contract for app-owned provider integrations. It exposes typed inbound messages and assistant text delivery, plus `projectChannelAssistantDelivery(...)` which emits only non‑whitespace assistant output.

- **New Features**
  - Exported `ChannelInboundMessage`, `ChannelAssistantTextDelivery`, `ChannelAssistantDelivery`, and `projectChannelAssistantDelivery` from `@minpeter/pss-runtime/channel`.
  - Projector preserves text and ignores empty or non-output events.
  - Keeps channel types off the package root; added tests and release checks for the new subpath.
  - Updated README with a small example for mapping and delivery.

<sup>Written for commit 1b5da97c04e550131ce0c11e9cf15b8dd5596985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

