### PR TITLE
chore(coding-agent): add patch tegami letter for workspace coding tools

### DIFF
--- a/.tegami/2026-07-23-workspace-coding-tools-exec.md
+++ b/.tegami/2026-07-23-workspace-coding-tools-exec.md
@@ -1,0 +1,27 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Add workspace coding tools and the headless `pss exec` runner
+
+The coding agent now ships a workspace tool set shared by the TUI and a new
+headless runner: `read_file`, `glob_files`, `grep_files`, `edit_file`
+(hashline-anchored with stale-hash guards), `write_file`, `delete_file`, and
+`shell_execute`. The file tools are confined to the workspace — path and
+symlink escapes are rejected — and writes are atomic with the target
+permissions applied from the outset. `shell_execute` is not a sandbox:
+commands run with the user's permissions, but AI provider API keys are
+withheld from the child environment.
+
+`pss exec` runs one headless coding task for CI, benchmarks, and scripts. It
+streams JSONL events (`metadata`, `agent_event`, `result`) to stdout and
+exits 0 only when the task completes, with `--workspace`, exactly one of
+`--prompt`/`--prompt-file`/`--stdin`, plus `--model`, `--base-url`,
+`--timeout-seconds`, `--web-tools`, and `--result-file`. A `.env` next to the
+working directory is loaded automatically.
+
+Both surfaces share one production agent factory, `createCodingAgent`: the
+workspace tools are always included and win name collisions, while a custom
+`tools` option replaces only the optional web tools.


### PR DESCRIPTION
Follow-up to #249, which merged the workspace coding tools and the headless `pss exec` runner **without** a tegami changelog letter — so no version bump was queued.

This PR adds only the missing letter, at **patch** level, for `@minpeter/pss-coding-agent`:

- `.tegami/2026-07-23-workspace-coding-tools-exec.md` → `npm:@minpeter/pss-coding-agent: { type: patch }`

No code changes. The runtime package is untouched (PR #249 changed only `apps/coding-agent` among publishable packages; the benchmark is private/ignored by tegami).

Verified the letter through tegami's own `parseChangelogFile`: it yields `{ "npm:@minpeter/pss-coding-agent": { "type": "patch" } }` with one changelog section, matching the authored form of the update-notifier letter from #247.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing tegami changelog letter to queue a patch release of `@minpeter/pss-coding-agent`. This covers the workspace coding tools and the headless `pss exec` runner shipped earlier; no code changes.

<sup>Written for commit 77b2325991e13b32778a2d57c02811e136747629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

