### PR TITLE
ci: close check-coverage gaps (experimental typecheck, local-file-agent, node matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,21 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   checks:
-    name: Validate
+    name: Validate (node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["24", "26"]
 
     steps:
       - name: Checkout
@@ -27,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version-file: .node-version
+          node-version: ${{ matrix.node }}
           cache: pnpm
 
       - name: Install dependencies

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.14-next.2",
   "description": "Coding-agent model and TUI wiring for pss-next.",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/experimental/pss-image-codec-edge-qa/package.json
+++ b/experimental/pss-image-codec-edge-qa/package.json
@@ -6,7 +6,8 @@
     "dev": "wrangler dev",
     "deploy": "CLOUDFLARE_ACCOUNT_ID=795b98fae2d3efac0afc7a41494cc697 wrangler deploy",
     "test:edge": "tsx qa-client.ts",
-    "test:edge:live": "EDGE_QA_URL=https://pss-image-codec-edge-qa.minpeter.workers.dev tsx qa-client.ts"
+    "test:edge:live": "EDGE_QA_URL=https://pss-image-codec-edge-qa.minpeter.workers.dev tsx qa-client.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.qa.json --noEmit"
   },
   "dependencies": {
     "@jsquash/avif": "^2.1.1",
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260716.1",
+    "@types/node": "^26.1.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "wrangler": "^4.107.0"

--- a/experimental/pss-image-codec-edge-qa/tsconfig.json
+++ b/experimental/pss-image-codec-edge-qa/tsconfig.json
@@ -1,13 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types"],
-    "strict": true,
-    "skipLibCheck": true,
-    "noEmit": true
+    "lib": ["ES2022", "DOM"],
+    "types": ["@cloudflare/workers-types", "node"],
+    "noEmit": true,
+    "customConditions": ["@minpeter/pss-source"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/experimental/pss-image-codec-edge-qa/tsconfig.qa.json
+++ b/experimental/pss-image-codec-edge-qa/tsconfig.qa.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["qa-client*.ts"]
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.0-next.3",
   "description": "Generic agent runtime for threads, model loops, and synchronized run events.",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^5.20260716.1
         version: 5.20260716.1
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       tsx:
         specifier: ^4.22.4
         version: 4.23.1

--- a/scripts/examples.fixture.mjs
+++ b/scripts/examples.fixture.mjs
@@ -1,0 +1,35 @@
+export const examplePackages = [
+  {
+    name: "@minpeter/pss-example-basic",
+    path: "examples/basic",
+    requiredSource: "src/index.ts",
+  },
+  {
+    name: "@minpeter/pss-example-plugin",
+    path: "examples/plugin",
+    requiredSource: "src/index.ts",
+  },
+  {
+    name: "@minpeter/pss-example-local-file-agent",
+    path: "examples/local-file-agent",
+    requiredSource: "src/index.ts",
+  },
+  {
+    name: "@minpeter/pss-example-sync-subagent",
+    path: "examples/sync-subagent",
+    requiredSource: "src/index.ts",
+  },
+  {
+    name: "@minpeter/pss-example-background-subagent",
+    path: "examples/background-subagent",
+    requiredSource: "src/index.ts",
+  },
+];
+export const appPackages = [
+  {
+    name: "@minpeter/pss-coding-agent",
+    path: "apps/coding-agent",
+    requiredSource: "src/index.ts",
+    buildScript: "tsdown",
+  },
+];

--- a/scripts/examples.test.mjs
+++ b/scripts/examples.test.mjs
@@ -1,37 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { appPackages, examplePackages } from "./examples.fixture.mjs";
 
-const examplePackages = [
-  {
-    name: "@minpeter/pss-example-basic",
-    path: "examples/basic",
-    requiredSource: "src/index.ts",
-  },
-  {
-    name: "@minpeter/pss-example-plugin",
-    path: "examples/plugin",
-    requiredSource: "src/index.ts",
-  },
-  {
-    name: "@minpeter/pss-example-sync-subagent",
-    path: "examples/sync-subagent",
-    requiredSource: "src/index.ts",
-  },
-  {
-    name: "@minpeter/pss-example-background-subagent",
-    path: "examples/background-subagent",
-    requiredSource: "src/index.ts",
-  },
-];
-const appPackages = [
-  {
-    name: "@minpeter/pss-coding-agent",
-    path: "apps/coding-agent",
-    requiredSource: "src/index.ts",
-    buildScript: "tsdown",
-  },
-];
 const finalRunEventsLoopPattern =
   /for await \(const event of run\.events\(\)\) \{\s+console\.log\(event\);\s+\}$/;
 

--- a/scripts/file-size.test.mjs
+++ b/scripts/file-size.test.mjs
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 
 const sourceFilesWithCurrentEdits = [
   "scripts/cloudflare-example.test.mjs",
+  "scripts/examples.fixture.mjs",
   "scripts/examples.test.mjs",
   "scripts/file-size.test.mjs",
+  "scripts/release-workflow.test.mjs",
   "scripts/verify-release-artifacts.mjs",
   "scripts/verify-release-artifacts.fixture.mjs",
   "scripts/verify-release-artifacts/core.mjs",

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -21,7 +21,10 @@ describe("release workflow", () => {
     expect(workflow).toContain("fetch-depth: 0");
     expect(ciWorkflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("node-version-file: .node-version");
-    expect(ciWorkflow).toContain("node-version-file: .node-version");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: pins the literal GitHub Actions matrix expression in ci.yml
+    expect(ciWorkflow).toContain("node-version: ${{ matrix.node }}");
+    expect(ciWorkflow).toContain('node: ["24", "26"]');
+    expect(ciWorkflow).toContain("cancel-in-progress: true");
     expect(workflow).toContain("pnpm tegami ci");
     expect(workflow).not.toContain(
       "Verify npm trusted publishing prerequisites"


### PR DESCRIPTION
## Summary

Follow-up to a CI audit that found two real coverage gaps and two cheap wins:

- **experimental/pss-image-codec-edge-qa was never typechecked in CI.** It is a workspace member but had no `typecheck` script (turbo skipped it) and the root `tsc` include never covered it. Adding the script surfaced two latent config bugs, fixed here: missing `customConditions` (it resolved the runtime through unbuilt `dist/`) and a `lib: ["ES2022"]` restriction that broke the transitively checked runtime source (`WebAssembly.compile`, which every other typecheck context in the repo resolves via the default DOM lib). The worker surface and the `qa-client*.ts` harness are checked by separate tsconfigs (workers-types vs node types).
- **examples/local-file-agent had no test coverage.** No `test` script and absent from the examples meta-test — only typecheck + lint applied. It is now pinned in the examples workspace-shape test. The package data arrays moved to `scripts/examples.fixture.mjs` to keep the test file under the 250 pure-LOC ceiling, and the file-size guard now lists the scripts this branch edits.
- **CI workflow hardening.** `concurrency` cancel-in-progress stops superseded PR runs; the validate job now runs on a node matrix of the supported lines — 24 (active LTS, matches `.node-version`) and 26 (current). Node 25 is EOL (2026-06) and excluded. Release still publishes from `.node-version`, and the meta-test pins were updated to the new shape (RED captured before the workflow change).
- **`engines.node >=24` declared in the two published packages** (`@minpeter/pss-runtime`, `@minpeter/pss-coding-agent`), matching the root floor so consumers get an install-time signal.

Deliberately left as-is: `release.yml` re-running the full check suite on main push (safety net for direct pushes) and an OS matrix (the runtime has no native dependencies — pure JS/WASM — so per-OS signal is low for the compute cost).

## Test plan

- [x] Full local suite green in the worktree: `boundaries`, `lint`, `typecheck`, `test` (11 files / 51 tests), `build`, `verify:release`
- [x] Mutation proofs: injected type errors in experimental `src/` and `qa-client.ts` fail the new typecheck, revert restores green; mutating the example's start script fails the new pin, revert restores green
- [x] Meta-test pins updated RED-first, then the workflow change turned them green
- [ ] This PR's own CI run exercises the new matrix (both `Validate (node 24)` and `Validate (node 26)` legs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes CI coverage gaps and hardens the pipeline: adds typechecking for the experimental edge QA worker, pins the local-file-agent example in tests, runs CI on Node 24 and 26 with concurrency, and declares `engines.node >=24` for published packages.

- Bug Fixes
  - Typecheck `experimental/pss-image-codec-edge-qa` in CI via a `typecheck` script; align tsconfigs (add DOM lib, worker and node types, `customConditions`) and add `tsconfig.qa.json` for the `qa-client*.ts` harness.
  - Add `examples/local-file-agent` to the examples meta-test; move package lists to `scripts/examples.fixture.mjs`; update the file-size guard.

- Refactors
  - CI: cancel superseded runs with `concurrency`; run Validate on Node 24 (LTS) and 26 (current); release still uses `.node-version` (Node 24).
  - Declare `engines.node >=24` in `@minpeter/pss-runtime` and `@minpeter/pss-coding-agent`; add `@types/node` to the edge QA package.

<sup>Written for commit 89190f6986ff4dd174774a9b873719b063c89f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

