### PR TITLE
test(scripts): make freeze-tree mismatch leg history-independent

### DIFF
--- a/scripts/cache-stable-tools-independent-verifier.adversarial.mjs
+++ b/scripts/cache-stable-tools-independent-verifier.adversarial.mjs
@@ -201,11 +201,20 @@ test("rejects a false clean-at-start attestation and mismatched freeze tree", as
   await rejectsWith(dirty, ["sourceWorktreeCleanAtStart"]);
 
   const wrongCommit = await copyPristine();
-  wrongCommit.configuration.sourceFreezeCommitSha = execFileSync(
+  // The swapped freeze reference must mismatch the synthesized manifest under
+  // every history shape. HEAD^ only differs from the working tree when the
+  // last commit touched packages/runtime/src, so docs-/app-only commits made
+  // the verifier accept the swap and this leg fail nondeterministically. The
+  // repository root commit predates the benchmark script, so rejection is
+  // deterministic regardless of what HEAD last touched.
+  const [rootCommit] = execFileSync(
     "git",
-    ["rev-parse", "--verify", "HEAD^"],
+    ["rev-list", "--max-parents=0", "HEAD"],
     { cwd: REPOSITORY_ROOT, encoding: "utf8" }
-  ).trim();
+  )
+    .trim()
+    .split("\n");
+  wrongCommit.configuration.sourceFreezeCommitSha = rootCommit;
   await rejectsWith(wrongCommit, ["sourceFreezeCommit"]);
 });
 


### PR DESCRIPTION
## Problem

`cache-stable-tools-independent-verifier.adversarial.mjs`'s "rejects a false clean-at-start attestation and mismatched freeze tree" leg swapped `sourceFreezeCommitSha` to `HEAD^` and expected the verifier to reject it. Rejection only happens when `HEAD^`'s `packages/runtime/src` tree differs from the test-synthesized manifest — so any commit that doesn't touch that path (docs-only, apps-only, version bumps) made the verifier **accept** the swap and the leg fail with `Missing expected rejection`.

Observed: release.yml red on the docs-only #220 merge run and the apps-only #224 merge run, green on src-touching merges (#221, #223) — same code, history-dependent outcome.

## Fix

Swap to the repository root commit instead of `HEAD^`. The root commit predates `scripts/benchmark-cache-stable-tools.mts`, so the swapped reference can never back the synthesized manifest and rejection is deterministic under every history shape.

## Evidence

- RED on main before this fix: `pnpm test:cache-stable-tools-verifier` → `Missing expected rejection` at this leg (main @ 37e418d).
- GREEN after: 47/47 pass; `test:cache-stable-tools-evidence` 2/2; full root `pnpm test` exit 0 (6/6 turbo tasks + scripts); boundaries/lint/typecheck clean.

No package behavior change (scripts-only); no tegami entry per docs/scripts precedent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the adversarial freeze-tree mismatch test by swapping the freeze reference to the repository root commit instead of `HEAD^`. This removes history-dependent flakiness and makes rejection deterministic across all histories.

- **Bug Fixes**
  - In `scripts/cache-stable-tools-independent-verifier.adversarial.mjs`, replace `HEAD^` with the root commit from `git rev-list --max-parents=0 HEAD`.
  - Prevents false accepts when the last commit didn’t touch `packages/runtime/src`.
  - Tests only; no package/runtime changes.

<sup>Written for commit a8f63b008a8168058d9065cb9eca985f5443b64a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

