### PR TITLE
feat(runtime): durable execution inspection (runId + inspectDurableTurn)

### DIFF
--- a/.tegami/2026-07-19-durable-execution-inspection.md
+++ b/.tegami/2026-07-19-durable-execution-inspection.md
@@ -1,0 +1,21 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: minor
+---
+
+## Inspect durable turn lifecycle by run ID
+
+Expose a stable optional `AgentTurn.runId` for durable work accepted by an
+execution host. Precreate queued user-turn runs after durable input admission,
+carry the same run through execution and checkpoints, and bind resumed
+notifications to the run ID returned by `dispatchAgentNotification`.
+
+Add read-only `inspectDurableTurn(source, runId)` to the existing `./execution`
+subpath. Recorded runs report status, thread key, checkpoint version, and the
+latest checkpoint, with explicit unsupported, unknown-run, and no-checkpoint
+states.
+
+Make thread shutdown await durable cancellation of queued, active, and
+admission-racing runs while preserving completed, failed, recovery, and already
+cancelled terminal statuses.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -863,7 +863,34 @@ internal plugin paths. App code should use `thread.send()`, `thread.steer()`,
 or `agent.resume(runId)` for host-scheduled durable work.
 
 Each accepted call returns one `AgentTurn`. Drain that turn's `events()` stream to
-observe the turn; each `AgentTurn.events()` stream is single-consumer.
+observe the turn; each `AgentTurn.events()` stream is single-consumer. Durable
+turns accepted by an `AgentHost` also expose `turn.runId`. A resumed notification
+uses the same run ID returned by `dispatchAgentNotification`, so dispatch,
+`agent.resume(runId)`, checkpoints, and terminal state share one correlation ID.
+
+Read durable state from the existing execution subpath without changing the turn
+event model:
+
+```ts
+import { inspectDurableTurn } from "@minpeter/pss-runtime/execution";
+
+if (turn.runId) {
+  const report = await inspectDurableTurn(agent.host, turn.runId);
+  console.log(report);
+}
+```
+
+Recorded runs report `runId`, `status`, `threadKey`, `checkpointVersion`,
+`latestCheckpoint`, and `state`. `state` is `"checkpointed"` or
+`"no-checkpoint"`; absent IDs return `"unknown-run"`, and a thread-only store
+returns `"unsupported"`. Lifecycle status distinguishes queued (`queued`),
+active (`running`), claimed/resumed (`leased`), completed (`completed`), failed
+(`error`), and cancelled (`cancelled`) work. Inspection is read-only and does
+not grant resume or cancellation authority.
+
+`dispatchAgentNotification` returns its durable `runId` and deduplicates by the
+owner-, thread-, and caller-scoped `idempotencyKey`. Repeated dispatches return
+the existing run ID with `deduplicated: true`.
 
 Input APIs accept strings, arrays of strings, or multipart arrays such as
 `[{ type: "text", text: "hello" }, { type: "file", data: imageBytes, mediaType: "image/png" }]`. Inline

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -158,7 +158,6 @@ export class Agent {
     const publicHandle: ThreadHandle = {
       compact: (input) => thread.compact(input),
       delete: async () => {
-        thread.kill();
         this.#evictThreadHandle(key);
         try {
           await thread.delete();
@@ -199,6 +198,7 @@ export class Agent {
     return this.#threadEntry(notification.threadKey).notify(
       notification.input,
       {
+        executionRun: { kind: "notification", runId: notification.runId },
         observerEvents: notification.observerEvents,
         overlays: [
           ...(notification.overlays ?? []),

--- a/packages/runtime/src/agent/resume/resume.ts
+++ b/packages/runtime/src/agent/resume/resume.ts
@@ -45,7 +45,9 @@ export async function resumeAgentTurn({
 
     try {
       const notificationRun = await resumeNotification(notification);
-      await completeNotificationRun(host, claimed.runId);
+      if (notificationRun.runId !== claimed.runId) {
+        await completeNotificationRun(host, claimed.runId);
+      }
       return notificationRun;
     } catch (error) {
       await host.store.notifications.releaseByIdempotencyKey(idempotencyKey);
@@ -102,7 +104,13 @@ export async function completeNotificationRun(
   runId: string
 ): Promise<void> {
   const run = await host.store.turns.get(runId);
-  if (run?.kind !== "notification" || run.status === "completed") {
+  if (
+    run?.kind !== "notification" ||
+    run.status === "cancelled" ||
+    run.status === "completed" ||
+    run.status === "error" ||
+    run.status === "needs-recovery"
+  ) {
     return;
   }
 

--- a/packages/runtime/src/contracts/durable-turn-inspection-api.test.ts
+++ b/packages/runtime/src/contracts/durable-turn-inspection-api.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { HostStore } from "../execution";
+import {
+  type DurableTurnInspectionResult,
+  type DurableTurnInspectionSource,
+  inspectDurableTurn,
+} from "../execution";
+import type { AgentTurn } from "../index";
+
+describe("durable turn inspection public API", () => {
+  it("keeps inspection on the existing execution subpath", async () => {
+    const execution = await import("../execution");
+    const runtime = await import("../index");
+
+    expect(execution).toHaveProperty("inspectDurableTurn", inspectDurableTurn);
+    expect(runtime).not.toHaveProperty("inspectDurableTurn");
+  });
+
+  it("types correlation and inspection without changing the turn event model", () => {
+    expectTypeOf<AgentTurn["runId"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<HostStore>().toMatchTypeOf<DurableTurnInspectionSource>();
+    expectTypeOf<
+      Awaited<ReturnType<typeof inspectDurableTurn>>
+    >().toEqualTypeOf<DurableTurnInspectionResult>();
+    expectTypeOf<AgentTurn["events"]>().toBeFunction();
+  });
+});

--- a/packages/runtime/src/execution/durable-lifecycle.characterization.test.ts
+++ b/packages/runtime/src/execution/durable-lifecycle.characterization.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { Agent, createAgent } from "../agent/core/agent";
+import { createInMemoryHost } from "../platform/memory";
+import { MemoryThreadStore } from "../platform/memory/storage/memory-thread-store";
+import {
+  assistantMessage,
+  createCallbackModel,
+  createDeferred,
+  eventTypes,
+  userText,
+} from "../testing/test-fixtures";
+import { collect } from "../thread/handle/test-support";
+import { AgentThread } from "../thread/handle/thread";
+import { dispatchAgentNotification } from "./dispatch/notification-dispatch";
+
+describe("durable lifecycle characterization", () => {
+  it("dispatches one durable notification for an idempotency key", async () => {
+    const host = createInMemoryHost();
+    const input = {
+      host,
+      idempotencyKey: "characterization-notification",
+      input: userText("background work completed"),
+      namespace: "characterization-agent",
+      threadKey: "characterization-thread",
+    } as const;
+
+    const first = await dispatchAgentNotification(input);
+    const duplicate = await dispatchAgentNotification(input);
+
+    expect(first.deduplicated).toBe(false);
+    expect(duplicate).toEqual({ ...first, deduplicated: true });
+    await expect(host.store.turns.get(first.runId)).resolves.toEqual(
+      expect.objectContaining({
+        kind: "notification",
+        runId: first.runId,
+        status: "queued",
+        threadKey: input.threadKey,
+      })
+    );
+  });
+
+  it("resumes a dispatched notification through the same event stream once", async () => {
+    const host = createInMemoryHost();
+    const agent = new Agent({
+      host,
+      model: createCallbackModel(() =>
+        Promise.resolve([assistantMessage("notification handled")])
+      ),
+      namespace: "characterization-agent",
+    });
+    const dispatched = await dispatchAgentNotification({
+      host,
+      idempotencyKey: "characterization-resume",
+      input: userText("resume this notification"),
+      namespace: "characterization-agent",
+      threadKey: "characterization-thread",
+    });
+
+    const turn = await agent.resume(dispatched.runId);
+    expect(turn).not.toBeNull();
+    if (!turn) {
+      throw new Error("Expected the dispatched notification to resume.");
+    }
+
+    expect(eventTypes(await collect(turn))).toEqual([
+      "turn-start",
+      "runtime-input",
+      "step-start",
+      "model-usage",
+      "assistant-output",
+      "step-end",
+      "turn-end",
+    ]);
+    await expect(agent.resume(dispatched.runId)).resolves.toBeNull();
+    await expect(host.store.turns.get(dispatched.runId)).resolves.toEqual(
+      expect.objectContaining({ status: "completed" })
+    );
+  });
+
+  it("dispose closes active and queued turns and rejects later input", async () => {
+    const modelStarted = createDeferred();
+    const modelGate = createDeferred();
+    const agent = await createAgent({
+      model: createCallbackModel(async () => {
+        modelStarted.resolve();
+        await modelGate.promise;
+        return [assistantMessage("done")];
+      }),
+    });
+    const thread = agent.thread("characterization-dispose");
+    const activeEvents = collect(await thread.send("active"));
+    const queuedEvents = collect(await thread.send("queued"));
+    await modelStarted.promise;
+
+    const disposal = thread.dispose();
+    modelGate.resolve();
+    await disposal;
+
+    expect(eventTypes(await activeEvents)).toContain("turn-error");
+    expect(eventTypes(await queuedEvents)).toEqual([
+      "user-input",
+      "turn-error",
+    ]);
+    await expect(thread.send("late")).rejects.toThrow("Thread killed");
+  });
+
+  it("kill immediately closes active and queued turns", async () => {
+    const modelStarted = createDeferred();
+    const modelGate = createDeferred();
+    const thread = new AgentThread(
+      {
+        model: createCallbackModel(async () => {
+          modelStarted.resolve();
+          await modelGate.promise;
+          return [assistantMessage("done")];
+        }),
+      },
+      {
+        key: "characterization-kill",
+        store: new MemoryThreadStore(),
+      }
+    );
+    const activeEvents = collect(await thread.send("active"));
+    const queuedEvents = collect(await thread.send("queued"));
+    await modelStarted.promise;
+
+    thread.kill();
+    modelGate.resolve();
+
+    expect(eventTypes(await activeEvents)).toContain("turn-error");
+    expect(eventTypes(await queuedEvents)).toEqual([
+      "user-input",
+      "turn-error",
+    ]);
+    await expect(thread.steer("late")).rejects.toThrow("Thread killed");
+  });
+});

--- a/packages/runtime/src/execution/host/thread-execution-run-id.test.ts
+++ b/packages/runtime/src/execution/host/thread-execution-run-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createThreadExecutionRunId } from "./thread-execution-run-id";
+
+describe("thread execution run IDs", () => {
+  it("preserves scoped thread-key and turn-id boundaries", () => {
+    const first = createThreadExecutionRunId({
+      threadKey: "scope:tenant:thread:room",
+      turnId: "message:1",
+    });
+    const second = createThreadExecutionRunId({
+      threadKey: "scope:tenant:thread:room:message",
+      turnId: "1",
+    });
+
+    expect(first).toBe("turn:v1:scope%3Atenant%3Athread%3Aroom:message%3A1");
+    expect(second).not.toBe(first);
+  });
+});

--- a/packages/runtime/src/execution/host/thread-execution-run-id.ts
+++ b/packages/runtime/src/execution/host/thread-execution-run-id.ts
@@ -1,0 +1,13 @@
+const THREAD_EXECUTION_RUN_PREFIX = "turn:v1:";
+
+export interface ThreadExecutionRunIdentity {
+  readonly threadKey: string;
+  readonly turnId: string;
+}
+
+export function createThreadExecutionRunId({
+  threadKey,
+  turnId,
+}: ThreadExecutionRunIdentity): string {
+  return `${THREAD_EXECUTION_RUN_PREFIX}${encodeURIComponent(threadKey)}:${encodeURIComponent(turnId)}`;
+}

--- a/packages/runtime/src/execution/index.ts
+++ b/packages/runtime/src/execution/index.ts
@@ -55,3 +55,8 @@ export type {
   TurnStatus,
   TurnStore,
 } from "./host/types";
+export type {
+  DurableTurnInspectionResult,
+  DurableTurnInspectionSource,
+} from "./inspect/durable-turn";
+export { inspectDurableTurn } from "./inspect/durable-turn";

--- a/packages/runtime/src/execution/inspect/durable-turn-lifecycle.test.ts
+++ b/packages/runtime/src/execution/inspect/durable-turn-lifecycle.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi } from "vitest";
+import { Agent } from "../../agent/core/agent";
+import { createInMemoryHost } from "../../platform/memory";
+import {
+  assistantMessage,
+  createCallbackModel,
+  createDeferred,
+  eventTypes,
+  userText,
+} from "../../testing/test-fixtures";
+import { collect } from "../../thread/handle/test-support";
+import { AgentThread } from "../../thread/handle/thread";
+import { dispatchAgentNotification } from "../dispatch/notification-dispatch";
+import { inspectDurableTurn } from "./durable-turn";
+
+describe("durable turn lifecycle inspection", () => {
+  it("exposes one run id across queued, running, and completed send states", async () => {
+    const host = createInMemoryHost();
+    const activeStarted = createDeferred();
+    const activeGate = createDeferred();
+    let calls = 0;
+    const agent = new Agent({
+      host,
+      model: createCallbackModel(async () => {
+        calls += 1;
+        if (calls === 1) {
+          activeStarted.resolve();
+          await activeGate.promise;
+        }
+        return [assistantMessage(`done ${calls}`)];
+      }),
+    });
+    const thread = agent.thread("lifecycle-send");
+    const active = await thread.send("active");
+    const activeDrain = collect(active);
+    await activeStarted.promise;
+    const queued = await thread.send("queued");
+
+    expect(active.runId).toEqual(expect.any(String));
+    expect(queued.runId).toEqual(expect.any(String));
+    expect(queued.runId).not.toBe(active.runId);
+    await expect(
+      inspectDurableTurn(host, active.runId ?? "")
+    ).resolves.toMatchObject({
+      runId: active.runId,
+      status: "running",
+      threadKey: "lifecycle-send",
+    });
+    await expect(
+      inspectDurableTurn(host, queued.runId ?? "")
+    ).resolves.toMatchObject({
+      runId: queued.runId,
+      status: "queued",
+      threadKey: "lifecycle-send",
+    });
+
+    activeGate.resolve();
+    await activeDrain;
+    await collect(queued);
+
+    await expect(
+      inspectDurableTurn(host, active.runId ?? "")
+    ).resolves.toMatchObject({
+      runId: active.runId,
+      status: "completed",
+    });
+    await expect(
+      inspectDurableTurn(host, queued.runId ?? "")
+    ).resolves.toMatchObject({
+      runId: queued.runId,
+      status: "completed",
+    });
+  });
+
+  it("reports failed durable turns without changing event semantics", async () => {
+    const host = createInMemoryHost();
+    const agent = new Agent({
+      host,
+      model: createCallbackModel(() => {
+        throw new Error("model failed");
+      }),
+    });
+
+    const turn = await agent.send("fail");
+    expect(eventTypes(await collect(turn))).toContain("turn-error");
+    await expect(
+      inspectDurableTurn(host, turn.runId ?? "")
+    ).resolves.toMatchObject({
+      runId: turn.runId,
+      state: "no-checkpoint",
+      status: "error",
+    });
+  });
+
+  it("cancels queued and active runs on dispose while preserving completed runs", async () => {
+    const host = createInMemoryHost();
+    const activeStarted = createDeferred();
+    const activeGate = createDeferred();
+    let calls = 0;
+    const agent = new Agent({
+      host,
+      model: createCallbackModel(async () => {
+        calls += 1;
+        if (calls === 2) {
+          activeStarted.resolve();
+          await activeGate.promise;
+        }
+        return [assistantMessage(`done ${calls}`)];
+      }),
+    });
+    const thread = agent.thread("lifecycle-cancel");
+    const completed = await thread.send("complete first");
+    await collect(completed);
+    const active = await thread.send("active");
+    const activeDrain = collect(active);
+    await activeStarted.promise;
+    const queued = await thread.send("queued");
+    const queuedDrain = collect(queued);
+
+    const disposal = thread.dispose();
+    activeGate.resolve();
+    await disposal;
+    await Promise.all([activeDrain, queuedDrain]);
+
+    await expect(
+      inspectDurableTurn(host, completed.runId ?? "")
+    ).resolves.toMatchObject({
+      status: "completed",
+    });
+    await expect(
+      inspectDurableTurn(host, active.runId ?? "")
+    ).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    await expect(
+      inspectDurableTurn(host, queued.runId ?? "")
+    ).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    await expect(
+      host.store.inputs.claimNext("lifecycle-cancel", "turn-idle")
+    ).resolves.toBeNull();
+  });
+
+  it("awaits durable active-run cancellation from kill", async () => {
+    const host = createInMemoryHost();
+    const modelStarted = createDeferred();
+    const modelGate = createDeferred();
+    const thread = new AgentThread(
+      {
+        model: createCallbackModel(async () => {
+          modelStarted.resolve();
+          await modelGate.promise;
+          return [assistantMessage("done")];
+        }),
+      },
+      { key: "lifecycle-kill", store: host.store.threads },
+      { executionHost: host }
+    );
+    const turn = await thread.send("kill active run");
+    const drain = collect(turn);
+    await modelStarted.promise;
+
+    const killed = thread.kill();
+    modelGate.resolve();
+    await killed;
+    await drain;
+
+    await expect(
+      inspectDurableTurn(host, turn.runId ?? "")
+    ).resolves.toMatchObject({
+      runId: turn.runId,
+      status: "cancelled",
+    });
+  });
+
+  it("cancels a precreated run when dispose races with admission", async () => {
+    const host = createInMemoryHost();
+    const createStarted = createDeferred();
+    const allowCreate = createDeferred();
+    const originalTransaction = host.store.transaction.bind(host.store);
+    let precreatedRunId: string | undefined;
+    vi.spyOn(host.store, "transaction").mockImplementation((callback) =>
+      originalTransaction((transaction) =>
+        callback({
+          ...transaction,
+          turns: {
+            claim: (targetRunId, options) =>
+              transaction.turns.claim(targetRunId, options),
+            create: async (record) => {
+              if (record.kind === "user-turn" && record.status === "queued") {
+                precreatedRunId = record.runId;
+                createStarted.resolve();
+                await allowCreate.promise;
+              }
+              return await transaction.turns.create(record);
+            },
+            get: (targetRunId) => transaction.turns.get(targetRunId),
+            getByDedupeKey: (dedupeKey) =>
+              transaction.turns.getByDedupeKey(dedupeKey),
+            listByParentRunId: (parentRunId) =>
+              transaction.turns.listByParentRunId(parentRunId),
+            update: (record) => transaction.turns.update(record),
+          },
+        })
+      )
+    );
+    const agent = new Agent({
+      host,
+      model: createCallbackModel(() =>
+        Promise.resolve([assistantMessage("not reached")])
+      ),
+    });
+    const thread = agent.thread("lifecycle-admission-race");
+
+    const sending = thread.send("race disposal");
+    await createStarted.promise;
+    const disposal = thread.dispose();
+    allowCreate.resolve();
+
+    await expect(sending).rejects.toThrow("Thread killed");
+    await disposal;
+    expect(precreatedRunId).toEqual(expect.any(String));
+    await expect(
+      inspectDurableTurn(host, precreatedRunId ?? "")
+    ).resolves.toMatchObject({
+      runId: precreatedRunId,
+      status: "cancelled",
+    });
+  });
+
+  it("resumes notification processing on the dispatched run id", async () => {
+    const host = createInMemoryHost();
+    const modelStarted = createDeferred();
+    const modelGate = createDeferred();
+    const agent = new Agent({
+      host,
+      model: createCallbackModel(async () => {
+        modelStarted.resolve();
+        await modelGate.promise;
+        return [assistantMessage("resumed")];
+      }),
+      namespace: "resume-owner",
+    });
+    const dispatched = await dispatchAgentNotification({
+      host,
+      idempotencyKey: "lifecycle-resume",
+      input: userText("resume notification"),
+      namespace: "resume-owner",
+      threadKey: "lifecycle-resume",
+    });
+
+    const turn = await agent.resume(dispatched.runId);
+    expect(turn?.runId).toBe(dispatched.runId);
+    if (!turn) {
+      throw new Error("Expected dispatched notification to resume.");
+    }
+    const drain = collect(turn);
+    await modelStarted.promise;
+    await expect(
+      inspectDurableTurn(host, dispatched.runId)
+    ).resolves.toMatchObject({
+      runId: dispatched.runId,
+      status: "running",
+      threadKey: "lifecycle-resume",
+    });
+
+    modelGate.resolve();
+    await drain;
+    await expect(
+      inspectDurableTurn(host, dispatched.runId)
+    ).resolves.toMatchObject({
+      runId: dispatched.runId,
+      status: "completed",
+    });
+  });
+});

--- a/packages/runtime/src/execution/inspect/durable-turn.test.ts
+++ b/packages/runtime/src/execution/inspect/durable-turn.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInMemoryHost, MemoryThreadStore } from "../../platform/memory";
+import type {
+  Checkpoint,
+  HostStore,
+  TurnRecord,
+  TurnStatus,
+} from "../host/types";
+import { inspectDurableTurn } from "./durable-turn";
+
+const runId = "inspect-run";
+
+describe("inspectDurableTurn", () => {
+  it("reports unsupported and unknown-run boundaries explicitly", async () => {
+    await expect(
+      inspectDurableTurn(new MemoryThreadStore(), runId)
+    ).resolves.toEqual({ runId, state: "unsupported" });
+
+    const host = createInMemoryHost();
+    const latest = vi.spyOn(host.store.checkpoints, "latest");
+    await expect(inspectDurableTurn(host, runId)).resolves.toEqual({
+      runId,
+      state: "unknown-run",
+    });
+    expect(latest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["queued", "queued"],
+    ["running", "running"],
+    ["resumed", "leased"],
+    ["completed", "completed"],
+    ["failed", "error"],
+    ["cancelled", "cancelled"],
+  ] satisfies readonly (readonly [
+    string,
+    TurnStatus,
+  ])[])("reports the %s lifecycle boundary without a checkpoint", async (_boundary, status) => {
+    const host = createInMemoryHost();
+    const turn = turnRecord(status);
+    await host.store.turns.create(turn);
+
+    await expect(inspectDurableTurn(host.store, runId)).resolves.toEqual({
+      checkpointVersion: 0,
+      latestCheckpoint: null,
+      runId,
+      state: "no-checkpoint",
+      status,
+      threadKey: "inspect-thread",
+    });
+  });
+
+  it("returns the latest checkpoint and matching version atomically", async () => {
+    const host = createInMemoryHost();
+    await host.store.turns.create(turnRecord("running"));
+    const checkpoint = inspectionCheckpoint();
+    await host.store.checkpoints.append(checkpoint, { expectedVersion: 0 });
+    const transaction = vi.spyOn(host.store, "transaction");
+
+    await expect(inspectDurableTurn(host, runId)).resolves.toEqual({
+      checkpointVersion: 1,
+      latestCheckpoint: checkpoint,
+      runId,
+      state: "checkpointed",
+      status: "running",
+      threadKey: "inspect-thread",
+    });
+    expect(transaction).toHaveBeenCalledOnce();
+  });
+
+  it("uses transaction ports instead of reading the outer store", async () => {
+    const host = createInMemoryHost();
+    await host.store.turns.create(turnRecord("queued"));
+    const source: HostStore = {
+      ...host.store,
+      checkpoints: {
+        ...host.store.checkpoints,
+        latest: () => Promise.reject(new Error("outer checkpoint read")),
+      },
+      transaction: (callback) => host.store.transaction(callback),
+      turns: {
+        ...host.store.turns,
+        get: () => Promise.reject(new Error("outer turn read")),
+      },
+    };
+
+    await expect(inspectDurableTurn(source, runId)).resolves.toMatchObject({
+      runId,
+      state: "no-checkpoint",
+      status: "queued",
+    });
+  });
+});
+
+function turnRecord(status: TurnStatus): TurnRecord {
+  return {
+    checkpointVersion: 0,
+    kind: "user-turn",
+    rootRunId: runId,
+    runId,
+    status,
+    threadKey: "inspect-thread",
+  };
+}
+
+function inspectionCheckpoint(): Checkpoint {
+  return {
+    checkpointId: "inspect-checkpoint-1",
+    phase: "before-model",
+    runId,
+    runtimeState: { runtimeStepIndex: 1 },
+    threadSnapshot: { history: [] },
+    version: 1,
+  };
+}

--- a/packages/runtime/src/execution/inspect/durable-turn.ts
+++ b/packages/runtime/src/execution/inspect/durable-turn.ts
@@ -1,0 +1,77 @@
+import type { ThreadStore } from "../../thread/store/types";
+import type {
+  AgentHost,
+  Checkpoint,
+  HostStore,
+  TurnStatus,
+} from "../host/types";
+
+export type DurableTurnInspectionSource = AgentHost | HostStore | ThreadStore;
+
+interface RecordedDurableTurnInspection {
+  readonly checkpointVersion: number;
+  readonly latestCheckpoint: Checkpoint | null;
+  readonly runId: string;
+  readonly state: "checkpointed" | "no-checkpoint";
+  readonly status: TurnStatus;
+  readonly threadKey: string;
+}
+
+export type DurableTurnInspectionResult =
+  | {
+      readonly runId: string;
+      readonly state: "unsupported";
+    }
+  | {
+      readonly runId: string;
+      readonly state: "unknown-run";
+    }
+  | RecordedDurableTurnInspection;
+
+/** Read one atomic run/checkpoint snapshot without granting recovery authority. */
+export async function inspectDurableTurn(
+  source: DurableTurnInspectionSource,
+  runId: string
+): Promise<DurableTurnInspectionResult> {
+  const store = hostStore(source);
+  if (!store) {
+    return { runId, state: "unsupported" };
+  }
+
+  return await store.transaction(async (transaction) => {
+    const turn = await transaction.turns.get(runId);
+    if (!turn) {
+      return { runId, state: "unknown-run" };
+    }
+
+    const latestCheckpoint = await transaction.checkpoints.latest(runId);
+    return {
+      checkpointVersion: turn.checkpointVersion,
+      latestCheckpoint,
+      runId,
+      state: latestCheckpoint ? "checkpointed" : "no-checkpoint",
+      status: turn.status,
+      threadKey: turn.threadKey,
+    };
+  });
+}
+
+function hostStore(source: DurableTurnInspectionSource): HostStore | undefined {
+  if (isHostStore(source)) {
+    return source;
+  }
+  if (isAgentHost(source)) {
+    return source.store;
+  }
+  return;
+}
+
+function isAgentHost(source: DurableTurnInspectionSource): source is AgentHost {
+  return "store" in source && isHostStore(source.store);
+}
+
+function isHostStore(source: object): source is HostStore {
+  return (
+    "checkpoints" in source && "transaction" in source && "turns" in source
+  );
+}

--- a/packages/runtime/src/execution/run/stored-agent-turn.test.ts
+++ b/packages/runtime/src/execution/run/stored-agent-turn.test.ts
@@ -33,6 +33,7 @@ describe("stored AgentTurn events", () => {
       runId: "run-1",
     });
 
+    expect(run.runId).toBe("run-1");
     await expect(collectRunEvents(run)).resolves.toEqual([
       { type: "turn-end" },
     ]);

--- a/packages/runtime/src/execution/run/stored-agent-turn.ts
+++ b/packages/runtime/src/execution/run/stored-agent-turn.ts
@@ -22,6 +22,10 @@ export class StoredAgentTurn implements AgentTurn {
     this.#runId = runId;
   }
 
+  get runId(): string {
+    return this.#runId;
+  }
+
   events(): AsyncIterable<AgentEvent> {
     if (this.#eventsStarted) {
       throw new Error("AgentTurn.events() can only be consumed once");

--- a/packages/runtime/src/thread/handle/durable-queue.test.ts
+++ b/packages/runtime/src/thread/handle/durable-queue.test.ts
@@ -155,11 +155,16 @@ function transformAnyInputToTextPlugin() {
 
 function duplicateAdmissionHost(): AgentHost {
   const base = createInMemoryHost();
+  const inputs = duplicateAdmissionInbox(base.store.inputs);
   return {
     ...base,
     store: {
       ...base.store,
-      inputs: duplicateAdmissionInbox(base.store.inputs),
+      inputs,
+      transaction: (callback) =>
+        base.store.transaction((transaction) =>
+          callback({ ...transaction, inputs })
+        ),
     },
   };
 }

--- a/packages/runtime/src/thread/handle/durable-queue.ts
+++ b/packages/runtime/src/thread/handle/durable-queue.ts
@@ -1,3 +1,4 @@
+import { createThreadExecutionRunId } from "../../execution/host/thread-execution-run-id";
 import type { AgentHost } from "../../execution/host/types";
 import {
   cleanupStagedRuntimeAttachments,
@@ -22,6 +23,10 @@ import {
   recoverDurableThreadInputs,
 } from "../runtime/durable-inputs";
 import type { ThreadEventDispatcher } from "../runtime/events";
+import {
+  cancelThreadExecutionRun,
+  precreateThreadExecutionRun,
+} from "../runtime/execution";
 import { startThreadQueueDrain } from "../runtime/notification";
 
 export class DurableInputRecoveryState {
@@ -159,11 +164,21 @@ export async function createQueuedSendInput({
       executionHost,
       input: queuedInput,
       kind: "send",
+      precreateExecutionRun: true,
       threadKey,
     });
-    if (admission.kind === "admitted" && admission.receipt.duplicate) {
-      run.close();
-      return { kind: "handled" };
+    let executionRun: QueuedInput["executionRun"];
+    if (admission.kind === "admitted") {
+      if (admission.receipt.duplicate) {
+        run.close();
+        return { kind: "handled" };
+      }
+
+      const precreated = admission.executionRun;
+      if (precreated) {
+        executionRun = { kind: precreated.kind, runId: precreated.runId };
+        run.bindRunId(precreated.runId);
+      }
     }
 
     const item = {
@@ -173,6 +188,7 @@ export async function createQueuedSendInput({
       ...(admission.kind === "admitted"
         ? { durableMessageId: admission.receipt.record.messageId }
         : {}),
+      ...(executionRun ? { executionRun } : {}),
       initialEvents: [],
       ...(admission.kind === "unavailable"
         ? { input: structuredClone(queuedInput) }
@@ -211,13 +227,26 @@ export async function claimOrphanDurableThreadInput({
     return;
   }
 
+  const runId = createThreadExecutionRunId({
+    threadKey: claimed.record.threadKey,
+    turnId: claimed.record.messageId,
+  });
+  const precreated = await precreateThreadExecutionRun({
+    executionHost,
+    kind: "user-turn",
+    runId,
+    threadKey,
+  });
   return {
     acceptedEvent: claimed.record.input,
     awaitBoundaries: false,
     durableInputClaim: claimed.record,
+    ...(precreated
+      ? { executionRun: { kind: precreated.kind, runId: precreated.runId } }
+      : {}),
     initialEvents: [],
     preUserRuntimeInputs: [],
-    run: new BufferedAgentTurn(),
+    run: new BufferedAgentTurn(precreated?.runId),
     runtimeInput: createRuntimeInputState([]),
   };
 }
@@ -245,6 +274,10 @@ export async function prepareQueuedDurableInput({
     return { ...item, durableInputClaim: claimed.record };
   }
 
+  await cancelThreadExecutionRun({
+    executionHost,
+    executionRun: item.executionRun,
+  });
   item.run.close();
   return;
 }

--- a/packages/runtime/src/thread/handle/thread.ts
+++ b/packages/runtime/src/thread/handle/thread.ts
@@ -57,6 +57,7 @@ export class AgentThread {
   #drainRequested = false;
   #inputAdmissionQueue: Promise<void> = Promise.resolve();
   #killed = false;
+  #killPromise?: Promise<void>;
   #running = false;
   #runToCloseOnKill?: BufferedAgentTurn;
   #shutdownPromise?: Promise<void>;
@@ -128,6 +129,7 @@ export class AgentThread {
       run,
       threadKey: this.#threadKey,
     });
+    this.#assertOpen();
   }
 
   overlay(input: AgentInput): this {
@@ -155,8 +157,11 @@ export class AgentThread {
       drain: () => this.#drainInputQueue(),
       emitObserverEvent: (run, event) =>
         this.#events.emitObserverEvent(run, event),
+      executionHost: this.#execution.executionHost,
       inputQueue: this.#inputQueue,
       pendingRuntimeInputs: this.#pendingRuntimeInputs,
+      threadKey: this.#threadKey,
+      throwIfTerminal: () => this.#assertOpen(),
     });
   }
 
@@ -206,27 +211,29 @@ export class AgentThread {
 
   delete(): Promise<void> {
     if (!this.#deletePromise) {
-      this.kill();
-      this.#deletePromise = this.#deleteThread().catch((error: unknown) => {
-        this.#deletePromise = undefined;
-        throw error;
-      });
+      this.#deletePromise = this.kill()
+        .then(() => this.#deleteThread())
+        .catch((error: unknown) => {
+          this.#deletePromise = undefined;
+          throw error;
+        });
     }
     return this.#deletePromise;
   }
 
   async dispose(): Promise<void> {
-    this.kill();
+    const kill = this.kill();
     try {
       await this.#drainPromise;
     } finally {
+      await kill;
       await this.#shutdownThread();
     }
   }
 
-  kill(): void {
+  kill(): Promise<void> {
     if (this.#killed) {
-      return;
+      return this.#killPromise ?? Promise.resolve();
     }
 
     this.#killed = true;
@@ -234,12 +241,29 @@ export class AgentThread {
     this.#pendingOverlays.length = 0;
     this.#pendingRuntimeInputs.length = 0;
     this.#activeAbort?.abort();
-    closeKilledRuntimeInputs({
+    const immediateClose = closeKilledRuntimeInputs({
       activeRuntimeInput: this.#activeRuntimeInput,
+      executionHost: this.#execution.executionHost,
       inputQueue: this.#inputQueue,
       message: killedError.message,
       runToClose: this.#runToCloseOnKill ?? this.#activeRun,
+      threadKey: this.#threadKey,
     });
+    const admissionClose = this.#inputAdmissionQueue.then(() =>
+      closeKilledRuntimeInputs({
+        activeRuntimeInput: undefined,
+        executionHost: this.#execution.executionHost,
+        inputQueue: this.#inputQueue,
+        message: killedError.message,
+        runToClose: undefined,
+        threadKey: this.#threadKey,
+      })
+    );
+    this.#killPromise = Promise.all([immediateClose, admissionClose]).then(
+      () => undefined
+    );
+    this.#killPromise.catch(() => undefined);
+    return this.#killPromise;
   }
 
   async #deleteThread(): Promise<void> {

--- a/packages/runtime/src/thread/input/runtime-input.ts
+++ b/packages/runtime/src/thread/input/runtime-input.ts
@@ -1,6 +1,7 @@
 import type { ClaimedThreadInput } from "../../execution/host/types";
 import type { AgentEvent, RuntimeInput } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
+import type { QueuedThreadExecutionRun } from "../runtime/execution";
 import {
   cleanupStagedRuntimeAttachments,
   type HostAttachmentStore,
@@ -34,6 +35,7 @@ export interface QueuedInput {
   readonly durableInput?: boolean;
   readonly durableInputClaim?: ClaimedThreadInput;
   readonly durableMessageId?: string;
+  readonly executionRun?: QueuedThreadExecutionRun;
   readonly initialEvents: AgentEvent[];
   readonly input?: UserInput;
   readonly preUserRuntimeInputs: QueuedRuntimeInput[];

--- a/packages/runtime/src/thread/protocol/turn.test.ts
+++ b/packages/runtime/src/thread/protocol/turn.test.ts
@@ -10,6 +10,19 @@ const expectPending = async (promise: Promise<unknown>) => {
 };
 
 describe("AgentTurn", () => {
+  it("binds one stable optional durable run id", () => {
+    const local = new BufferedAgentTurn();
+    expect(local.runId).toBeUndefined();
+
+    local.bindRunId("run-1");
+    local.bindRunId("run-1");
+
+    expect(local.runId).toBe("run-1");
+    expect(() => local.bindRunId("run-2")).toThrow(
+      "AgentTurn is already bound to run id run-1"
+    );
+  });
+
   it("delivers events emitted before events consumption", async () => {
     const run = new BufferedAgentTurn();
     run.emit({ type: "user-input", text: "hello" });

--- a/packages/runtime/src/thread/protocol/turn.ts
+++ b/packages/runtime/src/thread/protocol/turn.ts
@@ -2,6 +2,7 @@ import type { AgentEvent } from "./events";
 
 export interface AgentTurn {
   events(): AsyncIterable<AgentEvent>;
+  readonly runId?: string;
 }
 
 interface QueuedEvent {
@@ -20,8 +21,27 @@ export class BufferedAgentTurn implements AgentTurn {
   #error: unknown;
   #pendingAck: (() => void) | undefined;
   #resultPending = false;
+  #runId: string | undefined;
   #eventsStarted = false;
   #waiter: NextWaiter | undefined;
+
+  constructor(runId?: string) {
+    this.#runId = runId;
+  }
+
+  get runId(): string | undefined {
+    return this.#runId;
+  }
+
+  bindRunId(runId: string): void {
+    if (this.#runId === undefined) {
+      this.#runId = runId;
+      return;
+    }
+    if (this.#runId !== runId) {
+      throw new Error(`AgentTurn is already bound to run id ${this.#runId}`);
+    }
+  }
 
   emit(event: AgentEvent): void {
     if (this.#closed) {

--- a/packages/runtime/src/thread/runtime/durable-inputs.ts
+++ b/packages/runtime/src/thread/runtime/durable-inputs.ts
@@ -1,3 +1,4 @@
+import { createThreadExecutionRunId } from "../../execution/host/thread-execution-run-id";
 import type {
   AdmitReceipt,
   AgentHost,
@@ -7,10 +8,13 @@ import type {
   ThreadInputKind,
   ThreadInputPlacement,
   ThreadInputRecord,
+  TurnRecord,
 } from "../../execution/host/types";
 import { ThreadInputInboxUnavailableError } from "../../execution/host/unsupported-thread-input-inbox";
 import type { UserInput } from "../input/input";
+import type { QueuedInput } from "../input/runtime-input";
 import type { ThreadState } from "../state/thread-state";
+import { precreateThreadExecutionRun } from "./execution";
 import {
   appendDurableThreadEvents,
   type DurableThreadEventBuffer,
@@ -21,6 +25,7 @@ import {
 
 export type DurableInputAdmission =
   | {
+      readonly executionRun?: TurnRecord;
       readonly kind: "admitted";
       readonly receipt: AdmitReceipt;
     }
@@ -38,12 +43,14 @@ export async function admitDurableThreadInput({
   input,
   kind,
   placement,
+  precreateExecutionRun = false,
   threadKey,
 }: {
   readonly executionHost: AgentHost | undefined;
   readonly input: UserInput;
   readonly kind: ThreadInputKind;
   readonly placement?: ThreadInputPlacement;
+  readonly precreateExecutionRun?: boolean;
   readonly threadKey: string;
 }): Promise<DurableInputAdmission> {
   if (!executionHost) {
@@ -51,10 +58,33 @@ export async function admitDurableThreadInput({
   }
 
   try {
+    const messageId = crypto.randomUUID();
+    if (precreateExecutionRun) {
+      return await executionHost.store.transaction(async (transaction) => {
+        const receipt = await transaction.inputs.admit({
+          input,
+          kind,
+          messageId,
+          placement,
+          threadKey,
+        });
+        if (receipt.duplicate) {
+          return { kind: "admitted", receipt };
+        }
+        const executionRun = await precreateThreadExecutionRun({
+          kind: "user-turn",
+          runId: createThreadExecutionRunId({ threadKey, turnId: messageId }),
+          threadKey,
+          turnStore: transaction.turns,
+        });
+        return { executionRun, kind: "admitted", receipt };
+      });
+    }
+
     const receipt = await executionHost.store.inputs.admit({
       input,
       kind,
-      messageId: crypto.randomUUID(),
+      messageId,
       placement,
       threadKey,
     });
@@ -235,6 +265,63 @@ export async function releaseDurableThreadInputClaim({
   }
 
   await executionHost.store.inputs.releaseClaim(record);
+}
+
+export async function cancelQueuedDurableThreadInputs({
+  executionHost,
+  items,
+  threadKey,
+}: {
+  readonly executionHost: AgentHost | undefined;
+  readonly items: readonly QueuedInput[];
+  readonly threadKey: string;
+}): Promise<void> {
+  const durableItems = items.filter(
+    (item): item is QueuedInput & { readonly durableMessageId: string } =>
+      typeof item.durableMessageId === "string"
+  );
+  if (!(executionHost && durableItems.length > 0)) {
+    return;
+  }
+
+  await executionHost.store.transaction(async (transaction) => {
+    for (const item of durableItems) {
+      const claimed = await transaction.inputs.claimNext(
+        threadKey,
+        "turn-idle",
+        { messageId: item.durableMessageId }
+      );
+      if (!claimed) {
+        continue;
+      }
+      const promoted = await transaction.inputs.markPromoted(claimed);
+      if (!promoted) {
+        throw new DurableThreadInputClaimError("promote", claimed);
+      }
+      const acked = await transaction.inputs.ack(promoted);
+      if (!acked) {
+        throw new DurableThreadInputClaimError("ack", claimed);
+      }
+
+      const runId = item.executionRun?.runId ?? item.run.runId;
+      if (!runId) {
+        continue;
+      }
+      const run = await transaction.turns.get(runId);
+      if (run && !isTerminalTurnStatus(run.status)) {
+        await transaction.turns.update({ ...run, status: "cancelled" });
+      }
+    }
+  });
+}
+
+function isTerminalTurnStatus(status: TurnRecord["status"]): boolean {
+  return (
+    status === "cancelled" ||
+    status === "completed" ||
+    status === "error" ||
+    status === "needs-recovery"
+  );
 }
 
 function isThreadInputInboxUnavailable(

--- a/packages/runtime/src/thread/runtime/execution.test.ts
+++ b/packages/runtime/src/thread/runtime/execution.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryHost } from "../../platform/memory";
+import { ThreadState } from "../state/thread-state";
+import {
+  cancelThreadExecutionRun,
+  precreateThreadExecutionRun,
+  startThreadExecutionRun,
+} from "./execution";
+
+describe("thread execution run lifecycle helpers", () => {
+  it("precreates, starts, and cancels one durable run", async () => {
+    const host = createInMemoryHost();
+    const threadKey = "helper-lifecycle";
+    const runId = "turn:v1:helper-lifecycle:message-1";
+    const state = new ThreadState({
+      key: threadKey,
+      store: host.store.threads,
+    });
+
+    const precreated = await precreateThreadExecutionRun({
+      executionHost: host,
+      kind: "user-turn",
+      runId,
+      threadKey,
+    });
+    expect(precreated).toMatchObject({ runId, status: "queued", threadKey });
+
+    const started = await startThreadExecutionRun({
+      executionHost: host,
+      executionRun: { kind: "user-turn", runId },
+      state,
+      threadKey,
+      turnId: "unused",
+    });
+    expect(started?.runId).toBe(runId);
+    await expect(host.store.turns.get(runId)).resolves.toMatchObject({
+      status: "running",
+    });
+
+    await cancelThreadExecutionRun({ executionHost: host, runId });
+    await expect(host.store.turns.get(runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+  });
+
+  it("preserves every terminal status during cancellation", async () => {
+    const statuses = [
+      "cancelled",
+      "completed",
+      "error",
+      "needs-recovery",
+    ] as const;
+
+    for (const status of statuses) {
+      const host = createInMemoryHost();
+      const runId = `terminal-${status}`;
+      await host.store.turns.create({
+        checkpointVersion: 0,
+        kind: "user-turn",
+        rootRunId: runId,
+        runId,
+        status,
+        threadKey: "terminal-thread",
+      });
+
+      await cancelThreadExecutionRun({ executionHost: host, runId });
+      await expect(host.store.turns.get(runId)).resolves.toMatchObject({
+        status,
+      });
+    }
+  });
+});

--- a/packages/runtime/src/thread/runtime/execution.ts
+++ b/packages/runtime/src/thread/runtime/execution.ts
@@ -1,7 +1,10 @@
+import { createThreadExecutionRunId } from "../../execution/host/thread-execution-run-id";
 import type {
   AgentHost,
+  TurnKind,
   TurnRecord,
   TurnStatus,
+  TurnStore,
 } from "../../execution/host/types";
 import type { RuntimeToolExecutionContext } from "../../llm/llm";
 import type { PluginRuntime } from "../../plugins/runtime";
@@ -19,6 +22,11 @@ export interface ThreadExecutionOptions {
   readonly pluginRuntime?: PluginRuntime;
 }
 
+export interface QueuedThreadExecutionRun {
+  readonly kind: TurnKind;
+  readonly runId: string;
+}
+
 export interface ThreadExecutionRun {
   complete(status: ThreadExecutionTerminalStatus): Promise<void>;
   readonly runId: string;
@@ -30,7 +38,43 @@ export type ThreadExecutionTerminalStatus = Extract<
   "cancelled" | "completed" | "error" | "needs-recovery"
 >;
 
+export async function precreateThreadExecutionRun({
+  executionHost,
+  kind,
+  runId: requestedRunId,
+  threadKey,
+  turnStore,
+}: {
+  readonly executionHost?: AgentHost;
+  readonly kind: TurnKind;
+  readonly runId?: string;
+  readonly threadKey: string;
+  readonly turnStore?: TurnStore;
+}): Promise<TurnRecord | undefined> {
+  const turns = turnStore ?? executionHost?.store.turns;
+  if (!turns) {
+    return;
+  }
+
+  const runId =
+    requestedRunId ??
+    createThreadExecutionRunId({
+      threadKey,
+      turnId: crypto.randomUUID(),
+    });
+  const created = await turns.create(
+    createThreadExecutionRunRecord({
+      kind,
+      runId,
+      status: "queued",
+      threadKey,
+    })
+  );
+  return created.record;
+}
+
 export async function startThreadExecutionRun({
+  executionRun,
   executionHost,
   interceptToolCall,
   interceptToolResult,
@@ -38,6 +82,7 @@ export async function startThreadExecutionRun({
   state,
   turnId,
 }: {
+  readonly executionRun?: QueuedThreadExecutionRun;
   readonly executionHost?: AgentHost;
   readonly interceptToolCall?: ThreadToolCallInterceptor;
   readonly interceptToolResult?: ThreadToolResultInterceptor;
@@ -49,17 +94,22 @@ export async function startThreadExecutionRun({
     return;
   }
 
-  const runId = `turn:${threadKey}:${turnId}`;
-  const run: TurnRecord = {
-    checkpointVersion: 0,
-    dedupeKey: runId,
-    kind: "user-turn",
-    rootRunId: runId,
-    runId,
-    threadKey,
-    status: "running",
-  };
-  await executionHost.store.turns.create(run);
+  const runId =
+    executionRun?.runId ?? createThreadExecutionRunId({ threadKey, turnId });
+  const created = await executionHost.store.turns.create(
+    createThreadExecutionRunRecord({
+      kind: executionRun?.kind ?? "user-turn",
+      runId,
+      status: "running",
+      threadKey,
+    })
+  );
+  if (!(created.ok || isTerminalTurnStatus(created.record.status))) {
+    await executionHost.store.turns.update({
+      ...created.record,
+      status: "running",
+    });
+  }
 
   return {
     complete: (status) =>
@@ -75,6 +125,49 @@ export async function startThreadExecutionRun({
   };
 }
 
+export async function cancelThreadExecutionRun({
+  executionHost,
+  executionRun,
+  runId,
+}: {
+  readonly executionHost?: AgentHost;
+  readonly executionRun?: QueuedThreadExecutionRun;
+  readonly runId?: string;
+}): Promise<void> {
+  const targetRunId = runId ?? executionRun?.runId;
+  if (!(executionHost && targetRunId)) {
+    return;
+  }
+
+  const run = await executionHost.store.turns.get(targetRunId);
+  if (!run || isTerminalTurnStatus(run.status)) {
+    return;
+  }
+  await executionHost.store.turns.update({ ...run, status: "cancelled" });
+}
+
+export function createThreadExecutionRunRecord({
+  kind,
+  runId,
+  status,
+  threadKey,
+}: {
+  readonly kind: TurnKind;
+  readonly runId: string;
+  readonly status: Extract<TurnStatus, "queued" | "running">;
+  readonly threadKey: string;
+}): TurnRecord {
+  return {
+    checkpointVersion: 0,
+    dedupeKey: runId,
+    kind,
+    rootRunId: runId,
+    runId,
+    threadKey,
+    status,
+  };
+}
+
 async function completeThreadExecutionRun({
   executionHost,
   runId,
@@ -85,9 +178,18 @@ async function completeThreadExecutionRun({
   readonly status: ThreadExecutionTerminalStatus;
 }): Promise<void> {
   const run = await executionHost.store.turns.get(runId);
-  if (!run) {
+  if (!run || isTerminalTurnStatus(run.status)) {
     return;
   }
 
   await executionHost.store.turns.update({ ...run, status });
+}
+
+function isTerminalTurnStatus(status: TurnStatus): boolean {
+  return (
+    status === "cancelled" ||
+    status === "completed" ||
+    status === "error" ||
+    status === "needs-recovery"
+  );
 }

--- a/packages/runtime/src/thread/runtime/kill.ts
+++ b/packages/runtime/src/thread/runtime/kill.ts
@@ -1,31 +1,63 @@
+import type { AgentHost } from "../../execution/host/types";
 import {
   closeRuntimeInput,
   type QueuedInput,
   type RuntimeInputState,
 } from "../input/runtime-input";
 import type { BufferedAgentTurn } from "../protocol/turn";
+import { cancelQueuedDurableThreadInputs } from "./durable-inputs";
+import { cancelThreadExecutionRun } from "./execution";
 
 interface CloseKilledRuntimeInputsOptions {
   readonly activeRuntimeInput: RuntimeInputState | undefined;
+  readonly executionHost: AgentHost | undefined;
   readonly inputQueue: QueuedInput[];
   readonly message: string;
   readonly runToClose: BufferedAgentTurn | undefined;
+  readonly threadKey: string;
 }
 
-export function closeKilledRuntimeInputs({
+export async function closeKilledRuntimeInputs({
   activeRuntimeInput,
+  executionHost,
   inputQueue,
   message,
   runToClose,
-}: CloseKilledRuntimeInputsOptions): void {
+  threadKey,
+}: CloseKilledRuntimeInputsOptions): Promise<void> {
   closeRuntimeInput(activeRuntimeInput, message);
   runToClose?.emit({ type: "turn-error", message });
   runToClose?.close();
 
+  const queuedItems: QueuedInput[] = [];
   while (inputQueue.length > 0) {
     const item = inputQueue.shift();
     closeRuntimeInput(item?.runtimeInput, message);
     item?.run.emit({ type: "turn-error", message });
     item?.run.close();
+    if (item) {
+      queuedItems.push(item);
+    }
   }
+
+  const nonDurableRuns = queuedItems.filter(
+    (item) => item.durableMessageId === undefined
+  );
+  await Promise.all([
+    cancelQueuedDurableThreadInputs({
+      executionHost,
+      items: queuedItems,
+      threadKey,
+    }),
+    cancelThreadExecutionRun({
+      executionHost,
+      runId: runToClose?.runId,
+    }),
+    ...nonDurableRuns.map((item) =>
+      cancelThreadExecutionRun({
+        executionHost,
+        executionRun: item.executionRun,
+      })
+    ),
+  ]);
 }

--- a/packages/runtime/src/thread/runtime/notification.ts
+++ b/packages/runtime/src/thread/runtime/notification.ts
@@ -1,3 +1,4 @@
+import type { AgentHost } from "../../execution/host/types";
 import {
   type HostAttachmentStore,
   stageAgentEventsAttachments,
@@ -16,9 +17,15 @@ import {
 import type { AgentEvent } from "../protocol/events";
 import { type AgentTurn, BufferedAgentTurn } from "../protocol/turn";
 import { errorMessage } from "../state/thread-errors";
+import {
+  cancelThreadExecutionRun,
+  precreateThreadExecutionRun,
+  type QueuedThreadExecutionRun,
+} from "./execution";
 
 export interface NotifyOptions {
   readonly deferWhenUnobserved?: boolean;
+  readonly executionRun?: QueuedThreadExecutionRun;
   readonly observerEvents?: readonly AgentEvent[];
   readonly overlays?: readonly (AgentInput | UserInput)[];
 }
@@ -32,8 +39,11 @@ interface QueueThreadNotificationOptions {
     run: BufferedAgentTurn | undefined,
     event: AgentEvent
   ): Promise<void>;
+  readonly executionHost: AgentHost | undefined;
   readonly inputQueue: QueuedInput[];
   readonly pendingRuntimeInputs: QueuedRuntimeInput[];
+  readonly threadKey: string;
+  throwIfTerminal(): void;
 }
 
 export async function queueThreadNotification(
@@ -61,8 +71,9 @@ export async function queueThreadNotification(
     attachmentStore,
     { trustRuntimeAttachmentRefs: true }
   );
+  const needsDedicatedRun = options.executionRun !== undefined;
   const queuedTurn = state.inputQueue[0];
-  if (queuedTurn) {
+  if (queuedTurn && !needsDedicatedRun) {
     queuedTurn.initialEvents.push(...observerEvents);
     queuedTurn.preUserRuntimeInputs.push(...queuedOverlays, queuedRuntimeInput);
     return queuedTurn.run;
@@ -70,7 +81,12 @@ export async function queueThreadNotification(
 
   const activeRun = state.activeRun;
   const runtimeInput = state.activeRuntimeInput;
-  if (runtimeInput && activeRun && !runtimeInput.closedReason) {
+  if (
+    runtimeInput &&
+    activeRun &&
+    !runtimeInput.closedReason &&
+    !needsDedicatedRun
+  ) {
     for (const event of observerEvents) {
       await state.emitObserverEvent(activeRun, event);
     }
@@ -84,7 +100,7 @@ export async function queueThreadNotification(
     return activeRun;
   }
 
-  if (options.deferWhenUnobserved === true) {
+  if (options.deferWhenUnobserved === true && !needsDedicatedRun) {
     state.pendingRuntimeInputs.push(...queuedOverlays);
     state.pendingRuntimeInputs.push(queuedRuntimeInput);
     const deferredRun = new BufferedAgentTurn();
@@ -93,7 +109,36 @@ export async function queueThreadNotification(
   }
 
   const run = new BufferedAgentTurn();
+  const precreatedRun =
+    options.executionRun ??
+    (await precreateThreadExecutionRun({
+      executionHost: state.executionHost,
+      kind: "notification",
+      threadKey: state.threadKey,
+    }));
+  if (precreatedRun) {
+    run.bindRunId(precreatedRun.runId);
+  }
+  try {
+    state.throwIfTerminal();
+  } catch (error) {
+    await cancelThreadExecutionRun({
+      executionHost: state.executionHost,
+      runId: precreatedRun?.runId,
+    });
+    run.emit({ type: "turn-error", message: errorMessage(error) });
+    run.close();
+    throw error;
+  }
   state.inputQueue.push({
+    ...(precreatedRun
+      ? {
+          executionRun: {
+            kind: precreatedRun.kind,
+            runId: precreatedRun.runId,
+          },
+        }
+      : {}),
     initialEvents: observerEvents,
     preUserRuntimeInputs: queuedOverlays,
     run,

--- a/packages/runtime/src/thread/runtime/turn-processor.ts
+++ b/packages/runtime/src/thread/runtime/turn-processor.ts
@@ -44,6 +44,7 @@ export async function processQueuedInput({
   const activeAbort = new AbortController();
   const {
     durableInputClaim,
+    executionRun: queuedExecutionRun,
     awaitBoundaries = true,
     initialEvents,
     input: queuedInput,
@@ -92,6 +93,7 @@ export async function processQueuedInput({
 
   try {
     executionRun = await startThreadExecutionRun({
+      executionRun: queuedExecutionRun,
       executionHost: execution.executionHost,
       interceptToolCall: (checkpoint) =>
         events.interceptBeforeToolCall(checkpoint),

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -11,8 +11,8 @@ export const runtimeRootDeclaration = [
   "",
 ].join("\n");
 export const runtimeExecutionDeclaration = [
-  'export type { AdmitReceipt, AdmitThreadInput, CheckpointStore, ClaimedThreadInput, ClaimThreadInputOptions, EventStore, AgentHost, HostScheduler, HostStore, HostStoreTransaction, NotificationInbox, NotificationRecord, RecoverThreadInputClaimsResult, ThreadInputBoundary, ThreadInputInbox, ThreadInputKind, ThreadInputPlacement, ThreadInputRecord, ThreadInputStatus, TurnRecord, TurnStatus, TurnStore } from "./types";',
-  'export { threadStoreFromHost } from "./host";',
+  'export type { AdmitReceipt, AdmitThreadInput, CheckpointStore, ClaimedThreadInput, ClaimThreadInputOptions, DurableTurnInspectionResult, DurableTurnInspectionSource, EventStore, AgentHost, HostScheduler, HostStore, HostStoreTransaction, NotificationInbox, NotificationRecord, RecoverThreadInputClaimsResult, ThreadInputBoundary, ThreadInputInbox, ThreadInputKind, ThreadInputPlacement, ThreadInputRecord, ThreadInputStatus, TurnRecord, TurnStatus, TurnStore } from "./types";',
+  'export { inspectDurableTurn, threadStoreFromHost } from "./host";',
   'export { ThreadInputDuplicateConflictError } from "./types";',
   'export type { RuntimeToolExecutionCheckpoint, RuntimeToolExecutionContext, RuntimeToolExecutionDecision, RuntimeToolRetryPolicy } from "../llm-tool-execution";',
   'export { ToolExecutionNeedsRecoveryError } from "../llm-tool-execution";',

--- a/scripts/verify-release-artifacts/runtime-public-surface.mjs
+++ b/scripts/verify-release-artifacts/runtime-public-surface.mjs
@@ -11,6 +11,8 @@ export const REQUIRED_RUNTIME_EXECUTION_EXPORTS = [
   "ClaimedThreadInput",
   "ClaimThreadInputOptions",
   "AgentHost",
+  "DurableTurnInspectionResult",
+  "DurableTurnInspectionSource",
   "EventStore",
   "HostScheduler",
   "HostStore",
@@ -33,6 +35,7 @@ export const REQUIRED_RUNTIME_EXECUTION_EXPORTS = [
   "RuntimeToolExecutionDecision",
   "RuntimeToolRetryPolicy",
   "ToolExecutionNeedsRecoveryError",
+  "inspectDurableTurn",
   "threadStoreFromHost",
 ];
 


### PR DESCRIPTION
Closes #158

## Summary

- expose stable optional `AgentTurn.runId` for durable sends and stored turns
- atomically precreate queued execution runs with durable input admission, then carry that run ID through execution, checkpoints, completion, and recovery
- add read-only `inspectDurableTurn(source, runId)` on `@minpeter/pss-runtime/execution`, with checkpointed/no-checkpoint, unknown-run, and unsupported results plus raw durable lifecycle status
- bind resumed notifications to the same durable run returned by `dispatchAgentNotification`; existing dispatch idempotency continues returning the original run ID
- make internal thread `kill()` awaitable and harden `dispose()`/`delete()` so active, queued, and admission-racing runs become cancelled while terminal statuses remain unchanged
- atomically acknowledge cancelled queued inbox work with its cancelled run receipt so it cannot execute after recovery

## API surface

```ts
interface AgentTurn {
  readonly runId?: string;
  events(): AsyncIterable<AgentEvent>;
}

inspectDurableTurn(source, runId)
// recorded: { runId, status, threadKey, checkpointVersion, latestCheckpoint, state }
// boundaries: checkpointed | no-checkpoint | unknown-run | unsupported
```

Lifecycle status retains the host contract names: `queued`, `running`, `leased` (claimed/resumed), `completed`, `error` (failed), `cancelled`, plus existing recovery/suspension states.

## Behavior-change evidence

Characterization tests were added and passed before production changes:

```text
✓ src/execution/durable-lifecycle.characterization.test.ts (4 tests) 33ms
Test Files  1 passed (1)
Tests       4 passed (4)
Duration    519ms
```

The new behavior tests then failed RED on unchanged production code:

```text
FAIL src/execution/inspect/durable-turn-lifecycle.test.ts
Error: Cannot find module './durable-turn'
FAIL src/execution/inspect/durable-turn.test.ts
Error: Cannot find module './durable-turn'
FAIL src/contracts/durable-turn-inspection-api.test.ts
AssertionError: expected execution subpath to have property "inspectDurableTurn"
Test Files  3 failed (3)
```

Final GREEN:

```text
Test Files  119 passed (119)
Tests       745 passed | 3 skipped (748)
Duration    5.56s
```

The characterization suite remains part of that green run.

## Inspection boundary coverage

- `queued`: precreated second send while the first turn is active; table-driven direct inspection
- `running`: active send and active resumed notification
- `resumed`: table-driven `leased` record plus notification dispatch -> `agent.resume(dispatched.runId)` -> running/completed lifecycle
- `completed`: completed sends, resumed notification, and terminal-status preservation on shutdown
- `failed`: model failure observed as durable `error`
- `cancelled`: active, queued, direct-kill, dispose, and admission-race cancellation
- `unknown-run`: absent ID, with an assertion that checkpoint storage is not read
- `unsupported`: thread-only `MemoryThreadStore` source
- `no-checkpoint`: every raw lifecycle status is table-tested without a checkpoint
- checkpointed: latest checkpoint and matching run version are read in one transaction

## Test plan

- `pnpm install`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm --filter @minpeter/pss-runtime test`
- `pnpm --filter @minpeter/pss-runtime test:storage-stress`
- `pnpm typecheck`
- `pnpm exec ultracite check <changed files>`
- `pnpm build` (required to populate all release package artifacts)
- `node scripts/verify-release-artifacts.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable execution inspection with stable run IDs for agent turns. You can now read a turn’s lifecycle and last checkpoint via `inspectDurableTurn` without changing event streams; shutdown reliably cancels pending work.

- **New Features**
  - Optional `AgentTurn.runId` for durable sends and stored turns.
  - `inspectDurableTurn(source, runId)` in `@minpeter/pss-runtime/execution` returns lifecycle (`queued|running|leased|completed|error|cancelled`), checkpoint version, latest checkpoint, or `unknown-run`/`unsupported`.
  - Precreate queued runs at durable input admission; carry the same run across execution, checkpoints, completion, and recovery.
  - Resumed notifications bind to the run from `dispatchAgentNotification`; idempotent dispatch returns the original run ID.

- **Refactors**
  - `kill()` is awaitable; `dispose()`/`delete()` cancel active, queued, and admission‑racing runs while preserving terminal statuses.
  - Cancelled queued inbox work is atomically acknowledged and its run is marked cancelled so it cannot execute after recovery.

<sup>Written for commit 721938f76526597bd2f975653474569fcf45ef87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

