### PR TITLE
fix(telegram): drain in-flight forwards on shutdown, handle non-JSON API errors

### DIFF
--- a/apps/worker-agent/scripts/telegram-helpers.ts
+++ b/apps/worker-agent/scripts/telegram-helpers.ts
@@ -54,6 +54,13 @@ export async function telegramApi(
       signal,
     }
   );
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `${method} failed with status ${response.status}: ${text || response.statusText}`
+    );
+  }
   const payload = (await response.json()) as {
     readonly description?: string;
     readonly ok: boolean;

--- a/apps/worker-agent/scripts/telegram-relay.ts
+++ b/apps/worker-agent/scripts/telegram-relay.ts
@@ -82,6 +82,8 @@ export async function relay(): Promise<void> {
       await sleepMs(RELAY_RETRY_MS, abort.signal);
     }
   }
+
+  await Promise.allSettled(inFlightForwards);
 }
 
 export async function webhook(): Promise<void> {


### PR DESCRIPTION
## Changes

Addresses the two issues flagged by Gemini Code Assist on #233:

### 1. Shutdown message loss (HIGH)
`telegram-relay.ts` — the relay loop exits immediately on SIGINT/SIGTERM, abandoning in-flight webhook forwards. Since `offset` is advanced optimistically, those updates are acked to Telegram but never delivered → permanent message loss.

**Fix:** `await Promise.allSettled(inFlightForwards)` after the loop exits.

### 2. Opaque non-JSON errors (MEDIUM)
`telegram-helpers.ts` — `telegramApi()` calls `response.json()` unconditionally. When Telegram or a proxy (Cloudflare) returns an HTML error page (502/504), this throws a generic `SyntaxError` that masks the real status.

**Fix:** Check `content-type` first; if not JSON, read as text and throw with status code + body.

## Verification
- ✅ `pnpm typecheck` clean
- ✅ 27 telegram tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents lost Telegram messages on shutdown and makes API errors clearer. The relay now drains in-flight forwards, and non‑JSON responses include status and body for easier debugging.

- **Bug Fixes**
  - Drain in-flight webhook forwards on shutdown using Promise.allSettled to avoid losing optimistically acked updates.
  - In telegramApi, check content-type; if not JSON, read text and throw with HTTP status and body (handles HTML 502/504 from Telegram/proxies).

<sup>Written for commit 0e8db6e09a28e3e0bfc140ad1b2c063e85789095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

