### PR TITLE
feat(runtime): add OpenTelemetry trace adapter + turn instrumentations

### DIFF
--- a/.tegami/2026-07-19-otel-trace-adapter.md
+++ b/.tegami/2026-07-19-otel-trace-adapter.md
@@ -1,0 +1,17 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: minor
+---
+
+## Add OpenTelemetry turn tracing
+
+Add the `@minpeter/pss-runtime/otel` subpath with `traceAgentTurn()` for one
+turn and `openTelemetry()` for agent-wide instrumentation. Record turn, step,
+and tool spans plus metadata-only runtime events through
+`@opentelemetry/api`, leaving SDK and exporter configuration to applications.
+
+Expose general `AgentOptions.instrumentations` hooks for send, steer, and
+resume operations. Wrapped turns preserve single-consumption and pass through
+every original event, including model-usage telemetry, while payload summaries
+avoid raw content and do not invoke `toJSON()`.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -551,6 +551,46 @@ gate is indeterminate and fails when a selected post-warmup run emits
 replayed `model-usage` record reuses an `attemptId`. Duplicate records are
 reported but never counted as additional samples or token totals.
 
+## OpenTelemetry
+
+The OpenTelemetry adapter is published separately from the runtime root. Add
+`openTelemetry()` to `instrumentations` to trace every turn returned by an
+agent:
+
+```ts
+import { createAgent } from "@minpeter/pss-runtime";
+import { openTelemetry } from "@minpeter/pss-runtime/otel";
+
+const agent = await createAgent({
+  instrumentations: [
+    openTelemetry({
+      spanAttributes: { "app.agent": "support" },
+      tracerName: "my-app",
+    }),
+  ],
+  model,
+});
+```
+
+`openTelemetry()` records `pss.runtime.turn`, `pss.runtime.step`, and
+`pss.runtime.tool` spans with `pss.runtime.event` events. Applications configure
+their own OpenTelemetry SDK, processors, and exporters; this package depends
+only on `@opentelemetry/api`. Use `traceAgentTurn(turn, options)` from the same
+subpath to wrap one turn manually.
+
+The first-party attributes are metadata-only. User and assistant content is
+summarized by part count and text length, tool payloads by JavaScript type and
+item/key count, and errors by sanitized status. There is no built-in
+raw-payload capture mode. The wrapper passes every original event through unchanged, including
+`model-usage`, and preserves the turn's single-consumption `events()` contract.
+Stopping iteration calls the source iterator's `return()` and closes all open
+spans.
+
+Agent instrumentations run for `send`, `steer`, and durable `resume` turns.
+Custom `AgentInstrumentation.wrapTurn(turn, context)` implementations receive
+the operation, canonical thread key, optional agent namespace, and the durable
+run ID for resume operations.
+
 ## Delegation
 
 Delegation is app-owned. Build ordinary tools that call another `Agent`,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,6 +11,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./otel": {
+      "@minpeter/pss-source": "./src/otel/index.ts",
+      "types": "./dist/otel/index.d.ts",
+      "import": "./dist/otel/index.js"
+    },
     "./platform/memory": {
       "@minpeter/pss-source": "./src/platform/memory/index.ts",
       "types": "./dist/platform/memory/index.d.ts",
@@ -81,6 +86,7 @@
   "dependencies": {
     "@jsquash/avif": "^2.1.1",
     "@jsquash/webp": "^1.5.0",
+    "@opentelemetry/api": "^1.9.1",
     "ai": "7.0.30",
     "fast-png": "^8.0.0",
     "heic-decode": "^2.1.0",

--- a/packages/runtime/src/agent/core/agent.test.ts
+++ b/packages/runtime/src/agent/core/agent.test.ts
@@ -5,7 +5,13 @@ import {
   createMockLanguageModelV4,
   mockLanguageModelV4Text,
 } from "../../testing/mock-language-model-v4-test-utils";
-import { Agent, type AgentOptions, createAgent } from "./agent";
+import {
+  Agent,
+  type AgentInstrumentation,
+  type AgentInstrumentationContext,
+  type AgentOptions,
+  createAgent,
+} from "./agent";
 import { threadStoreKey } from "./thread-entry";
 
 const fakeModel = createMockLanguageModelV4([mockLanguageModelV4Text("DONE")]);
@@ -121,6 +127,40 @@ describe("Agent", () => {
   it("uses the default thread for agent.send", async () => {
     const agent = new Agent({ model: fakeModel });
     await expect(agent.send("hello")).resolves.toBeDefined();
+  });
+
+  it("wraps send and steer turns with operation context", async () => {
+    const contexts: AgentInstrumentationContext[] = [];
+    const instrumentation: AgentInstrumentation = {
+      wrapTurn: (turn, context) => {
+        contexts.push(context);
+        return turn;
+      },
+    };
+    const agent = new Agent({
+      instrumentations: [instrumentation],
+      model: createMockLanguageModelV4(() =>
+        Promise.resolve(mockLanguageModelV4Text("DONE"))
+      ),
+      namespace: "support",
+    });
+    const thread = agent.thread("customer-1");
+
+    await collectRun(await thread.send("hello"));
+    await collectRun(await thread.steer("one more thing"));
+
+    expect(contexts).toEqual([
+      {
+        namespace: "support",
+        operation: "send",
+        threadKey: "customer-1",
+      },
+      {
+        namespace: "support",
+        operation: "steer",
+        threadKey: "customer-1",
+      },
+    ]);
   });
 
   it("reuses handles for named threads", () => {

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -9,6 +9,12 @@ import { stableAgentNamespace } from "../identity/namespace";
 import { resumeAgentTurn } from "../resume/resume";
 import { threadStoreForHost } from "./host-thread-store";
 import {
+  type AgentInstrumentation,
+  type AgentInstrumentationContext,
+  applyAgentInstrumentations,
+  normalizeAgentInstrumentations,
+} from "./instrumentation";
+import {
   type AgentAutoCompactionOptions,
   type AgentModelOptions,
   type AgentOptions,
@@ -26,6 +32,11 @@ import {
 
 export type { AgentHost } from "../../execution/host/types";
 export type { ThreadCompactionInput } from "../../thread/handle/thread";
+export type {
+  AgentInstrumentation,
+  AgentInstrumentationContext,
+  AgentInstrumentationOperation,
+} from "./instrumentation";
 export type {
   AgentAutoCompactionOptions,
   AgentOptions,
@@ -47,6 +58,7 @@ export class Agent {
   readonly #ownerNamespace: string;
   readonly #store: ThreadStore;
   readonly #host: AgentHost;
+  readonly #instrumentations: readonly AgentInstrumentation[];
   readonly #pluginRuntime?: PluginRuntime;
   readonly #notificationOverlays?: AgentOptions["notificationOverlays"];
   readonly #autoCompaction?: AgentAutoCompactionOptions;
@@ -63,6 +75,9 @@ export class Agent {
     this.#host = providedHost ?? createInMemoryHost();
     this.host = this.#host;
     this.#store = threadStoreForHost(this.#host);
+    this.#instrumentations = normalizeAgentInstrumentations(
+      options.instrumentations
+    );
     this.#pluginRuntime = pluginRuntime;
     this.#notificationOverlays = options.notificationOverlays;
     this.#autoCompaction = normalizeAgentAutoCompactionOptions(
@@ -114,7 +129,7 @@ export class Agent {
       host: this.#host,
       ownerNamespace: this.#ownerNamespace,
       resumeNotification: (notification) =>
-        this.#resumeNotification(notification),
+        this.#resumeNotification(notification, runId),
       runId,
     });
   }
@@ -180,8 +195,18 @@ export class Agent {
         thread.overlay(input);
         return publicHandle;
       },
-      send: (input) => thread.send(input),
-      steer: (input) => thread.steer(input),
+      send: async (input) =>
+        this.#instrumentTurn(await thread.send(input), {
+          namespace: this.namespace,
+          operation: "send",
+          threadKey: key,
+        }),
+      steer: async (input) =>
+        this.#instrumentTurn(await thread.steer(input), {
+          namespace: this.namespace,
+          operation: "steer",
+          threadKey: key,
+        }),
     };
     const entry: AgentThreadEntry = {
       notify: (input, options) => thread.notify(input, options),
@@ -195,8 +220,11 @@ export class Agent {
     this.#threads.delete(key);
   }
 
-  #resumeNotification(notification: NotificationRecord): Promise<AgentTurn> {
-    return this.#threadEntry(notification.threadKey).notify(
+  async #resumeNotification(
+    notification: NotificationRecord,
+    runId: string
+  ): Promise<AgentTurn> {
+    const turn = await this.#threadEntry(notification.threadKey).notify(
       notification.input,
       {
         observerEvents: notification.observerEvents,
@@ -206,6 +234,19 @@ export class Agent {
         ],
       }
     );
+    return this.#instrumentTurn(turn, {
+      namespace: this.namespace,
+      operation: "resume",
+      runId,
+      threadKey: notification.threadKey,
+    });
+  }
+
+  #instrumentTurn(
+    turn: AgentTurn,
+    context: AgentInstrumentationContext
+  ): AgentTurn {
+    return applyAgentInstrumentations(turn, this.#instrumentations, context);
   }
 }
 

--- a/packages/runtime/src/agent/core/instrumentation.ts
+++ b/packages/runtime/src/agent/core/instrumentation.ts
@@ -1,0 +1,70 @@
+import type { AgentTurn } from "../../thread/protocol/turn";
+
+export type AgentInstrumentationOperation = "resume" | "send" | "steer";
+
+export interface AgentInstrumentationContext {
+  readonly namespace?: string;
+  readonly operation: AgentInstrumentationOperation;
+  readonly runId?: string;
+  readonly threadKey: string;
+}
+
+export interface AgentInstrumentation {
+  wrapTurn(turn: AgentTurn, context: AgentInstrumentationContext): AgentTurn;
+}
+
+export function normalizeAgentInstrumentations(
+  value: unknown
+): readonly AgentInstrumentation[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new TypeError("Agent: options.instrumentations must be an array.");
+  }
+
+  const instrumentations = [...value];
+  for (const instrumentation of instrumentations) {
+    assertAgentInstrumentation(instrumentation);
+  }
+  return Object.freeze(instrumentations);
+}
+
+export function applyAgentInstrumentations(
+  turn: AgentTurn,
+  instrumentations: readonly AgentInstrumentation[],
+  context: AgentInstrumentationContext
+): AgentTurn {
+  let wrapped = turn;
+  for (const instrumentation of instrumentations) {
+    wrapped = instrumentation.wrapTurn(wrapped, context);
+    assertAgentTurn(wrapped);
+  }
+  return wrapped;
+}
+
+function assertAgentInstrumentation(
+  value: unknown
+): asserts value is AgentInstrumentation {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    typeof (value as { readonly wrapTurn?: unknown }).wrapTurn !== "function"
+  ) {
+    throw new TypeError(
+      "Agent: each options.instrumentations entry must provide wrapTurn()."
+    );
+  }
+}
+
+function assertAgentTurn(value: unknown): asserts value is AgentTurn {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    typeof (value as { readonly events?: unknown }).events !== "function"
+  ) {
+    throw new TypeError(
+      "Agent: options.instrumentations entry wrapTurn() must return an AgentTurn."
+    );
+  }
+}

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -7,6 +7,10 @@ import type { PluginDefinition } from "../../plugins/api";
 import type { RuntimeDiagnosticsSink } from "../../plugins/diagnostics";
 import type { HostAttachmentStore } from "../../thread/input/attachments";
 import type { AgentInput, UserInput } from "../../thread/input/input";
+import {
+  type AgentInstrumentation,
+  normalizeAgentInstrumentations,
+} from "./instrumentation";
 
 export interface AgentAutoCompactionOptions {
   readonly background?: boolean;
@@ -23,6 +27,7 @@ export interface AgentOptions {
   readonly autoCompaction?: AgentAutoCompactionOptions | false;
   readonly host?: AgentHost;
   readonly instructions?: string;
+  readonly instrumentations?: readonly AgentInstrumentation[];
   readonly model: LanguageModel;
   readonly namespace?: string;
   readonly notificationOverlays?: readonly (AgentInput | UserInput)[];
@@ -93,6 +98,7 @@ export function assertAgentOptions(
   const candidate = options as {
     readonly alwaysActiveTools?: AgentOptions["alwaysActiveTools"];
     readonly autoCompaction?: AgentOptions["autoCompaction"];
+    readonly instrumentations?: AgentOptions["instrumentations"];
     readonly prepareModelStep?: AgentOptions["prepareModelStep"];
     readonly toolOrder?: AgentOptions["toolOrder"];
     readonly tools?: AgentOptions["tools"];
@@ -107,6 +113,7 @@ export function assertAgentOptions(
     throw new TypeError("Agent: options.prepareModelStep must be a function.");
   }
   normalizeAgentAutoCompactionOptions(candidate.autoCompaction);
+  normalizeAgentInstrumentations(candidate.instrumentations);
 }
 
 function assertToolNameList(

--- a/packages/runtime/src/agent/resume/notification-resume.test.ts
+++ b/packages/runtime/src/agent/resume/notification-resume.test.ts
@@ -8,7 +8,7 @@ import {
   userText,
 } from "../../testing/test-fixtures";
 import { collect } from "../../thread/handle/test-support";
-import { Agent } from "../core/agent";
+import { Agent, type AgentInstrumentationContext } from "../core/agent";
 import { agentNamespace } from "../identity/namespace";
 import {
   createThreadLoadFailingHost,
@@ -20,9 +20,18 @@ describe("host notification resume", () => {
   it("host resumes parent notification run once without direct prompt resume surface", async () => {
     const host = createInMemoryHost();
     const seenHistory: ModelMessage[][] = [];
+    const instrumentationContexts: AgentInstrumentationContext[] = [];
     let calls = 0;
     const agent = new Agent({
       host,
+      instrumentations: [
+        {
+          wrapTurn: (turn, context) => {
+            instrumentationContexts.push(context);
+            return turn;
+          },
+        },
+      ],
       model: createCallbackModel(({ history }) => {
         calls += 1;
         seenHistory.push([...history]);
@@ -72,6 +81,14 @@ describe("host notification resume", () => {
       "assistant-output",
       "step-end",
       "turn-end",
+    ]);
+    expect(instrumentationContexts).toEqual([
+      {
+        namespace: "notify-owner",
+        operation: "resume",
+        runId: notification.runId,
+        threadKey: "default",
+      },
     ]);
     expect(seenHistory).toHaveLength(1);
     expect(JSON.stringify(seenHistory[0])).toContain("bg_1");

--- a/packages/runtime/src/contracts/package-subpaths.test.ts
+++ b/packages/runtime/src/contracts/package-subpaths.test.ts
@@ -77,6 +77,22 @@ describe("runtime package subpaths", () => {
     expect(packageJson.exports["./node"]).toBeUndefined();
   });
 
+  it("declares the OpenTelemetry observability subpath", async () => {
+    const packageJson = await readRuntimePackageJson();
+    const root = await import("../index");
+    const otel = await import("../otel");
+
+    expect(packageJson.exports["./otel"]).toMatchObject({
+      "@minpeter/pss-source": "./src/otel/index.ts",
+      import: "./dist/otel/index.js",
+      types: "./dist/otel/index.d.ts",
+    });
+    expect(otel).toHaveProperty("openTelemetry");
+    expect(otel).toHaveProperty("traceAgentTurn");
+    expect(root).not.toHaveProperty("openTelemetry");
+    expect(root).not.toHaveProperty("traceAgentTurn");
+  });
+
   it("declares the testing subpath for AgentTurn test helpers", async () => {
     const packageJson = await readRuntimePackageJson();
 

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -19,6 +19,9 @@ import type {
   AgentAutoCompactionOptions,
   AgentEvent,
   AgentInput,
+  AgentInstrumentation,
+  AgentInstrumentationContext,
+  AgentInstrumentationOperation,
   AgentOptions,
   CompactionContextMessage,
   HostAttachmentStore,
@@ -39,6 +42,7 @@ import {
   threadStoreKey as runtimeThreadStoreKey,
   ThreadEventReplayUnsupportedError,
 } from "../index";
+import type { TraceAgentTurnOptions } from "../otel";
 
 type EmptyHostIsRejected =
   Record<string, never> extends AgentHost ? true : false;
@@ -139,9 +143,19 @@ describe("runtime public exports", () => {
     } satisfies AgentAutoCompactionOptions;
     const model = {} as AgentOptions["model"];
     const attachmentStore = {} as HostAttachmentStore;
+    const instrumentation = {
+      wrapTurn: (turn, context) => {
+        expectTypeOf(context).toEqualTypeOf<AgentInstrumentationContext>();
+        expectTypeOf(
+          context.operation
+        ).toEqualTypeOf<AgentInstrumentationOperation>();
+        return turn;
+      },
+    } satisfies AgentInstrumentation;
     const enabledOptions = {
       attachmentStore,
       autoCompaction,
+      instrumentations: [instrumentation],
       model,
       notificationOverlays: ["runtime context"],
     } satisfies AgentOptions;
@@ -188,10 +202,22 @@ describe("runtime public exports", () => {
     >().toEqualTypeOf<string>();
     expect(enabledOptions.autoCompaction).toEqual(autoCompaction);
     expect(enabledOptions.attachmentStore).toBe(attachmentStore);
+    expect(enabledOptions.instrumentations).toEqual([instrumentation]);
     expect(enabledOptions.notificationOverlays).toEqual(["runtime context"]);
     expect(disabledOptions.autoCompaction).toBe(false);
     expect(compaction.startSeq).toBe(0);
     expect(contextCompaction.role).toBe("compaction");
+  });
+
+  it("types OpenTelemetry adapter options from its subpath", () => {
+    const options = {
+      eventAttributes: (event: AgentEvent) => ({
+        "app.event_type": event.type,
+      }),
+      tracerName: "support-agent",
+    } satisfies TraceAgentTurnOptions;
+
+    expect(options.tracerName).toBe("support-agent");
   });
 
   it("exports cache-stable model-step contracts from the package root", async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,9 @@
 export {
   type Agent,
   type AgentAutoCompactionOptions,
+  type AgentInstrumentation,
+  type AgentInstrumentationContext,
+  type AgentInstrumentationOperation,
   type AgentOptions,
   type CreateAgentOptions,
   createAgent,

--- a/packages/runtime/src/otel/attributes.ts
+++ b/packages/runtime/src/otel/attributes.ts
@@ -1,0 +1,205 @@
+import type { Attributes } from "@opentelemetry/api";
+import type {
+  AgentEvent,
+  ModelUsage,
+  UserInput,
+  UserMessageContentPart,
+} from "../thread/protocol/events";
+
+export function defaultAgentEventAttributes(event: AgentEvent): Attributes {
+  const base: Attributes = { "pss.event.type": event.type };
+
+  switch (event.type) {
+    case "assistant-output":
+      return { ...base, "pss.assistant_output.text_length": event.text.length };
+    case "assistant-reasoning":
+      return {
+        ...base,
+        "pss.assistant_reasoning.text_length": event.text.length,
+      };
+    case "model-usage":
+      return { ...base, ...modelUsageAttributes(event) };
+    case "runtime-input":
+      return {
+        ...base,
+        "pss.runtime_input.placement": event.placement,
+        ...inputAttributes(
+          "pss.runtime_input",
+          event.input,
+          event.meta ?? event.input.meta
+        ),
+      };
+    case "step-end":
+    case "step-start":
+    case "turn-end":
+    case "turn-start":
+      return base;
+    case "tool-call":
+      return {
+        ...base,
+        "pss.tool.call_id": event.toolCallId,
+        "pss.tool.input.type": payloadType(event.input),
+        "pss.tool.name": event.toolName,
+        ...payloadSummaryAttributes("pss.tool.input", event.input),
+      };
+    case "tool-result":
+      return {
+        ...base,
+        "pss.tool.call_id": event.toolCallId,
+        "pss.tool.name": event.toolName,
+        "pss.tool.output.type": payloadType(event.output),
+        ...payloadSummaryAttributes("pss.tool.output", event.output),
+      };
+    case "turn-abort":
+      return { ...base, "pss.turn.abort": true };
+    case "turn-error":
+      return { ...base, "pss.turn.error": true };
+    case "user-input":
+      return { ...base, ...inputAttributes("pss.user_input", event) };
+    default:
+      return assertNever(event);
+  }
+}
+
+export function cleanAttributes(
+  attributes: Attributes
+): Attributes | undefined {
+  const cleaned: Attributes = {};
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined && value !== null) {
+      cleaned[key] = value;
+    }
+  }
+
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+}
+
+export function mergeAttributes(
+  base: Attributes,
+  extra: Attributes | undefined
+): Attributes | undefined {
+  return cleanAttributes(extra === undefined ? base : { ...base, ...extra });
+}
+
+function inputAttributes(
+  prefix: string,
+  input: UserInput,
+  meta = input.meta
+): Attributes {
+  const metaAttributes = meta?.source
+    ? { "pss.input.source": meta.source }
+    : {};
+
+  if ("text" in input) {
+    return {
+      ...metaAttributes,
+      [`${prefix}.kind`]: "text",
+      ...textContentAttributes(prefix, input.text),
+    };
+  }
+
+  const summary = messageContentSummary(input.content);
+  return {
+    ...metaAttributes,
+    [`${prefix}.file_count`]: summary.fileCount,
+    [`${prefix}.kind`]: "message",
+    [`${prefix}.part_count`]: input.content.length,
+    [`${prefix}.text_length`]: summary.textLength,
+    [`${prefix}.text_part_count`]: summary.textPartCount,
+  };
+}
+
+function messageContentSummary(content: readonly UserMessageContentPart[]) {
+  let fileCount = 0;
+  let textLength = 0;
+  let textPartCount = 0;
+
+  for (const part of content) {
+    switch (part.type) {
+      case "file":
+        fileCount += 1;
+        break;
+      case "text":
+        textLength += part.text.length;
+        textPartCount += 1;
+        break;
+      default:
+        assertNever(part);
+    }
+  }
+
+  return { fileCount, textLength, textPartCount };
+}
+
+function modelUsageAttributes(usage: ModelUsage): Attributes {
+  return (
+    cleanAttributes({
+      "pss.model_usage.attempt_id": usage.attemptId,
+      "pss.model_usage.cache_read_tokens": usage.cacheReadTokens,
+      "pss.model_usage.cache_write_tokens": usage.cacheWriteTokens,
+      "pss.model_usage.duration_ms": usage.durationMs,
+      "pss.model_usage.finish_reason": usage.finishReason,
+      "pss.model_usage.input_tokens": usage.inputTokens,
+      "pss.model_usage.model_id": usage.modelId,
+      "pss.model_usage.no_cache_tokens": usage.noCacheTokens,
+      "pss.model_usage.output_tokens": usage.outputTokens,
+      "pss.model_usage.provider": usage.provider,
+      "pss.model_usage.reasoning_tokens": usage.reasoningTokens,
+      "pss.model_usage.total_tokens": usage.totalTokens,
+    }) ?? {}
+  );
+}
+
+function payloadType(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  return typeof value;
+}
+
+function payloadSummaryAttributes(prefix: string, value: unknown): Attributes {
+  if (typeof value === "string") {
+    return { [`${prefix}.text_length`]: value.length };
+  }
+  if (Array.isArray(value)) {
+    return { [`${prefix}.item_count`]: value.length };
+  }
+  if (typeof value === "object" && value !== null) {
+    const keyCount = objectKeyCount(value);
+    return keyCount === undefined ? {} : { [`${prefix}.key_count`]: keyCount };
+  }
+  return {};
+}
+
+function objectKeyCount(value: object): number | undefined {
+  try {
+    return Object.keys(value).length;
+  } catch {
+    return;
+  }
+}
+
+function textContentAttributes(
+  prefix: string,
+  text: string | readonly string[]
+): Attributes {
+  if (typeof text === "string") {
+    return {
+      [`${prefix}.part_count`]: 1,
+      [`${prefix}.text_length`]: text.length,
+    };
+  }
+
+  return {
+    [`${prefix}.part_count`]: text.length,
+    [`${prefix}.text_length`]: text.reduce((sum, part) => sum + part.length, 0),
+  };
+}
+
+function assertNever(_value: never): never {
+  throw new Error("Unexpected event variant");
+}

--- a/packages/runtime/src/otel/index.test.ts
+++ b/packages/runtime/src/otel/index.test.ts
@@ -1,0 +1,283 @@
+import { SpanStatusCode } from "@opentelemetry/api";
+import { describe, expect, it } from "vitest";
+import { Agent } from "../agent/core/agent";
+import {
+  createMockLanguageModelV4,
+  mockLanguageModelV4Text,
+} from "../testing/mock-language-model-v4-test-utils";
+import type { AgentEvent } from "../thread/protocol/events";
+import type { AgentTurn } from "../thread/protocol/turn";
+import { openTelemetry, traceAgentTurn } from "./index";
+import { collectEvents, RecordingTracer, spanNamed } from "./test-support";
+
+describe("traceAgentTurn", () => {
+  it("traces every turn returned through agent instrumentation", async () => {
+    const tracer = new RecordingTracer();
+    const agent = new Agent({
+      instrumentations: [openTelemetry({ tracer })],
+      model: createMockLanguageModelV4(() =>
+        Promise.resolve(mockLanguageModelV4Text("DONE"))
+      ),
+    });
+
+    await collectEvents((await agent.send("first")).events());
+    await collectEvents((await agent.send("second")).events());
+
+    expect(
+      tracer.spans.filter((span) => span.name === "pss.runtime.turn")
+    ).toHaveLength(2);
+    expect(tracer.spans.every((span) => span.ended)).toBe(true);
+  });
+
+  it("passes every event through while closing turn, step, and tool spans", async () => {
+    const usage = {
+      attemptId: "attempt-1",
+      inputTokens: 12,
+      outputTokens: 3,
+      type: "model-usage",
+    } satisfies AgentEvent;
+    const sourceEvents = [
+      { meta: { source: "send" }, text: "private user", type: "user-input" },
+      { type: "turn-start" },
+      { type: "step-start" },
+      usage,
+      { text: "private answer", type: "assistant-output" },
+      {
+        input: { query: "private tool input" },
+        toolCallId: "call-1",
+        toolName: "search",
+        type: "tool-call",
+      },
+      {
+        output: { result: "private tool output" },
+        toolCallId: "call-1",
+        toolName: "search",
+        type: "tool-result",
+      },
+      { type: "step-end" },
+      { type: "turn-end" },
+    ] satisfies readonly AgentEvent[];
+    const tracer = new RecordingTracer();
+
+    const collected = await collectEvents(
+      traceAgentTurn(singleUseTurn(sourceEvents), { tracer }).events()
+    );
+
+    expect(collected).toEqual(sourceEvents);
+    expect(collected[3]).toBe(usage);
+    expect(tracer.spans.map((span) => span.name)).toEqual([
+      "pss.runtime.turn",
+      "pss.runtime.step",
+      "pss.runtime.tool",
+    ]);
+    expect(tracer.spans.every((span) => span.ended)).toBe(true);
+    expect(spanNamed(tracer, "pss.runtime.turn").status).toEqual({
+      code: SpanStatusCode.OK,
+    });
+    expect(
+      spanNamed(tracer, "pss.runtime.turn").events.map(
+        (event) => event.attributes?.["pss.event.type"]
+      )
+    ).toEqual(sourceEvents.map((event) => event.type));
+  });
+
+  it.each([
+    {
+      event: { type: "turn-abort" } as const,
+      message: "turn aborted",
+    },
+    {
+      event: { message: "private failure", type: "turn-error" } as const,
+      message: "turn error",
+    },
+  ])("marks $event.type spans as errors", async ({ event, message }) => {
+    const tracer = new RecordingTracer();
+
+    await collectEvents(
+      traceAgentTurn(
+        singleUseTurn([{ type: "turn-start" }, { type: "step-start" }, event]),
+        { tracer }
+      ).events()
+    );
+
+    expect(tracer.spans.every((span) => span.ended)).toBe(true);
+    expect(spanNamed(tracer, "pss.runtime.turn").status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message,
+    });
+    expect(telemetryText(tracer)).not.toContain("private failure");
+  });
+
+  it("records metadata-only summaries without invoking payload toJSON", async () => {
+    const secrets = [
+      "private user",
+      "private file",
+      "private answer",
+      "private reasoning",
+      "private tool input",
+      "private tool output",
+      "private failure",
+    ];
+    const throwingToJSON = () => {
+      throw new Error("payload toJSON must stay inert");
+    };
+    const sourceEvents = [
+      {
+        content: [
+          { text: secrets[0], type: "text" },
+          {
+            data: { text: secrets[1], type: "text" },
+            mediaType: "text/plain",
+            type: "file",
+          },
+        ],
+        type: "user-input",
+      },
+      { type: "turn-start" },
+      { type: "step-start" },
+      { text: secrets[2], type: "assistant-output" },
+      { text: secrets[3], type: "assistant-reasoning" },
+      {
+        input: { secret: secrets[4], toJSON: throwingToJSON },
+        toolCallId: "call-1",
+        toolName: "search",
+        type: "tool-call",
+      },
+      {
+        output: { secret: secrets[5], toJSON: throwingToJSON },
+        toolCallId: "call-1",
+        toolName: "search",
+        type: "tool-result",
+      },
+      { message: secrets[6], type: "turn-error" },
+    ] satisfies readonly AgentEvent[];
+    const tracer = new RecordingTracer();
+
+    const collected = await collectEvents(
+      traceAgentTurn(singleUseTurn(sourceEvents), { tracer }).events()
+    );
+
+    expect(collected).toEqual(sourceEvents);
+    const telemetry = telemetryText(tracer);
+    for (const secret of secrets) {
+      expect(telemetry).not.toContain(secret);
+    }
+    expect(eventAttributesFor(tracer, "assistant-output")).toMatchObject({
+      "pss.assistant_output.text_length": secrets[2].length,
+    });
+    expect(eventAttributesFor(tracer, "tool-call")).toMatchObject({
+      "pss.tool.input.key_count": 2,
+      "pss.tool.input.type": "object",
+    });
+    expect(eventAttributesFor(tracer, "tool-result")).toMatchObject({
+      "pss.tool.output.key_count": 2,
+      "pss.tool.output.type": "object",
+    });
+  });
+
+  it("preserves single-consumption and closes spans on iterator return", async () => {
+    let returned = false;
+    let sourceCalls = 0;
+    const tracer = new RecordingTracer();
+    const source: AgentTurn = {
+      events: () => {
+        sourceCalls += 1;
+        return (async function* () {
+          await Promise.resolve();
+          try {
+            yield { type: "turn-start" } satisfies AgentEvent;
+            yield { type: "step-start" } satisfies AgentEvent;
+          } finally {
+            returned = true;
+          }
+        })();
+      },
+    };
+    const traced = traceAgentTurn(source, { tracer });
+    const iterator = traced.events()[Symbol.asyncIterator]();
+
+    expect(() => traced.events()).toThrow(
+      "AgentTurn.events() can only be consumed once"
+    );
+    expect(sourceCalls).toBe(1);
+    await iterator.next();
+    await iterator.next();
+    await expect(iterator.return?.()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    expect(returned).toBe(true);
+    expect(tracer.spans.every((span) => span.ended)).toBe(true);
+  });
+
+  it("sanitizes source errors, closes spans, and rethrows the original", async () => {
+    const tracer = new RecordingTracer();
+    const sourceError = new Error("private source error");
+    const turn: AgentTurn = {
+      events: () =>
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "turn-start" } satisfies AgentEvent;
+          yield { type: "step-start" } satisfies AgentEvent;
+          throw sourceError;
+        })(),
+    };
+
+    await expect(
+      collectEvents(traceAgentTurn(turn, { tracer }).events())
+    ).rejects.toBe(sourceError);
+
+    expect(tracer.spans.every((span) => span.ended)).toBe(true);
+    expect(spanNamed(tracer, "pss.runtime.turn").status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message: "source iterator failed",
+    });
+    expect(telemetryText(tracer)).not.toContain(sourceError.message);
+  });
+});
+
+function eventAttributesFor(tracer: RecordingTracer, type: AgentEvent["type"]) {
+  const event = spanNamed(tracer, "pss.runtime.turn").events.find(
+    (candidate) => candidate.attributes?.["pss.event.type"] === type
+  );
+  if (!event?.attributes) {
+    throw new Error(`Missing telemetry event for ${type}`);
+  }
+  return event.attributes;
+}
+
+function singleUseTurn(
+  events: readonly AgentEvent[],
+  onReturn: () => void = () => undefined
+): AgentTurn {
+  let consumed = false;
+  return {
+    events: () => {
+      if (consumed) {
+        throw new Error("AgentTurn.events() can only be consumed once");
+      }
+      consumed = true;
+      return (async function* () {
+        await Promise.resolve();
+        try {
+          for (const event of events) {
+            yield event;
+          }
+        } finally {
+          onReturn();
+        }
+      })();
+    },
+  };
+}
+
+function telemetryText(tracer: RecordingTracer): string {
+  return JSON.stringify({
+    events: tracer.spans.flatMap((span) => span.events),
+    exceptions: tracer.spans.flatMap((span) =>
+      span.exceptions.map((exception) => exception.message)
+    ),
+    statuses: tracer.spans.map((span) => span.status),
+  });
+}

--- a/packages/runtime/src/otel/index.ts
+++ b/packages/runtime/src/otel/index.ts
@@ -1,0 +1,119 @@
+import type { AgentInstrumentation } from "../agent/core/instrumentation";
+import type { AgentEvent } from "../thread/protocol/events";
+import type { AgentTurn } from "../thread/protocol/turn";
+import {
+  closeTraceState,
+  INCOMPLETE_SPAN_STATUS,
+  recordRuntimeTraceEvent,
+  SOURCE_ERROR_STATUS,
+  TURN_OK_STATUS,
+} from "./trace-state";
+import {
+  createTraceState,
+  type TraceAgentTurnOptions,
+  type TraceAgentTurnState,
+} from "./types";
+
+export type {
+  TraceAgentTurnEventAttributes,
+  TraceAgentTurnOptions,
+  TraceAgentTurnSpan,
+  TraceAgentTurnTracer,
+} from "./types";
+
+export function openTelemetry(
+  options: TraceAgentTurnOptions = {}
+): AgentInstrumentation {
+  return {
+    wrapTurn: (turn) => traceAgentTurn(turn, options),
+  };
+}
+
+export function traceAgentTurn(
+  turn: AgentTurn,
+  options: TraceAgentTurnOptions = {}
+): AgentTurn {
+  let consumed = false;
+  return {
+    events: () => {
+      if (consumed) {
+        throw new Error("AgentTurn.events() can only be consumed once");
+      }
+      consumed = true;
+      return new TracedAgentEventIterator(
+        turn.events()[Symbol.asyncIterator](),
+        createTraceState(options)
+      );
+    },
+  };
+}
+
+class TracedAgentEventIterator implements AsyncIterableIterator<AgentEvent> {
+  readonly #source: AsyncIterator<AgentEvent>;
+  readonly #state: TraceAgentTurnState;
+  #closed = false;
+  #nextPending = false;
+
+  constructor(source: AsyncIterator<AgentEvent>, state: TraceAgentTurnState) {
+    this.#source = source;
+    this.#state = state;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<AgentEvent> {
+    return this;
+  }
+
+  async next(): Promise<IteratorResult<AgentEvent>> {
+    if (this.#closed) {
+      return { done: true, value: undefined };
+    }
+    if (this.#nextPending) {
+      throw new Error(
+        "AgentTurn.events() does not allow concurrent next() calls"
+      );
+    }
+
+    this.#nextPending = true;
+    try {
+      const next = await this.#source.next();
+      if (next.done) {
+        this.#closed = true;
+        closeTraceState(this.#state, {
+          childStatus: INCOMPLETE_SPAN_STATUS,
+          turnStatus: TURN_OK_STATUS,
+        });
+        return { done: true, value: undefined };
+      }
+
+      recordRuntimeTraceEvent(this.#state, next.value);
+      return { done: false, value: next.value };
+    } catch (error) {
+      this.#closed = true;
+      closeTraceState(this.#state, {
+        childStatus: SOURCE_ERROR_STATUS,
+        exception: new Error("Agent turn source failed"),
+        turnStatus: SOURCE_ERROR_STATUS,
+      });
+      throw error;
+    } finally {
+      this.#nextPending = false;
+    }
+  }
+
+  async return(): Promise<IteratorResult<AgentEvent>> {
+    if (this.#closed) {
+      return { done: true, value: undefined };
+    }
+
+    try {
+      await this.#source.return?.();
+    } finally {
+      this.#closed = true;
+      closeTraceState(this.#state, {
+        childStatus: INCOMPLETE_SPAN_STATUS,
+      });
+    }
+
+    return { done: true, value: undefined };
+  }
+}

--- a/packages/runtime/src/otel/test-support.ts
+++ b/packages/runtime/src/otel/test-support.ts
@@ -1,0 +1,66 @@
+import type { Attributes, SpanOptions, SpanStatus } from "@opentelemetry/api";
+import type { AgentEvent } from "../thread/protocol/events";
+import type { TraceAgentTurnSpan, TraceAgentTurnTracer } from "./index";
+
+export interface RecordedSpanEvent {
+  readonly attributes: Attributes | undefined;
+  readonly name: string;
+}
+
+export class RecordingSpan implements TraceAgentTurnSpan {
+  readonly events: RecordedSpanEvent[] = [];
+  readonly exceptions: Error[] = [];
+  readonly name: string;
+  readonly spanAttributes: Attributes | undefined;
+  ended = false;
+  status: SpanStatus | undefined;
+
+  constructor(name: string, attributes?: Attributes) {
+    this.name = name;
+    this.spanAttributes = attributes;
+  }
+
+  addEvent(name: string, attributes?: Attributes): this {
+    this.events.push({ attributes, name });
+    return this;
+  }
+
+  end(): void {
+    this.ended = true;
+  }
+
+  recordException(exception: Error): void {
+    this.exceptions.push(exception);
+  }
+
+  setStatus(status: SpanStatus): this {
+    this.status = status;
+    return this;
+  }
+}
+
+export class RecordingTracer implements TraceAgentTurnTracer {
+  readonly spans: RecordingSpan[] = [];
+
+  startSpan(name: string, options?: SpanOptions): RecordingSpan {
+    const span = new RecordingSpan(name, options?.attributes);
+    this.spans.push(span);
+    return span;
+  }
+}
+
+export async function collectEvents(events: AsyncIterable<AgentEvent>) {
+  const collected: AgentEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+export function spanNamed(tracer: RecordingTracer, name: string) {
+  const span = tracer.spans.find((candidate) => candidate.name === name);
+  if (!span) {
+    throw new Error(`Missing span ${name}`);
+  }
+  return span;
+}

--- a/packages/runtime/src/otel/trace-state.ts
+++ b/packages/runtime/src/otel/trace-state.ts
@@ -1,0 +1,237 @@
+import { type SpanStatus, SpanStatusCode } from "@opentelemetry/api";
+import type {
+  AgentEvent,
+  ToolCall,
+  ToolResult,
+} from "../thread/protocol/events";
+import {
+  cleanAttributes,
+  defaultAgentEventAttributes,
+  mergeAttributes,
+} from "./attributes";
+import type {
+  CloseTraceStateOptions,
+  TraceAgentTurnEventAttributes,
+  TraceAgentTurnSpan,
+  TraceAgentTurnState,
+} from "./types";
+
+export const INCOMPLETE_SPAN_STATUS = {
+  code: SpanStatusCode.ERROR,
+  message: "span closed before completion",
+} satisfies SpanStatus;
+export const SOURCE_ERROR_STATUS = {
+  code: SpanStatusCode.ERROR,
+  message: "source iterator failed",
+} satisfies SpanStatus;
+export const TURN_ABORT_STATUS = {
+  code: SpanStatusCode.ERROR,
+  message: "turn aborted",
+} satisfies SpanStatus;
+export const TURN_ERROR_STATUS = {
+  code: SpanStatusCode.ERROR,
+  message: "turn error",
+} satisfies SpanStatus;
+export const TURN_OK_STATUS = { code: SpanStatusCode.OK } satisfies SpanStatus;
+
+export function recordRuntimeTraceEvent(
+  state: TraceAgentTurnState,
+  event: AgentEvent
+): void {
+  const attributes = traceEventAttributes(state, event);
+  const turnSpan = ensureTurnSpan(state);
+  turnSpan.addEvent(state.options.eventName, attributes);
+
+  switch (event.type) {
+    case "step-start":
+      startStepSpan(state, attributes);
+      return;
+    case "step-end":
+      closeStepSpan(state, TURN_OK_STATUS, attributes);
+      return;
+    case "tool-call":
+      startToolSpan(state, event, attributes);
+      return;
+    case "tool-result":
+      closeToolSpan(state, event, attributes);
+      return;
+    case "turn-end":
+      closeTraceState(state, {
+        childStatus: INCOMPLETE_SPAN_STATUS,
+        turnStatus: TURN_OK_STATUS,
+      });
+      return;
+    case "turn-abort":
+      closeTraceState(state, {
+        childStatus: TURN_ABORT_STATUS,
+        turnStatus: TURN_ABORT_STATUS,
+      });
+      return;
+    case "turn-error":
+      closeTraceState(state, {
+        childStatus: TURN_ERROR_STATUS,
+        exception: new Error("Agent turn failed"),
+        turnStatus: TURN_ERROR_STATUS,
+      });
+      return;
+    case "assistant-output":
+    case "assistant-reasoning":
+    case "model-usage":
+    case "runtime-input":
+    case "turn-start":
+    case "user-input":
+      return;
+    default:
+      assertNever(event);
+  }
+}
+
+export function closeTraceState(
+  state: TraceAgentTurnState,
+  options: CloseTraceStateOptions = {}
+): void {
+  closeToolSpans(state, options.childStatus);
+  closeStepSpan(state, options.childStatus);
+  closeTurnSpan(state, options.turnStatus, options.exception);
+}
+
+function startStepSpan(
+  state: TraceAgentTurnState,
+  eventAttributes: TraceAgentTurnEventAttributes | undefined
+): void {
+  if (state.stepSpan) {
+    closeStepSpan(state, INCOMPLETE_SPAN_STATUS);
+  }
+
+  const span = startSpan(state, state.options.stepSpanName, {
+    "pss.runtime.span.kind": "step",
+  });
+  span.addEvent(state.options.eventName, eventAttributes);
+  state.stepSpan = span;
+}
+
+function closeStepSpan(
+  state: TraceAgentTurnState,
+  status?: SpanStatus,
+  eventAttributes?: TraceAgentTurnEventAttributes
+): void {
+  const span = state.stepSpan;
+  if (!span) {
+    return;
+  }
+  if (eventAttributes) {
+    span.addEvent(state.options.eventName, eventAttributes);
+  }
+  endSpan(span, status);
+  state.stepSpan = undefined;
+}
+
+function startToolSpan(
+  state: TraceAgentTurnState,
+  event: ToolCall,
+  eventAttributes: TraceAgentTurnEventAttributes | undefined
+): void {
+  const existing = state.toolSpans.get(event.toolCallId);
+  if (existing) {
+    endSpan(existing, INCOMPLETE_SPAN_STATUS);
+  }
+
+  const span = startSpan(state, state.options.toolSpanName, {
+    "pss.runtime.span.kind": "tool",
+    "pss.tool.call_id": event.toolCallId,
+    "pss.tool.name": event.toolName,
+  });
+  span.addEvent(state.options.eventName, eventAttributes);
+  state.toolSpans.set(event.toolCallId, span);
+}
+
+function closeToolSpan(
+  state: TraceAgentTurnState,
+  event: ToolResult,
+  eventAttributes: TraceAgentTurnEventAttributes | undefined
+): void {
+  const span = state.toolSpans.get(event.toolCallId);
+  if (!span) {
+    return;
+  }
+
+  span.addEvent(state.options.eventName, eventAttributes);
+  endSpan(span, TURN_OK_STATUS);
+  state.toolSpans.delete(event.toolCallId);
+}
+
+function closeToolSpans(
+  state: TraceAgentTurnState,
+  status: SpanStatus | undefined
+): void {
+  for (const span of state.toolSpans.values()) {
+    endSpan(span, status);
+  }
+  state.toolSpans.clear();
+}
+
+function ensureTurnSpan(state: TraceAgentTurnState): TraceAgentTurnSpan {
+  const current = state.turnSpan;
+  if (current) {
+    return current;
+  }
+
+  const span = startSpan(state, state.options.turnSpanName, {
+    "pss.runtime.span.kind": "turn",
+  });
+  state.turnSpan = span;
+  return span;
+}
+
+function closeTurnSpan(
+  state: TraceAgentTurnState,
+  status: SpanStatus | undefined,
+  exception: Error | undefined
+): void {
+  const span = state.turnSpan;
+  if (!span) {
+    return;
+  }
+  if (exception) {
+    span.recordException(exception);
+  }
+  endSpan(span, status);
+  state.turnSpan = undefined;
+}
+
+function startSpan(
+  state: TraceAgentTurnState,
+  name: string,
+  attributes: TraceAgentTurnEventAttributes
+): TraceAgentTurnSpan {
+  return state.options.tracer.startSpan(name, {
+    attributes: cleanAttributes({
+      ...state.options.spanAttributes,
+      ...attributes,
+    }),
+  });
+}
+
+function traceEventAttributes(
+  state: TraceAgentTurnState,
+  event: AgentEvent
+): TraceAgentTurnEventAttributes | undefined {
+  return mergeAttributes(
+    defaultAgentEventAttributes(event),
+    state.options.eventAttributes?.(event)
+  );
+}
+
+function endSpan(
+  span: TraceAgentTurnSpan,
+  status: SpanStatus | undefined
+): void {
+  if (status) {
+    span.setStatus(status);
+  }
+  span.end();
+}
+
+function assertNever(_value: never): never {
+  throw new Error("Unexpected event variant");
+}

--- a/packages/runtime/src/otel/types.ts
+++ b/packages/runtime/src/otel/types.ts
@@ -1,0 +1,101 @@
+import {
+  type Attributes,
+  type SpanOptions,
+  type SpanStatus,
+  trace,
+} from "@opentelemetry/api";
+import type { AgentEvent } from "../thread/protocol/events";
+
+export const DEFAULT_EVENT_NAME = "pss.runtime.event";
+export const DEFAULT_STEP_SPAN_NAME = "pss.runtime.step";
+export const DEFAULT_TOOL_SPAN_NAME = "pss.runtime.tool";
+export const DEFAULT_TURN_SPAN_NAME = "pss.runtime.turn";
+export const RUNTIME_COMPONENT = "@minpeter/pss-runtime";
+
+export type TraceAgentTurnEventAttributes = Attributes;
+
+export interface TraceAgentTurnSpan {
+  addEvent(
+    name: string,
+    attributes?: TraceAgentTurnEventAttributes
+  ): TraceAgentTurnSpan;
+  end(): void;
+  recordException(exception: Error): void;
+  setStatus(status: SpanStatus): TraceAgentTurnSpan;
+}
+
+export interface TraceAgentTurnTracer {
+  startSpan(name: string, options?: SpanOptions): TraceAgentTurnSpan;
+}
+
+export interface TraceAgentTurnOptions {
+  readonly eventAttributes?: (
+    event: AgentEvent
+  ) => TraceAgentTurnEventAttributes | undefined;
+  readonly eventName?: string;
+  readonly spanAttributes?: TraceAgentTurnEventAttributes;
+  readonly stepSpanName?: string;
+  readonly toolSpanName?: string;
+  readonly tracer?: TraceAgentTurnTracer;
+  readonly tracerName?: string;
+  readonly tracerVersion?: string;
+  readonly turnSpanName?: string;
+}
+
+export interface ResolvedTraceAgentTurnOptions {
+  readonly eventAttributes?: (
+    event: AgentEvent
+  ) => TraceAgentTurnEventAttributes | undefined;
+  readonly eventName: string;
+  readonly spanAttributes: TraceAgentTurnEventAttributes;
+  readonly stepSpanName: string;
+  readonly toolSpanName: string;
+  readonly tracer: TraceAgentTurnTracer;
+  readonly turnSpanName: string;
+}
+
+export interface TraceAgentTurnState {
+  readonly options: ResolvedTraceAgentTurnOptions;
+  stepSpan: TraceAgentTurnSpan | undefined;
+  readonly toolSpans: Map<string, TraceAgentTurnSpan>;
+  turnSpan: TraceAgentTurnSpan | undefined;
+}
+
+export interface CloseTraceStateOptions {
+  readonly childStatus?: SpanStatus;
+  readonly exception?: Error;
+  readonly turnStatus?: SpanStatus;
+}
+
+export function createTraceState(
+  options: TraceAgentTurnOptions
+): TraceAgentTurnState {
+  return {
+    options: resolveOptions(options),
+    stepSpan: undefined,
+    toolSpans: new Map(),
+    turnSpan: undefined,
+  };
+}
+
+function resolveOptions(
+  options: TraceAgentTurnOptions
+): ResolvedTraceAgentTurnOptions {
+  return {
+    eventAttributes: options.eventAttributes,
+    eventName: options.eventName ?? DEFAULT_EVENT_NAME,
+    spanAttributes: {
+      "pss.runtime.component": RUNTIME_COMPONENT,
+      ...options.spanAttributes,
+    },
+    stepSpanName: options.stepSpanName ?? DEFAULT_STEP_SPAN_NAME,
+    toolSpanName: options.toolSpanName ?? DEFAULT_TOOL_SPAN_NAME,
+    tracer:
+      options.tracer ??
+      trace.getTracer(
+        options.tracerName ?? RUNTIME_COMPONENT,
+        options.tracerVersion
+      ),
+    turnSpanName: options.turnSpanName ?? DEFAULT_TURN_SPAN_NAME,
+  };
+}

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: [
     "src/index.ts",
+    "src/otel/index.ts",
     "src/platform/cloudflare/index.ts",
     // Edge-only: static .wasm imports for Workers (not pulled into Node CF barrel).
     "src/platform/cloudflare/image-codecs-edge.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 7.9.4(eslint@10.7.0)(typescript@7.0.2)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -92,7 +92,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/worker-agent:
     dependencies:
@@ -144,7 +144,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
       wrangler:
         specifier: ^4.107.0
         version: 4.111.0(@cloudflare/workers-types@5.20260716.1)
@@ -178,7 +178,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
 
   examples/basic:
     dependencies:
@@ -353,6 +353,9 @@ importers:
       '@jsquash/webp':
         specifier: ^1.5.0
         version: 1.5.0
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       ai:
         specifier: 7.0.30
         version: 7.0.30(zod@4.4.3)
@@ -380,7 +383,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -1156,6 +1159,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
@@ -4570,6 +4577,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oxc-project/types@0.139.0': {}
 
   '@poppinss/colors@4.1.6':
@@ -7258,7 +7267,7 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
@@ -7281,6 +7290,7 @@ snapshots:
       vite: 8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.1
       jsdom: 29.1.1
     transitivePeerDependencies:

--- a/scripts/verify-release-artifacts-runtime-subpaths.test.mjs
+++ b/scripts/verify-release-artifacts-runtime-subpaths.test.mjs
@@ -6,6 +6,7 @@ import {
   REQUIRED_RUNTIME_CLOUDFLARE_AGENTS_EXPORTS,
   REQUIRED_RUNTIME_CLOUDFLARE_WORKER_EXPORTS,
   REQUIRED_RUNTIME_EXECUTION_EXPORTS,
+  REQUIRED_RUNTIME_OTEL_EXPORTS,
 } from "./verify-release-artifacts/runtime-public-surface.mjs";
 import {
   cleanupFixtures,
@@ -27,6 +28,27 @@ describe("verifyReleaseArtifacts runtime subpath checks", () => {
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
       "packages/runtime/dist/execution/index.d.ts: missing execution runtime declaration",
     ]);
+  });
+
+  it("requires the runtime otel declaration entrypoint", () => {
+    const cwd = createFixture();
+    rmSync(runtimeDistDeclaration(cwd, "otel"));
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
+      "packages/runtime/dist/otel/index.d.ts: missing otel runtime declaration",
+    ]);
+  });
+
+  it("checks the OpenTelemetry adapter declaration subpath", () => {
+    const cwd = createFixture();
+    writeFileSync(runtimeDistDeclaration(cwd, "otel"), "export {};\n");
+
+    expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual(
+      REQUIRED_RUNTIME_OTEL_EXPORTS.map(
+        (name) =>
+          `packages/runtime/dist/otel/index.d.ts: missing explicit otel runtime export ${name}`
+      )
+    );
   });
 
   it("requires the runtime cloudflare declaration entrypoint", () => {

--- a/scripts/verify-release-artifacts-runtime.test.mjs
+++ b/scripts/verify-release-artifacts-runtime.test.mjs
@@ -49,7 +49,7 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
     const cwd = createFixture();
     writeFileSync(
       join(cwd, "packages", "runtime", "dist", "index.d.ts"),
-      `export type { AgentMessage, ${forbiddenModelName}, AgentRun, AgentTool, AgentTools, CreateLlmOptions, Llm, LlmContext, LlmOutput, LlmOutputPart, ${removedRuntimeModelNames.join(", ")}, RuntimeInput } from "./llm";\nexport type { AgentHost } from "./execution/types";\nexport type { AgentTurn } from "./thread";\n`
+      `export type { AgentMessage, ${forbiddenModelName}, AgentRun, AgentTool, AgentTools, CreateLlmOptions, Llm, LlmContext, LlmOutput, LlmOutputPart, ${removedRuntimeModelNames.join(", ")}, RuntimeInput } from "./llm";\nexport type { AgentInstrumentation, AgentInstrumentationContext, AgentInstrumentationOperation } from "./agent";\nexport type { AgentHost } from "./execution/types";\nexport type { AgentTurn } from "./thread";\n`
     );
 
     expect(
@@ -175,6 +175,9 @@ describe("verifyReleaseArtifacts runtime declaration checks", () => {
     );
     expect(verifyReleaseArtifacts({ cwd, packages: ["runtime"] })).toEqual([
       "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentHost",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentInstrumentation",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentInstrumentationContext",
+      "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentInstrumentationOperation",
       "packages/runtime/dist/index.d.ts: missing explicit root runtime export AgentTurn",
       "packages/runtime/dist/index.d.ts: missing explicit root runtime export RuntimeInput",
     ]);

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -7,6 +7,7 @@ export const cliBinReadFailurePattern =
 export const forbiddenModelName = ["Agent", "Model"].join("");
 export const runtimeRootDeclaration = [
   'export type { AgentHost } from "./execution/types";',
+  'export type { AgentInstrumentation, AgentInstrumentationContext, AgentInstrumentationOperation } from "./agent";',
   'export type { AgentTurn, RuntimeInput } from "./thread";',
   "",
 ].join("\n");
@@ -40,6 +41,11 @@ export const runtimeCloudflareDeclaration = [
 export const runtimeFileDeclaration = [
   'export { ackScheduledNodeRun, ackScheduledNodeThreadPrompt, appendScheduledNodeRun, appendScheduledNodeThreadPrompt, createNodeFileAgentContext, createFileHost, createFileScheduler, drainScheduledNodeWork, FileExecutionStore, FileThreadStore, listScheduledNodeRuns, listScheduledNodeThreadPrompts } from "./index";',
   'export type { NodeFileAgentContext, NodeFileAgentContextFactoryOptions, NodeFileAgentContextOptions, FileHostOptions, NodeScheduledThreadPrompt, NodeScheduledWorkAppendOptions, NodeScheduledWorkDrainOptions, NodeScheduledWorkDrainResult, NodeScheduledWorkListOptions, NodeScheduledWorkRunContext } from "./index";',
+  "",
+].join("\n");
+export const runtimeOtelDeclaration = [
+  'export { openTelemetry, traceAgentTurn } from "./index";',
+  'export type { TraceAgentTurnEventAttributes, TraceAgentTurnOptions, TraceAgentTurnSpan, TraceAgentTurnTracer } from "./index";',
   "",
 ].join("\n");
 
@@ -172,6 +178,13 @@ function writeRuntimeDeclarationFixtures(cwd, packageName) {
       "index.d.ts"
     ),
     runtimeFileDeclaration
+  );
+  mkdirSync(join(cwd, "packages", packageName, "dist", "otel"), {
+    recursive: true,
+  });
+  writeFileSync(
+    join(cwd, "packages", packageName, "dist", "otel", "index.d.ts"),
+    runtimeOtelDeclaration
   );
   writeFileSync(
     join(cwd, "packages", packageName, "dist", "llm.d.ts"),

--- a/scripts/verify-release-artifacts/runtime-checks.mjs
+++ b/scripts/verify-release-artifacts/runtime-checks.mjs
@@ -9,6 +9,7 @@ import {
   REQUIRED_RUNTIME_EXECUTION_EXPORTS,
   REQUIRED_RUNTIME_FILE_EXPORTS,
   REQUIRED_RUNTIME_MEMORY_EXPORTS,
+  REQUIRED_RUNTIME_OTEL_EXPORTS,
   REQUIRED_RUNTIME_ROOT_EXPORTS,
 } from "./runtime-public-surface.mjs";
 import { listFiles, packageDistPath, relativeToCwd } from "./shared.mjs";
@@ -65,6 +66,12 @@ export function findRuntimeDeclarationLeaks({ cwd, packages }) {
       ),
       requiredExports: REQUIRED_RUNTIME_FILE_EXPORTS,
       surface: "file",
+    }),
+    ...findRuntimeDeclarationExportLeaks({
+      cwd,
+      file: join(packageDistPath(cwd, "runtime"), "otel", "index.d.ts"),
+      requiredExports: REQUIRED_RUNTIME_OTEL_EXPORTS,
+      surface: "otel",
     }),
     ...findRuntimePublicPatternLeaks({ cwd }),
   ];

--- a/scripts/verify-release-artifacts/runtime-public-surface.mjs
+++ b/scripts/verify-release-artifacts/runtime-public-surface.mjs
@@ -1,5 +1,8 @@
 export const REQUIRED_RUNTIME_ROOT_EXPORTS = [
   "AgentHost",
+  "AgentInstrumentation",
+  "AgentInstrumentationContext",
+  "AgentInstrumentationOperation",
   "AgentTurn",
   "RuntimeInput",
 ];
@@ -145,6 +148,11 @@ export const REQUIRED_RUNTIME_CLOUDFLARE_EXPORTS = [
 
 export const REQUIRED_RUNTIME_FILE_EXPORTS =
   "FileExecutionStore FileThreadStore NodeFileAgentContext NodeFileAgentContextFactoryOptions NodeFileAgentContextOptions FileHostOptions NodeScheduledThreadPrompt NodeScheduledWorkAppendOptions NodeScheduledWorkDrainOptions NodeScheduledWorkDrainResult NodeScheduledWorkListOptions NodeScheduledWorkRunContext ackScheduledNodeRun ackScheduledNodeThreadPrompt appendScheduledNodeRun appendScheduledNodeThreadPrompt createNodeFileAgentContext createFileHost createFileScheduler drainScheduledNodeWork listScheduledNodeRuns listScheduledNodeThreadPrompts".split(
+    " "
+  );
+
+export const REQUIRED_RUNTIME_OTEL_EXPORTS =
+  "TraceAgentTurnEventAttributes TraceAgentTurnOptions TraceAgentTurnSpan TraceAgentTurnTracer openTelemetry traceAgentTurn".split(
     " "
   );
 


### PR DESCRIPTION
Closes #159

## Summary

- add `@minpeter/pss-runtime/otel` with `traceAgentTurn()` and `openTelemetry()` backed only by `@opentelemetry/api`
- add composable `AgentOptions.instrumentations` wrapping send, steer, and resume turns with operation/thread/namespace/run context
- emit turn, step, and tool spans plus metadata-only runtime events; sanitize error telemetry and summarize content/tool payloads without serialization or `toJSON()` calls
- preserve `AgentTurn.events()` single consumption and source `return()`, while passing every original event through unchanged, including `model-usage`
- wire package exports, build entries, release contracts, README documentation, and the minor Tegami entry

## RED -> GREEN evidence

RED, before production code:

```text
FAIL src/otel/index.test.ts
Error: Cannot find module './index'
FAIL Agent > wraps send and steer turns with operation context
AssertionError: expected [] to deeply equal [ Array(2) ]
FAIL host notification resume > host resumes parent notification run once...
AssertionError: expected [] to deeply equal [ { operation: 'resume', ... } ]

Test Files  3 failed (3)
Tests       2 failed | 25 passed (27)
```

GREEN:

```text
Test Files  114 passed (114)
Tests       730 passed | 3 skipped (733)
Duration    5.33s
```

The OTel tests cover normal end, abort, turn error, source error, iterator return, metadata-only payload summaries (including throwing `toJSON()`), agent-wide tracing, `model-usage` passthrough, and wrapper-owned single consumption.

## Test plan

- `pnpm install`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm typecheck`
- `pnpm exec ultracite check <changed TypeScript/JavaScript/JSON files>`
- `pnpm build` (generate all workspace release artifacts in the fresh worktree)
- `node scripts/verify-release-artifacts.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry tracing for agent turns via a new `@minpeter/pss-runtime/otel` subpath, and introduces `AgentOptions.instrumentations` to wrap `send`, `steer`, and `resume` turns with context. Tracing is metadata-only, preserves event passthrough, and depends only on `@opentelemetry/api`.

- New Features
  - New `@minpeter/pss-runtime/otel` with `openTelemetry()` (agent-wide) and `traceAgentTurn()` (single turn).
  - New `AgentOptions.instrumentations` with `wrapTurn(turn, { operation, threadKey, namespace, runId? })`.
  - Emits `pss.runtime.turn`, `pss.runtime.step`, and `pss.runtime.tool` spans plus `pss.runtime.event` events; sanitizes errors and summarizes content/tool payloads without calling `toJSON()`.
  - Passes all original events unchanged (including `model-usage`), preserves single-consumption, and closes spans on end/abort/error/iterator return.

- Dependencies
  - Added `@opentelemetry/api`; documented usage in README.
  - Wired new `./otel` subpath exports, build entries, tests, and release-artifact checks.
  - Exposed `AgentInstrumentation`, `AgentInstrumentationContext`, and `AgentInstrumentationOperation` types from the runtime root API.

<sup>Written for commit d39caad3227e91965d7449fac0dac49b6a3625f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

