### PR TITLE
feat(coding-agent): explicit availability modes for provider-backed web tools

### DIFF
--- a/.tegami/2026-07-19-coding-agent-tool-availability.md
+++ b/.tegami/2026-07-19-coding-agent-tool-availability.md
@@ -1,0 +1,26 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+---
+
+## Add explicit availability modes for provider-backed web tools
+
+`createCodingAgentTools()` and `resolveStartTuiTools()` now gate on
+`TINYFISH_API_KEY` before wiring the OpenSearch client, controlled by the new
+`webToolsAvailability` option:
+
+- `required` throws `CodingAgentWebToolsUnavailableError` during tool/agent
+  initialization when the key is missing.
+- `optional` (default) omits `web_search`/`web_fetch` when the key is missing
+  and reports the omission through `onWebToolsDisabled` (default:
+  `console.warn` logs `web tools disabled: missing TINYFISH_API_KEY`).
+- `disabled` never registers the web tools.
+
+The key is read from `openSearchOptions.env` when provided, otherwise from
+`process.env`, using the same `;`-separated pool parsing as
+`@minpeter/opensearch`. An injected `client` counts as provider configuration.
+The default preserves today's no-key startup behavior while making the
+omission observable instead of advertising tools that can only fail at
+execution time.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -1,7 +1,8 @@
 # @minpeter/pss-coding-agent
 
 Model wiring and the `pss` TUI for pss-next. The TUI includes OpenSearch-backed
-`web_search` and `web_fetch` tools by default.
+`web_search` and `web_fetch` tools by default when `TINYFISH_API_KEY` is
+configured.
 
 ```ts
 import { createCodingLanguageModel } from "@minpeter/pss-coding-agent/model";
@@ -72,6 +73,35 @@ records, and version that runtime storage uses.
 The `pss` TUI starts with OpenSearch-backed `web_search` and `web_fetch` tools.
 Call `startTui({ tools })` from your own entrypoint when you want to replace the
 default tool set.
+
+## Web tools availability
+
+The web tools are backed by `@minpeter/opensearch` and need `TINYFISH_API_KEY`
+(one or more `;`-separated keys). `createCodingAgentTools()` gates on the key
+before wiring the OpenSearch client, controlled by `webToolsAvailability`:
+
+- `optional` (default): when the key is missing, the web tools are omitted
+  instead of advertised, and the omission is reported through
+  `onWebToolsDisabled` (default: `console.warn` logs
+  `web tools disabled: missing TINYFISH_API_KEY`). Startup still succeeds, so
+  environments without a key behave exactly as before minus the unusable tools.
+- `required`: throw `CodingAgentWebToolsUnavailableError` during tool/agent
+  initialization when the key is missing, so a model can never be offered a
+  tool that cannot execute.
+- `disabled`: never register the web tools.
+
+The key is read from `openSearchOptions.env` when provided, otherwise from
+`process.env`. An injected `client` counts as provider configuration in
+`optional` and `required` modes.
+
+```ts
+const tools = createCodingAgentTools({ webToolsAvailability: "required" });
+
+// Custom entrypoint around the TUI defaults:
+const tuiTools = resolveStartTuiTools(undefined, {
+  webToolsAvailability: "required",
+});
+```
 
 When the TUI is idle, submitting text starts a normal `thread.send()` turn. When
 a run is active, submitting text calls `thread.steer(trimmed)` so the text lands

--- a/apps/coding-agent/src/index.ts
+++ b/apps/coding-agent/src/index.ts
@@ -28,10 +28,13 @@ export type {
   CreateCodingAgentToolsOptions,
   WebFetchInput,
   WebSearchInput,
+  WebToolsAvailability,
 } from "./tools";
 export {
   CodingAgentToolAbortError,
   CodingAgentToolsConfigError,
+  CodingAgentWebToolsUnavailableError,
   createCodingAgentTools,
+  WEB_TOOLS_DISABLED_MESSAGE,
 } from "./tools";
 export { type StartTuiOptions, startTui } from "./tui";

--- a/apps/coding-agent/src/tools.test.ts
+++ b/apps/coding-agent/src/tools.test.ts
@@ -1,6 +1,13 @@
 import type { ToolExecutionOptions } from "ai";
-import { describe, expect, it, vi } from "vitest";
-import { createCodingAgentTools, resolveStartTuiTools } from "./tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CodingAgentWebToolsUnavailableError,
+  createCodingAgentTools,
+  resolveStartTuiTools,
+  WEB_TOOLS_DISABLED_MESSAGE,
+} from "./tools";
+
+const tinyfishApiKeyPattern = /TINYFISH_API_KEY/;
 
 const toolExecutionOptions: ToolExecutionOptions<Record<string, unknown>> = {
   context: {},
@@ -22,12 +29,21 @@ const fetchResult = {
   url: "https://example.com/",
 };
 
+function createStubClient() {
+  return {
+    fetch: vi.fn().mockResolvedValue([fetchResult]),
+    search: vi.fn().mockResolvedValue([searchResult]),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
 describe("coding-agent web tools", () => {
   it("creates OpenSearch-backed web_search and web_fetch tools", async () => {
-    const client = {
-      fetch: vi.fn().mockResolvedValue([fetchResult]),
-      search: vi.fn().mockResolvedValue([searchResult]),
-    };
+    const client = createStubClient();
 
     const tools = createCodingAgentTools({ client });
     const searchExecute = tools.web_search.execute;
@@ -62,6 +78,8 @@ describe("coding-agent web tools", () => {
   });
 
   it("uses OpenSearch tools by default for the TUI and preserves overrides", () => {
+    vi.stubEnv("TINYFISH_API_KEY", "test-key");
+
     const defaultTools = resolveStartTuiTools();
     const overrideTools = { custom_tool: defaultTools.web_search };
 
@@ -70,5 +88,177 @@ describe("coding-agent web tools", () => {
       "web_fetch",
     ]);
     expect(resolveStartTuiTools(overrideTools)).toBe(overrideTools);
+  });
+});
+
+describe("web tools availability modes", () => {
+  beforeEach(() => {
+    vi.stubEnv("TINYFISH_API_KEY", undefined);
+  });
+
+  it("registers web tools by default when TINYFISH_API_KEY is present", () => {
+    const tools = createCodingAgentTools({
+      openSearchOptions: { env: { TINYFISH_API_KEY: "test-key" } },
+    });
+
+    expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
+  });
+
+  it("reads TINYFISH_API_KEY from process.env by default", () => {
+    vi.stubEnv("TINYFISH_API_KEY", "test-key");
+
+    const tools = createCodingAgentTools();
+
+    expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
+  });
+
+  it("omits web tools in default optional mode when TINYFISH_API_KEY is missing and reports it", () => {
+    const onWebToolsDisabled = vi.fn();
+
+    const tools = createCodingAgentTools({ onWebToolsDisabled });
+
+    expect(Object.keys(tools)).toStrictEqual([]);
+    expect(onWebToolsDisabled).toHaveBeenCalledTimes(1);
+    expect(onWebToolsDisabled).toHaveBeenCalledWith(WEB_TOOLS_DISABLED_MESSAGE);
+    expect(WEB_TOOLS_DISABLED_MESSAGE).toBe(
+      "web tools disabled: missing TINYFISH_API_KEY"
+    );
+  });
+
+  it("warns by default when optional mode omits web tools", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const tools = createCodingAgentTools();
+
+    expect(Object.keys(tools)).toStrictEqual([]);
+    expect(warn).toHaveBeenCalledWith(WEB_TOOLS_DISABLED_MESSAGE);
+  });
+
+  it("registers web tools in required mode when TINYFISH_API_KEY is present", () => {
+    const tools = createCodingAgentTools({
+      openSearchOptions: { env: { TINYFISH_API_KEY: "test-key" } },
+      webToolsAvailability: "required",
+    });
+
+    expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
+  });
+
+  it("fails fast in required mode when TINYFISH_API_KEY is missing", () => {
+    expect(() =>
+      createCodingAgentTools({ webToolsAvailability: "required" })
+    ).toThrowError(CodingAgentWebToolsUnavailableError);
+    expect(() =>
+      createCodingAgentTools({ webToolsAvailability: "required" })
+    ).toThrowError(tinyfishApiKeyPattern);
+  });
+
+  it("never registers web tools in disabled mode, even when configured", () => {
+    const onWebToolsDisabled = vi.fn();
+
+    const tools = createCodingAgentTools({
+      onWebToolsDisabled,
+      openSearchOptions: { env: { TINYFISH_API_KEY: "test-key" } },
+      webToolsAvailability: "disabled",
+    });
+
+    expect(Object.keys(tools)).toStrictEqual([]);
+    expect(onWebToolsDisabled).not.toHaveBeenCalled();
+  });
+
+  it("treats an injected client as configured in required mode", () => {
+    const tools = createCodingAgentTools({
+      client: createStubClient(),
+      webToolsAvailability: "required",
+    });
+
+    expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
+  });
+
+  it("omits web tools in disabled mode even with an injected client", () => {
+    const tools = createCodingAgentTools({
+      client: createStubClient(),
+      webToolsAvailability: "disabled",
+    });
+
+    expect(Object.keys(tools)).toStrictEqual([]);
+  });
+
+  it("parses semicolon-separated TINYFISH_API_KEY pools like OpenSearch", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(
+      Object.keys(
+        createCodingAgentTools({
+          openSearchOptions: {
+            env: { TINYFISH_API_KEY: " ; key-a ;; key-b ; " },
+          },
+        })
+      )
+    ).toStrictEqual(["web_search", "web_fetch"]);
+    expect(
+      Object.keys(
+        createCodingAgentTools({
+          openSearchOptions: { env: { TINYFISH_API_KEY: " ; ; " } },
+        })
+      )
+    ).toStrictEqual([]);
+    expect(
+      Object.keys(
+        createCodingAgentTools({
+          openSearchOptions: { env: { TINYFISH_API_KEY: "" } },
+        })
+      )
+    ).toStrictEqual([]);
+  });
+
+  it("gates on the OpenSearch env override instead of process.env", () => {
+    vi.stubEnv("TINYFISH_API_KEY", "process-env-key");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const tools = createCodingAgentTools({ openSearchOptions: { env: {} } });
+
+    expect(Object.keys(tools)).toStrictEqual([]);
+    expect(warn).toHaveBeenCalledWith(WEB_TOOLS_DISABLED_MESSAGE);
+  });
+});
+
+describe("resolveStartTuiTools availability", () => {
+  beforeEach(() => {
+    vi.stubEnv("TINYFISH_API_KEY", undefined);
+  });
+
+  it("starts the TUI without web tools and warns when TINYFISH_API_KEY is missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const tools = resolveStartTuiTools();
+
+    expect(Object.keys(tools)).toStrictEqual([]);
+    expect(warn).toHaveBeenCalledWith(WEB_TOOLS_DISABLED_MESSAGE);
+  });
+
+  it("fails TUI tool resolution in required mode when TINYFISH_API_KEY is missing", () => {
+    expect(() =>
+      resolveStartTuiTools(undefined, { webToolsAvailability: "required" })
+    ).toThrowError(CodingAgentWebToolsUnavailableError);
+  });
+
+  it("omits TUI web tools in disabled mode even when TINYFISH_API_KEY is present", () => {
+    vi.stubEnv("TINYFISH_API_KEY", "test-key");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const tools = resolveStartTuiTools(undefined, {
+      webToolsAvailability: "disabled",
+    });
+
+    expect(Object.keys(tools)).toStrictEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns override tools unchanged regardless of availability mode", () => {
+    const overrideTools = {};
+
+    expect(
+      resolveStartTuiTools(overrideTools, { webToolsAvailability: "required" })
+    ).toBe(overrideTools);
   });
 });

--- a/apps/coding-agent/src/tools.ts
+++ b/apps/coding-agent/src/tools.ts
@@ -2,6 +2,7 @@ import {
   createOpenSearch,
   type FetchOptions,
   type FetchResult,
+  type OpenSearchEnvironment,
   type OpenSearchOptions,
   type SearchResult,
 } from "@minpeter/opensearch/node";
@@ -10,8 +11,23 @@ import { jsonSchema, type Tool, type ToolSet, tool } from "ai";
 const DEFAULT_SEARCH_RESULT_COUNT = 5;
 const MAX_FETCH_URLS = 10;
 const MAX_SEARCH_RESULTS = 15;
+const TINYFISH_API_KEY_ENV = "TINYFISH_API_KEY";
+
+export const WEB_TOOLS_DISABLED_MESSAGE = `web tools disabled: missing ${TINYFISH_API_KEY_ENV}`;
 
 type CodingAgentToolName = "web_fetch" | "web_search";
+
+/**
+ * Availability mode for the provider-backed web tools:
+ *
+ * - `required`: fail fast during tool/agent initialization when the provider
+ *   configuration (TINYFISH_API_KEY) is missing.
+ * - `optional` (default): omit the web tools when the provider configuration
+ *   is missing and report the omission through `onWebToolsDisabled`
+ *   (default: `console.warn`).
+ * - `disabled`: never register the web tools.
+ */
+export type WebToolsAvailability = "disabled" | "optional" | "required";
 
 export interface CodingAgentOpenSearchClient {
   fetch(
@@ -23,7 +39,9 @@ export interface CodingAgentOpenSearchClient {
 
 export interface CreateCodingAgentToolsOptions {
   readonly client?: CodingAgentOpenSearchClient;
+  readonly onWebToolsDisabled?: (message: string) => void;
   readonly openSearchOptions?: OpenSearchOptions;
+  readonly webToolsAvailability?: WebToolsAvailability;
 }
 
 export interface WebSearchInput {
@@ -58,6 +76,15 @@ export class CodingAgentToolsConfigError extends Error {
   }
 }
 
+export class CodingAgentWebToolsUnavailableError extends Error {
+  readonly code = "web-tools-config-missing";
+
+  constructor() {
+    super(`web tools required: missing ${TINYFISH_API_KEY_ENV}`);
+    this.name = "CodingAgentWebToolsUnavailableError";
+  }
+}
+
 export class CodingAgentToolAbortError extends Error {
   readonly reason: unknown;
   readonly toolName: CodingAgentToolName;
@@ -70,9 +97,43 @@ export class CodingAgentToolAbortError extends Error {
   }
 }
 
+/**
+ * Create the provider-backed web tools, gated on TINYFISH_API_KEY before the
+ * OpenSearch client is wired. An injected `client` counts as provider
+ * configuration in `optional` and `required` modes; `disabled` always returns
+ * an empty tool set. Defaults to `optional`, so startup succeeds without a
+ * key and the omission is reported instead of advertising tools that can only
+ * fail at execution time.
+ */
+export function createCodingAgentTools(
+  options: CreateCodingAgentToolsOptions & {
+    readonly client: CodingAgentOpenSearchClient;
+    readonly webToolsAvailability?: "optional" | "required";
+  }
+): CodingAgentToolSet;
+export function createCodingAgentTools(
+  options?: CreateCodingAgentToolsOptions
+): ToolSet;
 export function createCodingAgentTools(
   options: CreateCodingAgentToolsOptions = {}
-): CodingAgentToolSet {
+): ToolSet {
+  const availability = options.webToolsAvailability ?? "optional";
+  if (availability === "disabled") {
+    return {};
+  }
+
+  if (
+    options.client === undefined &&
+    !hasTinyFishApiKey(options.openSearchOptions?.env ?? process.env)
+  ) {
+    if (availability === "required") {
+      throw new CodingAgentWebToolsUnavailableError();
+    }
+
+    (options.onWebToolsDisabled ?? console.warn)(WEB_TOOLS_DISABLED_MESSAGE);
+    return {};
+  }
+
   const client = resolveOpenSearchClient(options);
   return {
     web_search: createWebSearchTool(client),
@@ -80,8 +141,17 @@ export function createCodingAgentTools(
   };
 }
 
-export function resolveStartTuiTools(tools?: ToolSet): ToolSet {
-  return tools ?? createCodingAgentTools();
+export function resolveStartTuiTools(
+  tools?: ToolSet,
+  options?: CreateCodingAgentToolsOptions
+): ToolSet {
+  return tools ?? createCodingAgentTools(options);
+}
+
+function hasTinyFishApiKey(env: OpenSearchEnvironment): boolean {
+  return (env[TINYFISH_API_KEY_ENV] ?? "")
+    .split(";")
+    .some((apiKey) => apiKey.trim().length > 0);
 }
 
 function resolveOpenSearchClient({

--- a/apps/coding-agent/src/tui.ts
+++ b/apps/coding-agent/src/tui.ts
@@ -19,7 +19,9 @@ import { createTuiRunner, formatTuiHeader } from "./tui-runner";
 export interface StartTuiOptions {
   /**
    * Optional tool set passed straight to the `Agent`. When omitted, the TUI
-   * enables OpenSearch-backed web_search and web_fetch tools.
+   * enables OpenSearch-backed web_search and web_fetch tools when
+   * TINYFISH_API_KEY is configured; otherwise the web tools are omitted and a
+   * warning is logged (availability mode "optional").
    */
   readonly tools?: ToolSet;
 }


### PR DESCRIPTION
Closes #16

## What

`createCodingAgentTools()` and `resolveStartTuiTools()` in `apps/coding-agent/src/tools.ts` now gate on `TINYFISH_API_KEY` **before** wiring the `@minpeter/opensearch` client, via a new explicit `webToolsAvailability` option.

## Mode contract

| Mode | Key present | Key missing |
|---|---|---|
| `required` | registers `web_search` + `web_fetch` | throws `CodingAgentWebToolsUnavailableError` (`web tools required: missing TINYFISH_API_KEY`) during tool/agent initialization — before a model can be offered an unusable tool |
| `optional` (**default**) | registers both tools | returns an empty tool set and reports the omission through `onWebToolsDisabled` (default: `console.warn` logs `web tools disabled: missing TINYFISH_API_KEY`, exported as `WEB_TOOLS_DISABLED_MESSAGE`) |
| `disabled` | empty tool set, never registers | empty tool set, never registers |

Details:

- The key is read from `openSearchOptions.env` when provided, otherwise `process.env` — the same source the OpenSearch client would use — and parsed with the same `;`-separated pool semantics as `@minpeter/opensearch` (`" ; key-a ;; key-b ; "` counts as configured, blanks do not).
- An injected `client` counts as provider configuration in `optional`/`required` (no env check); `disabled` omits the tools even with an injected client.
- Override tools passed to `resolveStartTuiTools(tools, options)` are returned unchanged regardless of mode.
- `createCodingAgentTools({ client })` keeps its precise `CodingAgentToolSet` return type via an overload (that call shape always yields the full set); all other shapes honestly return `ToolSet` since the set may now be empty.
- No new env var: the mode is a programmatic contract at the factory, per the issue's implementation-site guidance.

## Default + rationale

The issue leaves the default open. Chosen default: **`optional`**.

- It preserves today's no-key startup behavior: the TUI and agent initialize successfully without `TINYFISH_API_KEY` (a `required` default would turn every key-less `pss` start into a crash; a `disabled` default would remove web tools even for users who have a key configured).
- It fixes the flagged UX problem: tools that cannot execute are no longer advertised to the model.
- It makes the omission **observable** (logged + injectable callback + exported message constant) instead of silent, satisfying the issue's "observable, not silently hidden" criterion.

## Tegami bump

`.tegami/2026-07-19-coding-agent-tool-availability.md` bumps `npm:@minpeter/pss-coding-agent` with `replay: exit-prerelease(...)`, matching the convention of the previous coding-agent entry (`2026-07-19-remove-cloudflare-session-aliases.md`): the package publishes under the `next` prerelease dist-tag (`0.0.14-next.1`), so the change continues the prerelease line rather than cutting a stable semver bump. The change is additive and backward-compatible at runtime (default preserves no-key startup), so no stable major/minor justification is needed. No runtime (`@minpeter/pss-runtime`) behavior changed — no bump for it.

## RED → GREEN evidence

RED (tests written first, before production code; 10 new mode-matrix tests failing, all other suites untouched):

```
 Test Files  3 failed | 5 passed (8)    # cli/thread-inspect failures are pre-existing: unbuilt @minpeter/pss-runtime dist in a fresh worktree; green on clean origin/main once deps are built
      Tests  10 failed | 37 passed (47)
 × omits web tools in default optional mode when TINYFISH_API_KEY is missing and reports it
 × fails fast in required mode when TINYFISH_API_KEY is missing
 × never registers web tools in disabled mode, even when configured
 × gates on the OpenSearch env override instead of process.env
 × starts the TUI without web tools and warns when TINYFISH_API_KEY is missing
 × ... (10 total)
```

GREEN (after implementing the gate):

```
 Test Files  8 passed (8)
      Tests  52 passed (52)
```

No test performs real TinyFish/OpenSearch network calls: registration tests only construct the client (which is lazy), and execution tests use an injected stub client.

## Test plan / verification

- `pnpm --filter @minpeter/pss-coding-agent test` — 52/52 pass, including the full mode matrix (key present/absent × required/optional/disabled × factory/TUI wiring × injected client × env-override source × `;`-pool parsing × default `console.warn` observability).
- `pnpm --filter @minpeter/pss-coding-agent build` — tsdown build clean; `dist/tools.d.ts` exposes the new API.
- `pnpm typecheck` (turbo across the workspace + root `tsc --noEmit`) — clean.
- `pnpm exec ultracite check` on all changed files — clean.
- Default behavior is documented in `apps/coding-agent/README.md` ("Web tools availability"), TSDoc on `WebToolsAvailability`/`createCodingAgentTools`/`StartTuiOptions.tools`, and covered by tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit availability modes for `web_search`/`web_fetch` so we gate on `TINYFISH_API_KEY` before wiring `@minpeter/opensearch`. This prevents offering unusable tools and keeps no-key startup working by default.

- **New Features**
  - `webToolsAvailability` option in `createCodingAgentTools()` and `resolveStartTuiTools()`:
    - `optional` (default): omit tools when missing key; report via `onWebToolsDisabled` (defaults to `console.warn` with `WEB_TOOLS_DISABLED_MESSAGE`).
    - `required`: throw `CodingAgentWebToolsUnavailableError` when missing key.
    - `disabled`: never register web tools.
  - Key source: `openSearchOptions.env` first, then `process.env`; supports `;`-separated pools like `@minpeter/opensearch`.
  - Injected `client` counts as configured in `optional`/`required`; `disabled` still omits.
  - Override tools passed to `resolveStartTuiTools(tools, options)` are returned unchanged.
  - New exports: `WebToolsAvailability`, `CodingAgentWebToolsUnavailableError`, `WEB_TOOLS_DISABLED_MESSAGE`.

<sup>Written for commit f49eca7433d25d78221197673f571596111b20c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

