### PR TITLE
feat(worker-agent): session transport — submit-turn, cursor replay, optional SSE (RFC 0002 phases 1-4)

### DIFF
--- a/apps/worker-agent/README.md
+++ b/apps/worker-agent/README.md
@@ -41,3 +41,24 @@ RFC 0002 names the generalized transport fields as follows:
 | `SubmitTurnResponse.eventCursor` | Not present | Clients use durable replay cursors when replay is available. |
 
 The current route is intentionally retained while the `session` transport is added. Telegram continues to use its webhook delivery path.
+
+## Session submit and replay
+
+Authenticated clients can use the generalized tRPC procedures at `/trpc`:
+
+- `session.submitTurn` accepts `{ channel, text, sessionScopeKey?, idempotencyKey? }` and returns immediately after durable admission with `{ accepted: true, runId, threadKey }`.
+- `session.replayEvents` accepts `{ channel, after?, limit?, sessionScopeKey? }` and returns committed runtime thread events plus the last `nextCursor` in the page.
+
+Cursor polling through `session.replayEvents` is the baseline reconnect mechanism. Store the latest event cursor, pass it as `after`, and repeat; replay is exclusive of that cursor, so reconnect does not duplicate the last processed event. Replay reads `ThreadHandle.events({ after, limit })` from the runtime's canonical durable thread event history, not a projected `ThreadStore` snapshot.
+
+## Optional SSE stream
+
+Browser-like clients may additionally connect to:
+
+```text
+GET /session/events?channel=tui%3Alocal&after=<serialized-cursor>
+Authorization: Bearer <WORKER_AGENT_TUI_TOKEN>
+Accept: text/event-stream
+```
+
+The stream replays committed events after `after` before waiting for newly committed events. Each `thread-event` frame has the serialized cursor as its SSE `id` and a `StoredThreadEvent` JSON object as `data`. `streamRemoteSessionEvents()` reconnects a dropped response with its last received cursor. SSE is an optimization only: clients must retain cursor-polling replay as the deployment-neutral fallback.

--- a/apps/worker-agent/README.md
+++ b/apps/worker-agent/README.md
@@ -15,3 +15,29 @@ pnpm -F "@minpeter/pss-worker-agent" ship   # deploy
 ```
 
 After local `dev`, run `ship` again to restore the prod webhook.
+
+## Session transport (RFC 0002 phase 1)
+
+The initial remote submit-turn RPC is the existing authenticated tRPC mutation:
+
+```text
+POST /trpc/tui.turn
+Authorization: Bearer <WORKER_AGENT_TUI_TOKEN>
+```
+
+Development accepts requests without a token; production requires the configured bearer token. `createRemoteTuiDeliveryClient()` is the supported client for this compatibility surface. It waits for the existing tool-only delivery result, so its response is a delivery result rather than an admission receipt.
+
+RFC 0002 names the generalized transport fields as follows:
+
+| RFC shape | Initial `tui.turn` shape | Notes |
+| --- | --- | --- |
+| `SubmitTurnRequest.channel` | `input.channel` | Currently restricted to `{ kind: "tui", id }`. |
+| `SubmitTurnRequest.text` | `input.text` | Trimmed and rejected when empty. |
+| `SubmitTurnRequest.sessionScopeKey` | `input.sessionScopeKey` | Optional and trimmed before forwarding. |
+| `SubmitTurnRequest.idempotencyKey` | Not present | Added by the generalized session admission surface in a later phase. |
+| `SubmitTurnResponse.accepted` | `output.delivered` | Not equivalent: `delivered` reports tool delivery after the run. |
+| `SubmitTurnResponse.runId` | Not present | Added by the generalized durable-admission surface. |
+| `SubmitTurnResponse.threadKey` | Implicit (`default` inside the channel DO) | Runtime naming remains `threadKey`; transport naming remains `session`. |
+| `SubmitTurnResponse.eventCursor` | Not present | Clients use durable replay cursors when replay is available. |
+
+The current route is intentionally retained while the `session` transport is added. Telegram continues to use its webhook delivery path.

--- a/apps/worker-agent/package.json
+++ b/apps/worker-agent/package.json
@@ -3,9 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prebuild": "pnpm -F @minpeter/pss-runtime build",
     "predev": "pnpm -F @minpeter/pss-runtime build",
     "pretypecheck": "pnpm -F @minpeter/pss-runtime build",
     "preship:worker": "pnpm -F @minpeter/pss-runtime build",
+    "build": "wrangler deploy --dry-run --env=\"\"",
     "dev": "run-p dev:worker dev:relay",
     "dev:ingress": "run-p dev:worker:ingress dev:relay",
     "dev:worker": "wrangler dev -e dev",

--- a/apps/worker-agent/src/agent-do.ts
+++ b/apps/worker-agent/src/agent-do.ts
@@ -51,9 +51,16 @@ import type { Env } from "./env";
 import { AGENT_TURN_ADMISSION_LAYER } from "./message-path-layers";
 import { createTurnEventCollector } from "./observability";
 import {
+  parseSessionChannel,
+  parseThreadEventCursor,
   ReplayEventsRequestSchema,
   SubmitTurnRequestSchema,
+  type ThreadEventCursor,
 } from "./session-contract";
+import {
+  createSessionEventLiveSignal,
+  createSessionEventStreamResponse,
+} from "./session-events";
 import {
   createSessionIndexStore,
   type SessionIndexStore,
@@ -94,6 +101,7 @@ installCloudflareImageCodecs();
 
 const SESSION_SUBMIT_PATH = "/session/turn";
 const SESSION_REPLAY_PATH = "/session/events/replay";
+const SESSION_STREAM_PATH = "/session/events";
 const SESSION_BINDING_STORAGE_KEY = "session:binding";
 
 /**
@@ -122,6 +130,7 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
   #sessionScopeKey: string | undefined;
   #observability: ReturnType<typeof createTurnEventCollector> | undefined;
   #tuiMessageCapture: WorkerAgentDeliveredMessage[] = [];
+  readonly #sessionEventLive = createSessionEventLiveSignal();
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -139,6 +148,9 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
         createConfiguredAgent(agentEnv, host, {
           sendMessage: createSendMessageToolOptions(agentEnv, () => undefined),
         }),
+      drain: {
+        onEvent: () => this.#sessionEventLive.publish(),
+      },
       durableObjectContext: this.ctx,
       env,
     });
@@ -147,25 +159,39 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
   /** Agents scheduler callback for delayed PSS run/thread resumes. */
   async resumePssRuntimeFiber(payload: unknown): Promise<void> {
     await this.#restoreSessionBinding();
-    await this.#platform.resumeScheduledFiber(payload);
+    try {
+      await this.#platform.resumeScheduledFiber(payload);
+    } finally {
+      this.#sessionEventLive.publish();
+    }
   }
 
   override async onFiberRecovered(
     ctx: CloudflareAgentsFiberRecoveryContext
   ): Promise<undefined | CloudflareAgentsFiberRecoveryResult> {
-    const result = await this.#platform.recoverFiber(ctx);
-    if (result === false) {
-      return;
+    try {
+      const result = await this.#platform.recoverFiber(ctx);
+      if (result === false) {
+        return;
+      }
+      return result;
+    } finally {
+      this.#sessionEventLive.publish();
     }
-    return result;
   }
 
   override async onRequest(request: Request): Promise<Response> {
+    const pathname = new URL(request.url).pathname;
+    if (pathname === SESSION_STREAM_PATH) {
+      if (request.method !== "GET") {
+        return new Response("method not allowed", { status: 405 });
+      }
+      return await this.#handleSessionEventStreamRequest(request);
+    }
     if (request.method !== "POST") {
       return new Response("method not allowed", { status: 405 });
     }
 
-    const pathname = new URL(request.url).pathname;
     if (pathname === SESSION_SUBMIT_PATH) {
       return await this.#handleSessionSubmitRequest(request);
     }
@@ -222,14 +248,19 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
         : {}),
     });
 
-    const runTurn = (): Promise<Response> =>
-      this.#runPayloadTurn({
-        imageOmits,
-        imagePrepares,
-        log,
-        payload,
-        turnEvents,
-      });
+    const runTurn = async (): Promise<Response> => {
+      try {
+        return await this.#runPayloadTurn({
+          imageOmits,
+          imagePrepares,
+          log,
+          payload,
+          turnEvents,
+        });
+      } finally {
+        this.#sessionEventLive.publish();
+      }
+    };
 
     return await runWithImagePrepareDiagnosticsListener(
       (diagnostics) => {
@@ -422,6 +453,47 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
     return Response.json({
       ...withCapturedMessages({ delivered: true }, sendMessage.messages()),
       mode: delivery.mode,
+    });
+  }
+
+  async #handleSessionEventStreamRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const serializedChannel = url.searchParams.get("channel");
+    if (!serializedChannel) {
+      return new Response("channel required", { status: 400 });
+    }
+
+    let channel: ChannelAddress;
+    let after: ThreadEventCursor | undefined;
+    try {
+      channel = parseSessionChannel(serializedChannel);
+      const serializedAfter = url.searchParams.get("after");
+      after =
+        serializedAfter === null
+          ? undefined
+          : parseThreadEventCursor(serializedAfter);
+    } catch {
+      return new Response("invalid session event stream", { status: 400 });
+    }
+    this.#channel = channel;
+    this.#sessionScopeKey =
+      url.searchParams.get("sessionScopeKey")?.trim() || undefined;
+    await this.#ensureTurnSession(durableObjectChannelBinding(channel));
+    const thread = this.#runtimeThread;
+    if (!thread) {
+      throw new AgentDurableObjectInvariantError(
+        "Session runtime thread was not initialized."
+      );
+    }
+
+    return createSessionEventStreamResponse({
+      ...(after ? { after } : {}),
+      live: this.#sessionEventLive,
+      replay: (cursor) =>
+        replayDurableThreadEvents(thread, {
+          ...(cursor ? { after: cursor } : {}),
+          limit: 100,
+        }),
     });
   }
 

--- a/apps/worker-agent/src/agent-do.ts
+++ b/apps/worker-agent/src/agent-do.ts
@@ -3,12 +3,14 @@ import type {
   AgentInput,
   ImageOmitDiagnostics,
   ImagePrepareDiagnostics,
+  ThreadHandle,
 } from "@minpeter/pss-runtime";
 import {
   IMAGE_PREPARE_LOG_MESSAGE,
   runWithImageOmitDiagnosticsListener,
   runWithImagePrepareDiagnosticsListener,
 } from "@minpeter/pss-runtime";
+import { dispatchAgentNotification } from "@minpeter/pss-runtime/execution";
 import {
   type CloudflareAgentsFiberRecoveryContext,
   type CloudflareAgentsFiberRecoveryResult,
@@ -18,7 +20,11 @@ import {
 import { installCloudflareImageCodecs } from "@minpeter/pss-runtime/platform/cloudflare/image-codecs";
 import { Agent as CloudflareAgent } from "agents";
 
-import { createConfiguredAgent, DEFAULT_MODEL } from "./agent";
+import {
+  createConfiguredAgent,
+  DEFAULT_MODEL,
+  WORKER_AGENT_NAMESPACE,
+} from "./agent";
 import {
   type WorkerAgentDeliveredMessage,
   withCapturedMessages,
@@ -45,6 +51,10 @@ import type { Env } from "./env";
 import { AGENT_TURN_ADMISSION_LAYER } from "./message-path-layers";
 import { createTurnEventCollector } from "./observability";
 import {
+  ReplayEventsRequestSchema,
+  SubmitTurnRequestSchema,
+} from "./session-contract";
+import {
   createSessionIndexStore,
   type SessionIndexStore,
 } from "./session-index";
@@ -55,6 +65,7 @@ import {
 } from "./session-index-client";
 import { handleSessionIndexRequest } from "./session-index-routes";
 import { createSqlSessionIndexRepository } from "./session-index-sql";
+import { replayDurableThreadEvents } from "./session-runtime";
 import {
   createThreadStoreSessionTranscriptReader,
   type SessionTranscriptReader,
@@ -81,6 +92,10 @@ import {
 // DO isolate may load this module without worker-entry side-effects.
 installCloudflareImageCodecs();
 
+const SESSION_SUBMIT_PATH = "/session/turn";
+const SESSION_REPLAY_PATH = "/session/events/replay";
+const SESSION_BINDING_STORAGE_KEY = "session:binding";
+
 /**
  * Channel agent Durable Object on the Cloudflare Agents SDK.
  * Scheduling/resume uses Agents fibers; HTTP remains app-owned via onRequest.
@@ -102,6 +117,7 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
   /** Layer 2: reused so send/steer share in-memory active-run state. */
   #turnSession: TurnSession | undefined;
   #turnSessionPromise: Promise<TurnSession> | undefined;
+  #runtimeThread: ThreadHandle | undefined;
   #channel: ChannelAddress | undefined;
   #sessionScopeKey: string | undefined;
   #observability: ReturnType<typeof createTurnEventCollector> | undefined;
@@ -130,6 +146,7 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
 
   /** Agents scheduler callback for delayed PSS run/thread resumes. */
   async resumePssRuntimeFiber(payload: unknown): Promise<void> {
+    await this.#restoreSessionBinding();
     await this.#platform.resumeScheduledFiber(payload);
   }
 
@@ -149,6 +166,12 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
     }
 
     const pathname = new URL(request.url).pathname;
+    if (pathname === SESSION_SUBMIT_PATH) {
+      return await this.#handleSessionSubmitRequest(request);
+    }
+    if (pathname === SESSION_REPLAY_PATH) {
+      return await this.#handleSessionReplayRequest(request);
+    }
     if (isSessionIndexPath(pathname)) {
       return await handleSessionIndexRequest({
         pathname,
@@ -402,6 +425,84 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
     });
   }
 
+  async #handleSessionSubmitRequest(request: Request): Promise<Response> {
+    const body = await readRequestJson(request);
+    const parsed = SubmitTurnRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return new Response("invalid session turn", { status: 400 });
+    }
+
+    const channelId = parsed.data.channel.id.trim();
+    const text = parsed.data.text.trim();
+    if (!(channelId && text)) {
+      return new Response("invalid session turn", { status: 400 });
+    }
+    const channel = { id: channelId, kind: parsed.data.channel.kind };
+    const sessionScopeKey = parsed.data.sessionScopeKey?.trim();
+    this.#channel = channel;
+    this.#sessionScopeKey = sessionScopeKey || undefined;
+    await this.#storage.put(SESSION_BINDING_STORAGE_KEY, {
+      channel,
+      ...(sessionScopeKey ? { sessionScopeKey } : {}),
+    } satisfies SessionBindingRecord);
+
+    const admitted = await dispatchAgentNotification({
+      host: this.#platform.host(),
+      idempotencyKey: parsed.data.idempotencyKey?.trim() || crypto.randomUUID(),
+      input: { text, type: "user-input" },
+      namespace: WORKER_AGENT_NAMESPACE,
+      threadKey: CHANNEL_DURABLE_OBJECT_THREAD_KEY,
+    });
+    return Response.json({
+      accepted: true,
+      runId: admitted.runId,
+      threadKey: CHANNEL_DURABLE_OBJECT_THREAD_KEY,
+    });
+  }
+
+  async #handleSessionReplayRequest(request: Request): Promise<Response> {
+    const body = await readRequestJson(request);
+    const parsed = ReplayEventsRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return new Response("invalid session replay", { status: 400 });
+    }
+
+    const channelId = parsed.data.channel.id.trim();
+    if (!channelId) {
+      return new Response("invalid session replay", { status: 400 });
+    }
+    const channel = { id: channelId, kind: parsed.data.channel.kind };
+    this.#channel = channel;
+    this.#sessionScopeKey = parsed.data.sessionScopeKey?.trim() || undefined;
+    await this.#ensureTurnSession(durableObjectChannelBinding(channel));
+    const thread = this.#runtimeThread;
+    if (!thread) {
+      throw new AgentDurableObjectInvariantError(
+        "Session runtime thread was not initialized."
+      );
+    }
+
+    return Response.json(
+      await replayDurableThreadEvents(thread, {
+        ...(parsed.data.after ? { after: parsed.data.after } : {}),
+        ...(parsed.data.limit === undefined
+          ? {}
+          : { limit: parsed.data.limit }),
+      })
+    );
+  }
+
+  async #restoreSessionBinding(): Promise<void> {
+    const stored = await this.#storage.get<SessionBindingRecord>(
+      SESSION_BINDING_STORAGE_KEY
+    );
+    if (!stored) {
+      return;
+    }
+    this.#channel = stored.channel;
+    this.#sessionScopeKey = stored.sessionScopeKey;
+  }
+
   async #handleSessionTranscriptRequest(request: Request): Promise<Response> {
     let body: unknown;
     try {
@@ -484,7 +585,9 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
         }
       );
       try {
-        const session = createTurnSession(agent.thread(binding.thread));
+        const thread = agent.thread(binding.thread);
+        const session = createTurnSession(thread);
+        this.#runtimeThread = thread;
         this.#turnSession = session;
         return session;
       } catch (error) {
@@ -558,6 +661,19 @@ export class AgentDurableObject extends CloudflareAgent<Env> {
         { scope: "agent-do" }
       );
     }
+  }
+}
+
+interface SessionBindingRecord {
+  readonly channel: ChannelAddress;
+  readonly sessionScopeKey?: string;
+}
+
+async function readRequestJson(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return;
   }
 }
 

--- a/apps/worker-agent/src/agent.ts
+++ b/apps/worker-agent/src/agent.ts
@@ -23,6 +23,7 @@ import {
 } from "./tools";
 
 const DEFAULT_BASE_URL = "https://apis.opengateway.ai/v1";
+export const WORKER_AGENT_NAMESPACE = "worker-agent";
 
 /** Default model id when `AI_MODEL` is unset (also used on wide-event `ai.model`). */
 export const DEFAULT_MODEL = "minimax/MiniMax-M2.7";
@@ -149,6 +150,7 @@ export async function createConfiguredAgent(
     host,
     instructions: WORKER_AGENT_INSTRUCTIONS,
     model: provider(env.AI_MODEL?.trim() || DEFAULT_MODEL),
+    namespace: WORKER_AGENT_NAMESPACE,
     plugins,
     ...(tools ? { tools } : {}),
   });

--- a/apps/worker-agent/src/index.ts
+++ b/apps/worker-agent/src/index.ts
@@ -2,6 +2,7 @@ import { installCloudflareImageCodecs } from "@minpeter/pss-runtime/platform/clo
 import { defineWorkerFetch } from "evlog/workers";
 
 import type { Env } from "./env";
+import { handleSessionEventsRequest } from "./session-events-server";
 import { handleTelegramWebhook } from "./telegram";
 import { handleTuiRpcRequest } from "./tui-rpc";
 import { ensureWorkerLogger, newCorrelationId } from "./worker-log";
@@ -13,6 +14,7 @@ installCloudflareImageCodecs();
 export { AgentDurableObject } from "./agent-do";
 export type { Env } from "./env";
 
+const SESSION_EVENTS_PATHNAME = "/session/events";
 const TUI_RPC_PATHNAME = "/trpc";
 
 export default defineWorkerFetch<Env>(async (request, env, ctx, log) => {
@@ -22,11 +24,7 @@ export default defineWorkerFetch<Env>(async (request, env, ctx, log) => {
   });
   const url = new URL(request.url);
   const correlationId = newCorrelationId();
-  const handler =
-    url.pathname === TUI_RPC_PATHNAME ||
-    url.pathname.startsWith(`${TUI_RPC_PATHNAME}/`)
-      ? "tui-rpc"
-      : "telegram-webhook";
+  const handler = selectRequestHandler(url.pathname);
 
   log.set({
     correlationId,
@@ -36,12 +34,25 @@ export default defineWorkerFetch<Env>(async (request, env, ctx, log) => {
   });
 
   try {
-    const response =
-      handler === "tui-rpc"
-        ? await handleTuiRpcRequest(request, env)
-        : await handleTelegramWebhook(request, env, ctx as ExecutionContext, {
-            correlationId,
-          });
+    let response: Response;
+    switch (handler) {
+      case "session-events":
+        response = await handleSessionEventsRequest(request, env);
+        break;
+      case "tui-rpc":
+        response = await handleTuiRpcRequest(request, env);
+        break;
+      case "telegram-webhook":
+        response = await handleTelegramWebhook(
+          request,
+          env,
+          ctx as ExecutionContext,
+          { correlationId }
+        );
+        break;
+      default:
+        response = assertNever(handler);
+    }
 
     log.set({ status: response.status });
     log.emit({ status: response.status });
@@ -52,3 +63,22 @@ export default defineWorkerFetch<Env>(async (request, env, ctx, log) => {
     throw error;
   }
 });
+
+function selectRequestHandler(
+  pathname: string
+): "session-events" | "telegram-webhook" | "tui-rpc" {
+  if (pathname === SESSION_EVENTS_PATHNAME) {
+    return "session-events";
+  }
+  if (
+    pathname === TUI_RPC_PATHNAME ||
+    pathname.startsWith(`${TUI_RPC_PATHNAME}/`)
+  ) {
+    return "tui-rpc";
+  }
+  return "telegram-webhook";
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected worker request handler: ${String(value)}`);
+}

--- a/apps/worker-agent/src/session-contract.test.ts
+++ b/apps/worker-agent/src/session-contract.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import {
+  parseThreadEventCursor,
+  type SerializedThreadEventCursor,
+  serializeThreadEventCursor,
+  type ThreadEventCursor,
+} from "./session-contract";
+
+describe("session event cursor contract", () => {
+  it("round-trips the transport cursor through its serialized form", () => {
+    const cursor = { offset: 42 } satisfies ThreadEventCursor;
+    const serialized = serializeThreadEventCursor(cursor);
+
+    expect(serialized).toBe("42");
+    expect(parseThreadEventCursor(serialized)).toEqual(cursor);
+    expectTypeOf(serialized).toEqualTypeOf<SerializedThreadEventCursor>();
+  });
+
+  it.each([
+    "",
+    "-1",
+    "1.5",
+    "01",
+    "offset:1",
+    "not-a-cursor",
+  ])("rejects malformed serialized cursor %j", (serialized) => {
+    expect(() => parseThreadEventCursor(serialized)).toThrow(
+      "invalid thread event cursor"
+    );
+  });
+});

--- a/apps/worker-agent/src/session-contract.ts
+++ b/apps/worker-agent/src/session-contract.ts
@@ -5,7 +5,11 @@ import type {
 } from "@minpeter/pss-runtime";
 import { z } from "zod";
 
-import { type ChannelAddress, ChannelAddressSchema } from "./channel";
+import {
+  type ChannelAddress,
+  ChannelAddressSchema,
+  channelKey,
+} from "./channel";
 
 const SERIALIZED_CURSOR_PATTERN = /^(0|[1-9]\d*)$/u;
 const SESSION_REPLAY_MAX_LIMIT = 100;
@@ -119,6 +123,32 @@ function isAgentEvent(value: unknown): value is AgentEvent {
     "type" in value &&
     typeof value.type === "string"
   );
+}
+
+export function serializeSessionChannel(channel: ChannelAddress): string {
+  return channelKey(channel);
+}
+
+export function parseSessionChannel(serialized: string): ChannelAddress {
+  const separator = serialized.indexOf(":");
+  if (separator < 1) {
+    throw new InvalidSessionChannelError();
+  }
+  const parsed = ChannelAddressSchema.safeParse({
+    id: serialized.slice(separator + 1),
+    kind: serialized.slice(0, separator),
+  });
+  if (!(parsed.success && parsed.data.id.trim())) {
+    throw new InvalidSessionChannelError();
+  }
+  return { id: parsed.data.id.trim(), kind: parsed.data.kind };
+}
+
+export class InvalidSessionChannelError extends Error {
+  constructor() {
+    super("invalid session channel");
+    this.name = "InvalidSessionChannelError";
+  }
 }
 
 export function serializeThreadEventCursor(

--- a/apps/worker-agent/src/session-contract.ts
+++ b/apps/worker-agent/src/session-contract.ts
@@ -1,22 +1,125 @@
+import type {
+  AgentEvent,
+  StoredThreadEvent as RuntimeStoredThreadEvent,
+  ThreadEventCursor as RuntimeThreadEventCursor,
+} from "@minpeter/pss-runtime";
 import { z } from "zod";
 
+import { type ChannelAddress, ChannelAddressSchema } from "./channel";
+
 const SERIALIZED_CURSOR_PATTERN = /^(0|[1-9]\d*)$/u;
+const SESSION_REPLAY_MAX_LIMIT = 100;
 
 declare const serializedThreadEventCursorBrand: unique symbol;
 
 /** Transport cursor for durable, thread-scoped event replay. */
-export interface ThreadEventCursor {
-  readonly offset: number;
-}
+export type ThreadEventCursor = RuntimeThreadEventCursor;
 
 /** Canonical URL/SSE representation of a thread event cursor. */
 export type SerializedThreadEventCursor = string & {
   readonly [serializedThreadEventCursorBrand]: true;
 };
 
+export type StoredThreadEvent = RuntimeStoredThreadEvent;
+
+export interface SubmitTurnRequest {
+  readonly channel: ChannelAddress;
+  readonly idempotencyKey?: string;
+  readonly sessionScopeKey?: string;
+  readonly text: string;
+}
+
+export interface SubmitTurnResponse {
+  readonly accepted: true;
+  readonly eventCursor?: ThreadEventCursor;
+  readonly runId: string;
+  readonly threadKey: string;
+}
+
+export interface ReplayEventsRequest {
+  readonly after?: ThreadEventCursor;
+  readonly channel: ChannelAddress;
+  readonly limit?: number;
+  readonly sessionScopeKey?: string;
+}
+
+export interface ReplayEventsResponse {
+  readonly events: readonly StoredThreadEvent[];
+  readonly nextCursor?: ThreadEventCursor;
+}
+
 export const ThreadEventCursorSchema = z
   .object({ offset: z.number().int().nonnegative().safe() })
   .strict();
+
+export const SubmitTurnRequestSchema = z
+  .object({
+    channel: ChannelAddressSchema,
+    idempotencyKey: z.string().optional(),
+    sessionScopeKey: z.string().optional(),
+    text: z.string(),
+  })
+  .strict();
+
+export const SubmitTurnResponseSchema = z
+  .object({
+    accepted: z.literal(true),
+    eventCursor: ThreadEventCursorSchema.optional(),
+    runId: z.string().min(1),
+    threadKey: z.string().min(1),
+  })
+  .strict();
+
+export const ReplayEventsRequestSchema = z
+  .object({
+    after: ThreadEventCursorSchema.optional(),
+    channel: ChannelAddressSchema,
+    limit: z.number().int().positive().max(SESSION_REPLAY_MAX_LIMIT).optional(),
+    sessionScopeKey: z.string().optional(),
+  })
+  .strict();
+
+export const ReplayEventsResponseSchema = z.custom<ReplayEventsResponse>(
+  isReplayEventsResponse
+);
+
+function isReplayEventsResponse(value: unknown): value is ReplayEventsResponse {
+  if (!(typeof value === "object" && value !== null && "events" in value)) {
+    return false;
+  }
+  if (
+    !(Array.isArray(value.events) && value.events.every(isStoredThreadEvent))
+  ) {
+    return false;
+  }
+  return (
+    !("nextCursor" in value) ||
+    value.nextCursor === undefined ||
+    ThreadEventCursorSchema.safeParse(value.nextCursor).success
+  );
+}
+
+function isStoredThreadEvent(value: unknown): value is StoredThreadEvent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "cursor" in value &&
+    ThreadEventCursorSchema.safeParse(value.cursor).success &&
+    "event" in value &&
+    isAgentEvent(value.event) &&
+    "threadKey" in value &&
+    typeof value.threadKey === "string"
+  );
+}
+
+function isAgentEvent(value: unknown): value is AgentEvent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    typeof value.type === "string"
+  );
+}
 
 export function serializeThreadEventCursor(
   cursor: ThreadEventCursor

--- a/apps/worker-agent/src/session-contract.ts
+++ b/apps/worker-agent/src/session-contract.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const SERIALIZED_CURSOR_PATTERN = /^(0|[1-9]\d*)$/u;
+
+declare const serializedThreadEventCursorBrand: unique symbol;
+
+/** Transport cursor for durable, thread-scoped event replay. */
+export interface ThreadEventCursor {
+  readonly offset: number;
+}
+
+/** Canonical URL/SSE representation of a thread event cursor. */
+export type SerializedThreadEventCursor = string & {
+  readonly [serializedThreadEventCursorBrand]: true;
+};
+
+export const ThreadEventCursorSchema = z
+  .object({ offset: z.number().int().nonnegative().safe() })
+  .strict();
+
+export function serializeThreadEventCursor(
+  cursor: ThreadEventCursor
+): SerializedThreadEventCursor {
+  const parsed = ThreadEventCursorSchema.parse(cursor);
+  return String(parsed.offset) as SerializedThreadEventCursor;
+}
+
+export function parseThreadEventCursor(serialized: string): ThreadEventCursor {
+  if (!SERIALIZED_CURSOR_PATTERN.test(serialized)) {
+    throw new InvalidThreadEventCursorError();
+  }
+
+  const offset = Number(serialized);
+  if (!Number.isSafeInteger(offset)) {
+    throw new InvalidThreadEventCursorError();
+  }
+  return { offset };
+}
+
+export class InvalidThreadEventCursorError extends Error {
+  constructor() {
+    super("invalid thread event cursor");
+    this.name = "InvalidThreadEventCursorError";
+  }
+}

--- a/apps/worker-agent/src/session-events-server.test.ts
+++ b/apps/worker-agent/src/session-events-server.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Env } from "./env";
+import { handleSessionEventsRequest } from "./session-events-server";
+
+const durableObjectMock = vi.hoisted(
+  (): {
+    readonly requests: Request[];
+  } => ({ requests: [] })
+);
+
+vi.mock("@minpeter/pss-runtime/platform/cloudflare", () => ({
+  fetchCloudflareDurableObject: (options: unknown) => {
+    if (
+      !(
+        typeof options === "object" &&
+        options !== null &&
+        "request" in options &&
+        options.request instanceof Request
+      )
+    ) {
+      throw new Error("Expected Durable Object fetch options.");
+    }
+    durableObjectMock.requests.push(options.request);
+    return Promise.resolve(
+      new Response("event: ready\ndata: {}\n\n", {
+        headers: { "content-type": "text/event-stream" },
+      })
+    );
+  },
+}));
+
+describe("session SSE worker route", () => {
+  beforeEach(() => {
+    durableObjectMock.requests.length = 0;
+  });
+
+  it("rejects a production stream without bearer auth", async () => {
+    const response = await handleSessionEventsRequest(
+      new Request("https://worker.example/session/events?channel=tui%3Alocal"),
+      createEnv()
+    );
+
+    expect(response.status).toBe(401);
+    expect(durableObjectMock.requests).toEqual([]);
+  });
+
+  it("proxies an authorized cursor stream to the channel Durable Object", async () => {
+    const response = await handleSessionEventsRequest(
+      new Request(
+        "https://worker.example/session/events?channel=tui%3Alocal&after=4&sessionScopeKey=tui%3Auser",
+        { headers: { authorization: "Bearer secret" } }
+      ),
+      createEnv()
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    expect(durableObjectMock.requests).toHaveLength(1);
+    const internal = durableObjectMock.requests[0];
+    if (!internal) {
+      throw new Error("expected internal event stream request");
+    }
+    const url = new URL(internal.url);
+    expect(url.pathname).toBe("/session/events");
+    expect(url.searchParams.get("channel")).toBe("tui:local");
+    expect(url.searchParams.get("after")).toBe("4");
+    expect(url.searchParams.get("sessionScopeKey")).toBe("tui:user");
+  });
+});
+
+function createEnv(): Env {
+  return {
+    AGENT_DO: {
+      get: () => {
+        throw new Error("namespace should be mocked");
+      },
+      getByName: () => {
+        throw new Error("namespace should be mocked");
+      },
+      idFromName: (name: string) => ({ name, toString: () => name }),
+    } as unknown as DurableObjectNamespace,
+    AI_API_KEY: "test-key",
+    ENVIRONMENT: "production",
+    TELEGRAM_BOT_TOKEN: "test-token",
+    TELEGRAM_WEBHOOK_SECRET_TOKEN: "secret",
+    WORKER_AGENT_TUI_TOKEN: "secret",
+  };
+}

--- a/apps/worker-agent/src/session-events-server.ts
+++ b/apps/worker-agent/src/session-events-server.ts
@@ -1,0 +1,52 @@
+import { fetchCloudflareDurableObject } from "@minpeter/pss-runtime/platform/cloudflare";
+
+import { type ChannelAddress, channelKey } from "./channel";
+import { durableObjectName, type Env } from "./env";
+import {
+  parseSessionChannel,
+  parseThreadEventCursor,
+} from "./session-contract";
+import { isAuthorizedWorkerRequest } from "./tui-rpc";
+
+const INTERNAL_SESSION_EVENTS_URL = "https://agent.internal/session/events";
+
+export async function handleSessionEventsRequest(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  if (request.method !== "GET") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  if (!isAuthorizedWorkerRequest(request, env)) {
+    return new Response("unauthorized", { status: 401 });
+  }
+
+  const sourceUrl = new URL(request.url);
+  const serializedChannel = sourceUrl.searchParams.get("channel");
+  if (!serializedChannel) {
+    return new Response("channel required", { status: 400 });
+  }
+
+  let channel: ChannelAddress;
+  try {
+    channel = parseSessionChannel(serializedChannel);
+    const after = sourceUrl.searchParams.get("after");
+    if (after !== null) {
+      parseThreadEventCursor(after);
+    }
+  } catch {
+    return new Response("invalid session event stream", { status: 400 });
+  }
+
+  const internalUrl = new URL(INTERNAL_SESSION_EVENTS_URL);
+  internalUrl.search = sourceUrl.search;
+  const response = await fetchCloudflareDurableObject({
+    namespace: env.AGENT_DO,
+    objectName: durableObjectName(channelKey(channel)),
+    request: new Request(internalUrl, { method: "GET" }),
+  });
+  if (!response) {
+    return new Response("agent durable object unavailable", { status: 502 });
+  }
+  return response;
+}

--- a/apps/worker-agent/src/session-events.test.ts
+++ b/apps/worker-agent/src/session-events.test.ts
@@ -1,0 +1,162 @@
+import type { StoredThreadEvent } from "@minpeter/pss-runtime";
+import { describe, expect, it } from "vitest";
+
+import {
+  createSessionEventLiveSignal,
+  createSessionEventStreamResponse,
+} from "./session-events";
+import { streamRemoteSessionEvents } from "./session-remote";
+
+const firstEvent = {
+  cursor: { offset: 0 },
+  event: { type: "turn-start" },
+  threadKey: "default",
+} satisfies StoredThreadEvent;
+const secondEvent = {
+  cursor: { offset: 1 },
+  event: { text: "hello", type: "assistant-output" },
+  threadKey: "default",
+} satisfies StoredThreadEvent;
+const thirdEvent = {
+  cursor: { offset: 2 },
+  event: { type: "turn-end" },
+  threadKey: "default",
+} satisfies StoredThreadEvent;
+
+describe("session SSE event stream", () => {
+  it("replays committed events before streaming a newly committed event", async () => {
+    const committed: StoredThreadEvent[] = [firstEvent, secondEvent];
+    const live = createSessionEventLiveSignal();
+    const response = createSessionEventStreamResponse({
+      live,
+      replay: (after) =>
+        Promise.resolve(replayAfterCursor(committed, after?.offset)),
+    });
+    const reader = createSseTestReader(response);
+
+    await expect(reader.next()).resolves.toEqual(firstEvent);
+    await expect(reader.next()).resolves.toEqual(secondEvent);
+
+    committed.push(thirdEvent);
+    live.publish();
+
+    await expect(reader.next()).resolves.toEqual(thirdEvent);
+    await reader.close();
+  });
+
+  it("reconnects after a dropped stream with the last received cursor", async () => {
+    const requests: Request[] = [];
+    const events = [firstEvent, secondEvent];
+    const stream = streamRemoteSessionEvents({
+      channel: { id: "local", kind: "tui" },
+      endpoint: "https://worker.example/session/events",
+      fetch: (request) => {
+        requests.push(request);
+        const event = events.shift();
+        if (!event) {
+          throw new Error("unexpected third connection");
+        }
+        return Promise.resolve(
+          new Response(formatSseEvent(event), {
+            headers: { "content-type": "text/event-stream" },
+          })
+        );
+      },
+      token: "secret",
+    });
+    const iterator = stream[Symbol.asyncIterator]();
+
+    await expect(withTimeout(iterator.next())).resolves.toEqual({
+      done: false,
+      value: firstEvent,
+    });
+    await expect(withTimeout(iterator.next())).resolves.toEqual({
+      done: false,
+      value: secondEvent,
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer secret");
+    expect(
+      new URL(requests[0]?.url ?? "").searchParams.get("after")
+    ).toBeNull();
+    expect(new URL(requests[1]?.url ?? "").searchParams.get("after")).toBe("0");
+    await iterator.return?.();
+  });
+});
+
+function replayAfterCursor(
+  committed: readonly StoredThreadEvent[],
+  offset: number | undefined
+) {
+  const events = committed.filter(
+    (record) => offset === undefined || record.cursor.offset > offset
+  );
+  const nextCursor = events.at(-1)?.cursor;
+  return {
+    events,
+    ...(nextCursor ? { nextCursor } : {}),
+  };
+}
+
+function formatSseEvent(event: StoredThreadEvent): string {
+  return `id: ${event.cursor.offset}\nevent: thread-event\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+function createSseTestReader(response: Response) {
+  if (!response.body) {
+    throw new Error("expected SSE response body");
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const queued: StoredThreadEvent[] = [];
+
+  return {
+    close: () => reader.cancel(),
+    async next(): Promise<StoredThreadEvent> {
+      while (queued.length === 0) {
+        const result = await withTimeout(reader.read());
+        if (result.done) {
+          throw new Error("SSE stream ended before the next event");
+        }
+        buffer += decoder.decode(result.value, { stream: true });
+        const frames = buffer.split("\n\n");
+        buffer = frames.pop() ?? "";
+        for (const frame of frames) {
+          const data = frame
+            .split("\n")
+            .find((line) => line.startsWith("data: "))
+            ?.slice("data: ".length);
+          if (data) {
+            queued.push(JSON.parse(data) as StoredThreadEvent);
+          }
+        }
+      }
+      const event = queued.shift();
+      if (!event) {
+        throw new Error("expected queued SSE event");
+      }
+      return event;
+    },
+  };
+}
+
+function withTimeout<T>(promise: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("timed out waiting for exact stream signal")),
+      1000
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error);
+      }
+    );
+  });
+}

--- a/apps/worker-agent/src/session-events.ts
+++ b/apps/worker-agent/src/session-events.ts
@@ -1,0 +1,130 @@
+import type { StoredThreadEvent } from "@minpeter/pss-runtime";
+
+import {
+  type ReplayEventsResponse,
+  serializeThreadEventCursor,
+  type ThreadEventCursor,
+} from "./session-contract";
+
+const SSE_EVENT_NAME = "thread-event";
+
+export interface SessionEventLiveSignal {
+  publish(): void;
+  subscribe(listener: () => void): () => void;
+}
+
+export interface SessionEventStreamOptions {
+  readonly after?: ThreadEventCursor;
+  readonly live: SessionEventLiveSignal;
+  readonly replay: (
+    after: ThreadEventCursor | undefined
+  ) => Promise<ReplayEventsResponse>;
+}
+
+export function createSessionEventLiveSignal(): SessionEventLiveSignal {
+  const listeners = new Set<() => void>();
+  return {
+    publish() {
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+export function createSessionEventStreamResponse({
+  after,
+  live,
+  replay,
+}: SessionEventStreamOptions): Response {
+  let cancelled = false;
+  let stop: (() => void) | undefined;
+  let wake: (() => void) | undefined;
+  const stream = new ReadableStream<Uint8Array>({
+    cancel() {
+      cancelled = true;
+      stop?.();
+      wake?.();
+    },
+    start(controller) {
+      const cursor = after;
+      let publishedVersion = 0;
+      let observedVersion = 0;
+      stop = live.subscribe(() => {
+        publishedVersion += 1;
+        const resolve = wake;
+        wake = undefined;
+        resolve?.();
+      });
+
+      const waitForPublish = async (): Promise<void> => {
+        if (publishedVersion === observedVersion) {
+          await new Promise<void>((resolve) => {
+            wake = resolve;
+          });
+        }
+        observedVersion = publishedVersion;
+      };
+
+      pumpSessionEventStream({
+        after: cursor,
+        controller,
+        isCancelled: () => cancelled,
+        replay,
+        waitForPublish,
+      }).catch((error: unknown) => {
+        stop?.();
+        controller.error(error);
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+      "content-type": "text/event-stream; charset=utf-8",
+    },
+  });
+}
+
+async function pumpSessionEventStream({
+  after,
+  controller,
+  isCancelled,
+  replay,
+  waitForPublish,
+}: {
+  readonly after: ThreadEventCursor | undefined;
+  readonly controller: ReadableStreamDefaultController<Uint8Array>;
+  readonly isCancelled: () => boolean;
+  readonly replay: SessionEventStreamOptions["replay"];
+  readonly waitForPublish: () => Promise<void>;
+}): Promise<void> {
+  let cursor = after;
+  while (!isCancelled()) {
+    const page = await replay(cursor);
+    if (isCancelled()) {
+      return;
+    }
+    for (const event of page.events) {
+      controller.enqueue(encodeSseEvent(event));
+      cursor = event.cursor;
+    }
+    cursor = page.nextCursor ?? cursor;
+    if (page.events.length === 0) {
+      await waitForPublish();
+    }
+  }
+}
+
+function encodeSseEvent(event: StoredThreadEvent): Uint8Array {
+  const id = serializeThreadEventCursor(event.cursor);
+  return new TextEncoder().encode(
+    `id: ${id}\nevent: ${SSE_EVENT_NAME}\ndata: ${JSON.stringify(event)}\n\n`
+  );
+}

--- a/apps/worker-agent/src/session-remote.ts
+++ b/apps/worker-agent/src/session-remote.ts
@@ -4,9 +4,13 @@ import {
   type ReplayEventsRequest,
   type ReplayEventsResponse,
   ReplayEventsResponseSchema,
+  type StoredThreadEvent,
   type SubmitTurnRequest,
   type SubmitTurnResponse,
   SubmitTurnResponseSchema,
+  serializeSessionChannel,
+  serializeThreadEventCursor,
+  type ThreadEventCursor,
 } from "./session-contract";
 import type { WorkerAgentRouter } from "./tui-rpc";
 
@@ -17,6 +21,16 @@ export interface RemoteSessionClient {
 
 export interface RemoteSessionClientConfig {
   readonly endpoint: string;
+  readonly token?: string;
+}
+
+export interface RemoteSessionEventStreamConfig {
+  readonly after?: ThreadEventCursor;
+  readonly channel: SubmitTurnRequest["channel"];
+  readonly endpoint: string;
+  readonly fetch?: (request: Request) => Promise<Response>;
+  readonly sessionScopeKey?: string;
+  readonly signal?: AbortSignal;
   readonly token?: string;
 }
 
@@ -43,4 +57,98 @@ export function createRemoteSessionClient(
       return SubmitTurnResponseSchema.parse(response);
     },
   };
+}
+
+export async function* streamRemoteSessionEvents(
+  config: RemoteSessionEventStreamConfig
+): AsyncIterable<StoredThreadEvent> {
+  const fetchSessionEvents = config.fetch ?? ((request) => fetch(request));
+  let cursor = config.after;
+
+  while (!config.signal?.aborted) {
+    const url = new URL(config.endpoint);
+    url.searchParams.set("channel", serializeSessionChannel(config.channel));
+    if (cursor) {
+      url.searchParams.set("after", serializeThreadEventCursor(cursor));
+    }
+    if (config.sessionScopeKey) {
+      url.searchParams.set("sessionScopeKey", config.sessionScopeKey);
+    }
+    const request = new Request(url, {
+      headers: {
+        accept: "text/event-stream",
+        ...(config.token ? { authorization: `Bearer ${config.token}` } : {}),
+      },
+      ...(config.signal ? { signal: config.signal } : {}),
+    });
+    const response = await fetchSessionEvents(request);
+    if (!response.ok) {
+      throw new RemoteSessionEventStreamError(response.status);
+    }
+
+    for await (const event of decodeSessionEventStream(response)) {
+      cursor = event.cursor;
+      yield event;
+    }
+  }
+}
+
+async function* decodeSessionEventStream(
+  response: Response
+): AsyncIterable<StoredThreadEvent> {
+  if (!response.body) {
+    throw new RemoteSessionEventStreamError(response.status, "missing body");
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) {
+        return;
+      }
+      buffer += decoder
+        .decode(result.value, { stream: true })
+        .replaceAll("\r\n", "\n");
+      const frames = buffer.split("\n\n");
+      buffer = frames.pop() ?? "";
+      for (const frame of frames) {
+        const event = parseSessionEventFrame(frame);
+        if (event) {
+          yield event;
+        }
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+}
+
+function parseSessionEventFrame(frame: string): StoredThreadEvent | undefined {
+  const lines = frame.split("\n");
+  if (!lines.includes("event: thread-event")) {
+    return;
+  }
+  const data = lines
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trimStart())
+    .join("\n");
+  if (!data) {
+    return;
+  }
+  const parsed: unknown = JSON.parse(data);
+  const replay = ReplayEventsResponseSchema.parse({ events: [parsed] });
+  const event = replay.events[0];
+  if (!event) {
+    throw new RemoteSessionEventStreamError(200, "invalid event");
+  }
+  return event;
+}
+
+export class RemoteSessionEventStreamError extends Error {
+  constructor(status: number, detail = "request failed") {
+    super(`session event stream ${detail}: ${status}`);
+    this.name = "RemoteSessionEventStreamError";
+  }
 }

--- a/apps/worker-agent/src/session-remote.ts
+++ b/apps/worker-agent/src/session-remote.ts
@@ -1,0 +1,46 @@
+import { createTRPCClient, httpLink } from "@trpc/client";
+
+import {
+  type ReplayEventsRequest,
+  type ReplayEventsResponse,
+  ReplayEventsResponseSchema,
+  type SubmitTurnRequest,
+  type SubmitTurnResponse,
+  SubmitTurnResponseSchema,
+} from "./session-contract";
+import type { WorkerAgentRouter } from "./tui-rpc";
+
+export interface RemoteSessionClient {
+  replayEvents(input: ReplayEventsRequest): Promise<ReplayEventsResponse>;
+  submitTurn(input: SubmitTurnRequest): Promise<SubmitTurnResponse>;
+}
+
+export interface RemoteSessionClientConfig {
+  readonly endpoint: string;
+  readonly token?: string;
+}
+
+export function createRemoteSessionClient(
+  config: RemoteSessionClientConfig
+): RemoteSessionClient {
+  const client = createTRPCClient<WorkerAgentRouter>({
+    links: [
+      httpLink({
+        headers: () =>
+          config.token ? { authorization: `Bearer ${config.token}` } : {},
+        url: config.endpoint,
+      }),
+    ],
+  });
+
+  return {
+    replayEvents: async (input) => {
+      const response: unknown = await client.session.replayEvents.query(input);
+      return ReplayEventsResponseSchema.parse(response);
+    },
+    submitTurn: async (input) => {
+      const response: unknown = await client.session.submitTurn.mutate(input);
+      return SubmitTurnResponseSchema.parse(response);
+    },
+  };
+}

--- a/apps/worker-agent/src/session-runtime.test.ts
+++ b/apps/worker-agent/src/session-runtime.test.ts
@@ -1,0 +1,71 @@
+import { createInMemoryHost } from "@minpeter/pss-runtime/platform/memory";
+import { describe, expect, it } from "vitest";
+
+import {
+  replayDurableThreadEvents,
+  submitDurableSessionTurn,
+} from "./session-runtime";
+
+describe("durable session runtime adapter", () => {
+  it("returns the runtime run id immediately after durable admission", async () => {
+    const host = createInMemoryHost();
+
+    const admitted = await submitDurableSessionTurn({
+      host,
+      idempotencyKey: "client-turn-1",
+      input: "hello",
+      namespace: "worker-agent",
+      threadKey: "default",
+    });
+
+    expect(admitted).toEqual({
+      accepted: true,
+      runId: expect.any(String),
+      threadKey: "default",
+    });
+    await expect(host.store.turns.get(admitted.runId)).resolves.toMatchObject({
+      runId: admitted.runId,
+      status: "queued",
+      threadKey: "default",
+    });
+  });
+
+  it("gap-fills committed runtime events strictly after the cursor", async () => {
+    const host = createInMemoryHost();
+    const eventLog = host.store.threadEvents;
+    if (!eventLog) {
+      throw new Error("expected runtime thread event replay");
+    }
+    const firstCursor = await eventLog.append("default", {
+      type: "turn-start",
+    });
+    const secondCursor = await eventLog.append("default", {
+      text: "one",
+      type: "assistant-output",
+    });
+    const lastCursor = await eventLog.append("default", { type: "turn-end" });
+
+    const replayed = await replayDurableThreadEvents(
+      {
+        events: (options) => eventLog.read("default", options),
+      },
+      { after: firstCursor, limit: 10 }
+    );
+
+    expect(replayed).toEqual({
+      events: [
+        {
+          cursor: secondCursor,
+          event: { text: "one", type: "assistant-output" },
+          threadKey: "default",
+        },
+        {
+          cursor: lastCursor,
+          event: { type: "turn-end" },
+          threadKey: "default",
+        },
+      ],
+      nextCursor: lastCursor,
+    });
+  });
+});

--- a/apps/worker-agent/src/session-runtime.ts
+++ b/apps/worker-agent/src/session-runtime.ts
@@ -1,0 +1,72 @@
+import type {
+  AgentInput,
+  StoredThreadEvent,
+  ThreadEventReadOptions,
+  UserInput,
+} from "@minpeter/pss-runtime";
+import {
+  type AgentHost,
+  dispatchAgentNotification,
+} from "@minpeter/pss-runtime/execution";
+
+import type {
+  ReplayEventsResponse,
+  SubmitTurnResponse,
+} from "./session-contract";
+
+export interface DurableThreadEventReader {
+  events(options?: ThreadEventReadOptions): AsyncIterable<StoredThreadEvent>;
+}
+
+export async function submitDurableSessionTurn({
+  host,
+  idempotencyKey,
+  input,
+  namespace,
+  threadKey,
+}: {
+  readonly host: AgentHost;
+  readonly idempotencyKey: string;
+  readonly input: AgentInput;
+  readonly namespace: string;
+  readonly threadKey: string;
+}): Promise<SubmitTurnResponse> {
+  const admitted = await dispatchAgentNotification({
+    host,
+    idempotencyKey,
+    input: normalizeSessionUserInput(input),
+    namespace,
+    threadKey,
+  });
+
+  return {
+    accepted: true,
+    runId: admitted.runId,
+    threadKey,
+  };
+}
+
+export async function replayDurableThreadEvents(
+  thread: DurableThreadEventReader,
+  options: ThreadEventReadOptions = {}
+): Promise<ReplayEventsResponse> {
+  const events: StoredThreadEvent[] = [];
+  for await (const event of thread.events(options)) {
+    events.push(event);
+  }
+  const nextCursor = events.at(-1)?.cursor;
+  return {
+    events,
+    ...(nextCursor ? { nextCursor } : {}),
+  };
+}
+
+function normalizeSessionUserInput(input: AgentInput): UserInput {
+  if (typeof input === "string") {
+    return { text: input, type: "user-input" };
+  }
+  if (input.every((part) => typeof part === "string")) {
+    return { text: input, type: "user-input" };
+  }
+  return { content: input, type: "user-input" };
+}

--- a/apps/worker-agent/src/session-server.ts
+++ b/apps/worker-agent/src/session-server.ts
@@ -1,0 +1,109 @@
+import { fetchCloudflareDurableObject } from "@minpeter/pss-runtime/platform/cloudflare";
+
+import { channelKey } from "./channel";
+import { durableObjectName, type Env } from "./env";
+import {
+  type ReplayEventsRequest,
+  ReplayEventsResponseSchema,
+  type SubmitTurnRequest,
+  SubmitTurnResponseSchema,
+} from "./session-contract";
+import { TuiServerBadRequestError, TuiServerUpstreamError } from "./tui-server";
+
+const SESSION_SUBMIT_PATH = "/session/turn";
+const SESSION_REPLAY_PATH = "/session/events/replay";
+
+export async function dispatchSessionSubmitTurn(
+  input: SubmitTurnRequest,
+  env: Env
+) {
+  const payload = normalizeSubmitTurnRequest(input);
+  return await requestSessionDurableObject({
+    env,
+    path: SESSION_SUBMIT_PATH,
+    payload,
+    parse: (body) => SubmitTurnResponseSchema.parse(body),
+  });
+}
+
+export async function dispatchSessionEventReplay(
+  input: ReplayEventsRequest,
+  env: Env
+) {
+  const payload = normalizeReplayEventsRequest(input);
+  return await requestSessionDurableObject({
+    env,
+    path: SESSION_REPLAY_PATH,
+    payload,
+    parse: (body) => ReplayEventsResponseSchema.parse(body),
+  });
+}
+
+function normalizeSubmitTurnRequest(
+  input: SubmitTurnRequest
+): SubmitTurnRequest {
+  const channel = normalizeChannel(input.channel);
+  const text = input.text.trim();
+  if (!text) {
+    throw new TuiServerBadRequestError("text and channel required");
+  }
+  const idempotencyKey = input.idempotencyKey?.trim();
+  const sessionScopeKey = input.sessionScopeKey?.trim();
+  return {
+    channel,
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(sessionScopeKey ? { sessionScopeKey } : {}),
+    text,
+  };
+}
+
+function normalizeReplayEventsRequest(
+  input: ReplayEventsRequest
+): ReplayEventsRequest {
+  const sessionScopeKey = input.sessionScopeKey?.trim();
+  return {
+    ...(input.after ? { after: input.after } : {}),
+    channel: normalizeChannel(input.channel),
+    ...(input.limit === undefined ? {} : { limit: input.limit }),
+    ...(sessionScopeKey ? { sessionScopeKey } : {}),
+  };
+}
+
+function normalizeChannel(channel: SubmitTurnRequest["channel"]) {
+  const id = channel.id.trim();
+  if (!id) {
+    throw new TuiServerBadRequestError("text and channel required");
+  }
+  return { id, kind: channel.kind };
+}
+
+async function requestSessionDurableObject<T>({
+  env,
+  parse,
+  path,
+  payload,
+}: {
+  readonly env: Env;
+  readonly parse: (body: unknown) => T;
+  readonly path: string;
+  readonly payload: ReplayEventsRequest | SubmitTurnRequest;
+}): Promise<T> {
+  const response = await fetchCloudflareDurableObject({
+    namespace: env.AGENT_DO,
+    objectName: durableObjectName(channelKey(payload.channel)),
+    request: new Request(`https://agent.internal${path}`, {
+      body: JSON.stringify(payload),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }),
+  });
+  if (!response) {
+    throw new TuiServerUpstreamError("agent durable object unavailable");
+  }
+  if (!response.ok) {
+    throw new TuiServerUpstreamError(
+      `agent durable object session request failed: ${response.status}`
+    );
+  }
+  return parse(await response.json());
+}

--- a/apps/worker-agent/src/tui-rpc.ts
+++ b/apps/worker-agent/src/tui-rpc.ts
@@ -28,7 +28,7 @@ interface TuiRpcContext {
 const trpc = initTRPC.context<TuiRpcContext>().create({ isDev: false });
 
 const authorizedProcedure = trpc.procedure.use(({ ctx, next }) => {
-  if (!isAuthorizedTuiRequest(ctx.request, ctx.env)) {
+  if (!isAuthorizedWorkerRequest(ctx.request, ctx.env)) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
       message: UNAUTHORIZED_MESSAGE,
@@ -95,7 +95,7 @@ async function translateServerErrors<T>(operation: () => Promise<T>) {
   }
 }
 
-function isAuthorizedTuiRequest(request: Request, env: Env): boolean {
+export function isAuthorizedWorkerRequest(request: Request, env: Env): boolean {
   const token = env.WORKER_AGENT_TUI_TOKEN?.trim();
   if (!token) {
     return isDevelopment(env);

--- a/apps/worker-agent/src/tui-rpc.ts
+++ b/apps/worker-agent/src/tui-rpc.ts
@@ -2,6 +2,14 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 
 import { type Env, isDevelopment } from "./env";
+import {
+  ReplayEventsRequestSchema,
+  SubmitTurnRequestSchema,
+} from "./session-contract";
+import {
+  dispatchSessionEventReplay,
+  dispatchSessionSubmitTurn,
+} from "./session-server";
 import { TuiTurnInputSchema, TuiTurnOutputSchema } from "./tui-contract";
 import {
   dispatchTuiTurn,
@@ -31,29 +39,25 @@ const authorizedProcedure = trpc.procedure.use(({ ctx, next }) => {
 });
 
 export const workerAgentRouter = trpc.router({
+  session: trpc.router({
+    replayEvents: authorizedProcedure
+      .input(ReplayEventsRequestSchema)
+      .query(async ({ ctx, input }) =>
+        translateServerErrors(() => dispatchSessionEventReplay(input, ctx.env))
+      ),
+    submitTurn: authorizedProcedure
+      .input(SubmitTurnRequestSchema)
+      .mutation(async ({ ctx, input }) =>
+        translateServerErrors(() => dispatchSessionSubmitTurn(input, ctx.env))
+      ),
+  }),
   tui: trpc.router({
     turn: authorizedProcedure
       .input(TuiTurnInputSchema)
       .output(TuiTurnOutputSchema)
-      .mutation(async ({ ctx, input }) => {
-        try {
-          return await dispatchTuiTurn(input, ctx.env);
-        } catch (error) {
-          if (error instanceof TuiServerBadRequestError) {
-            throw new TRPCError({
-              code: "BAD_REQUEST",
-              message: error.message,
-            });
-          }
-          if (error instanceof TuiServerUpstreamError) {
-            throw new TRPCError({
-              code: "BAD_GATEWAY",
-              message: error.message,
-            });
-          }
-          throw error;
-        }
-      }),
+      .mutation(async ({ ctx, input }) =>
+        translateServerErrors(() => dispatchTuiTurn(input, ctx.env))
+      ),
   }),
 });
 
@@ -69,6 +73,26 @@ export function handleTuiRpcRequest(
     req: request,
     router: workerAgentRouter,
   });
+}
+
+async function translateServerErrors<T>(operation: () => Promise<T>) {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof TuiServerBadRequestError) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: error.message,
+      });
+    }
+    if (error instanceof TuiServerUpstreamError) {
+      throw new TRPCError({
+        code: "BAD_GATEWAY",
+        message: error.message,
+      });
+    }
+    throw error;
+  }
 }
 
 function isAuthorizedTuiRequest(request: Request, env: Env): boolean {

--- a/apps/worker-agent/src/tui-server.test.ts
+++ b/apps/worker-agent/src/tui-server.test.ts
@@ -121,6 +121,92 @@ describe("TUI worker tRPC route", () => {
     });
   });
 
+  it("returns a durable admission receipt from session.submitTurn", async () => {
+    const env = createEnv({ ENVIRONMENT: "development" });
+    durableObjectMock.responses.push(
+      Response.json({
+        accepted: true,
+        runId: "run-durable-1",
+        threadKey: "default",
+      })
+    );
+    const client = createTuiRpcTestClient(env);
+
+    await expect(
+      client.session.submitTurn.mutate({
+        channel: { id: " local ", kind: "tui" },
+        idempotencyKey: " turn-1 ",
+        sessionScopeKey: " tui:user ",
+        text: " hello ",
+      })
+    ).resolves.toEqual({
+      accepted: true,
+      runId: "run-durable-1",
+      threadKey: "default",
+    });
+
+    const [request] = durableObjectMock.requests;
+    if (!request) {
+      throw new Error("Expected a Durable Object request.");
+    }
+    expect(new URL(request.request.url).pathname).toBe("/session/turn");
+    await expect(request.request.json()).resolves.toEqual({
+      channel: { id: "local", kind: "tui" },
+      idempotencyKey: "turn-1",
+      sessionScopeKey: "tui:user",
+      text: "hello",
+    });
+  });
+
+  it("replays durable session events after a cursor", async () => {
+    const env = createEnv({ ENVIRONMENT: "development" });
+    durableObjectMock.responses.push(
+      Response.json({
+        events: [
+          {
+            cursor: { offset: 3 },
+            event: { type: "turn-end" },
+            threadKey: "default",
+          },
+        ],
+        nextCursor: { offset: 3 },
+      })
+    );
+    const client = createTuiRpcTestClient(env);
+
+    await expect(
+      client.session.replayEvents.query({
+        after: { offset: 2 },
+        channel: { id: "local", kind: "tui" },
+        limit: 25,
+        sessionScopeKey: "tui:user",
+      })
+    ).resolves.toEqual({
+      events: [
+        {
+          cursor: { offset: 3 },
+          event: { type: "turn-end" },
+          threadKey: "default",
+        },
+      ],
+      nextCursor: { offset: 3 },
+    });
+
+    const [request] = durableObjectMock.requests;
+    if (!request) {
+      throw new Error("Expected a Durable Object request.");
+    }
+    expect(new URL(request.request.url).pathname).toBe(
+      "/session/events/replay"
+    );
+    await expect(request.request.json()).resolves.toEqual({
+      after: { offset: 2 },
+      channel: { id: "local", kind: "tui" },
+      limit: 25,
+      sessionScopeKey: "tui:user",
+    });
+  });
+
   it("rejects production TUI turns without the configured token", async () => {
     const env = createEnv({
       ENVIRONMENT: "production",


### PR DESCRIPTION
## Summary

Implements RFC 0002 phases 1-4 in the private `apps/worker-agent` package.

### Phase 1 - existing submit-turn compatibility surface

- Documents authenticated `/trpc/tui.turn` as the initial submit-turn RPC.
- Maps the existing input/delivery response to `SubmitTurnRequest` / `SubmitTurnResponse` terminology.
- Keeps `createRemoteTuiDeliveryClient()` and its wait-for-tool-delivery behavior unchanged.

### Phase 2 - shared cursor contract

- Adds the shared transport `ThreadEventCursor` and branded serialized cursor form.
- Adds strict canonical cursor parse/serialize behavior and contract tests.
- Shares the contract across the tRPC server and remote session clients.

### Phase 3 - durable submit and replay

- Adds `session.submitTurn` and `session.replayEvents` to the existing tRPC router.
- `submitTurn` returns `{ accepted: true, runId, threadKey }` immediately after `dispatchAgentNotification()` durable admission.
- `replayEvents` gap-fills from the runtime's canonical `ThreadHandle.events({ after, limit })` history, never from projected `ThreadStore` snapshots.
- Persists the channel/session binding required by a later durable notification resume.
- Adds a remote session RPC client while preserving `tui.turn`.

### Phase 4 - optional SSE

- Adds bearer-authenticated `GET /session/events?channel=...&after=...`.
- Subscribes before replay, emits durable replay first, then re-reads canonical committed events on live signals.
- Uses Web `ReadableStream`, `Request`, `Response`, `TextEncoder`, and `TextDecoder` APIs only.
- Adds a remote async-iterable SSE client that reconnects with its latest cursor after a dropped response.
- Documents cursor polling through `session.replayEvents` as the baseline fallback.
- Adds the missing private-package build gate as a Wrangler deployment dry run.

## Design decisions applied

- tRPC remains in place; `tui.turn` and `createRemoteTuiDeliveryClient()` remain compatible.
- SSE is optional; cursor polling is the documented baseline.
- durable admission returns the runtime run ID immediately.
- Telegram webhook routing/delivery remains untouched.
- public transport naming is `session`; runtime `threadKey` / channel terminology remains unchanged.

## Runtime API used

No runtime package change or export was needed.

- Public API: `ThreadHandle.events(options?: ThreadEventReadOptions)`
- Declaration: `packages/runtime/src/agent/core/thread-entry.ts:30`
- Runtime implementation: `packages/runtime/src/thread/handle/thread.ts:198`
- Durable admission/run ID: `dispatchAgentNotification`, `packages/runtime/src/execution/dispatch/notification-dispatch.ts:40`

## RED -> GREEN evidence

Characterization before production changes:

```text
Test Files  4 passed (4)
Tests       23 passed (23)
```

Phase 2 RED:

```text
Error: Cannot find module './session-contract'
Test Files  1 failed (1)
Tests       no tests
```

Phase 3 RED:

```text
Error: Cannot find module './session-runtime'
TRPCClientError: No procedure found on path "session.submitTurn"
TRPCClientError: No procedure found on path "session.replayEvents"
Test Files  2 failed (2)
Tests       2 failed | 6 passed (8)
```

Phase 4 RED:

```text
Cannot find module './session-events'
Cannot find module '/src/session-events-server'
Test Files  2 failed (2)
Tests       no tests
```

GREEN:

```text
Test Files  30 passed (30)
Tests       163 passed (163)
```

The SSE tests subscribe to the exact live signal before appending/publishing and use only a bounded timeout as a failure guard; there are no fixed sleeps or polling delays.

## Test plan

- [x] Existing TUI remote/turn-session/DO characterization: 4 files, 23 tests
- [x] Cursor roundtrip and malformed cursor contract tests
- [x] Durable admission returns persisted runtime `runId`
- [x] Replay gap-fill is exclusive of `after`
- [x] SSE replay-before-live ordering
- [x] SSE bearer auth and channel DO proxying
- [x] Dropped SSE reconnect uses latest cursor
- [x] `pnpm --filter @minpeter/pss-worker-agent build` (Wrangler dry run)
- [x] `pnpm --filter @minpeter/pss-worker-agent test` (30 files, 163 tests)
- [x] `pnpm typecheck` (10 tasks)
- [x] `pnpm exec ultracite check <changed files>`

## Release metadata

`apps/worker-agent` is private and `packages/runtime` is unchanged, so no tegami entry is required.

## Follow-up

RFC 0002 phase 5 (unifying the TUI/browser UX around submit + replay + stream) is deliberately out of scope.

Refs docs/rfc/0002-app-owned-session-rpc.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements RFC 0002 phases 1–4 for session transport in `apps/worker-agent`: durable submit + replay, shared event cursor, and optional SSE streaming. Keeps `tui.turn` fully compatible while adding new session APIs and a remote client.

- New Features
  - Added tRPC `session.submitTurn` that returns durable admission `{ accepted, runId, threadKey }` and persists channel/session binding.
  - Added tRPC `session.replayEvents` that reads canonical runtime history via `ThreadHandle.events`, is exclusive of `after`, and returns `nextCursor`.
  - Introduced shared `ThreadEventCursor` with strict parse/serialize and contract tests; used by server and remote clients.
  - Added bearer-authenticated SSE `GET /session/events` that replays before live; worker route proxies to the channel DO; async-iterable client auto-reconnects with the last cursor.

- Migration
  - No breaking changes. `tui.turn` and `createRemoteTuiDeliveryClient()` remain unchanged.
  - SSE is optional. Use cursor polling via `session.replayEvents` as the baseline and store the latest cursor for reconnects.

<sup>Written for commit 574e40a54bd9246c68b637ac3466c23373c262d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

