### PR TITLE
feat(worker-agent): wire runtime OpenTelemetry instrumentation

### DIFF
--- a/apps/worker-agent/package.json
+++ b/apps/worker-agent/package.json
@@ -31,6 +31,7 @@
     "@chat-adapter/state-memory": "4.34.0",
     "@chat-adapter/telegram": "4.34.0",
     "@minpeter/pss-runtime": "workspace:*",
+    "@opentelemetry/api": "^1.9.1",
     "@trpc/client": "11.18.0",
     "@trpc/server": "11.18.0",
     "agents": "0.17.4",

--- a/apps/worker-agent/src/agent-otel.test.ts
+++ b/apps/worker-agent/src/agent-otel.test.ts
@@ -1,0 +1,260 @@
+import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
+import { createInMemoryHost } from "@minpeter/pss-runtime/platform/memory";
+import {
+  type Attributes,
+  type Span,
+  type SpanContext,
+  type SpanOptions,
+  type SpanStatus,
+  SpanStatusCode,
+  type TimeInput,
+  type Tracer,
+  type TracerProvider,
+  trace,
+} from "@opentelemetry/api";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  collectTurnDelivery,
+  createConfiguredAgent,
+  type WorkerAgentModelEnv,
+} from "./agent";
+
+const USER_TEXT = "SENTINEL-USER-TEXT-6f2c";
+const ASSISTANT_REPLY = "SENTINEL-ASSISTANT-REPLY-91ab";
+
+// Default span names from @minpeter/pss-runtime/otel. Hardcoded on purpose:
+// the worker wires the stock instrumentation, so these names are its contract.
+const TURN_SPAN_NAME = "pss.runtime.turn";
+const STEP_SPAN_NAME = "pss.runtime.step";
+
+interface RecordedSpanEvent {
+  readonly attributes?: Attributes;
+  readonly name: string;
+}
+
+interface RecordedSpan {
+  attributes: Attributes;
+  ended: boolean;
+  events: RecordedSpanEvent[];
+  exceptions: unknown[];
+  name: string;
+  status: SpanStatus | undefined;
+}
+
+const recordedSpans: RecordedSpan[] = [];
+
+const TEST_SPAN_CONTEXT: SpanContext = {
+  spanId: "0000000000000001",
+  traceFlags: 1,
+  traceId: "00000000000000000000000000000001",
+};
+
+function isAttributes(value: unknown): value is Attributes {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createRecordingStartSpan(recorded: RecordedSpan[]) {
+  return (name: string, options?: SpanOptions): Span => {
+    const record: RecordedSpan = {
+      attributes: { ...options?.attributes },
+      ended: false,
+      events: [],
+      exceptions: [],
+      name,
+      status: undefined,
+    };
+    recorded.push(record);
+
+    const span: Span = {
+      addEvent: (
+        eventName: string,
+        attributesOrStartTime?: Attributes | TimeInput,
+        _startTime?: TimeInput
+      ): Span => {
+        record.events.push({
+          name: eventName,
+          ...(isAttributes(attributesOrStartTime)
+            ? { attributes: attributesOrStartTime }
+            : {}),
+        });
+        return span;
+      },
+      addLink: (): Span => span,
+      addLinks: (): Span => span,
+      end: (): void => {
+        record.ended = true;
+      },
+      isRecording: (): boolean => !record.ended,
+      recordException: (exception: unknown): void => {
+        record.exceptions.push(exception);
+      },
+      setAttribute: (key: string, value: unknown): Span => {
+        record.attributes[key] = value as Attributes[string];
+        return span;
+      },
+      setAttributes: (attributes: Attributes): Span => {
+        Object.assign(record.attributes, attributes);
+        return span;
+      },
+      setStatus: (status: SpanStatus): Span => {
+        record.status = status;
+        return span;
+      },
+      spanContext: (): SpanContext => TEST_SPAN_CONTEXT,
+      updateName: (nextName: string): Span => {
+        record.name = nextName;
+        return span;
+      },
+    };
+    return span;
+  };
+}
+
+const inMemoryTracer: Tracer = {
+  startActiveSpan: ((): never => {
+    throw new Error(
+      "startActiveSpan is not supported by the in-memory test tracer"
+    );
+  }) as Tracer["startActiveSpan"],
+  startSpan: createRecordingStartSpan(recordedSpans),
+};
+
+const inMemoryTracerProvider: TracerProvider = {
+  getTracer: (): Tracer => inMemoryTracer,
+};
+
+function testEnv(): WorkerAgentModelEnv {
+  return {
+    AI_API_KEY: "test-api-key",
+    AI_BASE_URL: "https://ai.test/v1",
+    AI_MODEL: "test-model",
+    ENVIRONMENT: "development",
+  };
+}
+
+function chatCompletionResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [
+        {
+          finish_reason: "stop",
+          message: { content: ASSISTANT_REPLY, role: "assistant" },
+        },
+      ],
+      created: 0,
+      id: "chatcmpl-test",
+      model: "test-model",
+      usage: { completion_tokens: 2, prompt_tokens: 3, total_tokens: 5 },
+    }),
+    { headers: { "content-type": "application/json" }, status: 200 }
+  );
+}
+
+async function drainTurn(
+  turn: AgentTurn
+): Promise<{ readonly events: AgentEvent[] }> {
+  const events: AgentEvent[] = [];
+  await collectTurnDelivery(turn, {
+    onEvent: (event) => {
+      events.push(event);
+    },
+  });
+  return { events };
+}
+
+describe("worker-agent OpenTelemetry wiring", () => {
+  beforeAll(() => {
+    trace.setGlobalTracerProvider(inMemoryTracerProvider);
+  });
+
+  afterEach(() => {
+    recordedSpans.length = 0;
+    vi.unstubAllGlobals();
+  });
+
+  it("emits turn and step spans for a send turn", async () => {
+    vi.stubGlobal("fetch", () => Promise.resolve(chatCompletionResponse()));
+    const agent = await createConfiguredAgent(testEnv(), createInMemoryHost());
+
+    const turn = await agent.thread("otel-test").send(USER_TEXT);
+    const { events } = await drainTurn(turn);
+
+    const turnSpan = recordedSpans.find((span) => span.name === TURN_SPAN_NAME);
+    const stepSpan = recordedSpans.find((span) => span.name === STEP_SPAN_NAME);
+
+    expect(turnSpan).toBeDefined();
+    expect(stepSpan).toBeDefined();
+    expect(turnSpan?.ended).toBe(true);
+    expect(stepSpan?.ended).toBe(true);
+    expect(turnSpan?.status?.code).toBe(SpanStatusCode.OK);
+    expect(stepSpan?.status?.code).toBe(SpanStatusCode.OK);
+    expect(turnSpan?.attributes["pss.runtime.component"]).toBe(
+      "@minpeter/pss-runtime"
+    );
+    expect(
+      turnSpan?.events.some((event) => event.name === "pss.runtime.event")
+    ).toBe(true);
+
+    // Events flow through the wrapper unchanged and in order: the runtime
+    // records user-input before the turn-start boundary.
+    const eventTypes = events.map((event) => event.type);
+    expect(eventTypes.at(0)).toBe("user-input");
+    expect(eventTypes.at(-1)).toBe("turn-end");
+    expect(eventTypes.indexOf("user-input")).toBeLessThan(
+      eventTypes.indexOf("turn-start")
+    );
+    expect(eventTypes.indexOf("turn-start")).toBeLessThan(
+      eventTypes.indexOf("step-start")
+    );
+    expect(eventTypes.indexOf("step-start")).toBeLessThan(
+      eventTypes.indexOf("step-end")
+    );
+    expect(eventTypes.indexOf("step-end")).toBeLessThan(
+      eventTypes.indexOf("turn-end")
+    );
+    const assistantOutput = events.find(
+      (event): event is Extract<AgentEvent, { type: "assistant-output" }> =>
+        event.type === "assistant-output"
+    );
+    expect(assistantOutput?.text).toBe(ASSISTANT_REPLY);
+
+    // Spans carry metadata only, never message content.
+    const serializedSpans = JSON.stringify(recordedSpans);
+    expect(serializedSpans).not.toContain(USER_TEXT);
+    expect(serializedSpans).not.toContain(ASSISTANT_REPLY);
+  });
+
+  it("preserves single-consumption of turn events", async () => {
+    vi.stubGlobal("fetch", () => Promise.resolve(chatCompletionResponse()));
+    const agent = await createConfiguredAgent(testEnv(), createInMemoryHost());
+
+    const turn = await agent.thread("otel-test").send(USER_TEXT);
+    await drainTurn(turn);
+
+    expect(() => turn.events()).toThrow(
+      "AgentTurn.events() can only be consumed once"
+    );
+  });
+
+  it("traces steer turns through the same instrumentation", async () => {
+    const completions: string[] = [];
+    vi.stubGlobal("fetch", () => {
+      completions.push("completion");
+      return Promise.resolve(chatCompletionResponse());
+    });
+    const agent = await createConfiguredAgent(testEnv(), createInMemoryHost());
+    const thread = agent.thread("otel-test");
+
+    await drainTurn(await thread.send(USER_TEXT));
+    recordedSpans.length = 0;
+    await drainTurn(await thread.steer(USER_TEXT));
+
+    expect(recordedSpans.some((span) => span.name === TURN_SPAN_NAME)).toBe(
+      true
+    );
+    expect(recordedSpans.some((span) => span.name === STEP_SPAN_NAME)).toBe(
+      true
+    );
+  });
+});

--- a/apps/worker-agent/src/agent.ts
+++ b/apps/worker-agent/src/agent.ts
@@ -8,6 +8,7 @@ import {
   createAgent,
   type PluginDefinition,
 } from "@minpeter/pss-runtime";
+import { openTelemetry } from "@minpeter/pss-runtime/otel";
 import { drainAgentTurn } from "@minpeter/pss-runtime/platform/cloudflare";
 
 import type { EnvironmentName } from "./env";
@@ -148,6 +149,7 @@ export async function createConfiguredAgent(
     autoCompaction: WORKER_AGENT_AUTO_COMPACTION,
     host,
     instructions: WORKER_AGENT_INSTRUCTIONS,
+    instrumentations: [openTelemetry()],
     model: provider(env.AI_MODEL?.trim() || DEFAULT_MODEL),
     plugins,
     ...(tools ? { tools } : {}),

--- a/apps/worker-agent/tsconfig.json
+++ b/apps/worker-agent/tsconfig.json
@@ -5,6 +5,9 @@
     "noEmit": true,
     "paths": {
       "@minpeter/pss-runtime": ["../../packages/runtime/src/index.ts"],
+      "@minpeter/pss-runtime/otel": [
+        "../../packages/runtime/src/otel/index.ts"
+      ],
       "@minpeter/pss-runtime/platform/cloudflare": [
         "../../packages/runtime/src/platform/cloudflare/index.ts"
       ],
@@ -13,6 +16,9 @@
       ],
       "@minpeter/pss-runtime/platform/file": [
         "../../packages/runtime/src/platform/file/index.ts"
+      ],
+      "@minpeter/pss-runtime/platform/memory": [
+        "../../packages/runtime/src/platform/memory/index.ts"
       ],
       "chat": ["./node_modules/chat"],
       "chat/*": ["./node_modules/chat/*"]

--- a/apps/worker-agent/vitest.config.ts
+++ b/apps/worker-agent/vitest.config.ts
@@ -27,6 +27,20 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@minpeter\/pss-runtime\/otel$/,
+        replacement: resolve(
+          import.meta.dirname,
+          "../../packages/runtime/src/otel/index.ts"
+        ),
+      },
+      {
+        find: /^@minpeter\/pss-runtime\/platform\/memory$/,
+        replacement: resolve(
+          import.meta.dirname,
+          "../../packages/runtime/src/platform/memory/index.ts"
+        ),
+      },
+      {
         find: /^@minpeter\/pss-runtime\/platform\/file$/,
         replacement: resolve(
           import.meta.dirname,

--- a/docs/worker-agent.md
+++ b/docs/worker-agent.md
@@ -1,0 +1,46 @@
+# Worker agent notes
+
+## OpenTelemetry tracing
+
+`apps/worker-agent` wires the runtime's OpenTelemetry instrumentation into
+every agent it constructs: `createConfiguredAgent` (the single factory used by
+the Durable Object and the local TUI) passes
+`instrumentations: [openTelemetry()]` from `@minpeter/pss-runtime/otel`. Every
+`send`, `steer`, and `resume` turn is wrapped, so each turn emits a
+`pss.runtime.turn` span with `pss.runtime.step` / `pss.runtime.tool` child
+spans and per-event span events.
+
+Span data is metadata only: event attributes carry counts, lengths, ids, and
+token usage (for example `pss.assistant_output.text_length`), never message
+text or tool payloads. Keep it that way when adding custom `eventAttributes`.
+
+### No provider is registered by default
+
+The worker depends on `@opentelemetry/api` only — no SDK and no exporter are
+bundled. Until a deployment registers a tracer provider, `trace.getTracer()`
+returns the API's built-in no-op tracer and the instrumentation is inert. This
+is deliberate: the Cloudflare deployment has no tracing backend configured
+yet.
+
+### Registering a provider later
+
+A deployment that wants these spans registers a `TracerProvider` through the
+API global before any agent is constructed (worker module init or the DO
+constructor's first run):
+
+```ts
+import { trace } from "@opentelemetry/api";
+
+trace.setGlobalTracerProvider(myWorkersCompatibleProvider);
+```
+
+Requirements for the provider:
+
+- It must implement the `@opentelemetry/api` `TracerProvider` interface and
+  run in the Workers runtime (no Node-only SDK auto-instrumentation).
+- Export is deployment-owned: point the provider at an OTLP/HTTP collector or
+  a Workers-native tracing bridge, with whatever sampling the deployment
+  wants.
+- Registration is process-global and idempotent-once; do it exactly once per
+  isolate. The instrumentation resolves the tracer lazily per turn, so spans
+  start flowing on the next turn after registration.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@minpeter/pss-runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       '@trpc/client':
         specifier: 11.18.0
         version: 11.18.0(@trpc/server@11.18.0(typescript@7.0.2))(typescript@7.0.2)


### PR DESCRIPTION
## Summary

Wires the new `@minpeter/pss-runtime/otel` instrumentation (0.3.0-next.3) into the private worker app. `createConfiguredAgent` — the single factory used by every agent construction site — now passes `instrumentations: [openTelemetry()]`, so every `send`/`steer`/`resume` turn emits `pss.runtime.turn` / `pss.runtime.step` / `pss.runtime.tool` spans.

## Construction sites

All runtime `Agent` construction sites in the app:

| Site | Path | Wired? |
|---|---|---|
| Durable Object (production send/steer/resume) | `apps/worker-agent/src/agent-do.ts` (`createCloudflarePlatformContext` + line ~462) | via factory |
| Local TUI | `apps/worker-agent/src/tui.ts:105` | via factory |
| Shared factory | `apps/worker-agent/src/agent.ts` `createConfiguredAgent` | **wired here (single place)** |
| Eval harness | `apps/worker-agent/src/evals/thread.ts` (direct `createAgent`) | intentionally not wired — scripted eval models, not a deployment surface |

Wiring lives only in the factory; no per-call-site duplication.

## No provider registered by default (no-op until configured)

Only `@opentelemetry/api` was added to worker deps — no SDK, no exporter. Until a deployment calls `trace.setGlobalTracerProvider(...)`, the API returns its built-in no-op tracer and the instrumentation is inert: zero spans leave the isolate, and the wrapped turn iterator is the only added cost. `docs/worker-agent.md` documents how a deployment registers a Workers-compatible provider later.

Spans are **metadata-only**: attributes carry counts/lengths/ids/token usage (e.g. `pss.assistant_output.text_length`), never message text or tool payloads. The new test asserts serialized span data contains neither the user text nor the assistant reply.

## RED → GREEN evidence

New `apps/worker-agent/src/agent-otel.test.ts`: registers a minimal in-memory `TracerProvider` via the `@opentelemetry/api` global, builds the app's agent through `createConfiguredAgent` with an in-memory host and a stubbed `fetch` (canned OpenAI-compatible completion), and drives real turns.

RED (production change stashed — factory without `instrumentations`):

```
FAIL src/agent-otel.test.ts > worker-agent OpenTelemetry wiring > emits turn and step spans for a send turn
AssertionError: expected undefined to be defined
FAIL src/agent-otel.test.ts > worker-agent OpenTelemetry wiring > traces steer turns through the same instrumentation
AssertionError: expected false to be true // Object.is equality
 Test Files 1 failed (1)
      Tests 2 failed | 1 passed (3)
```

GREEN (with `instrumentations: [openTelemetry()]`):

```
 ✓ src/agent-otel.test.ts (3 tests) 44ms
 Test Files 1 passed (1)
      Tests 3 passed (3)
```

Covered: turn/step spans emitted and ended with `SpanStatusCode.OK` for `send`; same for `steer`; events flow through the wrapper unchanged and in order (user-input → turn-start → step-start → step-end → turn-end, assistant text intact); single-consumption of `turn.events()` preserved (second call throws).

## Test plan

- `pnpm --filter @minpeter/pss-worker-agent test` — 27 files, 151 tests, all pass
- `pnpm typecheck` (repo, turbo) — 10/10 tasks successful
- `pnpm exec ultracite check` on changed files — clean
- `pnpm --filter @minpeter/pss-worker-agent build` — N/A: the private worker has no `build` script (deployed via `wrangler deploy`); the repo build (`turbo run build`, incl. runtime `dist`) is exercised transitively by `pnpm typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires runtime OpenTelemetry into the worker agent via the shared factory so all `send`/`steer`/`resume` turns are traced. Spans cover turns/steps/tools and carry metadata only.

- New Features
  - Pass `instrumentations: [openTelemetry()]` from `@minpeter/pss-runtime/otel` in `createConfiguredAgent` used by the Durable Object and TUI.
  - Emit `pss.runtime.turn`, `pss.runtime.step`, and `pss.runtime.tool` spans; event order is preserved.
  - Add tests to assert spans are emitted with OK status, contain no message text, and preserve single-consumption of `turn.events()`.
  - Add docs (`docs/worker-agent.md`) on registering a Workers-compatible tracer provider.

- Dependencies
  - Add `@opentelemetry/api` only; no SDK/exporter. Instrumentation is inert until `trace.setGlobalTracerProvider(...)` is registered.

<sup>Written for commit eb5b858afa702cd97dedf909faf7ac327184392a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

