### PR TITLE
feat(coding-agent): render assistant markdown via pi-tui 0.80.10 themes

### DIFF
--- a/.tegami/2026-07-19-pi-tui-markdown-assistant-output.md
+++ b/.tegami/2026-07-19-pi-tui-markdown-assistant-output.md
@@ -1,0 +1,27 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+---
+
+## Render assistant output with pi-tui Markdown and centralized themes
+
+Upgrade `@earendil-works/pi-tui` from 0.80.7 to 0.80.10. The new release
+expands visible tabs to the layout's fixed width during output normalization,
+so terminal tab stops can no longer wrap a logical line mid-render.
+
+The TUI now renders `assistant-output` through pi-tui's `Markdown` component
+instead of a single green line: headings, bold/italic, inline code, code
+blocks, lists, quotes, and links are styled through a `MarkdownTheme` with the
+assistant green applied as the default body style. `createTuiRunner()` accepts
+an optional `addMarkdown` sink and routes assistant output there when present,
+falling back to the plain formatted line otherwise, so the runner stays
+decoupled from pi-tui components.
+
+Scattered hand-rolled ANSI codes in `tui-runner.ts` and `tui-tool-printer.ts`
+move into a shared `tui-theme.ts` module (label color functions plus the
+markdown theme), preserving the exact SGR sequences the TUI emitted before.
+`truncateDetail()` now uses pi-tui's width-aware `truncateToWidth`, so
+double-column CJK/emoji text can no longer overflow the truncation budget the
+way character-count slicing did.

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "3.0.11",
-    "@earendil-works/pi-tui": "^0.80.7",
+    "@earendil-works/pi-tui": "^0.80.10",
     "@minpeter/opensearch": "0.0.4",
     "@minpeter/pss-runtime": "workspace:^",
     "@t3-oss/env-core": "^0.13.11",

--- a/apps/coding-agent/src/tui-runner.test.ts
+++ b/apps/coding-agent/src/tui-runner.test.ts
@@ -205,6 +205,51 @@ describe("TUI runner", () => {
       "Timed out waiting for TUI runner test condition"
     );
   });
+
+  it("routes assistant output to addMarkdown when provided", async () => {
+    const run = createRun([
+      { text: "**hi**", type: "assistant-output" },
+      { type: "turn-end" },
+    ]);
+    const lines: string[] = [];
+    const markdown: string[] = [];
+    const runner = createTuiRunner({
+      addLine: (line) => lines.push(line),
+      addMarkdown: (text) => markdown.push(text),
+      requestRender: vi.fn(),
+      thread: {
+        send: vi.fn().mockResolvedValue(run),
+        steer: vi.fn().mockResolvedValue(run),
+      },
+    });
+
+    runner.submit("go");
+    await run.done;
+
+    expect(markdown).toEqual(["**hi**"]);
+    expect(lines.some((line) => line.includes("assistant"))).toBe(false);
+  });
+
+  it("falls back to formatted lines when addMarkdown is absent", async () => {
+    const run = createRun([
+      { text: "**hi**", type: "assistant-output" },
+      { type: "turn-end" },
+    ]);
+    const lines: string[] = [];
+    const runner = createTuiRunner({
+      addLine: (line) => lines.push(line),
+      requestRender: vi.fn(),
+      thread: {
+        send: vi.fn().mockResolvedValue(run),
+        steer: vi.fn().mockResolvedValue(run),
+      },
+    });
+
+    runner.submit("go");
+    await run.done;
+
+    expect(lines).toContain("\x1b[32massistant\x1b[0m: **hi**");
+  });
 });
 
 function createRun(events: readonly EventItem[]): TestRun {

--- a/apps/coding-agent/src/tui-runner.ts
+++ b/apps/coding-agent/src/tui-runner.ts
@@ -8,6 +8,15 @@ import type {
   UserTextContent,
 } from "@minpeter/pss-runtime";
 import {
+  assistantText,
+  boldText,
+  dimText,
+  errorText,
+  reasoningText,
+  toolText,
+  userText,
+} from "./tui-theme";
+import {
   formatToolCallForTui,
   formatToolResultForTui,
   safeInlineText,
@@ -17,6 +26,12 @@ import {
 
 export interface TuiRunnerOptions {
   readonly addLine: (text: string) => void;
+  /**
+   * Render assistant output as rich markdown instead of a plain formatted
+   * line. When provided, `assistant-output` events are routed here and skip
+   * `formatEvent`/`addLine`.
+   */
+  readonly addMarkdown?: (text: string) => void;
   readonly requestRender: () => void;
   readonly thread: Pick<ThreadHandle, "send" | "steer">;
 }
@@ -27,9 +42,6 @@ export interface TuiRunner {
   consumeRun(run: AgentTurn): Promise<void>;
   submit(text: string): void;
 }
-
-const dimText = "\x1b[2m";
-const resetText = "\x1b[0m";
 
 export interface TuiHeaderOptions {
   readonly autoCompaction: AgentOptions["autoCompaction"];
@@ -43,7 +55,7 @@ export function formatTuiHeader({
   const compactionText = autoCompaction
     ? `compaction min=${autoCompaction.minMessages} retain=${autoCompaction.retainMessages}`
     : "compaction off";
-  return `\x1b[1mpss-next\x1b[0m \x1b[2m(thread ${safeInlineText(threadKey)} \u00b7 ${compactionText} \u00b7 Esc to interrupt \u00b7 Ctrl-C to quit)\x1b[0m`;
+  return `${boldText("pss-next")} ${dimText(`(thread ${safeInlineText(threadKey)} \u00b7 ${compactionText} \u00b7 Esc to interrupt \u00b7 Ctrl-C to quit)`)}`;
 }
 
 export const formatUserTextContent = (text: UserTextContent): string =>
@@ -52,25 +64,25 @@ export const formatUserTextContent = (text: UserTextContent): string =>
 export const formatEvent = (event: AgentEvent): string | undefined => {
   switch (event.type) {
     case "user-input":
-      return `\x1b[36myou\x1b[0m: ${safeText(formatUserInput(event))}`;
+      return `${userText("you")}: ${safeText(formatUserInput(event))}`;
     case "runtime-input":
-      return `${dimText}runtime: ${safeText(formatRuntimeInput(event.input))}${resetText}`;
+      return dimText(`runtime: ${safeText(formatRuntimeInput(event.input))}`);
     case "assistant-output":
-      return `\x1b[32massistant\x1b[0m: ${safeText(event.text)}`;
+      return `${assistantText("assistant")}: ${safeText(event.text)}`;
     case "assistant-reasoning":
-      return `\x1b[35mreasoning\x1b[0m: ${truncateDetail(safeInlineText(event.text), 240)}`;
+      return `${reasoningText("reasoning")}: ${truncateDetail(safeInlineText(event.text), 240)}`;
     case "tool-call":
-      return `\x1b[33mtool\x1b[0m ${formatToolCallForTui(event)}`;
+      return `${toolText("tool")} ${formatToolCallForTui(event)}`;
     case "tool-result":
-      return `\x1b[33mtool result\x1b[0m ${formatToolResultForTui(event)}`;
+      return `${toolText("tool result")} ${formatToolResultForTui(event)}`;
     case "turn-start":
-      return `${dimText}running...${resetText}`;
+      return dimText("running...");
     case "turn-abort":
-      return `${dimText}interrupted${resetText}`;
+      return dimText("interrupted");
     case "turn-error":
-      return `\x1b[31merror\x1b[0m: ${safeText(event.message)}`;
+      return `${errorText("error")}: ${safeText(event.message)}`;
     case "turn-end":
-      return `${dimText}done${resetText}`;
+      return dimText("done");
     case "step-start":
     case "step-end":
       return;
@@ -81,6 +93,7 @@ export const formatEvent = (event: AgentEvent): string | undefined => {
 
 export function createTuiRunner({
   addLine,
+  addMarkdown,
   requestRender,
   thread,
 }: TuiRunnerOptions): TuiRunner {
@@ -97,9 +110,13 @@ export function createTuiRunner({
 
     try {
       for await (const event of run.events()) {
-        const line = formatEvent(event);
-        if (line) {
-          addLine(line);
+        if (event.type === "assistant-output" && addMarkdown !== undefined) {
+          addMarkdown(event.text);
+        } else {
+          const line = formatEvent(event);
+          if (line) {
+            addLine(line);
+          }
         }
 
         if (isTerminalTurnEvent(event)) {

--- a/apps/coding-agent/src/tui-theme.test.ts
+++ b/apps/coding-agent/src/tui-theme.test.ts
@@ -1,0 +1,61 @@
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import {
+  assistantText,
+  boldText,
+  darkGrayText,
+  dimText,
+  errorText,
+  markdownDefaultTextStyle,
+  markdownTheme,
+  reasoningText,
+  toolText,
+  userText,
+} from "./tui-theme";
+
+describe("TUI theme", () => {
+  it("wraps label colors in a single SGR code and a full reset", () => {
+    expect(userText("you")).toBe("\x1b[36myou\x1b[0m");
+    expect(assistantText("assistant")).toBe("\x1b[32massistant\x1b[0m");
+    expect(toolText("tool")).toBe("\x1b[33mtool\x1b[0m");
+    expect(errorText("error")).toBe("\x1b[31merror\x1b[0m");
+    expect(reasoningText("reasoning")).toBe("\x1b[35mreasoning\x1b[0m");
+    expect(dimText("done")).toBe("\x1b[2mdone\x1b[0m");
+    expect(boldText("pss-next")).toBe("\x1b[1mpss-next\x1b[0m");
+    expect(darkGrayText("#abc")).toBe("\x1b[90m#abc\x1b[0m");
+  });
+
+  it("provides a style function for every markdown element", () => {
+    const requiredKeys: readonly (keyof MarkdownTheme)[] = [
+      "bold",
+      "code",
+      "codeBlock",
+      "codeBlockBorder",
+      "heading",
+      "hr",
+      "italic",
+      "link",
+      "linkUrl",
+      "listBullet",
+      "quote",
+      "quoteBorder",
+      "strikethrough",
+      "underline",
+    ];
+
+    for (const key of requiredKeys) {
+      expect(markdownTheme[key]).toBeTypeOf("function");
+    }
+  });
+
+  it("styles markdown body text with the assistant color", () => {
+    expect(markdownDefaultTextStyle.color?.("body")).toBe(
+      "\x1b[32mbody\x1b[0m"
+    );
+  });
+
+  it("renders markdown chrome without crashing", () => {
+    expect(markdownTheme.heading("Title")).toContain("Title");
+    expect(markdownTheme.codeBlockBorder("|")).toBe("\x1b[2m|\x1b[0m");
+  });
+});

--- a/apps/coding-agent/src/tui-theme.ts
+++ b/apps/coding-agent/src/tui-theme.ts
@@ -1,0 +1,52 @@
+import type { DefaultTextStyle, MarkdownTheme } from "@earendil-works/pi-tui";
+
+const wrap =
+  (open: string) =>
+  (text: string): string =>
+    `${open}${text}\x1b[0m`;
+
+/**
+ * Foreground label colors shared by the TUI event formatter and the tool
+ * printer. Each function wraps text in a single SGR code and resets with
+ * `\x1b[0m`, matching the ANSI the TUI emitted before themes were centralized.
+ */
+export const assistantText = wrap("\x1b[32m");
+export const boldText = wrap("\x1b[1m");
+export const darkGrayText = wrap("\x1b[90m");
+export const dimText = wrap("\x1b[2m");
+export const errorText = wrap("\x1b[31m");
+export const italicText = wrap("\x1b[3m");
+export const reasoningText = wrap("\x1b[35m");
+export const strikethroughText = wrap("\x1b[9m");
+export const toolText = wrap("\x1b[33m");
+export const underlineText = wrap("\x1b[4m");
+export const userText = wrap("\x1b[36m");
+
+const identity = (text: string): string => text;
+
+/**
+ * Theme for rendering assistant output through pi-tui's `Markdown` component.
+ * Structural chrome (borders, bullets, URLs) stays dim so the body text keeps
+ * the assistant green applied by `markdownDefaultTextStyle`.
+ */
+export const markdownTheme: MarkdownTheme = {
+  bold: boldText,
+  code: darkGrayText,
+  codeBlock: identity,
+  codeBlockBorder: dimText,
+  heading: boldText,
+  hr: dimText,
+  italic: italicText,
+  link: underlineText,
+  linkUrl: dimText,
+  listBullet: dimText,
+  quote: dimText,
+  quoteBorder: dimText,
+  strikethrough: strikethroughText,
+  underline: underlineText,
+};
+
+/** Base style applied to markdown body text. */
+export const markdownDefaultTextStyle: DefaultTextStyle = {
+  color: assistantText,
+};

--- a/apps/coding-agent/src/tui-tool-printer.ts
+++ b/apps/coding-agent/src/tui-tool-printer.ts
@@ -1,3 +1,6 @@
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import { darkGrayText } from "./tui-theme";
+
 export interface TuiToolCallView {
   input: unknown;
   toolCallId: string;
@@ -11,10 +14,8 @@ export interface TuiToolResultView {
 }
 
 const defaultJsonLength = 220;
-const darkGrayText = "\x1b[90m";
 const errorPrefixPattern = /^Error: /;
 const maxDetailLength = 600;
-const resetText = "\x1b[0m";
 const toolCallIdDisplayEnd = 13;
 const toolCallIdDisplayStart = 5;
 const whitespacePattern = /\s+/g;
@@ -27,11 +28,15 @@ export const safeText = (text: string): string =>
 export const safeInlineText = (text: string): string =>
   safeText(text).replace(whitespacePattern, " ").trim();
 
+/**
+ * Truncate detail text to a maximum visible terminal column width. Uses
+ * pi-tui's width-aware truncation so CJK/emoji (double-column) text cannot
+ * overflow the budget the way character-count slicing did.
+ */
 export const truncateDetail = (
   text: string,
   maxLength = maxDetailLength
-): string =>
-  text.length <= maxLength ? text : `${text.slice(0, maxLength - 3)}...`;
+): string => truncateToWidth(text, maxLength);
 
 export function formatToolCallForTui(event: TuiToolCallView): string {
   return `${formatToolLabel(event)} ${formatToolInput(event.input)}`;
@@ -45,7 +50,7 @@ function formatToolLabel(event: {
   toolCallId: string;
   toolName: string;
 }): string {
-  return `${safeInlineText(event.toolName)}${darkGrayText}#${shortToolCallId(event.toolCallId)}${resetText}`;
+  return `${safeInlineText(event.toolName)}${darkGrayText(`#${shortToolCallId(event.toolCallId)}`)}`;
 }
 
 function isTerminalControlCharacter(value: string): boolean {

--- a/apps/coding-agent/src/tui.ts
+++ b/apps/coding-agent/src/tui.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from "node:url";
 import {
   Container,
   Input,
+  Markdown,
   matchesKey,
   ProcessTerminal,
   Text,
@@ -15,6 +16,12 @@ import { createCodingLanguageModel } from "./model";
 import { resolveCodingAgentThreadConfig } from "./thread-config";
 import { resolveStartTuiTools } from "./tools";
 import { createTuiRunner, formatTuiHeader } from "./tui-runner";
+import {
+  assistantText,
+  markdownDefaultTextStyle,
+  markdownTheme,
+} from "./tui-theme";
+import { safeText } from "./tui-tool-printer";
 
 export interface StartTuiOptions {
   /**
@@ -69,8 +76,23 @@ export async function startTui(options: StartTuiOptions = {}): Promise<void> {
     tui.requestRender();
   };
 
+  const addMarkdown = (text: string): void => {
+    chat.addChild(new Text(assistantText("assistant:"), 1, 0));
+    chat.addChild(
+      new Markdown(
+        safeText(text),
+        1,
+        0,
+        markdownTheme,
+        markdownDefaultTextStyle
+      )
+    );
+    tui.requestRender();
+  };
+
   const runner = createTuiRunner({
     addLine,
+    addMarkdown,
     requestRender: () => tui.requestRender(),
     thread,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 3.0.11
         version: 3.0.11(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.80.7
-        version: 0.80.7
+        specifier: ^0.80.10
+        version: 0.80.10
       '@minpeter/opensearch':
         specifier: 0.0.4
         version: 0.0.4
@@ -722,8 +722,8 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@earendil-works/pi-tui@0.80.7':
-    resolution: {integrity: sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==}
+  '@earendil-works/pi-tui@0.80.10':
+    resolution: {integrity: sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.1':
@@ -1889,8 +1889,8 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
-  caniuse-lite@1.0.30001805:
-    resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2099,8 +2099,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.392:
-    resolution: {integrity: sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==}
+  electron-to-chromium@1.5.393:
+    resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -3083,6 +3083,10 @@ packages:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3486,11 +3490,11 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.4.8:
-    resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
 
-  tldts@7.4.8:
-    resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
     hasBin: true
 
   toidentifier@1.0.1:
@@ -3987,7 +3991,7 @@ snapshots:
       gensync: 1.0.0-beta.2
       import-meta-resolve: 4.2.0
       json5: 2.2.3
-      obug: 2.1.3
+      obug: 2.1.4
       semver: 7.8.5
 
   '@babel/generator@8.0.0':
@@ -4096,7 +4100,7 @@ snapshots:
       '@babel/parser': 8.0.4
       '@babel/template': 8.0.0
       '@babel/types': 8.0.4
-      obug: 2.1.3
+      obug: 2.1.4
 
   '@babel/types@8.0.4':
     dependencies:
@@ -4243,7 +4247,7 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@earendil-works/pi-tui@0.80.7':
+  '@earendil-works/pi-tui@0.80.10':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -5101,8 +5105,8 @@ snapshots:
   browserslist@4.28.6:
     dependencies:
       baseline-browser-mapping: 2.10.43
-      caniuse-lite: 1.0.30001805
-      electron-to-chromium: 1.5.392
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.393
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
@@ -5127,7 +5131,7 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
-  caniuse-lite@1.0.30001805: {}
+  caniuse-lite@1.0.30001806: {}
 
   ccount@2.0.1: {}
 
@@ -5342,7 +5346,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.392: {}
+  electron-to-chromium@1.5.393: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6513,6 +6517,8 @@ snapshots:
 
   obug@2.1.3: {}
 
+  obug@2.1.4: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7016,17 +7022,17 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.4.8: {}
+  tldts-core@7.4.9: {}
 
-  tldts@7.4.8:
+  tldts@7.4.9:
     dependencies:
-      tldts-core: 7.4.8
+      tldts-core: 7.4.9
 
   toidentifier@1.0.1: {}
 
   tough-cookie@6.0.2:
     dependencies:
-      tldts: 7.4.8
+      tldts: 7.4.9
 
   tr46@6.0.0:
     dependencies:


### PR DESCRIPTION
## What

- Upgrade `@earendil-works/pi-tui` **0.80.7 → 0.80.10** (latest). The delta is `normalizeTerminalOutput` now expanding visible tabs to the layout's fixed width, so terminal tab stops can no longer wrap a logical line mid-render.
- Render `assistant-output` through pi-tui's **`Markdown` component** (headings, bold/italic, inline code, code blocks, lists, quotes, links) with a `MarkdownTheme` + assistant-green default body style, instead of one flat green line.
- Centralize scattered hand-rolled ANSI codes from `tui-runner.ts`/`tui-tool-printer.ts` into a new **`tui-theme.ts`** module (same SGR sequences as before).
- `truncateDetail()` now uses pi-tui's width-aware `truncateToWidth` — double-column CJK/emoji can no longer overflow the truncation budget.

## Design notes

- `createTuiRunner()` gains an optional `addMarkdown` sink; assistant output routes there when present and falls back to `formatEvent`/`addLine` otherwise. The runner stays decoupled from pi-tui components (only `tui.ts` imports `Markdown`).
- No public API changes; label colors byte-identical to before.

## Verification

- `turbo run test typecheck --filter @minpeter/pss-coding-agent`: **57/57 tests**, typecheck, ultracite all green.
- Live tmux verification against a local mock OpenAI-compatible server returning markdown:

```
 you: show me markdown
 running...
 assistant:
 Hi            ← ## heading, bold
 bold and code ← **bold** green body, `code` dark gray
 done
```

ANSI capture confirms `ESC[1mHi`, `ESC[32m` body, `ESC[90mcode` styling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render assistant messages as rich Markdown in the TUI using `@earendil-works/pi-tui` 0.80.10 themes for better readability. Also improves truncation for wide characters and prevents tab-based mid-line wraps.

- **New Features**
  - Assistant output now uses `Markdown` with a `MarkdownTheme` (assistant-green body; headings, bold/italic, code, lists, quotes, links).
  - `createTuiRunner` supports an optional `addMarkdown` sink and falls back to formatted lines when absent.
  - Centralized ANSI styling in `tui-theme.ts` with the same SGR sequences as before.
  - Truncation now uses `truncateToWidth` to handle CJK/emoji correctly.

- **Dependencies**
  - Upgrade `@earendil-works/pi-tui` 0.80.7 → 0.80.10. Normalization now expands tabs to the layout’s fixed width to avoid mid-render wraps. No public API changes.

<sup>Written for commit 17e997d077305bad0fd14c7fdec22ec0b53cf973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

