### PR TITLE
feat(coding-agent): local extension discovery and -e CLI flag

### DIFF
--- a/.tegami/2026-07-26-local-cli-extensions.md
+++ b/.tegami/2026-07-26-local-cli-extensions.md
@@ -1,0 +1,29 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Load local extensions without installing
+
+Loose extension modules now load automatically from
+`~/.pss/extensions/<name>.<ts|mts|js|mjs>` and
+`~/.pss/extensions/<name>/index.*`, plus the project-scoped
+`<project>/.pss/extensions/` once the project is trusted. TypeScript modules
+run directly through Node's native type stripping, so authoring an extension
+needs no packaging or build step. File and directory names become the stable
+extension id and must match `[a-z0-9][a-z0-9._-]*`; symbolic links and invalid
+names are skipped with startup notices instead of failing startup.
+
+Managed installs keep precedence: a local module whose id collides with an
+installed extension is skipped with a notice, and project-local modules
+override global-local modules with the same id. Untrusted projects that
+contain loose extension modules surface the existing blocked-extensions
+notice.
+
+Add a repeatable `-e`/`--extension <path>` flag to the TUI and `pss exec` that
+loads a module file or index directory for the current run only, without
+touching settings. CLI extensions are an explicit user action, so they load
+without trust gating and take precedence over configured extensions with the
+same id. Invalid paths, non-module files, duplicate ids, and missing index
+modules fail fast with actionable errors before the session starts.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -184,6 +184,30 @@ Loose local modules must be runnable `.js` or `.mjs` files and require
 default stable ID and must ship runnable ESM. Dependency lifecycle scripts are
 disabled during managed installation.
 
+### Local extensions without installing
+
+Drop loose modules into an extensions directory and they load automatically:
+
+- `~/.pss/extensions/<name>.<ts|mts|js|mjs>` (global, every project)
+- `~/.pss/extensions/<name>/index.*` (global, directory form)
+- `<project>/.pss/extensions/<name>.*` (project, loads only after trust)
+
+TypeScript files run directly through Node's native type stripping — no build
+step. The file or directory name is the extension id and must match
+`[a-z0-9][a-z0-9._-]*`. Symbolic links are skipped, and a local id that
+collides with an installed extension is skipped with a startup notice.
+Project-local files override global-local files with the same id.
+
+For one run only, pass `-e`/`--extension` (repeatable) to the TUI or exec:
+
+```sh
+pss -e ./review-guard.ts
+pss exec --prompt "..." -e ./review-guard.ts -e ./metrics
+```
+
+CLI extensions load without trust gating (running them is an explicit user
+action) and take precedence over configured extensions with the same id.
+
 Programmatic static-object extensions remain supported through
 `defineCodingAgentExtension()` and the `extensions` option on `startTui()` or
 `runCodingAgentExec()`. Their existing `registry.runtime.use()` API remains an

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -194,9 +194,11 @@ Drop loose modules into an extensions directory and they load automatically:
 
 TypeScript files run directly through Node's native type stripping — no build
 step. The file or directory name is the extension id and must match
-`[a-z0-9][a-z0-9._-]*`. Symbolic links are skipped, and a local id that
-collides with an installed extension is skipped with a startup notice.
-Project-local files override global-local files with the same id.
+`[a-z0-9][a-z0-9._-]*` (reserved names such as `constructor` are rejected;
+declaration files like `guard.d.ts` are ignored). Symbolic links, duplicate
+ids, and ids that collide with an installed extension — enabled or disabled —
+are skipped with startup notices. Project-local files override global-local
+files with the same id.
 
 For one run only, pass `-e`/`--extension` (repeatable) to the TUI or exec:
 

--- a/apps/coding-agent/src/cli.test.ts
+++ b/apps/coding-agent/src/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -20,7 +20,7 @@ describe("coding-agent CLI", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(output).toContain("Usage: pss [command]\n");
+    expect(output).toContain("Usage: pss [command] [-e <path>]\n");
     expect(output).toContain("exec");
     expect(output).toContain("inspect-thread");
     expect(output).toContain("extension");
@@ -66,6 +66,87 @@ describe("coding-agent CLI", () => {
     expect(exitCode).toBe(7);
   });
 
+  it("loads -e extensions for the TUI and overrides configured ids", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "pss-cli-extension-"));
+    try {
+      await writeFile(
+        join(root, "review-guard.mjs"),
+        "export default function cliReviewGuard() {}\n",
+        "utf8"
+      );
+      const started: (readonly { readonly id: string }[])[] = [];
+
+      // When
+      const exitCode = await runCodingAgentCli({
+        argv: ["-e", "./review-guard.mjs"],
+        cwd: root,
+        loadExtensions: () =>
+          Promise.resolve({
+            extensions: [
+              { default: () => undefined, id: "review-guard" },
+              { default: () => undefined, id: "other" },
+            ],
+            notices: [],
+          }),
+        start: (extensions) => {
+          started.push(extensions.map(({ id }) => ({ id })));
+          return Promise.resolve(0);
+        },
+      });
+
+      // Then
+      expect(exitCode).toBe(0);
+      expect(started).toEqual([[{ id: "other" }, { id: "review-guard" }]]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects -e without a path value", async () => {
+    let output = "";
+
+    const exitCode = await runCodingAgentCli({
+      argv: ["--extension"],
+      start: () =>
+        Promise.reject(new Error("TUI should not start for bad flags")),
+      stdout: {
+        write(text: string): void {
+          output += text;
+        },
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(output).toContain("--extension requires a path value.");
+    expect(output).toContain("Usage: pss");
+  });
+
+  it("reports missing -e paths without starting the TUI", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pss-cli-extension-"));
+    try {
+      let output = "";
+
+      const exitCode = await runCodingAgentCli({
+        argv: ["-e", "./missing.ts"],
+        cwd: root,
+        loadExtensions: () => Promise.resolve({ extensions: [], notices: [] }),
+        start: () =>
+          Promise.reject(new Error("TUI should not start for bad paths")),
+        stdout: {
+          write(text: string): void {
+            output += text;
+          },
+        },
+      });
+
+      expect(exitCode).toBe(1);
+      expect(output).toContain("--extension path not found");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("returns an error code with usage when the command is unknown", async () => {
     let output = "";
 
@@ -82,7 +163,7 @@ describe("coding-agent CLI", () => {
 
     expect(exitCode).toBe(1);
     expect(output).toContain("Unknown pss command: wat\n\n");
-    expect(output).toContain("Usage: pss [command]\n");
+    expect(output).toContain("Usage: pss [command] [-e <path>]\n");
   });
 
   it("routes inspect-thread through the local inspection surface", async () => {

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -6,8 +6,9 @@ import type {
   LoadedConfiguredExtensions,
 } from "./extensions";
 import {
-  loadCliExtensions,
+  importCliExtensions,
   mergeCliExtensions,
+  resolveCliExtensionTargets,
 } from "./extensions/manager/cli-extensions";
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
 import { resolveCodingAgentThreadConfig } from "./thread-config";
@@ -127,20 +128,35 @@ async function runTuiCommand({
     stdout.write(`${errorMessage(error)}\n\n${formatUsage()}\n`);
     return 1;
   }
+  let cliTargets: Awaited<ReturnType<typeof resolveCliExtensionTargets>>;
+  try {
+    cliTargets = await resolveCliExtensionTargets({
+      cwd,
+      paths: extensionPaths,
+    });
+  } catch (error) {
+    stdout.write(`${errorMessage(error)}\n`);
+    return 1;
+  }
+  const excludeIds = new Set(cliTargets.map((target) => target.id));
   const configured =
     (await loadExtensions?.()) ??
     (start
       ? { extensions: [], notices: [] }
-      : await loadConfiguredCodingAgentExtensions({ cwd, home }));
+      : await loadConfiguredCodingAgentExtensions({
+          cwd,
+          ...(excludeIds.size === 0 ? {} : { excludeIds }),
+          home,
+        }));
   for (const notice of configured.notices) {
     stdout.write(`${notice}\n`);
   }
   let extensions = configured.extensions;
-  if (extensionPaths.length > 0) {
+  if (cliTargets.length > 0) {
     try {
       extensions = mergeCliExtensions(
         configured.extensions,
-        await loadCliExtensions({ cwd, paths: extensionPaths })
+        await importCliExtensions({ targets: cliTargets })
       );
     } catch (error) {
       stdout.write(`${errorMessage(error)}\n`);

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -5,6 +5,10 @@ import type {
   CodingAgentExtensionInput,
   LoadedConfiguredExtensions,
 } from "./extensions";
+import {
+  loadCliExtensions,
+  mergeCliExtensions,
+} from "./extensions/manager/cli-extensions";
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
 import { resolveCodingAgentThreadConfig } from "./thread-config";
 import {
@@ -52,20 +56,15 @@ export async function runCodingAgentCli({
 }: RunCodingAgentCliOptions = {}): Promise<number> {
   const command = argv[0];
 
-  if (command === undefined) {
-    const configured =
-      (await loadExtensions?.()) ??
-      (start
-        ? { extensions: [], notices: [] }
-        : await loadConfiguredCodingAgentExtensions({ cwd, home }));
-    for (const notice of configured.notices) {
-      stdout.write(`${notice}\n`);
-    }
-    return await (
-      start ??
-      ((extensions: readonly CodingAgentExtensionInput[]) =>
-        startTui({ extensions }))
-    )(configured.extensions);
+  if (command === undefined || isExtensionFlag(command)) {
+    return await runTuiCommand({
+      argv,
+      cwd,
+      home,
+      ...(loadExtensions === undefined ? {} : { loadExtensions }),
+      ...(start === undefined ? {} : { start }),
+      stdout,
+    });
   }
 
   if (command === "help" || command === "--help" || command === "-h") {
@@ -104,12 +103,89 @@ export async function runCodingAgentCli({
   return 1;
 }
 
+async function runTuiCommand({
+  argv,
+  cwd,
+  home,
+  loadExtensions,
+  start,
+  stdout,
+}: {
+  readonly argv: readonly string[];
+  readonly cwd: string;
+  readonly home: string;
+  readonly loadExtensions?: () => Promise<LoadedConfiguredExtensions>;
+  readonly start?: (
+    extensions: readonly CodingAgentExtensionInput[]
+  ) => Promise<number>;
+  readonly stdout: { write(text: string): void };
+}): Promise<number> {
+  let extensionPaths: readonly string[];
+  try {
+    extensionPaths = parseTuiExtensionPaths(argv);
+  } catch (error) {
+    stdout.write(`${errorMessage(error)}\n\n${formatUsage()}\n`);
+    return 1;
+  }
+  const configured =
+    (await loadExtensions?.()) ??
+    (start
+      ? { extensions: [], notices: [] }
+      : await loadConfiguredCodingAgentExtensions({ cwd, home }));
+  for (const notice of configured.notices) {
+    stdout.write(`${notice}\n`);
+  }
+  let extensions = configured.extensions;
+  if (extensionPaths.length > 0) {
+    try {
+      extensions = mergeCliExtensions(
+        configured.extensions,
+        await loadCliExtensions({ cwd, paths: extensionPaths })
+      );
+    } catch (error) {
+      stdout.write(`${errorMessage(error)}\n`);
+      return 1;
+    }
+  }
+  return await (
+    start ??
+    ((loaded: readonly CodingAgentExtensionInput[]) =>
+      startTui({ extensions: loaded }))
+  )(extensions);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isExtensionFlag(value: string): boolean {
+  return value === "-e" || value === "--extension";
+}
+
+function parseTuiExtensionPaths(argv: readonly string[]): readonly string[] {
+  const paths: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index] ?? "";
+    if (!isExtensionFlag(flag)) {
+      throw new Error(`Unknown pss option: ${flag}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("-")) {
+      throw new Error(`${flag} requires a path value.`);
+    }
+    paths.push(value);
+    index += 1;
+  }
+  return paths;
+}
+
 function formatUsage(): string {
   return [
-    "Usage: pss [command]",
+    "Usage: pss [command] [-e <path>]",
     "",
     "Commands:",
     "  (no command)     Start the interactive TUI",
+    "                   (-e/--extension <path> loads an extension for this run)",
     "  exec             Run one headless coding task",
     "  extension        Manage coding-agent extensions",
     "  inspect-thread   Print a report for the configured thread",

--- a/apps/coding-agent/src/exec-cli.test.ts
+++ b/apps/coding-agent/src/exec-cli.test.ts
@@ -4,6 +4,7 @@ import { formatExecUsage, parseExecArguments } from "./exec-cli";
 const choosePromptPattern = /Choose exactly one/u;
 const timeoutPattern = /1 to 1200/u;
 const unknownOptionPattern = /Unknown pss exec option/u;
+const extensionValuePattern = /-e requires a value/u;
 
 describe("headless exec arguments", () => {
   it("parses a pinned benchmark invocation", () => {
@@ -28,6 +29,7 @@ describe("headless exec arguments", () => {
       )
     ).toStrictEqual({
       baseUrl: "https://gateway.example/v1",
+      extensionPaths: [],
       help: false,
       model: "qwen3.8-max-preview",
       readStdin: true,
@@ -62,5 +64,18 @@ describe("headless exec arguments", () => {
   it("allows help without a prompt", () => {
     expect(parseExecArguments(["--help"], "/repo").help).toBe(true);
     expect(formatExecUsage()).toContain("pss exec --workspace");
+    expect(formatExecUsage()).toContain("--extension");
+  });
+
+  it("collects repeatable -e/--extension paths", () => {
+    expect(
+      parseExecArguments(
+        ["--stdin", "-e", "./one.ts", "--extension", "./two.mjs"],
+        "/repo"
+      ).extensionPaths
+    ).toEqual(["./one.ts", "./two.mjs"]);
+    expect(() => parseExecArguments(["--stdin", "-e"], "/repo")).toThrow(
+      extensionValuePattern
+    );
   });
 });

--- a/apps/coding-agent/src/exec-cli.ts
+++ b/apps/coding-agent/src/exec-cli.ts
@@ -5,8 +5,9 @@ import { config } from "dotenv";
 import type { CodingAgentRuntimeEnv } from "./env";
 import { runCodingAgentExec } from "./exec";
 import {
-  loadCliExtensions,
+  importCliExtensions,
   mergeCliExtensions,
+  resolveCliExtensionTargets,
 } from "./extensions/manager/cli-extensions";
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
 import { createOpenAICompatibleModelFromEnv } from "./model";
@@ -211,8 +212,14 @@ export async function runExecCli({
     (args.promptFile === undefined
       ? await readAllStdin()
       : await readFile(resolve(cwd, args.promptFile), "utf8"));
+  const cliTargets = await resolveCliExtensionTargets({
+    cwd,
+    paths: args.extensionPaths,
+  });
+  const excludeIds = new Set(cliTargets.map((target) => target.id));
   const configured = await loadConfiguredCodingAgentExtensions({
     cwd: args.workspace,
+    ...(excludeIds.size === 0 ? {} : { excludeIds }),
     home,
   });
   for (const notice of configured.notices) {
@@ -221,11 +228,11 @@ export async function runExecCli({
     );
   }
   const extensions =
-    args.extensionPaths.length === 0
+    cliTargets.length === 0
       ? configured.extensions
       : mergeCliExtensions(
           configured.extensions,
-          await loadCliExtensions({ cwd, paths: args.extensionPaths })
+          await importCliExtensions({ targets: cliTargets })
         );
   const result = await runCodingAgentExec({
     extensions,

--- a/apps/coding-agent/src/exec-cli.ts
+++ b/apps/coding-agent/src/exec-cli.ts
@@ -4,12 +4,17 @@ import { resolve } from "node:path";
 import { config } from "dotenv";
 import type { CodingAgentRuntimeEnv } from "./env";
 import { runCodingAgentExec } from "./exec";
+import {
+  loadCliExtensions,
+  mergeCliExtensions,
+} from "./extensions/manager/cli-extensions";
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
 import { createOpenAICompatibleModelFromEnv } from "./model";
 import type { WebToolsAvailability } from "./tools";
 
 interface ExecArguments {
   readonly baseUrl?: string;
+  readonly extensionPaths: readonly string[];
   readonly help: boolean;
   readonly model?: string;
   readonly prompt?: string;
@@ -23,6 +28,7 @@ interface ExecArguments {
 
 interface MutableExecArguments {
   baseUrl?: string;
+  extensionPaths: string[];
   help: boolean;
   model?: string;
   prompt?: string;
@@ -44,6 +50,7 @@ interface RunExecCliOptions {
 
 const VALUE_FLAGS = new Set([
   "--base-url",
+  "--extension",
   "--model",
   "--prompt",
   "--prompt-file",
@@ -86,6 +93,9 @@ function setValueOption(
       return;
     case "--base-url":
       options.baseUrl = value;
+      return;
+    case "--extension":
+      options.extensionPaths.push(value);
       return;
     case "--result-file":
       options.resultFile = resolve(cwd, value);
@@ -132,6 +142,7 @@ export function parseExecArguments(
   cwd = process.cwd()
 ): ExecArguments {
   const options: MutableExecArguments = {
+    extensionPaths: [],
     help: false,
     readStdin: false,
     timeoutSeconds: 1200,
@@ -148,10 +159,11 @@ export function parseExecArguments(
       options.readStdin = true;
       continue;
     }
-    if (!VALUE_FLAGS.has(flag)) {
+    const valueFlag = flag === "-e" ? "--extension" : flag;
+    if (!VALUE_FLAGS.has(valueFlag)) {
       throw new Error(`Unknown pss exec option: ${flag}`);
     }
-    setValueOption(options, flag, requiredValue(argv, index, flag), cwd);
+    setValueOption(options, valueFlag, requiredValue(argv, index, flag), cwd);
     index += 1;
   }
   validateArguments(options);
@@ -171,6 +183,7 @@ export function formatExecUsage(): string {
     "Usage: pss exec --workspace <dir> (--prompt <text> | --prompt-file <file> | --stdin)",
     "                [--model <id>] [--base-url <url>] [--timeout-seconds <1-1200>]",
     "                [--web-tools disabled|optional|required] [--result-file <file>]",
+    "                [-e|--extension <path>]...",
   ].join("\n");
 }
 
@@ -207,8 +220,15 @@ export async function runExecCli({
       `${JSON.stringify({ message: notice, type: "extension_notice" })}\n`
     );
   }
+  const extensions =
+    args.extensionPaths.length === 0
+      ? configured.extensions
+      : mergeCliExtensions(
+          configured.extensions,
+          await loadCliExtensions({ cwd, paths: args.extensionPaths })
+        );
   const result = await runCodingAgentExec({
-    extensions: configured.extensions,
+    extensions,
     model: createOpenAICompatibleModelFromEnv({ runtimeEnv }),
     prompt,
     ...(args.resultFile === undefined ? {} : { resultFile: args.resultFile }),

--- a/apps/coding-agent/src/extensions/manager/cli-extensions.test.ts
+++ b/apps/coding-agent/src/extensions/manager/cli-extensions.test.ts
@@ -105,6 +105,10 @@ describe("loadCliExtensions", () => {
     await expect(
       loadCliExtensions({ cwd: root, paths: ["Bad Name.mjs"] })
     ).rejects.toThrow(invalidIdPattern);
+    await writeFile(join(root, "constructor.mjs"), "export default () => {};");
+    await expect(
+      loadCliExtensions({ cwd: root, paths: ["constructor.mjs"] })
+    ).rejects.toThrow(invalidIdPattern);
     await expect(
       loadCliExtensions({ cwd: root, paths: ["dup.mjs", "nested/dup.mjs"] })
     ).rejects.toThrow(duplicateIdPattern);

--- a/apps/coding-agent/src/extensions/manager/cli-extensions.test.ts
+++ b/apps/coding-agent/src/extensions/manager/cli-extensions.test.ts
@@ -1,0 +1,135 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CodingAgentExtensionInput } from "../types";
+import { loadCliExtensions, mergeCliExtensions } from "./cli-extensions";
+
+const pathNotFoundPattern = /--extension path not found/u;
+const moduleKindPattern = /must be a \.ts, \.mts, \.js, or \.mjs module/u;
+const noIndexPattern = /has no index module/u;
+const invalidIdPattern = /not a valid extension id/u;
+const duplicateIdPattern = /Duplicate --extension id "dup"/u;
+
+const cleanupRoots: string[] = [];
+
+afterEach(async () => {
+  for (const root of cleanupRoots.splice(0)) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pss-cli-extensions-"));
+  cleanupRoots.push(root);
+  return root;
+}
+
+describe("loadCliExtensions", () => {
+  it("loads a TypeScript module file with an id from its file name", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    const modulePath = join(root, "review-guard.ts");
+    await writeFile(
+      modulePath,
+      [
+        "interface Marker { readonly loaded: boolean }",
+        "const marker: Marker = { loaded: true };",
+        "export default function reviewGuard(): void {",
+        "  void marker;",
+        "}",
+        "",
+      ].join("\n")
+    );
+
+    // When
+    const extensions = await loadCliExtensions({
+      cwd: root,
+      paths: ["./review-guard.ts"],
+    });
+
+    // Then
+    expect(extensions).toHaveLength(1);
+    expect(extensions[0]?.id).toBe("review-guard");
+  });
+
+  it("loads a directory extension through its index module", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await mkdir(join(root, "checkpoint"));
+    await writeFile(
+      join(root, "checkpoint", "index.mjs"),
+      "export default function checkpoint() {}\n"
+    );
+
+    // When
+    const extensions = await loadCliExtensions({
+      cwd: root,
+      paths: ["checkpoint"],
+    });
+
+    // Then
+    expect(extensions.map((extension) => extension.id)).toEqual(["checkpoint"]);
+  });
+
+  it("rejects missing paths, non-module files, and empty directories", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "notes.txt"), "hello");
+    await mkdir(join(root, "empty"));
+
+    // When / Then
+    await expect(
+      loadCliExtensions({ cwd: root, paths: ["missing.ts"] })
+    ).rejects.toThrow(pathNotFoundPattern);
+    await expect(
+      loadCliExtensions({ cwd: root, paths: ["notes.txt"] })
+    ).rejects.toThrow(moduleKindPattern);
+    await expect(
+      loadCliExtensions({ cwd: root, paths: ["empty"] })
+    ).rejects.toThrow(noIndexPattern);
+  });
+
+  it("rejects invalid ids and duplicate ids", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "Bad Name.mjs"), "export default () => {};");
+    await writeFile(join(root, "dup.mjs"), "export default () => {};");
+    await mkdir(join(root, "nested"));
+    await writeFile(
+      join(root, "nested", "dup.mjs"),
+      "export default () => {};"
+    );
+
+    // When / Then
+    await expect(
+      loadCliExtensions({ cwd: root, paths: ["Bad Name.mjs"] })
+    ).rejects.toThrow(invalidIdPattern);
+    await expect(
+      loadCliExtensions({ cwd: root, paths: ["dup.mjs", "nested/dup.mjs"] })
+    ).rejects.toThrow(duplicateIdPattern);
+  });
+});
+
+describe("mergeCliExtensions", () => {
+  it("replaces configured extensions that share a CLI extension id", () => {
+    // Given
+    const configured: CodingAgentExtensionInput[] = [
+      { default: () => undefined, id: "keep" },
+      { default: () => undefined, id: "replaced" },
+    ];
+    const cli: CodingAgentExtensionInput[] = [
+      { default: () => undefined, id: "replaced" },
+    ];
+
+    // When
+    const merged = mergeCliExtensions(configured, cli);
+
+    // Then
+    expect(merged.map((extension) => extension.id)).toEqual([
+      "keep",
+      "replaced",
+    ]);
+    expect(merged[1]).toBe(cli[0]);
+  });
+});

--- a/apps/coding-agent/src/extensions/manager/cli-extensions.ts
+++ b/apps/coding-agent/src/extensions/manager/cli-extensions.ts
@@ -10,24 +10,27 @@ import type { ImportExtensionModule } from "./types";
 
 const MODULE_FILE_EXTENSIONS = new Set([".ts", ".mts", ".js", ".mjs"]);
 
+/** One `-e <path>` argument resolved to a module path and stable id. */
+export interface ResolvedCliExtension {
+  readonly id: string;
+  readonly path: string;
+}
+
 /**
- * Load extensions passed explicitly on the command line via `-e <path>`.
+ * Resolve `-e <path>` arguments to module paths and ids without importing.
  *
  * Paths may point at a loose module file or a directory containing an
- * `index.*` module. CLI extensions are an explicit user action, so they load
- * without trust gating and take precedence over configured extensions with
- * the same id.
+ * `index.*` module. Resolution happens before configured extensions load so
+ * overridden configured modules are never imported.
  */
-export async function loadCliExtensions({
+export async function resolveCliExtensionTargets({
   cwd,
-  importer,
   paths,
 }: {
   readonly cwd: string;
-  readonly importer?: ImportExtensionModule;
   readonly paths: readonly string[];
-}): Promise<readonly CodingAgentExtensionInput[]> {
-  const extensions: CodingAgentExtensionInput[] = [];
+}): Promise<readonly ResolvedCliExtension[]> {
+  const targets: ResolvedCliExtension[] = [];
   const seen = new Set<string>();
   for (const path of paths) {
     const target = await resolveCliExtensionTarget(resolve(cwd, path));
@@ -37,6 +40,26 @@ export async function loadCliExtensions({
       );
     }
     seen.add(target.id);
+    targets.push(target);
+  }
+  return targets;
+}
+
+/**
+ * Import previously resolved CLI extensions.
+ *
+ * CLI extensions are an explicit user action, so they load without trust
+ * gating and take precedence over configured extensions with the same id.
+ */
+export async function importCliExtensions({
+  importer,
+  targets,
+}: {
+  readonly importer?: ImportExtensionModule;
+  readonly targets: readonly ResolvedCliExtension[];
+}): Promise<readonly CodingAgentExtensionInput[]> {
+  const extensions: CodingAgentExtensionInput[] = [];
+  for (const target of targets) {
     extensions.push(
       await loadExtensionTarget({
         id: target.id,
@@ -47,6 +70,22 @@ export async function loadCliExtensions({
     );
   }
   return extensions;
+}
+
+/** Resolve and import `-e <path>` extensions in one step. */
+export async function loadCliExtensions({
+  cwd,
+  importer,
+  paths,
+}: {
+  readonly cwd: string;
+  readonly importer?: ImportExtensionModule;
+  readonly paths: readonly string[];
+}): Promise<readonly CodingAgentExtensionInput[]> {
+  return await importCliExtensions({
+    ...(importer === undefined ? {} : { importer }),
+    targets: await resolveCliExtensionTargets({ cwd, paths }),
+  });
 }
 
 /** Drop configured extensions that a CLI extension with the same id replaces. */
@@ -63,16 +102,16 @@ export function mergeCliExtensions(
 
 async function resolveCliExtensionTarget(
   path: string
-): Promise<{ readonly id: string; readonly path: string }> {
+): Promise<ResolvedCliExtension> {
   const details = await lstat(path).catch(() => {
     throw new Error(`--extension path not found: ${path}`);
   });
   if (details.isDirectory()) {
-    const indexPath = await directoryIndexModule(path);
-    if (indexPath === undefined) {
+    const index = await directoryIndexModule(path);
+    if (index === undefined) {
       throw new Error(`--extension directory has no index module: ${path}`);
     }
-    return { id: cliExtensionId(basename(path), path), path: indexPath };
+    return { id: cliExtensionId(basename(path), path), path: index.path };
   }
   const moduleExtension = extname(path);
   if (!MODULE_FILE_EXTENSIONS.has(moduleExtension)) {

--- a/apps/coding-agent/src/extensions/manager/cli-extensions.ts
+++ b/apps/coding-agent/src/extensions/manager/cli-extensions.ts
@@ -1,0 +1,97 @@
+import { lstat } from "node:fs/promises";
+import { basename, dirname, extname, resolve } from "node:path";
+import type { CodingAgentExtensionInput } from "../types";
+import {
+  directoryIndexModule,
+  localExtensionIdFromName,
+} from "./local-discovery";
+import { loadExtensionTarget } from "./module-loader";
+import type { ImportExtensionModule } from "./types";
+
+const MODULE_FILE_EXTENSIONS = new Set([".ts", ".mts", ".js", ".mjs"]);
+
+/**
+ * Load extensions passed explicitly on the command line via `-e <path>`.
+ *
+ * Paths may point at a loose module file or a directory containing an
+ * `index.*` module. CLI extensions are an explicit user action, so they load
+ * without trust gating and take precedence over configured extensions with
+ * the same id.
+ */
+export async function loadCliExtensions({
+  cwd,
+  importer,
+  paths,
+}: {
+  readonly cwd: string;
+  readonly importer?: ImportExtensionModule;
+  readonly paths: readonly string[];
+}): Promise<readonly CodingAgentExtensionInput[]> {
+  const extensions: CodingAgentExtensionInput[] = [];
+  const seen = new Set<string>();
+  for (const path of paths) {
+    const target = await resolveCliExtensionTarget(resolve(cwd, path));
+    if (seen.has(target.id)) {
+      throw new Error(
+        `Duplicate --extension id "${target.id}" from "${path}".`
+      );
+    }
+    seen.add(target.id);
+    extensions.push(
+      await loadExtensionTarget({
+        id: target.id,
+        ...(importer === undefined ? {} : { importer }),
+        installRoot: dirname(target.path),
+        target: { kind: "module", path: target.path },
+      })
+    );
+  }
+  return extensions;
+}
+
+/** Drop configured extensions that a CLI extension with the same id replaces. */
+export function mergeCliExtensions(
+  configured: readonly CodingAgentExtensionInput[],
+  cli: readonly CodingAgentExtensionInput[]
+): readonly CodingAgentExtensionInput[] {
+  const cliIds = new Set(cli.map((extension) => extension.id));
+  return [
+    ...configured.filter((extension) => !cliIds.has(extension.id)),
+    ...cli,
+  ];
+}
+
+async function resolveCliExtensionTarget(
+  path: string
+): Promise<{ readonly id: string; readonly path: string }> {
+  const details = await lstat(path).catch(() => {
+    throw new Error(`--extension path not found: ${path}`);
+  });
+  if (details.isDirectory()) {
+    const indexPath = await directoryIndexModule(path);
+    if (indexPath === undefined) {
+      throw new Error(`--extension directory has no index module: ${path}`);
+    }
+    return { id: cliExtensionId(basename(path), path), path: indexPath };
+  }
+  const moduleExtension = extname(path);
+  if (!MODULE_FILE_EXTENSIONS.has(moduleExtension)) {
+    throw new Error(
+      `--extension path must be a .ts, .mts, .js, or .mjs module: ${path}`
+    );
+  }
+  return {
+    id: cliExtensionId(basename(path, moduleExtension), path),
+    path,
+  };
+}
+
+function cliExtensionId(name: string, path: string): string {
+  const id = localExtensionIdFromName(name);
+  if (id === undefined) {
+    throw new Error(
+      `--extension name "${name}" is not a valid extension id (${path}). Use lowercase letters, digits, ".", "_", or "-".`
+    );
+  }
+  return id;
+}

--- a/apps/coding-agent/src/extensions/manager/loader.test.ts
+++ b/apps/coding-agent/src/extensions/manager/loader.test.ts
@@ -247,6 +247,83 @@ describe("configured extension loading", () => {
       "conflicts with an installed extension"
     );
   });
+
+  it("skips local extensions whose id matches a disabled install", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-loader-"));
+    cleanupRoots.push(root);
+    const home = join(root, "home");
+    const cwd = join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(join(home, ".pss", "extensions"), { recursive: true });
+    const managedModule = join(root, "managed.mjs");
+    await writeFile(
+      managedModule,
+      "export default function managedExtension() {}\n",
+      "utf8"
+    );
+    await writeFile(
+      join(home, ".pss", "extensions", "managed.mjs"),
+      "export default function looseImpostor() {}\n",
+      "utf8"
+    );
+    const globalPaths = await extensionScopePaths({
+      cwd,
+      home,
+      scope: "global",
+    });
+    await writeExtensionSettings(globalPaths.settingsPath, {
+      extensions: [entry("managed", managedModule, false)],
+      values: {},
+    });
+
+    // When
+    const loaded = await loadConfiguredCodingAgentExtensions({ cwd, home });
+
+    // Then
+    expect(loaded.extensions).toEqual([]);
+    expect(loaded.notices).toHaveLength(1);
+    expect(loaded.notices[0]).toContain(
+      "conflicts with an installed extension"
+    );
+  });
+
+  it("never imports configured modules excluded by CLI extension ids", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-loader-"));
+    cleanupRoots.push(root);
+    const home = join(root, "home");
+    const cwd = join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(join(home, ".pss", "extensions"), { recursive: true });
+    const throwingModule = join(root, "throwing.mjs");
+    await writeFile(throwingModule, 'throw new Error("must not import");\n');
+    await writeFile(
+      join(home, ".pss", "extensions", "local-guard.mjs"),
+      'throw new Error("must not import");\n',
+      "utf8"
+    );
+    const globalPaths = await extensionScopePaths({
+      cwd,
+      home,
+      scope: "global",
+    });
+    await writeExtensionSettings(globalPaths.settingsPath, {
+      extensions: [entry("managed-guard", throwingModule, true)],
+      values: {},
+    });
+
+    // When
+    const loaded = await loadConfiguredCodingAgentExtensions({
+      cwd,
+      excludeIds: new Set(["managed-guard", "local-guard"]),
+      home,
+    });
+
+    // Then
+    expect(loaded.extensions).toEqual([]);
+    expect(loaded.notices).toEqual([]);
+  });
 });
 
 function entry(id: string, path: string, enabled: boolean) {

--- a/apps/coding-agent/src/extensions/manager/loader.test.ts
+++ b/apps/coding-agent/src/extensions/manager/loader.test.ts
@@ -143,6 +143,110 @@ describe("configured extension loading", () => {
       "Project extensions are blocked until explicitly enabled or installed for this project.",
     ]);
   });
+
+  it("loads loose local extensions from global and trusted project directories", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-loader-"));
+    cleanupRoots.push(root);
+    const home = join(root, "home");
+    const cwd = join(root, "project");
+    await mkdir(join(home, ".pss", "extensions"), { recursive: true });
+    await mkdir(join(cwd, ".pss", "extensions"), { recursive: true });
+    await writeFile(
+      join(home, ".pss", "extensions", "global-local.mjs"),
+      "export default function globalLocal() {}\n",
+      "utf8"
+    );
+    await writeFile(
+      join(cwd, ".pss", "extensions", "project-local.ts"),
+      [
+        "interface Marker { readonly on: boolean }",
+        "const marker: Marker = { on: true };",
+        "export default function projectLocal(): void {",
+        "  void marker;",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    // When
+    const blocked = await loadConfiguredCodingAgentExtensions({ cwd, home });
+    await writeTrustedProjects(extensionTrustPath(home), [cwd]);
+    const trusted = await loadConfiguredCodingAgentExtensions({ cwd, home });
+
+    // Then
+    expect(blocked.extensions.map((extension) => extension.id)).toEqual([
+      "global-local",
+    ]);
+    expect(blocked.notices).toEqual([
+      "Project extensions are blocked until explicitly enabled or installed for this project.",
+    ]);
+    expect(trusted.extensions.map((extension) => extension.id)).toEqual([
+      "global-local",
+      "project-local",
+    ]);
+    expect(trusted.notices).toEqual([]);
+  });
+
+  it("prefers trusted project local extensions and skips managed id conflicts", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-loader-"));
+    cleanupRoots.push(root);
+    const home = join(root, "home");
+    const cwd = join(root, "project");
+    await mkdir(join(home, ".pss", "extensions"), { recursive: true });
+    await mkdir(join(cwd, ".pss", "extensions"), { recursive: true });
+    const managedModule = join(root, "managed.mjs");
+    await writeFile(
+      managedModule,
+      "export default function managedExtension() {}\n",
+      "utf8"
+    );
+    await writeFile(
+      join(home, ".pss", "extensions", "shared.mjs"),
+      "export default function globalSharedLocal() {}\n",
+      "utf8"
+    );
+    await writeFile(
+      join(cwd, ".pss", "extensions", "shared.mjs"),
+      "export default function projectSharedLocal() {}\n",
+      "utf8"
+    );
+    await writeFile(
+      join(cwd, ".pss", "extensions", "managed.mjs"),
+      "export default function localManagedConflict() {}\n",
+      "utf8"
+    );
+    const globalPaths = await extensionScopePaths({
+      cwd,
+      home,
+      scope: "global",
+    });
+    await writeExtensionSettings(globalPaths.settingsPath, {
+      extensions: [entry("managed", managedModule, true)],
+      values: {},
+    });
+    await writeTrustedProjects(extensionTrustPath(home), [cwd]);
+
+    // When
+    const loaded = await loadConfiguredCodingAgentExtensions({ cwd, home });
+
+    // Then
+    expect(loaded.extensions.map((extension) => extension.id)).toEqual([
+      "managed",
+      "shared",
+    ]);
+    const shared = loaded.extensions[1];
+    if (shared === undefined || !("default" in shared)) {
+      throw new Error("Expected a loaded extension module");
+    }
+    expect(shared.default.name).toBe("projectSharedLocal");
+    expect(loaded.notices).toHaveLength(1);
+    expect(loaded.notices[0]).toContain(
+      "conflicts with an installed extension"
+    );
+  });
 });
 
 function entry(id: string, path: string, enabled: boolean) {

--- a/apps/coding-agent/src/extensions/manager/loader.ts
+++ b/apps/coding-agent/src/extensions/manager/loader.ts
@@ -1,5 +1,10 @@
 import { realpath } from "node:fs/promises";
 import type { CodingAgentExtensionInput } from "../types";
+import {
+  discoverLocalExtensions,
+  hasLocalExtensionCandidates,
+  type LocalExtensionCandidate,
+} from "./local-discovery";
 import { loadExtensionTarget } from "./module-loader";
 import {
   type ExtensionScopePaths,
@@ -58,9 +63,9 @@ export async function loadConfiguredCodingAgentExtensions({
         scope: "project",
       });
       const settings = await readExtensionSettings(paths.settingsPath);
-      hasBlockedProjectExtension = settings.extensions.some(
-        (entry) => entry.enabled
-      );
+      hasBlockedProjectExtension =
+        settings.extensions.some((entry) => entry.enabled) ||
+        (await hasLocalExtensionCandidates(paths.installRoot));
     } catch (error) {
       if (!(error instanceof TypeError)) {
         throw error;
@@ -88,14 +93,125 @@ export async function loadConfiguredCodingAgentExtensions({
           ...(importer === undefined ? {} : { importer }),
           installRoot: projectConfiguration.paths.installRoot,
         });
+  const local = await loadLocalExtensions({
+    globalInstallRoot: globalPaths.installRoot,
+    ...(importer === undefined ? {} : { importer }),
+    managedIds: new Set(
+      [...globalExtensions, ...projectExtensions].map(
+        (extension) => extension.id
+      )
+    ),
+    projectInstallRoot: projectConfiguration?.paths.installRoot,
+  });
   return {
-    extensions: [...globalExtensions, ...projectExtensions],
-    notices: hasBlockedProjectExtension
-      ? [
-          "Project extensions are blocked until explicitly enabled or installed for this project.",
-        ]
-      : [],
+    extensions: [
+      ...globalExtensions,
+      ...local.globalExtensions,
+      ...projectExtensions,
+      ...local.projectExtensions,
+    ],
+    notices: [
+      ...(hasBlockedProjectExtension
+        ? [
+            "Project extensions are blocked until explicitly enabled or installed for this project.",
+          ]
+        : []),
+      ...local.notices,
+    ],
   };
+}
+
+async function loadLocalExtensions(options: {
+  readonly globalInstallRoot: string;
+  readonly importer?: ImportExtensionModule;
+  readonly managedIds: ReadonlySet<string>;
+  readonly projectInstallRoot?: string | undefined;
+}): Promise<{
+  readonly globalExtensions: readonly CodingAgentExtensionInput[];
+  readonly notices: readonly string[];
+  readonly projectExtensions: readonly CodingAgentExtensionInput[];
+}> {
+  const globalDiscovery = await discoverLocalExtensions(
+    options.globalInstallRoot
+  );
+  const projectDiscovery =
+    options.projectInstallRoot === undefined
+      ? { candidates: [], notices: [] }
+      : await discoverLocalExtensions(options.projectInstallRoot);
+  const notices: string[] = [
+    ...globalDiscovery.notices,
+    ...projectDiscovery.notices,
+  ];
+  const projectCandidates = selectLocalCandidates(
+    projectDiscovery.candidates,
+    options.managedIds,
+    notices
+  );
+  const projectLocalIds = new Set(
+    projectCandidates.map((candidate) => candidate.id)
+  );
+  const globalCandidates = selectLocalCandidates(
+    globalDiscovery.candidates.filter(
+      (candidate) => !projectLocalIds.has(candidate.id)
+    ),
+    options.managedIds,
+    notices
+  );
+  return {
+    globalExtensions: await loadLocalCandidates({
+      candidates: globalCandidates,
+      ...(options.importer === undefined ? {} : { importer: options.importer }),
+      installRoot: options.globalInstallRoot,
+    }),
+    notices,
+    projectExtensions:
+      options.projectInstallRoot === undefined
+        ? []
+        : await loadLocalCandidates({
+            candidates: projectCandidates,
+            ...(options.importer === undefined
+              ? {}
+              : { importer: options.importer }),
+            installRoot: options.projectInstallRoot,
+          }),
+  };
+}
+
+function selectLocalCandidates(
+  candidates: readonly LocalExtensionCandidate[],
+  managedIds: ReadonlySet<string>,
+  notices: string[]
+): readonly LocalExtensionCandidate[] {
+  return candidates.filter((candidate) => {
+    if (managedIds.has(candidate.id)) {
+      notices.push(
+        `Skipped local extension "${candidate.path}": id "${candidate.id}" conflicts with an installed extension.`
+      );
+      return false;
+    }
+    return true;
+  });
+}
+
+async function loadLocalCandidates(options: {
+  readonly candidates: readonly LocalExtensionCandidate[];
+  readonly importer?: ImportExtensionModule;
+  readonly installRoot: string;
+}): Promise<readonly CodingAgentExtensionInput[]> {
+  const extensions: CodingAgentExtensionInput[] = [];
+  for (const candidate of options.candidates) {
+    extensions.push(
+      await loadExtensionTarget({
+        id: candidate.id,
+        ...(options.importer === undefined
+          ? {}
+          : { importer: options.importer }),
+        installRoot: options.installRoot,
+        target: { kind: "module", path: candidate.path },
+      })
+    );
+  }
+  return extensions;
 }
 
 async function loadEnabledExtensions(options: {

--- a/apps/coding-agent/src/extensions/manager/loader.ts
+++ b/apps/coding-agent/src/extensions/manager/loader.ts
@@ -24,10 +24,13 @@ import type {
 
 export async function loadConfiguredCodingAgentExtensions({
   cwd,
+  excludeIds,
   home,
   importer,
 }: {
   readonly cwd: string;
+  /** IDs supplied via `-e`; matching configured modules are never imported. */
+  readonly excludeIds?: ReadonlySet<string>;
   readonly home: string;
   readonly importer?: ImportExtensionModule;
 }): Promise<LoadedConfiguredExtensions> {
@@ -78,9 +81,10 @@ export async function loadConfiguredCodingAgentExtensions({
       .filter((entry) => entry.enabled)
       .map((entry) => entry.id) ?? []
   );
+  const skippedIds = excludeIds ?? new Set<string>();
   const globalExtensions = await loadEnabledExtensions({
     entries: globalSettings.extensions.filter(
-      (entry) => !enabledProjectIds.has(entry.id)
+      (entry) => !(enabledProjectIds.has(entry.id) || skippedIds.has(entry.id))
     ),
     ...(importer === undefined ? {} : { importer }),
     installRoot: globalPaths.installRoot,
@@ -89,17 +93,21 @@ export async function loadConfiguredCodingAgentExtensions({
     projectConfiguration === undefined
       ? []
       : await loadEnabledExtensions({
-          entries: projectConfiguration.settings.extensions,
+          entries: projectConfiguration.settings.extensions.filter(
+            (entry) => !skippedIds.has(entry.id)
+          ),
           ...(importer === undefined ? {} : { importer }),
           installRoot: projectConfiguration.paths.installRoot,
         });
   const local = await loadLocalExtensions({
+    excludeIds: skippedIds,
     globalInstallRoot: globalPaths.installRoot,
     ...(importer === undefined ? {} : { importer }),
     managedIds: new Set(
-      [...globalExtensions, ...projectExtensions].map(
-        (extension) => extension.id
-      )
+      [
+        ...globalSettings.extensions,
+        ...(projectConfiguration?.settings.extensions ?? []),
+      ].map((entry) => entry.id)
     ),
     projectInstallRoot: projectConfiguration?.paths.installRoot,
   });
@@ -122,6 +130,7 @@ export async function loadConfiguredCodingAgentExtensions({
 }
 
 async function loadLocalExtensions(options: {
+  readonly excludeIds: ReadonlySet<string>;
   readonly globalInstallRoot: string;
   readonly importer?: ImportExtensionModule;
   readonly managedIds: ReadonlySet<string>;
@@ -143,7 +152,9 @@ async function loadLocalExtensions(options: {
     ...projectDiscovery.notices,
   ];
   const projectCandidates = selectLocalCandidates(
-    projectDiscovery.candidates,
+    projectDiscovery.candidates.filter(
+      (candidate) => !options.excludeIds.has(candidate.id)
+    ),
     options.managedIds,
     notices
   );
@@ -152,7 +163,11 @@ async function loadLocalExtensions(options: {
   );
   const globalCandidates = selectLocalCandidates(
     globalDiscovery.candidates.filter(
-      (candidate) => !projectLocalIds.has(candidate.id)
+      (candidate) =>
+        !(
+          projectLocalIds.has(candidate.id) ||
+          options.excludeIds.has(candidate.id)
+        )
     ),
     options.managedIds,
     notices

--- a/apps/coding-agent/src/extensions/manager/local-discovery.test.ts
+++ b/apps/coding-agent/src/extensions/manager/local-discovery.test.ts
@@ -1,0 +1,148 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  discoverLocalExtensions,
+  hasLocalExtensionCandidates,
+} from "./local-discovery";
+
+const cleanupRoots: string[] = [];
+
+afterEach(async () => {
+  for (const root of cleanupRoots.splice(0)) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pss-local-discovery-"));
+  cleanupRoots.push(root);
+  return root;
+}
+
+describe("local extension discovery", () => {
+  it("returns nothing for a missing directory", async () => {
+    // Given
+    const root = await temporaryDirectory();
+
+    // When
+    const discovered = await discoverLocalExtensions(join(root, "missing"));
+
+    // Then
+    expect(discovered.candidates).toEqual([]);
+    expect(discovered.notices).toEqual([]);
+  });
+
+  it("discovers module files and index directories in name order", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "beta.mjs"), "export default () => {};");
+    await writeFile(join(root, "alpha.ts"), "export default () => {};");
+    await mkdir(join(root, "gamma"));
+    await writeFile(
+      join(root, "gamma", "index.ts"),
+      "export default () => {};"
+    );
+    await writeFile(join(root, "notes.txt"), "not a module");
+
+    // When
+    const discovered = await discoverLocalExtensions(root);
+
+    // Then
+    expect(discovered.candidates).toEqual([
+      { id: "alpha", path: join(root, "alpha.ts") },
+      { id: "beta", path: join(root, "beta.mjs") },
+      { id: "gamma", path: join(root, "gamma", "index.ts") },
+    ]);
+    expect(discovered.notices).toEqual([]);
+  });
+
+  it("ignores managed install metadata and dotfiles", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await mkdir(join(root, "node_modules", "pkg"), { recursive: true });
+    await writeFile(
+      join(root, "node_modules", "pkg", "index.js"),
+      "export default () => {};"
+    );
+    await writeFile(join(root, "package.json"), "{}");
+    await writeFile(join(root, "package-lock.json"), "{}");
+    await writeFile(join(root, ".hidden.ts"), "export default () => {};");
+
+    // When
+    const discovered = await discoverLocalExtensions(root);
+
+    // Then
+    expect(discovered.candidates).toEqual([]);
+    expect(discovered.notices).toEqual([]);
+  });
+
+  it("skips symbolic links and invalid names with notices", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    const outside = join(root, "outside.mjs");
+    await writeFile(outside, "export default () => {};");
+    const extensionsDirectory = join(root, "extensions");
+    await mkdir(extensionsDirectory);
+    await symlink(outside, join(extensionsDirectory, "linked.mjs"));
+    await writeFile(
+      join(extensionsDirectory, "Bad Name.ts"),
+      "export default () => {};"
+    );
+
+    // When
+    const discovered = await discoverLocalExtensions(extensionsDirectory);
+
+    // Then
+    expect(discovered.candidates).toEqual([]);
+    expect(discovered.notices).toHaveLength(2);
+    const combined = discovered.notices.join("\n");
+    expect(combined).toContain("symbolic links");
+    expect(combined).toContain("Bad Name.ts");
+  });
+
+  it("skips directories without an index module", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await mkdir(join(root, "helpers"));
+    await writeFile(join(root, "helpers", "util.ts"), "export const x = 1;");
+
+    // When
+    const discovered = await discoverLocalExtensions(root);
+
+    // Then
+    expect(discovered.candidates).toEqual([]);
+  });
+});
+
+describe("hasLocalExtensionCandidates", () => {
+  it("reports false for empty or missing directories", async () => {
+    // Given
+    const root = await temporaryDirectory();
+
+    // When / Then
+    expect(await hasLocalExtensionCandidates(join(root, "missing"))).toBe(
+      false
+    );
+    expect(await hasLocalExtensionCandidates(root)).toBe(false);
+  });
+
+  it("reports true when a loose module exists", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "guard.ts"), "export default () => {};");
+
+    // When / Then
+    expect(await hasLocalExtensionCandidates(root)).toBe(true);
+  });
+
+  it("reports true when only skipped entries exist", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "Bad Name.ts"), "export default () => {};");
+
+    // When / Then
+    expect(await hasLocalExtensionCandidates(root)).toBe(true);
+  });
+});

--- a/apps/coding-agent/src/extensions/manager/local-discovery.test.ts
+++ b/apps/coding-agent/src/extensions/manager/local-discovery.test.ts
@@ -102,6 +102,72 @@ describe("local extension discovery", () => {
     expect(combined).toContain("Bad Name.ts");
   });
 
+  it("ignores declaration files", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "guard.d.ts"), "declare const x: number;");
+    await writeFile(join(root, "guard.d.mts"), "declare const y: number;");
+    await writeFile(join(root, "guard.js"), "export default () => {};");
+
+    // When
+    const discovered = await discoverLocalExtensions(root);
+
+    // Then
+    expect(discovered.candidates).toEqual([
+      { id: "guard", path: join(root, "guard.js") },
+    ]);
+    expect(discovered.notices).toEqual([]);
+  });
+
+  it("keeps the first candidate per id and reports duplicates", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "guard.js"), "export default () => {};");
+    await writeFile(join(root, "guard.ts"), "export default () => {};");
+
+    // When
+    const discovered = await discoverLocalExtensions(root);
+
+    // Then
+    expect(discovered.candidates).toEqual([
+      { id: "guard", path: join(root, "guard.js") },
+    ]);
+    expect(discovered.notices).toHaveLength(1);
+    expect(discovered.notices[0]).toContain('duplicate id "guard"');
+  });
+
+  it("rejects host-reserved ids with a notice", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "constructor.mjs"), "export default () => {};");
+    await writeFile(join(root, "prototype.mjs"), "export default () => {};");
+
+    // When
+    const discovered = await discoverLocalExtensions(root);
+
+    // Then
+    expect(discovered.candidates).toEqual([]);
+    expect(discovered.notices).toHaveLength(2);
+  });
+
+  it("reports symlinked directory index modules with a notice", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    const outside = join(root, "outside.mjs");
+    await writeFile(outside, "export default () => {};");
+    const extensionsDirectory = join(root, "extensions");
+    await mkdir(join(extensionsDirectory, "guard"), { recursive: true });
+    await symlink(outside, join(extensionsDirectory, "guard", "index.mjs"));
+
+    // When
+    const discovered = await discoverLocalExtensions(extensionsDirectory);
+
+    // Then
+    expect(discovered.candidates).toEqual([]);
+    expect(discovered.notices).toHaveLength(1);
+    expect(discovered.notices[0]).toContain("symbolic links");
+  });
+
   it("skips directories without an index module", async () => {
     // Given
     const root = await temporaryDirectory();

--- a/apps/coding-agent/src/extensions/manager/local-discovery.ts
+++ b/apps/coding-agent/src/extensions/manager/local-discovery.ts
@@ -1,0 +1,171 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const LOCAL_EXTENSION_ID_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+const MODULE_FILE_EXTENSIONS = [".ts", ".mts", ".js", ".mjs"] as const;
+const RESERVED_ENTRY_NAMES = new Set([
+  "node_modules",
+  "package.json",
+  "package-lock.json",
+]);
+
+/** One loose extension module found in a local extensions directory. */
+export interface LocalExtensionCandidate {
+  readonly id: string;
+  readonly path: string;
+}
+
+export interface LocalExtensionDiscovery {
+  readonly candidates: readonly LocalExtensionCandidate[];
+  readonly notices: readonly string[];
+}
+
+/**
+ * Discover loose extension modules in one extensions directory.
+ *
+ * Loads `<dir>/<name>.<ts|mts|js|mjs>` files and `<dir>/<name>/index.*`
+ * directories. Managed npm metadata (`node_modules`, package manifests),
+ * dotfiles, and symbolic links are ignored; symlinks and invalid names
+ * produce notices instead of failing startup.
+ */
+export async function discoverLocalExtensions(
+  directory: string
+): Promise<LocalExtensionDiscovery> {
+  const entries = await readDirectoryEntries(directory);
+  if (entries === undefined) {
+    return { candidates: [], notices: [] };
+  }
+  const candidates: LocalExtensionCandidate[] = [];
+  const notices: string[] = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || RESERVED_ENTRY_NAMES.has(entry.name)) {
+      continue;
+    }
+    if (entry.isSymbolicLink()) {
+      notices.push(
+        `Skipped local extension entry "${join(directory, entry.name)}": symbolic links are not loaded.`
+      );
+      continue;
+    }
+    if (entry.isFile()) {
+      collectFileCandidate(directory, entry.name, candidates, notices);
+      continue;
+    }
+    if (entry.isDirectory()) {
+      await collectDirectoryCandidate(
+        directory,
+        entry.name,
+        candidates,
+        notices
+      );
+    }
+  }
+  return { candidates, notices };
+}
+
+/**
+ * Report whether a directory contains loose extension candidates without
+ * loading them. Read failures count as present so untrusted projects fail
+ * toward the blocked-extensions notice instead of silently loading nothing.
+ */
+export async function hasLocalExtensionCandidates(
+  directory: string
+): Promise<boolean> {
+  try {
+    const discovered = await discoverLocalExtensions(directory);
+    return discovered.candidates.length > 0 || discovered.notices.length > 0;
+  } catch {
+    return true;
+  }
+}
+
+/** Derive the stable extension id used for one loose module path. */
+export function localExtensionIdFromName(name: string): string | undefined {
+  return LOCAL_EXTENSION_ID_PATTERN.test(name) ? name : undefined;
+}
+
+async function readDirectoryEntries(directory: string) {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    return entries.sort((left, right) => left.name.localeCompare(right.name));
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT") || hasErrorCode(error, "ENOTDIR")) {
+      return;
+    }
+    throw error;
+  }
+}
+
+function collectFileCandidate(
+  directory: string,
+  fileName: string,
+  candidates: LocalExtensionCandidate[],
+  notices: string[]
+): void {
+  const moduleExtension = MODULE_FILE_EXTENSIONS.find((extension) =>
+    fileName.endsWith(extension)
+  );
+  if (moduleExtension === undefined) {
+    return;
+  }
+  const path = join(directory, fileName);
+  const id = localExtensionIdFromName(
+    fileName.slice(0, -moduleExtension.length)
+  );
+  if (id === undefined) {
+    notices.push(
+      `Skipped local extension "${path}": file name must match ${LOCAL_EXTENSION_ID_PATTERN}.`
+    );
+    return;
+  }
+  candidates.push({ id, path });
+}
+
+async function collectDirectoryCandidate(
+  directory: string,
+  directoryName: string,
+  candidates: LocalExtensionCandidate[],
+  notices: string[]
+): Promise<void> {
+  const indexPath = await directoryIndexModule(join(directory, directoryName));
+  if (indexPath === undefined) {
+    return;
+  }
+  const id = localExtensionIdFromName(directoryName);
+  if (id === undefined) {
+    notices.push(
+      `Skipped local extension "${indexPath}": directory name must match ${LOCAL_EXTENSION_ID_PATTERN}.`
+    );
+    return;
+  }
+  candidates.push({ id, path: indexPath });
+}
+
+/** Resolve `<dir>/index.*` for directory-shaped local extensions. */
+export async function directoryIndexModule(
+  directory: string
+): Promise<string | undefined> {
+  const entries = await readDirectoryEntries(directory);
+  if (entries === undefined) {
+    return;
+  }
+  for (const moduleExtension of MODULE_FILE_EXTENSIONS) {
+    const indexName = `index${moduleExtension}`;
+    const match = entries.find(
+      (entry) =>
+        entry.name === indexName && entry.isFile() && !entry.isSymbolicLink()
+    );
+    if (match !== undefined) {
+      return join(directory, indexName);
+    }
+  }
+  return;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === code
+  );
+}

--- a/apps/coding-agent/src/extensions/manager/local-discovery.ts
+++ b/apps/coding-agent/src/extensions/manager/local-discovery.ts
@@ -3,11 +3,14 @@ import { join } from "node:path";
 
 const LOCAL_EXTENSION_ID_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
 const MODULE_FILE_EXTENSIONS = [".ts", ".mts", ".js", ".mjs"] as const;
+const DECLARATION_FILE_SUFFIXES = [".d.ts", ".d.mts"] as const;
 const RESERVED_ENTRY_NAMES = new Set([
   "node_modules",
   "package.json",
   "package-lock.json",
 ]);
+/** IDs the extension host rejects as unsafe; never derive them locally. */
+const UNSAFE_EXTENSION_IDS = new Set(["__proto__", "constructor", "prototype"]);
 
 /** One loose extension module found in a local extensions directory. */
 export interface LocalExtensionCandidate {
@@ -60,7 +63,25 @@ export async function discoverLocalExtensions(
       );
     }
   }
-  return { candidates, notices };
+  return { candidates: dedupeCandidates(candidates, notices), notices };
+}
+
+function dedupeCandidates(
+  candidates: readonly LocalExtensionCandidate[],
+  notices: string[]
+): readonly LocalExtensionCandidate[] {
+  const byId = new Map<string, LocalExtensionCandidate>();
+  for (const candidate of candidates) {
+    const first = byId.get(candidate.id);
+    if (first === undefined) {
+      byId.set(candidate.id, candidate);
+      continue;
+    }
+    notices.push(
+      `Skipped local extension "${candidate.path}": duplicate id "${candidate.id}" (already provided by "${first.path}").`
+    );
+  }
+  return [...byId.values()];
 }
 
 /**
@@ -81,6 +102,9 @@ export async function hasLocalExtensionCandidates(
 
 /** Derive the stable extension id used for one loose module path. */
 export function localExtensionIdFromName(name: string): string | undefined {
+  if (UNSAFE_EXTENSION_IDS.has(name)) {
+    return;
+  }
   return LOCAL_EXTENSION_ID_PATTERN.test(name) ? name : undefined;
 }
 
@@ -102,6 +126,9 @@ function collectFileCandidate(
   candidates: LocalExtensionCandidate[],
   notices: string[]
 ): void {
+  if (DECLARATION_FILE_SUFFIXES.some((suffix) => fileName.endsWith(suffix))) {
+    return;
+  }
   const moduleExtension = MODULE_FILE_EXTENSIONS.find((extension) =>
     fileName.endsWith(extension)
   );
@@ -127,24 +154,35 @@ async function collectDirectoryCandidate(
   candidates: LocalExtensionCandidate[],
   notices: string[]
 ): Promise<void> {
-  const indexPath = await directoryIndexModule(join(directory, directoryName));
-  if (indexPath === undefined) {
+  const index = await directoryIndexModule(join(directory, directoryName));
+  if (index === undefined) {
+    return;
+  }
+  if (index.symlink) {
+    notices.push(
+      `Skipped local extension entry "${index.path}": symbolic links are not loaded.`
+    );
     return;
   }
   const id = localExtensionIdFromName(directoryName);
   if (id === undefined) {
     notices.push(
-      `Skipped local extension "${indexPath}": directory name must match ${LOCAL_EXTENSION_ID_PATTERN}.`
+      `Skipped local extension "${index.path}": directory name must match ${LOCAL_EXTENSION_ID_PATTERN}.`
     );
     return;
   }
-  candidates.push({ id, path: indexPath });
+  candidates.push({ id, path: index.path });
+}
+
+export interface DirectoryIndexModule {
+  readonly path: string;
+  readonly symlink: boolean;
 }
 
 /** Resolve `<dir>/index.*` for directory-shaped local extensions. */
 export async function directoryIndexModule(
   directory: string
-): Promise<string | undefined> {
+): Promise<DirectoryIndexModule | undefined> {
   const entries = await readDirectoryEntries(directory);
   if (entries === undefined) {
     return;
@@ -153,10 +191,13 @@ export async function directoryIndexModule(
     const indexName = `index${moduleExtension}`;
     const match = entries.find(
       (entry) =>
-        entry.name === indexName && entry.isFile() && !entry.isSymbolicLink()
+        entry.name === indexName && (entry.isFile() || entry.isSymbolicLink())
     );
     if (match !== undefined) {
-      return join(directory, indexName);
+      return {
+        path: join(directory, indexName),
+        symlink: match.isSymbolicLink(),
+      };
     }
   }
   return;


### PR DESCRIPTION
Closes the first two items of #257 (extension developer experience).

## Summary

- discover loose extension modules in `~/.pss/extensions/*.{ts,mts,js,mjs}` and `~/.pss/extensions/<name>/index.*`, plus project `.pss/extensions/` after trust, with TypeScript loading through Node's native type stripping (no build step, no new dependency)
- keep managed-install precedence: local ids that collide with installed extensions are skipped with a startup notice, project-local overrides global-local, symlinks and invalid names skip with notices instead of failing startup
- untrusted projects containing loose modules surface the existing blocked-extensions notice (fail-safe on unreadable directories)
- add a repeatable `-e`/`--extension <path>` flag to the TUI and `pss exec` that loads a module file or index directory for the current run only, without touching settings; CLI extensions load without trust gating and take precedence over configured ids
- fail fast with actionable errors for missing paths, non-module files, missing index modules, invalid ids, and duplicate `-e` ids
- queue a patch Tegami letter for `@minpeter/pss-coding-agent` and document local/one-run extension usage in the README

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (9/9 tasks; 459 coding-agent tests)
- `pnpm build`
- built CLI smoke: `pss help`, `-e` missing-path/missing-value error paths, and `pss exec -e ./guard.ts` loading a native-TS factory end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add local extension discovery and a repeatable `-e`/`--extension` flag so extensions can be loaded without installing, with hardened safety and precedence. Addresses #257 by improving the extension developer experience and preventing accidental module loads.

- **New Features**
  - Auto-load loose modules from `~/.pss/extensions/<name>.<ts|mts|js|mjs>` and `<name>/index.*`, plus trusted `<project>/.pss/extensions/`. TypeScript runs via Node’s native type stripping. Symlinks and invalid names are skipped with notices; `.d.ts` files are ignored; host-reserved ids are rejected; symlinked directory indexes are reported.
  - New repeatable `-e|--extension <path>` for the TUI and `pss exec`: load a module file or index directory for this run only, no trust gating. Clear errors for missing paths, non-module files, missing `index.*`, invalid ids, and duplicate ids. Targets are resolved before configured modules import so overridden ids never execute.
  - Precedence: managed installs (enabled or disabled) > local; project-local > global-local; CLI `-e` ids override configured ids.

- **Migration**
  - To use local modules, drop `<name>.*` or `<name>/index.*` into `~/.pss/extensions/` or `<project>/.pss/extensions/` (trust the project to enable project-local).
  - For one run: `pss -e ./review-guard.ts` or `pss exec ... -e ./review-guard.ts -e ./metrics`.

<sup>Written for commit 6d10e9e9601cfa8d596e6c46502a15f3559c2a11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

