### PR TITLE
test(scripts): deflake cache-stable-tools verifier (stale index metadata)

### DIFF
--- a/scripts/cache-stable-tools-independent-verifier.adversarial.mjs
+++ b/scripts/cache-stable-tools-independent-verifier.adversarial.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -141,6 +142,44 @@ test("pins manual topology and request-artifact oracles", () => {
         "011ee0de97c3f67c6103bfc1b3d39ccf9b55f87da7a277532eec9c53fc23a76e",
     }
   );
+});
+
+test("uses HEAD when only tracked-file stat metadata changed", async (t) => {
+  const repositoryRoot = await mkdtemp(
+    resolve(tmpdir(), "cache-verifier-stale-index-")
+  );
+  t.after(() => rm(repositoryRoot, { force: true, recursive: true }));
+  execFileSync("git", ["init", "--quiet"], { cwd: repositoryRoot });
+  const sourcePath = resolve(repositoryRoot, "source.txt");
+  await writeFile(sourcePath, "unchanged\n");
+  const indexedTime = new Date("2020-01-01T00:00:00.000Z");
+  await utimes(sourcePath, indexedTime, indexedTime);
+  execFileSync("git", ["add", "source.txt"], { cwd: repositoryRoot });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Cache Verifier Test",
+      "-c",
+      "user.email=cache-verifier@example.invalid",
+      "commit",
+      "--quiet",
+      "-m",
+      "fixture",
+    ],
+    { cwd: repositoryRoot }
+  );
+  await utimes(
+    sourcePath,
+    new Date(indexedTime.getTime() + 2000),
+    new Date(indexedTime.getTime() + 2000)
+  );
+  const head = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  }).trim();
+
+  assert.equal(sourceFreezeCommit(repositoryRoot), head);
 });
 
 test("accepts a complete synthetic 480-request schema-v3 campaign", async () => {
@@ -1289,18 +1328,32 @@ function refreshEvidence(evidence) {
   evidence.responseIdAudit = deriveResponseIdAudit(allRequests);
 }
 
+function sourceFreezeCommit(repositoryRoot) {
+  const head = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  }).trim();
+  try {
+    execFileSync("git", ["diff", "--quiet", head, "--"], {
+      cwd: repositoryRoot,
+    });
+    return head;
+  } catch (error) {
+    if (!(error instanceof Error && error.status === 1)) {
+      throw error;
+    }
+  }
+  return (
+    execFileSync(
+      "git",
+      ["stash", "create", "synthetic cache verifier source freeze"],
+      { cwd: repositoryRoot, encoding: "utf8" }
+    ).trim() || head
+  );
+}
+
 async function syntheticConfiguration() {
-  const workingTreeCommit = execFileSync(
-    "git",
-    ["stash", "create", "synthetic cache verifier source freeze"],
-    { cwd: REPOSITORY_ROOT, encoding: "utf8" }
-  ).trim();
-  const sourceFreezeCommitSha =
-    workingTreeCommit ||
-    execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
-      cwd: REPOSITORY_ROOT,
-      encoding: "utf8",
-    }).trim();
+  const sourceFreezeCommitSha = sourceFreezeCommit(REPOSITORY_ROOT);
   const implementationSourcesSha256 = {};
   for (const sourcePath of REQUIRED_IMPLEMENTATION_SOURCE_PATHS) {
     implementationSourcesSha256[sourcePath] = sha256(


### PR DESCRIPTION
## Summary

- avoid `git stash create` for a content-clean tracked worktree by resolving the synthetic freeze directly to `HEAD`
- retain `stash create` for genuine tracked edits so locally modified verifier sources are still represented in the synthetic freeze
- add a temporary-Git-repository regression where file bytes are unchanged but the cached index stat metadata is stale

## Root cause

The suite called `git stash create` unconditionally. With clean tracked bytes but a tracked file mtime newer than its cached index entry, Git refreshes the index and exits 1 with empty stdout/stderr instead of returning the normal empty successful result. `execFileSync` therefore throws before synthetic evidence exists.

This matches the observed shape: the first synthetic campaign test fails, that Git invocation refreshes the index, and later tests retry synthesis successfully, leaving exactly one failure.

Failing-before evidence (`/tmp/flake-run-1.log`):

```text
tests 47
pass 46
fail 1
accepts a complete synthetic 480-request schema-v3 campaign
Error: Command failed: git stash create synthetic cache verifier source freeze
    at syntheticConfiguration (...adversarial.mjs:1293:29)
```

A controlled stale-stat trigger reproduced 6/6 verifier failures (runs 5-10), always in that test and at that command. Three normal runs passed. Running the verifier concurrently with a full root build also passed, excluding Turbo/dist writes as the trigger. The stack fails before benchmark-derived assertions or the verifier's parallel read-only `git show` work, and the suite is one test file with sequential top-level tests; test-runner Git contention, cache-trial order, and persistent script fixture state are not causal.

## Fix

Check `git diff --quiet HEAD --` first. If tracked content is unchanged, use `HEAD`; if Git reports a real diff, preserve the existing `stash create` snapshot path. Git errors other than the ordinary diff exit status still propagate.

## Verification

- stale-stat condition + `pnpm test:cache-stable-tools-verifier`: 10 consecutive passes, 48/48 each
- `pnpm test:cache-stable-tools-evidence`: 2/2 passed
- root `pnpm test`: passed (including 48/48 adversarial verifier tests)
- `pnpm exec ultracite check scripts/cache-stable-tools-independent-verifier.adversarial.mjs`: passed
- `node --check scripts/cache-stable-tools-independent-verifier.adversarial.mjs`: passed

Scripts-only; no Tegami entry.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky failure in the cache-stable tools verifier by using `HEAD` when tracked file content is unchanged, avoiding `git stash create` errors from stale index metadata. This stabilizes the synthetic campaign test.

- **Bug Fixes**
  - Added `sourceFreezeCommit()` to prefer `HEAD` if `git diff --quiet` shows no content changes; otherwise use `git stash create`.
  - Introduced a temp-repo test that simulates stale index stat metadata and verifies `HEAD` is selected.

<sup>Written for commit d87783d1aa114dda82cf8e002a1e64a11c478465. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

