### PR TITLE
chore: replace stale .omx tool dir with .senpi in ignores

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 .DS_Store
 .env
 .env.*
+.omo/
+.senpi/
 node_modules/
 !.env.example

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 .DS_Store
 .env
 .env.*
-.omx/
 node_modules/
 !.env.example

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,7 +3,7 @@
   "root": true,
   "extends": ["ultracite/biome/core"],
   "files": {
-    "includes": ["**/*", "!!**/.omo", "!!**/.omx"]
+    "includes": ["**/*", "!!**/.omo", "!!**/.senpi"]
   },
   "assist": {
     "actions": {


### PR DESCRIPTION
## Summary
- `.npmignore`: drop stale `.omx/` entry (directory no longer exists)
- `biome.jsonc`: switch lint exclusion from `.omx` to `.senpi` (current tool working directory)

## Test plan
- [x] Verified `.omx` is absent locally and `.senpi` is the active session dir

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up ignore configs: removed stale `.omx`, excluded `.senpi` from linting, and excluded `.senpi/` and `.omo/` from npm packaging. Prevents bundling agent session dirs and avoids unnecessary lint checks.

<sup>Written for commit 98f64a8989abc0f322d66fa855887b6150176ad6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

