### PR TITLE
feat(coding-agent): /reload command, extension event bus, and provider observations

### DIFF
--- a/.tegami/2026-07-26-extension-runtime-surface.md
+++ b/.tegami/2026-07-26-extension-runtime-surface.md
@@ -1,5 +1,7 @@
 ---
 packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
   npm:@minpeter/pss-coding-agent:
     type: patch
 ---
@@ -13,8 +15,14 @@ cache, and activated against a replacement agent while the durable thread
 keeps its history. The swap is fail-safe: the replacement host, agent,
 command set, and renderer set are fully constructed and activated before
 anything is swapped, so a failing reload leaves the current session
-untouched and reports the error in chat. `reload` joins the reserved command
-names extensions cannot register.
+untouched and reports the error in chat. Reload cache busting propagates
+through the whole extension module graph via a module customization hook,
+including CommonJS helpers, so edited sibling modules are re-imported too.
+The runtime exports `validateThreadStateMigrations` and `/reload` uses it to
+prove reloaded migrations accept the stored thread before the swap commits;
+a failed reload also refreshes the surviving thread handle so replacement
+activation writes cannot strand the old session on a stale revision.
+`reload` joins the reserved command names extensions cannot register.
 
 Extension services gain `services.events`, a shared publish/subscribe bus
 for extension-to-extension communication. Payloads are JSON values cloned
@@ -25,7 +33,8 @@ reserved for host-originated events.
 
 The host now publishes read-only provider HTTP observations on the bus:
 `provider:request`, `provider:response`, and `provider:error`. URLs are
-stripped of credentials and query strings, request bodies and request
-headers are never exposed, and response headers pass a safelist. Observation
+stripped of credentials, query strings, and fragments, request bodies and
+request headers are never exposed, response headers pass a safelist, and
+transport error messages are scrubbed of URL-like tokens. Observation
 failures never interrupt provider traffic, and both the TUI and headless
 exec wire the observation fetch automatically.

--- a/.tegami/2026-07-26-extension-runtime-surface.md
+++ b/.tegami/2026-07-26-extension-runtime-surface.md
@@ -12,21 +12,22 @@ The TUI gains a `/reload` command that rebuilds the extension runtime from
 disk without restarting the session. Extensions are rediscovered across
 managed installs, local modules, and `-e` paths, re-imported past the module
 cache, and activated against a replacement agent while the durable thread
-keeps its history. The swap is fail-safe: the replacement host, agent,
-command set, and renderer set are fully constructed and activated before
-anything is swapped, so a failing reload leaves the current session
-untouched and reports the error in chat. Reload cache busting propagates
-through the extension-owned module graph via a module customization hook,
-including CommonJS helpers, so edited sibling modules are re-imported too;
-CommonJS eviction is transactional and restored when a reload fails, and
-dependencies under `node_modules` keep their loaded versions so repeated
-reloads do not accumulate duplicate dependency graphs. Cleanup of the
-previous runtime is bounded by a timeout so an unresponsive extension
-cannot hang the reload command.
-The runtime exports `validateThreadStateMigrations` and `/reload` uses it to
-prove reloaded migrations accept the stored thread before the swap commits;
-a failed reload also refreshes the surviving thread handle so replacement
-activation writes cannot strand the old session on a stale revision.
+keeps its history. Reload is staged for safety: discovery, configuration,
+validation, and agent construction happen while the previous runtime keeps
+running, the previous runtime is then disposed under a bounded timeout
+before the replacement activates (so old cleanup can never overwrite the
+replacement's extension state), and an activation failure rebuilds a
+runtime from the previous extensions so the session stays usable. Cache
+busting propagates through the extension-owned module graph via a module
+customization hook, including CommonJS helpers and a managed package's own
+modules; CommonJS eviction is transactional and restored when a reload
+fails, and dependency trees under `node_modules` keep their loaded versions
+so repeated reloads do not accumulate duplicate dependency graphs. The
+runtime exports `commitThreadStateMigrations`, which `/reload` uses to run
+and commit reloaded migrations for the stored thread before the swap,
+preserving exactly-once migration semantics; a failed reload also refreshes
+the surviving thread handle so it cannot commit on a stale revision. The
+command is offered only when the host can rediscover extensions, and
 `reload` joins the reserved command names extensions cannot register.
 
 Extension services gain `services.events`, a shared publish/subscribe bus

--- a/.tegami/2026-07-26-extension-runtime-surface.md
+++ b/.tegami/2026-07-26-extension-runtime-surface.md
@@ -1,0 +1,31 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Add /reload, an inter-extension event bus, and provider observations
+
+The TUI gains a `/reload` command that rebuilds the extension runtime from
+disk without restarting the session. Extensions are rediscovered across
+managed installs, local modules, and `-e` paths, re-imported past the module
+cache, and activated against a replacement agent while the durable thread
+keeps its history. The swap is fail-safe: the replacement host, agent,
+command set, and renderer set are fully constructed and activated before
+anything is swapped, so a failing reload leaves the current session
+untouched and reports the error in chat. `reload` joins the reserved command
+names extensions cannot register.
+
+Extension services gain `services.events`, a shared publish/subscribe bus
+for extension-to-extension communication. Payloads are JSON values cloned
+per delivery, handlers run under the host timeout/abort boundary, and
+failures are attributed to the subscribing extension without affecting the
+publisher or other subscribers. The `host:` and `provider:` namespaces are
+reserved for host-originated events.
+
+The host now publishes read-only provider HTTP observations on the bus:
+`provider:request`, `provider:response`, and `provider:error`. URLs are
+stripped of credentials and query strings, request bodies and request
+headers are never exposed, and response headers pass a safelist. Observation
+failures never interrupt provider traffic, and both the TUI and headless
+exec wire the observation fetch automatically.

--- a/.tegami/2026-07-26-extension-runtime-surface.md
+++ b/.tegami/2026-07-26-extension-runtime-surface.md
@@ -16,8 +16,13 @@ keeps its history. The swap is fail-safe: the replacement host, agent,
 command set, and renderer set are fully constructed and activated before
 anything is swapped, so a failing reload leaves the current session
 untouched and reports the error in chat. Reload cache busting propagates
-through the whole extension module graph via a module customization hook,
-including CommonJS helpers, so edited sibling modules are re-imported too.
+through the extension-owned module graph via a module customization hook,
+including CommonJS helpers, so edited sibling modules are re-imported too;
+CommonJS eviction is transactional and restored when a reload fails, and
+dependencies under `node_modules` keep their loaded versions so repeated
+reloads do not accumulate duplicate dependency graphs. Cleanup of the
+previous runtime is bounded by a timeout so an unresponsive extension
+cannot hang the reload command.
 The runtime exports `validateThreadStateMigrations` and `/reload` uses it to
 prove reloaded migrations accept the stored thread before the swap commits;
 a failed reload also refreshes the surviving thread handle so replacement
@@ -26,7 +31,8 @@ activation writes cannot strand the old session on a stale revision.
 
 Extension services gain `services.events`, a shared publish/subscribe bus
 for extension-to-extension communication. Payloads are JSON values cloned
-per delivery, handlers run under the host timeout/abort boundary, and
+per delivery, delivery is deferred so synchronous handler work cannot block
+the publisher, handlers run under the host timeout/abort boundary, and
 failures are attributed to the subscribing extension without affecting the
 publisher or other subscribers. The `host:` and `provider:` namespaces are
 reserved for host-originated events.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -210,6 +210,44 @@ pss exec --prompt "..." -e ./review-guard.ts -e ./metrics
 CLI extensions load without trust gating (running them is an explicit user
 action) and take precedence over configured extensions with the same id.
 
+### Reloading extensions
+
+In the TUI, `/reload` rebuilds the extension runtime from disk without
+restarting the session: extensions are rediscovered (managed installs, local
+modules, and `-e` paths), re-imported past the module cache, and activated
+against a replacement agent while the durable thread keeps its history. The
+swap is fail-safe — if any extension fails to load, configure, or activate,
+the current session keeps running unchanged and the error is shown in chat.
+
+### Inter-extension events
+
+`services.events` is a shared bus for extension-to-extension communication:
+
+```ts
+const unsubscribe = services.events.on("checkpoint:saved", (payload) => {
+  services.logger.info("checkpoint", payload);
+});
+services.events.emit("checkpoint:saved", { revision: 7 });
+```
+
+Payloads are JSON values cloned per delivery, handlers run under the host
+timeout/abort boundary, and failures are attributed to the subscribing
+extension without affecting the publisher. The `host:` and `provider:`
+namespaces are reserved for host-originated events; extensions can subscribe
+to them but cannot publish into them.
+
+### Provider observations
+
+The host publishes read-only provider HTTP observations on the bus:
+
+- `provider:request` — `{ method, url }` before each model call
+- `provider:response` — `{ status, url, headers }` after each response
+- `provider:error` — `{ message, url }` when the request fails
+
+URLs are stripped of credentials and query strings, request bodies and
+headers are never exposed, and response headers pass a safelist
+(`content-type`, `retry-after`, `x-request-id`, and rate-limit headers).
+
 Programmatic static-object extensions remain supported through
 `defineCodingAgentExtension()` and the `extensions` option on `startTui()` or
 `runCodingAgentExec()`. Their existing `registry.runtime.use()` API remains an

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -217,7 +217,10 @@ restarting the session: extensions are rediscovered (managed installs, local
 modules, and `-e` paths), re-imported past the module cache, and activated
 against a replacement agent while the durable thread keeps its history. The
 swap is fail-safe — if any extension fails to load, configure, or activate,
-the current session keeps running unchanged and the error is shown in chat.
+the current session keeps running unchanged (including its CommonJS module
+cache) and the error is shown in chat. Reload refreshes extension-owned
+files only; dependencies under `node_modules` keep their loaded versions, so
+updating a dependency still requires `pss extension update` or a restart.
 
 ### Inter-extension events
 

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -216,11 +216,18 @@ In the TUI, `/reload` rebuilds the extension runtime from disk without
 restarting the session: extensions are rediscovered (managed installs, local
 modules, and `-e` paths), re-imported past the module cache, and activated
 against a replacement agent while the durable thread keeps its history. The
-swap is fail-safe — if any extension fails to load, configure, or activate,
-the current session keeps running unchanged (including its CommonJS module
-cache) and the error is shown in chat. Reload refreshes extension-owned
-files only; dependencies under `node_modules` keep their loaded versions, so
-updating a dependency still requires `pss extension update` or a restart.
+previous runtime is cleaned up before the replacement activates so old
+cleanup can never overwrite the replacement's extension state; if loading,
+configuration, or validation fails, the current session keeps running
+unchanged (including its CommonJS module cache), and if activation itself
+fails, a runtime is rebuilt from the previous extensions so the session
+stays usable. Reloaded thread migrations are committed for the current
+thread before the swap, preserving exactly-once semantics. Reload refreshes
+extension-owned files only (including a managed package's own helpers);
+dependencies under `node_modules` keep their loaded versions, so updating a
+dependency still requires `pss extension update` or a restart. The command
+appears only when the session was started through the `pss` CLI, which can
+rediscover extensions.
 
 ### Inter-extension events
 

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -21,6 +21,7 @@ import {
   inspectCodingAgentThread,
 } from "./thread-inspect";
 import { startTui } from "./tui/app";
+import { boundedReloadOperation } from "./tui/reload";
 import { cliVersion } from "./update/cli-version";
 import { runUpdateCommand } from "./update/command";
 
@@ -182,17 +183,24 @@ async function runTuiCommand({
       await reloadCacheRoots({ cwd, home, targets })
     );
     try {
-      const reloaded = await loadConfiguredCodingAgentExtensions({
-        cacheBust,
-        cwd,
-        ...(targetIds.size === 0 ? {} : { excludeIds: targetIds }),
-        home,
-      });
+      // Bound imports so an edited extension with a never-settling
+      // top-level await fails the reload instead of freezing the session
+      // with the CommonJS cache already evicted.
+      const { cliExtensions, reloaded } = await boundedReloadOperation(
+        (async () => ({
+          cliExtensions: await importCliExtensions({ cacheBust, targets }),
+          reloaded: await loadConfiguredCodingAgentExtensions({
+            cacheBust,
+            cwd,
+            ...(targetIds.size === 0 ? {} : { excludeIds: targetIds }),
+            home,
+          }),
+        }))(),
+        RELOAD_IMPORT_TIMEOUT_MS,
+        "Extension reload import"
+      );
       return {
-        extensions: mergeCliExtensions(
-          reloaded.extensions,
-          await importCliExtensions({ cacheBust, targets })
-        ),
+        extensions: mergeCliExtensions(reloaded.extensions, cliExtensions),
         notices: reloaded.notices,
         rollbackModuleCache: () => transaction.rollback(),
       };
@@ -207,6 +215,8 @@ async function runTuiCommand({
       startTui({ extensions: loaded, reloadExtensions }))
   )(extensions);
 }
+
+const RELOAD_IMPORT_TIMEOUT_MS = 30_000;
 
 async function reloadCacheRoots({
   cwd,

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -183,18 +183,25 @@ async function runTuiCommand({
     const transaction = beginCommonJsReloadTransaction(
       await reloadCacheRoots({ cwd, home, targets })
     );
+    // Bound imports so an edited extension with a never-settling top-level
+    // await fails the reload instead of freezing the session; the abort
+    // signal stops the detached task from importing further modules after
+    // the timeout so it cannot repopulate the rolled-back module cache.
+    const importAbort = new AbortController();
     try {
-      // Bound imports so an edited extension with a never-settling
-      // top-level await fails the reload instead of freezing the session
-      // with the CommonJS cache already evicted.
       const { cliExtensions, reloaded } = await boundedReloadOperation(
         (async () => ({
-          cliExtensions: await importCliExtensions({ cacheBust, targets }),
+          cliExtensions: await importCliExtensions({
+            cacheBust,
+            signal: importAbort.signal,
+            targets,
+          }),
           reloaded: await loadConfiguredCodingAgentExtensions({
             cacheBust,
             cwd,
             ...(targetIds.size === 0 ? {} : { excludeIds: targetIds }),
             home,
+            signal: importAbort.signal,
           }),
         }))(),
         RELOAD_IMPORT_TIMEOUT_MS,
@@ -206,6 +213,7 @@ async function runTuiCommand({
         rollbackModuleCache: () => transaction.rollback(),
       };
     } catch (error) {
+      importAbort.abort();
       transaction.rollback();
       throw error;
     }

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { runExecCli } from "./exec-cli";
 import { runExtensionCli } from "./extension-cli";
 import type {
@@ -14,6 +14,7 @@ import {
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
 import { extensionScopePaths } from "./extensions/manager/paths";
 import { beginCommonJsReloadTransaction } from "./extensions/manager/reload-module-graph";
+import { readExtensionSettings } from "./extensions/manager/settings";
 import { resolveCodingAgentThreadConfig } from "./thread-config";
 import {
   formatThreadInspectionReport,
@@ -216,14 +217,29 @@ async function reloadCacheRoots({
   readonly home: string;
   readonly targets: readonly { readonly path: string }[];
 }): Promise<readonly string[]> {
-  const roots = [
-    (await extensionScopePaths({ cwd, home, scope: "global" })).installRoot,
-    ...targets.map((target) => dirname(target.path)),
-  ];
+  const roots = targets.map((target) => dirname(target.path));
+  const addScope = async (scope: "global" | "project"): Promise<void> => {
+    const paths = await extensionScopePaths({ cwd, home, scope });
+    roots.push(paths.installRoot);
+    // Managed extensions live at <installRoot>/node_modules/<package>; add
+    // each package root so its own CommonJS helpers reload while nested
+    // dependency trees stay cached.
+    const settings = await readExtensionSettings(paths.settingsPath);
+    for (const entry of settings.extensions) {
+      if (entry.target.kind === "package") {
+        roots.push(
+          join(
+            paths.installRoot,
+            "node_modules",
+            ...entry.target.packageName.split("/")
+          )
+        );
+      }
+    }
+  };
+  await addScope("global");
   try {
-    roots.push(
-      (await extensionScopePaths({ cwd, home, scope: "project" })).installRoot
-    );
+    await addScope("project");
   } catch {
     // Untrusted or malformed project layouts simply contribute no root.
   }

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -163,10 +163,31 @@ async function runTuiCommand({
       return 1;
     }
   }
+  const reloadExtensions = async (): Promise<LoadedConfiguredExtensions> => {
+    const cacheBust = Date.now().toString(36);
+    const targets = await resolveCliExtensionTargets({
+      cwd,
+      paths: extensionPaths,
+    });
+    const targetIds = new Set(targets.map((target) => target.id));
+    const reloaded = await loadConfiguredCodingAgentExtensions({
+      cacheBust,
+      cwd,
+      ...(targetIds.size === 0 ? {} : { excludeIds: targetIds }),
+      home,
+    });
+    return {
+      extensions: mergeCliExtensions(
+        reloaded.extensions,
+        await importCliExtensions({ cacheBust, targets })
+      ),
+      notices: reloaded.notices,
+    };
+  };
   return await (
     start ??
     ((loaded: readonly CodingAgentExtensionInput[]) =>
-      startTui({ extensions: loaded }))
+      startTui({ extensions: loaded, reloadExtensions }))
   )(extensions);
 }
 

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -217,7 +217,10 @@ async function reloadCacheRoots({
   readonly home: string;
   readonly targets: readonly { readonly path: string }[];
 }): Promise<readonly string[]> {
-  const roots = targets.map((target) => dirname(target.path));
+  // The cwd covers loose `-e` extensions whose CommonJS helpers live
+  // outside the entry directory (for example `plugins/review/index.mjs`
+  // importing `../shared.cjs`); nested node_modules stay untouched.
+  const roots = [cwd, ...targets.map((target) => dirname(target.path))];
   const addScope = async (scope: "global" | "project"): Promise<void> => {
     const paths = await extensionScopePaths({ cwd, home, scope });
     roots.push(paths.installRoot);

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -1,3 +1,4 @@
+import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { runExecCli } from "./exec-cli";
@@ -230,7 +231,12 @@ async function reloadCacheRoots({
   // The cwd covers loose `-e` extensions whose CommonJS helpers live
   // outside the entry directory (for example `plugins/review/index.mjs`
   // importing `../shared.cjs`); nested node_modules stay untouched.
-  const roots = [cwd, ...targets.map((target) => dirname(target.path))];
+  const roots = [
+    cwd,
+    ...(await Promise.all(
+      targets.map(async (target) => dirname(await canonicalPath(target.path)))
+    )),
+  ];
   const addScope = async (scope: "global" | "project"): Promise<void> => {
     const paths = await extensionScopePaths({ cwd, home, scope });
     roots.push(paths.installRoot);
@@ -256,7 +262,17 @@ async function reloadCacheRoots({
   } catch {
     // Untrusted or malformed project layouts simply contribute no root.
   }
-  return roots;
+  // Node keys require.cache by real resolved filenames, so symlinked roots
+  // must be canonicalized or their helpers would evade the transaction.
+  return await Promise.all(roots.map(canonicalPath));
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return path;
+  }
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import { dirname } from "node:path";
 import { runExecCli } from "./exec-cli";
 import { runExtensionCli } from "./extension-cli";
 import type {
@@ -11,6 +12,8 @@ import {
   resolveCliExtensionTargets,
 } from "./extensions/manager/cli-extensions";
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
+import { extensionScopePaths } from "./extensions/manager/paths";
+import { beginCommonJsReloadTransaction } from "./extensions/manager/reload-module-graph";
 import { resolveCodingAgentThreadConfig } from "./thread-config";
 import {
   formatThreadInspectionReport,
@@ -163,32 +166,68 @@ async function runTuiCommand({
       return 1;
     }
   }
-  const reloadExtensions = async (): Promise<LoadedConfiguredExtensions> => {
+  const reloadExtensions = async (): Promise<
+    LoadedConfiguredExtensions & { rollbackModuleCache(): void }
+  > => {
     const cacheBust = Date.now().toString(36);
     const targets = await resolveCliExtensionTargets({
       cwd,
       paths: extensionPaths,
     });
     const targetIds = new Set(targets.map((target) => target.id));
-    const reloaded = await loadConfiguredCodingAgentExtensions({
-      cacheBust,
-      cwd,
-      ...(targetIds.size === 0 ? {} : { excludeIds: targetIds }),
-      home,
-    });
-    return {
-      extensions: mergeCliExtensions(
-        reloaded.extensions,
-        await importCliExtensions({ cacheBust, targets })
-      ),
-      notices: reloaded.notices,
-    };
+    // Evict extension-owned CommonJS modules so cache-busted imports
+    // re-execute helpers; the snapshot restores them if the reload fails.
+    const transaction = beginCommonJsReloadTransaction(
+      await reloadCacheRoots({ cwd, home, targets })
+    );
+    try {
+      const reloaded = await loadConfiguredCodingAgentExtensions({
+        cacheBust,
+        cwd,
+        ...(targetIds.size === 0 ? {} : { excludeIds: targetIds }),
+        home,
+      });
+      return {
+        extensions: mergeCliExtensions(
+          reloaded.extensions,
+          await importCliExtensions({ cacheBust, targets })
+        ),
+        notices: reloaded.notices,
+        rollbackModuleCache: () => transaction.rollback(),
+      };
+    } catch (error) {
+      transaction.rollback();
+      throw error;
+    }
   };
   return await (
     start ??
     ((loaded: readonly CodingAgentExtensionInput[]) =>
       startTui({ extensions: loaded, reloadExtensions }))
   )(extensions);
+}
+
+async function reloadCacheRoots({
+  cwd,
+  home,
+  targets,
+}: {
+  readonly cwd: string;
+  readonly home: string;
+  readonly targets: readonly { readonly path: string }[];
+}): Promise<readonly string[]> {
+  const roots = [
+    (await extensionScopePaths({ cwd, home, scope: "global" })).installRoot,
+    ...targets.map((target) => dirname(target.path)),
+  ];
+  try {
+    roots.push(
+      (await extensionScopePaths({ cwd, home, scope: "project" })).installRoot
+    );
+  } catch {
+    // Untrusted or malformed project layouts simply contribute no root.
+  }
+  return roots;
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/coding-agent/src/exec-cli.ts
+++ b/apps/coding-agent/src/exec-cli.ts
@@ -11,6 +11,10 @@ import {
 } from "./extensions/manager/cli-extensions";
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
 import { createOpenAICompatibleModelFromEnv } from "./model";
+import {
+  createProviderObservationFetch,
+  type ProviderObservationEmitter,
+} from "./provider-observation";
 import type { WebToolsAvailability } from "./tools";
 
 interface ExecArguments {
@@ -234,9 +238,16 @@ export async function runExecCli({
           configured.extensions,
           await importCliExtensions({ targets: cliTargets })
         );
+  const providerEmitter: ProviderObservationEmitter = {};
   const result = await runCodingAgentExec({
+    bindProviderObservation: (emit) => {
+      providerEmitter.current = emit;
+    },
     extensions,
-    model: createOpenAICompatibleModelFromEnv({ runtimeEnv }),
+    model: createOpenAICompatibleModelFromEnv({
+      fetch: createProviderObservationFetch(providerEmitter),
+      runtimeEnv,
+    }),
     prompt,
     ...(args.resultFile === undefined ? {} : { resultFile: args.resultFile }),
     stdout,

--- a/apps/coding-agent/src/exec.ts
+++ b/apps/coding-agent/src/exec.ts
@@ -7,7 +7,10 @@ import {
   isStreamAgentEvent,
 } from "@minpeter/pss-runtime";
 import { createCodingAgent } from "./coding-agent";
-import type { CodingAgentExtensionInput } from "./extensions";
+import type {
+  CodingAgentExtensionInput,
+  ExtensionJsonValue,
+} from "./extensions";
 import { createCodingAgentExtensionHost } from "./extensions";
 import type { WebToolsAvailability } from "./tools";
 
@@ -42,6 +45,10 @@ export interface CodingAgentExecResult {
 }
 
 export interface RunCodingAgentExecOptions {
+  /** Receives a host-bound emitter for provider observation bus events. */
+  readonly bindProviderObservation?: (
+    emit: (type: string, payload: ExtensionJsonValue) => void
+  ) => void;
   readonly extensions?: readonly CodingAgentExtensionInput[];
   readonly model: AgentOptions["model"];
   readonly prompt: string;
@@ -105,6 +112,7 @@ function recordEvent(
 }
 
 export async function runCodingAgentExec({
+  bindProviderObservation,
   extensions = [],
   model,
   prompt,
@@ -131,6 +139,9 @@ export async function runCodingAgentExec({
   };
   const absoluteWorkspace = resolve(workspace);
   const extensionHost = await createCodingAgentExtensionHost(extensions);
+  bindProviderObservation?.((type, payload) => {
+    extensionHost.emitHostEvent(type, payload);
+  });
   let agent: Awaited<ReturnType<typeof createCodingAgent>>;
   try {
     agent = await createCodingAgent({

--- a/apps/coding-agent/src/exec.ts
+++ b/apps/coding-agent/src/exec.ts
@@ -139,11 +139,11 @@ export async function runCodingAgentExec({
   };
   const absoluteWorkspace = resolve(workspace);
   const extensionHost = await createCodingAgentExtensionHost(extensions);
-  bindProviderObservation?.((type, payload) => {
-    extensionHost.emitHostEvent(type, payload);
-  });
   let agent: Awaited<ReturnType<typeof createCodingAgent>>;
   try {
+    bindProviderObservation?.((type, payload) => {
+      extensionHost.emitHostEvent(type, payload);
+    });
     agent = await createCodingAgent({
       extensionHost,
       model,

--- a/apps/coding-agent/src/extensions/event-bus.test.ts
+++ b/apps/coding-agent/src/extensions/event-bus.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CodingAgentExtensionError } from "./error";
+import { ExtensionHostEventBus } from "./event-bus";
+
+const reservedPattern = /reserved "provider:" namespace/u;
+const invalidTypePattern = /Invalid extension event type/u;
+const disposedPattern = /disposed/u;
+const handlerFunctionPattern = /must be a function/u;
+const payloadPattern = /payload/u;
+
+function createBus(options?: {
+  readonly onHandlerError?: (error: CodingAgentExtensionError) => void;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}): ExtensionHostEventBus {
+  return new ExtensionHostEventBus({
+    ...(options?.onHandlerError === undefined
+      ? {}
+      : { onHandlerError: options.onHandlerError }),
+    signal: options?.signal ?? new AbortController().signal,
+    timeoutMs: options?.timeoutMs ?? 50,
+  });
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, 0));
+}
+
+describe("extension host event bus", () => {
+  it("delivers cloned payloads to matching subscribers only", async () => {
+    // Given
+    const bus = createBus();
+    const received: unknown[] = [];
+    const other: unknown[] = [];
+    bus.subscribe("listener", "metrics:sample", (payload) => {
+      received.push(payload);
+    });
+    bus.subscribe("listener", "different", (payload) => {
+      other.push(payload);
+    });
+    const payload = { nested: { count: 1 } };
+
+    // When
+    bus.emitFromExtension("emitter", "metrics:sample", payload);
+    await settle();
+
+    // Then
+    expect(received).toEqual([{ nested: { count: 1 } }]);
+    expect(received[0]).not.toBe(payload);
+    expect(other).toEqual([]);
+  });
+
+  it("supports unsubscribe and dispose", async () => {
+    // Given
+    const bus = createBus();
+    const received: unknown[] = [];
+    const unsubscribe = bus.subscribe("listener", "topic", (payload) => {
+      received.push(payload);
+    });
+
+    // When
+    unsubscribe();
+    bus.emitFromExtension("emitter", "topic", 1);
+    await settle();
+    bus.dispose();
+
+    // Then
+    expect(received).toEqual([]);
+    expect(() => bus.subscribe("listener", "topic", () => undefined)).toThrow(
+      disposedPattern
+    );
+    expect(() => bus.emitFromExtension("emitter", "topic", 2)).not.toThrow();
+  });
+
+  it("rejects reserved namespaces for extensions but allows the host", async () => {
+    // Given
+    const bus = createBus();
+    const received: unknown[] = [];
+    bus.subscribe("listener", "provider:response", (payload) => {
+      received.push(payload);
+    });
+
+    // When / Then
+    expect(() =>
+      bus.emitFromExtension("emitter", "provider:response", { status: 200 })
+    ).toThrow(reservedPattern);
+    bus.emitFromHost("provider:response", { status: 200 });
+    await settle();
+    expect(received).toEqual([{ status: 200 }]);
+  });
+
+  it("rejects invalid event types and non-function handlers", () => {
+    // Given
+    const bus = createBus();
+
+    // When / Then
+    expect(() => bus.emitFromExtension("emitter", "", 1)).toThrow(
+      invalidTypePattern
+    );
+    expect(() => bus.emitFromExtension("emitter", "Bad Type", 1)).toThrow(
+      invalidTypePattern
+    );
+    expect(() =>
+      bus.subscribe(
+        "listener",
+        "topic",
+        "not-a-function" as unknown as () => void
+      )
+    ).toThrow(handlerFunctionPattern);
+  });
+
+  it("attributes handler failures without breaking other subscribers", async () => {
+    // Given
+    const failures: CodingAgentExtensionError[] = [];
+    const bus = createBus({ onHandlerError: (error) => failures.push(error) });
+    const received: unknown[] = [];
+    bus.subscribe("broken", "topic", () => {
+      throw new Error("handler exploded");
+    });
+    bus.subscribe("healthy", "topic", (payload) => {
+      received.push(payload);
+    });
+
+    // When
+    bus.emitFromExtension("emitter", "topic", "ping");
+    await settle();
+
+    // Then
+    expect(received).toEqual(["ping"]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.extensionId).toBe("broken");
+  });
+
+  it("times out never-settling handlers under the host budget", async () => {
+    // Given
+    vi.useFakeTimers();
+    try {
+      const failures: CodingAgentExtensionError[] = [];
+      const bus = createBus({
+        onHandlerError: (error) => failures.push(error),
+        timeoutMs: 20,
+      });
+      bus.subscribe("hang", "topic", () => new Promise<void>(() => undefined));
+
+      // When
+      bus.emitFromExtension("emitter", "topic", 1);
+      await vi.advanceTimersByTimeAsync(25);
+
+      // Then
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.extensionId).toBe("hang");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects non-JSON payloads", () => {
+    // Given
+    const bus = createBus();
+
+    // When / Then
+    expect(() =>
+      bus.emitFromExtension("emitter", "topic", {
+        fn: () => undefined,
+      } as never)
+    ).toThrow(payloadPattern);
+  });
+});

--- a/apps/coding-agent/src/extensions/event-bus.test.ts
+++ b/apps/coding-agent/src/extensions/event-bus.test.ts
@@ -42,9 +42,11 @@ describe("extension host event bus", () => {
 
     // When
     bus.emitFromExtension("emitter", "metrics:sample", payload);
+    const receivedSynchronously = received.length;
     await settle();
 
-    // Then
+    // Then — delivery is deferred so handlers cannot block the publisher.
+    expect(receivedSynchronously).toBe(0);
     expect(received).toEqual([{ nested: { count: 1 } }]);
     expect(received[0]).not.toBe(payload);
     expect(other).toEqual([]);

--- a/apps/coding-agent/src/extensions/event-bus.test.ts
+++ b/apps/coding-agent/src/extensions/event-bus.test.ts
@@ -52,6 +52,24 @@ describe("extension host event bus", () => {
     expect(other).toEqual([]);
   });
 
+  it("snapshots payloads at publication time", async () => {
+    // Given
+    const bus = createBus();
+    const received: unknown[] = [];
+    bus.subscribe("listener", "topic", (payload) => {
+      received.push(payload);
+    });
+    const payload = { count: 1 };
+
+    // When — the publisher mutates the payload right after emit().
+    bus.emitFromExtension("emitter", "topic", payload);
+    payload.count = 99;
+    await settle();
+
+    // Then
+    expect(received).toEqual([{ count: 1 }]);
+  });
+
   it("supports unsubscribe and dispose", async () => {
     // Given
     const bus = createBus();

--- a/apps/coding-agent/src/extensions/event-bus.ts
+++ b/apps/coding-agent/src/extensions/event-bus.ts
@@ -123,6 +123,15 @@ export class ExtensionHostEventBus {
       // Defer past the publisher so synchronous handler work cannot block
       // emit(); the timeout timer below is installed before this runs.
       await Promise.resolve();
+      // The host may have been disposed between emit() and this microtask;
+      // never run handlers against torn-down resources.
+      if (
+        this.#disposed ||
+        this.#signal.aborted ||
+        !this.#subscriptions.has(subscription)
+      ) {
+        return;
+      }
       await subscription.handler(
         payload === undefined ? undefined : structuredClone(payload)
       );

--- a/apps/coding-agent/src/extensions/event-bus.ts
+++ b/apps/coding-agent/src/extensions/event-bus.ts
@@ -120,6 +120,9 @@ export class ExtensionHostEventBus {
     payload: ExtensionJsonValue | undefined
   ): void {
     const task = (async () => {
+      // Defer past the publisher so synchronous handler work cannot block
+      // emit(); the timeout timer below is installed before this runs.
+      await Promise.resolve();
       await subscription.handler(
         payload === undefined ? undefined : structuredClone(payload)
       );

--- a/apps/coding-agent/src/extensions/event-bus.ts
+++ b/apps/coding-agent/src/extensions/event-bus.ts
@@ -107,11 +107,15 @@ export class ExtensionHostEventBus {
     if (payload !== undefined) {
       assertJsonValue(payload, `Extension event "${type}" payload`);
     }
+    // Snapshot at publication time so publisher mutations after emit() are
+    // never observed and cloning failures surface to the publisher.
+    const snapshot =
+      payload === undefined ? undefined : structuredClone(payload);
     for (const subscription of [...this.#subscriptions]) {
       if (subscription.type !== type) {
         continue;
       }
-      this.#deliver(subscription, payload);
+      this.#deliver(subscription, snapshot);
     }
   }
 

--- a/apps/coding-agent/src/extensions/event-bus.ts
+++ b/apps/coding-agent/src/extensions/event-bus.ts
@@ -28,6 +28,7 @@ interface BusSubscription {
  */
 export class ExtensionHostEventBus {
   #disposed = false;
+  readonly #inFlight = new Set<Promise<unknown>>();
   readonly #onHandlerError: (error: CodingAgentExtensionError) => void;
   readonly #signal: AbortSignal;
   readonly #subscriptions = new Set<BusSubscription>();
@@ -91,9 +92,16 @@ export class ExtensionHostEventBus {
     };
   }
 
-  dispose(): void {
+  /**
+   * Stop accepting publications and drain in-flight deliveries. Each
+   * delivery is bounded by the host timeout, so draining is bounded too;
+   * handlers that outlive their timeout are detached and their state
+   * writes are rejected by the post-disposal revocation.
+   */
+  async dispose(): Promise<void> {
     this.#disposed = true;
     this.#subscriptions.clear();
+    await Promise.allSettled([...this.#inFlight]);
   }
 
   #publish(
@@ -140,10 +148,15 @@ export class ExtensionHostEventBus {
         payload === undefined ? undefined : structuredClone(payload)
       );
     })();
-    raceWithExtensionTimeout(subscription.extensionId, "event", task, {
-      signal: this.#signal,
-      timeoutMs: this.#timeoutMs,
-    }).catch((error: unknown) => {
+    const delivery = raceWithExtensionTimeout(
+      subscription.extensionId,
+      "event",
+      task,
+      {
+        signal: this.#signal,
+        timeoutMs: this.#timeoutMs,
+      }
+    ).catch((error: unknown) => {
       this.#onHandlerError(
         error instanceof CodingAgentExtensionError
           ? error
@@ -153,6 +166,10 @@ export class ExtensionHostEventBus {
               error
             )
       );
+    });
+    this.#inFlight.add(delivery);
+    delivery.finally(() => {
+      this.#inFlight.delete(delivery);
     });
   }
 }

--- a/apps/coding-agent/src/extensions/event-bus.ts
+++ b/apps/coding-agent/src/extensions/event-bus.ts
@@ -1,0 +1,155 @@
+import { CodingAgentExtensionError } from "./error";
+import { assertJsonValue } from "./json-state";
+import { raceWithExtensionTimeout } from "./operation-timeout";
+import type { ExtensionJsonValue } from "./types";
+
+const EVENT_TYPE_PATTERN = /^[a-z0-9][a-z0-9:._-]*$/;
+const MAX_EVENT_TYPE_LENGTH = 128;
+/** Event namespaces only the host may publish. */
+const HOST_EVENT_PREFIXES = ["host:", "provider:"] as const;
+
+export type ExtensionBusHandler = (
+  payload: ExtensionJsonValue | undefined
+) => Promise<void> | void;
+
+interface BusSubscription {
+  readonly extensionId: string;
+  readonly handler: ExtensionBusHandler;
+  readonly type: string;
+}
+
+/**
+ * Shared publish/subscribe bus for one extension host.
+ *
+ * Payloads are JSON values cloned per delivery so subscribers cannot mutate
+ * shared state. Handlers run under the host timeout/abort boundary; failures
+ * are attributed to the subscribing extension and reported without
+ * interrupting other subscribers or the publisher.
+ */
+export class ExtensionHostEventBus {
+  #disposed = false;
+  readonly #onHandlerError: (error: CodingAgentExtensionError) => void;
+  readonly #signal: AbortSignal;
+  readonly #subscriptions = new Set<BusSubscription>();
+  readonly #timeoutMs: number;
+
+  constructor(options: {
+    readonly onHandlerError?: (error: CodingAgentExtensionError) => void;
+    readonly signal: AbortSignal;
+    readonly timeoutMs: number;
+  }) {
+    this.#onHandlerError =
+      options.onHandlerError ??
+      ((error) => {
+        process.stderr.write(`${error.message}\n`);
+      });
+    this.#signal = options.signal;
+    this.#timeoutMs = options.timeoutMs;
+  }
+
+  /** Publish from an extension; host-reserved namespaces are rejected. */
+  emitFromExtension(
+    extensionId: string,
+    type: string,
+    payload: ExtensionJsonValue | undefined
+  ): void {
+    assertEventType(type);
+    for (const prefix of HOST_EVENT_PREFIXES) {
+      if (type.startsWith(prefix)) {
+        throw new TypeError(
+          `Extension event type "${type}" uses the reserved "${prefix}" namespace`
+        );
+      }
+    }
+    this.#publish(`extension:${extensionId}`, type, payload);
+  }
+
+  /** Publish a host-originated event such as provider observations. */
+  emitFromHost(type: string, payload: ExtensionJsonValue | undefined): void {
+    assertEventType(type);
+    this.#publish("host", type, payload);
+  }
+
+  subscribe(
+    extensionId: string,
+    type: string,
+    handler: ExtensionBusHandler
+  ): () => void {
+    if (this.#disposed) {
+      throw new Error("Coding agent extension host is disposed");
+    }
+    assertEventType(type);
+    if (typeof handler !== "function") {
+      throw new TypeError(
+        `Extension event handler for "${type}" must be a function`
+      );
+    }
+    const subscription: BusSubscription = { extensionId, handler, type };
+    this.#subscriptions.add(subscription);
+    return () => {
+      this.#subscriptions.delete(subscription);
+    };
+  }
+
+  dispose(): void {
+    this.#disposed = true;
+    this.#subscriptions.clear();
+  }
+
+  #publish(
+    _source: string,
+    type: string,
+    payload: ExtensionJsonValue | undefined
+  ): void {
+    if (this.#disposed || this.#signal.aborted) {
+      return;
+    }
+    if (payload !== undefined) {
+      assertJsonValue(payload, `Extension event "${type}" payload`);
+    }
+    for (const subscription of [...this.#subscriptions]) {
+      if (subscription.type !== type) {
+        continue;
+      }
+      this.#deliver(subscription, payload);
+    }
+  }
+
+  #deliver(
+    subscription: BusSubscription,
+    payload: ExtensionJsonValue | undefined
+  ): void {
+    const task = (async () => {
+      await subscription.handler(
+        payload === undefined ? undefined : structuredClone(payload)
+      );
+    })();
+    raceWithExtensionTimeout(subscription.extensionId, "event", task, {
+      signal: this.#signal,
+      timeoutMs: this.#timeoutMs,
+    }).catch((error: unknown) => {
+      this.#onHandlerError(
+        error instanceof CodingAgentExtensionError
+          ? error
+          : new CodingAgentExtensionError(
+              subscription.extensionId,
+              "event",
+              error
+            )
+      );
+    });
+  }
+}
+
+function assertEventType(type: string): void {
+  if (
+    typeof type !== "string" ||
+    type.length === 0 ||
+    type.length > MAX_EVENT_TYPE_LENGTH ||
+    !EVENT_TYPE_PATTERN.test(type)
+  ) {
+    throw new TypeError(
+      `Invalid extension event type "${String(type)}": use lowercase letters, digits, ":", ".", "_", or "-"`
+    );
+  }
+}

--- a/apps/coding-agent/src/extensions/events-bus-wiring.test.ts
+++ b/apps/coding-agent/src/extensions/events-bus-wiring.test.ts
@@ -1,0 +1,104 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { createAgent } from "@minpeter/pss-runtime";
+import { describe, expect, it } from "vitest";
+import { createCodingAgentExtensionHost } from "./host";
+import type { CodingAgentExtensionModule, ExtensionJsonValue } from "./types";
+
+async function createTestAgent() {
+  const provider = createOpenAICompatible({
+    apiKey: "test",
+    baseURL: "https://example.com/v1",
+    name: "test",
+  });
+  return await createAgent({ model: provider("model") });
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, 0));
+}
+
+describe("extension services event bus wiring", () => {
+  it("routes extension-emitted events between extensions", async () => {
+    // Given
+    const received: (ExtensionJsonValue | undefined)[] = [];
+    const listener: CodingAgentExtensionModule = {
+      default(pss) {
+        pss.on("activate", ({ services }) => {
+          const unsubscribe = services.events.on(
+            "checkpoint:saved",
+            (payload) => {
+              received.push(payload);
+            }
+          );
+          return () => {
+            unsubscribe();
+          };
+        });
+      },
+      id: "listener",
+    };
+    const emitter: CodingAgentExtensionModule = {
+      default(pss) {
+        pss.on("activate", ({ services }) => {
+          services.events.emit("checkpoint:saved", { revision: 7 });
+          return;
+        });
+      },
+      id: "emitter",
+    };
+
+    // When
+    const host = await createCodingAgentExtensionHost([listener, emitter]);
+    const agent = await createTestAgent();
+    try {
+      await host.activate(agent, "exec");
+      await settle();
+    } finally {
+      await host.dispose();
+      await agent.dispose();
+    }
+
+    // Then
+    expect(received).toEqual([{ revision: 7 }]);
+  });
+
+  it("delivers host provider observations while blocking extension spoofing", async () => {
+    // Given
+    const received: (ExtensionJsonValue | undefined)[] = [];
+    let spoofError: unknown;
+    const observer: CodingAgentExtensionModule = {
+      default(pss) {
+        pss.on("activate", ({ services }) => {
+          services.events.on("provider:response", (payload) => {
+            received.push(payload);
+          });
+          try {
+            services.events.emit("provider:response", { status: 500 });
+          } catch (error) {
+            spoofError = error;
+          }
+          return;
+        });
+      },
+      id: "observer",
+    };
+
+    // When
+    const host = await createCodingAgentExtensionHost([observer]);
+    const agent = await createTestAgent();
+    try {
+      await host.activate(agent, "exec");
+      host.emitHostEvent("provider:response", { status: 200 });
+      await settle();
+    } finally {
+      await host.dispose();
+      await agent.dispose();
+    }
+    host.emitHostEvent("provider:response", { status: 201 });
+    await settle();
+
+    // Then
+    expect(received).toEqual([{ status: 200 }]);
+    expect(spoofError).toBeInstanceOf(TypeError);
+  });
+});

--- a/apps/coding-agent/src/extensions/host-lifecycle.ts
+++ b/apps/coding-agent/src/extensions/host-lifecycle.ts
@@ -50,6 +50,15 @@ export class ExtensionHostLifecycle {
     this.#services = new ExtensionHostServices(options, this.#bus);
   }
 
+  /**
+   * Reject further extension state writes. Called when disposal was
+   * detached by a timeout so late cleanup cannot overwrite state that a
+   * replacement runtime now owns.
+   */
+  revokeExtensionState(): void {
+    this.#services.revokeStateWrites();
+  }
+
   /** Publish a host-originated bus event such as a provider observation. */
   emitHostEvent(type: string, payload?: ExtensionJsonValue): void {
     if (this.#disposed) {

--- a/apps/coding-agent/src/extensions/host-lifecycle.ts
+++ b/apps/coding-agent/src/extensions/host-lifecycle.ts
@@ -206,8 +206,11 @@ export class ExtensionHostLifecycle {
       return;
     }
     this.#disposed = true;
+    // Drain in-flight bus deliveries (bounded by the host timeout) before
+    // aborting and running cleanups so handlers finish against live
+    // services instead of resuming mid-teardown.
+    await this.#bus.dispose();
     this.#controller.abort();
-    this.#bus.dispose();
     const failures: unknown[] = [];
     for (const { cleanup, id } of this.#cleanups.reverse()) {
       try {

--- a/apps/coding-agent/src/extensions/host-lifecycle.ts
+++ b/apps/coding-agent/src/extensions/host-lifecycle.ts
@@ -1,6 +1,7 @@
 import type { Agent } from "@minpeter/pss-runtime";
 import type { TuiCommandContext } from "../tui/command";
 import { CodingAgentExtensionError } from "./error";
+import { ExtensionHostEventBus } from "./event-bus";
 import { runExtensionOperation } from "./host-operation";
 import { ExtensionHostServices } from "./host-services";
 import { DEFAULT_EXTENSION_TIMEOUT_MS } from "./host-validation";
@@ -18,11 +19,13 @@ import type {
   CodingAgentExtensionMode,
   CodingAgentExtensionServices,
   CodingAgentExtensionUi,
+  ExtensionJsonValue,
 } from "./types";
 
 export class ExtensionHostLifecycle {
   #activated = false;
   #agent: Agent | undefined;
+  readonly #bus: ExtensionHostEventBus;
   #cleanups: { cleanup: CodingAgentExtensionCleanup; id: string }[] = [];
   readonly #collections: ExtensionRegistryCollections;
   readonly #controller = new AbortController();
@@ -39,8 +42,20 @@ export class ExtensionHostLifecycle {
   ) {
     this.#collections = collections;
     this.#extensions = extensions;
-    this.#services = new ExtensionHostServices(options);
     this.#timeoutMs = options.timeoutMs ?? DEFAULT_EXTENSION_TIMEOUT_MS;
+    this.#bus = new ExtensionHostEventBus({
+      signal: this.#controller.signal,
+      timeoutMs: this.#timeoutMs,
+    });
+    this.#services = new ExtensionHostServices(options, this.#bus);
+  }
+
+  /** Publish a host-originated bus event such as a provider observation. */
+  emitHostEvent(type: string, payload?: ExtensionJsonValue): void {
+    if (this.#disposed) {
+      return;
+    }
+    this.#bus.emitFromHost(type, payload);
   }
 
   get signal(): AbortSignal {
@@ -183,6 +198,7 @@ export class ExtensionHostLifecycle {
     }
     this.#disposed = true;
     this.#controller.abort();
+    this.#bus.dispose();
     const failures: unknown[] = [];
     for (const { cleanup, id } of this.#cleanups.reverse()) {
       try {

--- a/apps/coding-agent/src/extensions/host-lifecycle.ts
+++ b/apps/coding-agent/src/extensions/host-lifecycle.ts
@@ -51,12 +51,13 @@ export class ExtensionHostLifecycle {
   }
 
   /**
-   * Reject further extension state writes. Called when disposal was
-   * detached by a timeout so late cleanup cannot overwrite state that a
-   * replacement runtime now owns.
+   * Reject further extension state writes and release detached interactive
+   * UI work. Called when disposal was detached by a timeout so late cleanup
+   * cannot overwrite state or steal focus from a replacement runtime.
    */
   revokeExtensionState(): void {
     this.#services.revokeStateWrites();
+    this.#services.revokeInteractiveUi();
   }
 
   /** Publish a host-originated bus event such as a provider observation. */

--- a/apps/coding-agent/src/extensions/host-lifecycle.ts
+++ b/apps/coding-agent/src/extensions/host-lifecycle.ts
@@ -51,13 +51,14 @@ export class ExtensionHostLifecycle {
   }
 
   /**
-   * Reject further extension state writes and release detached interactive
-   * UI work. Called when disposal was detached by a timeout so late cleanup
-   * cannot overwrite state or steal focus from a replacement runtime.
+   * Reject further extension state writes (draining already-admitted
+   * writes) and release detached interactive UI work. Called when disposal
+   * was detached by a timeout so late cleanup cannot overwrite state or
+   * steal focus from a replacement runtime.
    */
-  revokeExtensionState(): void {
-    this.#services.revokeStateWrites();
+  async revokeExtensionState(): Promise<void> {
     this.#services.revokeInteractiveUi();
+    await this.#services.revokeStateWrites();
   }
 
   /** Publish a host-originated bus event such as a provider observation. */

--- a/apps/coding-agent/src/extensions/host-services.ts
+++ b/apps/coding-agent/src/extensions/host-services.ts
@@ -105,6 +105,13 @@ export class ExtensionHostServices {
     ).services;
   }
 
+  /** Reject further extension state writes across every service scope. */
+  revokeStateWrites(): void {
+    for (const scope of this.#scopes.values()) {
+      scope.revokeStateWrites();
+    }
+  }
+
   async dispose(): Promise<readonly unknown[]> {
     const failures: unknown[] = [];
     const scopes = [...this.#scopes.entries()].reverse();

--- a/apps/coding-agent/src/extensions/host-services.ts
+++ b/apps/coding-agent/src/extensions/host-services.ts
@@ -1,6 +1,7 @@
 import type { Agent } from "@minpeter/pss-runtime";
 import type { TuiCommandContext } from "../tui/command";
 import { CodingAgentExtensionError } from "./error";
+import type { ExtensionHostEventBus } from "./event-bus";
 import {
   createExtensionServiceScope,
   type ExtensionServiceScope,
@@ -27,6 +28,7 @@ interface ExtensionCommandContext {
 }
 
 export class ExtensionHostServices {
+  readonly #bus: ExtensionHostEventBus;
   readonly #config: CodingAgentExtensionHostOptions["config"];
   readonly #dataRoot: string | undefined;
   readonly #interactiveUiRequests = new Map<string, number>();
@@ -35,7 +37,11 @@ export class ExtensionHostServices {
   #ui: CodingAgentExtensionUi | undefined;
   #workspace: string | undefined;
 
-  constructor(options: CodingAgentExtensionHostOptions) {
+  constructor(
+    options: CodingAgentExtensionHostOptions,
+    bus: ExtensionHostEventBus
+  ) {
+    this.#bus = bus;
     this.#config = options.config;
     this.#dataRoot = options.dataRoot;
     this.#model = options.model;
@@ -140,6 +146,16 @@ export class ExtensionHostServices {
     const scope = createExtensionServiceScope({
       config: this.#config?.[extensionId],
       ...(this.#dataRoot === undefined ? {} : { dataRoot: this.#dataRoot }),
+      events: Object.freeze({
+        emit: (
+          type: string,
+          payload?: Parameters<ExtensionHostEventBus["emitFromExtension"]>[2]
+        ) => this.#bus.emitFromExtension(extensionId, type, payload),
+        on: (
+          type: string,
+          handler: Parameters<ExtensionHostEventBus["subscribe"]>[2]
+        ) => this.#bus.subscribe(extensionId, type, handler),
+      }),
       extensionId,
       mode: options.mode,
       model: this.#model,

--- a/apps/coding-agent/src/extensions/host-services.ts
+++ b/apps/coding-agent/src/extensions/host-services.ts
@@ -35,6 +35,7 @@ export class ExtensionHostServices {
   #model: CodingAgentExtensionHostOptions["model"];
   readonly #scopes = new Map<string, ExtensionServiceScope>();
   #ui: CodingAgentExtensionUi | undefined;
+  readonly #uiRevokedController = new AbortController();
   #workspace: string | undefined;
 
   constructor(
@@ -112,6 +113,15 @@ export class ExtensionHostServices {
     }
   }
 
+  /**
+   * Release detached interactive UI work: pending prompts resolve to their
+   * cancelled value and new prompts are rejected, so cleanup that outlived
+   * its timeout cannot keep stealing focus from a replacement runtime.
+   */
+  revokeInteractiveUi(): void {
+    this.#uiRevokedController.abort();
+  }
+
   async dispose(): Promise<readonly unknown[]> {
     const failures: unknown[] = [];
     const scopes = [...this.#scopes.entries()].reverse();
@@ -185,11 +195,43 @@ export class ExtensionHostServices {
       confirm: async (
         message: Parameters<CodingAgentExtensionUi["confirm"]>[0]
       ) =>
-        await this.#withInteractiveUi(extensionId, () => ui.confirm(message)),
+        await this.#withInteractiveUi(extensionId, () =>
+          this.#raceUiRevocation(() => ui.confirm(message), false)
+        ),
       input: async (input: Parameters<CodingAgentExtensionUi["input"]>[0]) =>
-        await this.#withInteractiveUi(extensionId, () => ui.input(input)),
+        await this.#withInteractiveUi(extensionId, () =>
+          this.#raceUiRevocation(() => ui.input(input), undefined)
+        ),
       select: async (input: Parameters<CodingAgentExtensionUi["select"]>[0]) =>
-        await this.#withInteractiveUi(extensionId, () => ui.select(input)),
+        await this.#withInteractiveUi(extensionId, () =>
+          this.#raceUiRevocation(() => ui.select(input), undefined)
+        ),
+    });
+  }
+
+  #raceUiRevocation<Value>(
+    operation: () => Promise<Value>,
+    revokedValue: Value
+  ): Promise<Value> {
+    const signal = this.#uiRevokedController.signal;
+    if (signal.aborted) {
+      return Promise.resolve(revokedValue);
+    }
+    return new Promise<Value>((resolvePromise, rejectPromise) => {
+      const onRevoke = () => resolvePromise(revokedValue);
+      signal.addEventListener("abort", onRevoke, { once: true });
+      operation().then(
+        (value) => {
+          signal.removeEventListener("abort", onRevoke);
+          resolvePromise(value);
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", onRevoke);
+          rejectPromise(
+            error instanceof Error ? error : new Error(String(error))
+          );
+        }
+      );
     });
   }
 }

--- a/apps/coding-agent/src/extensions/host-services.ts
+++ b/apps/coding-agent/src/extensions/host-services.ts
@@ -34,6 +34,7 @@ export class ExtensionHostServices {
   readonly #interactiveUiRequests = new Map<string, number>();
   #model: CodingAgentExtensionHostOptions["model"];
   readonly #scopes = new Map<string, ExtensionServiceScope>();
+  readonly #statusDisposers = new Set<() => void>();
   #ui: CodingAgentExtensionUi | undefined;
   readonly #uiRevokedController = new AbortController();
   #workspace: string | undefined;
@@ -120,6 +121,14 @@ export class ExtensionHostServices {
    */
   revokeInteractiveUi(): void {
     this.#uiRevokedController.abort();
+    for (const dispose of [...this.#statusDisposers]) {
+      try {
+        dispose();
+      } catch {
+        // Clearing a stale status must never fail revocation.
+      }
+    }
+    this.#statusDisposers.clear();
   }
 
   async dispose(): Promise<readonly unknown[]> {
@@ -202,10 +211,27 @@ export class ExtensionHostServices {
         await this.#withInteractiveUi(extensionId, () =>
           this.#raceUiRevocation(() => ui.input(input), undefined)
         ),
+      notify: (message: string) => {
+        if (!this.#uiRevokedController.signal.aborted) {
+          ui.notify(message);
+        }
+      },
       select: async (input: Parameters<CodingAgentExtensionUi["select"]>[0]) =>
         await this.#withInteractiveUi(extensionId, () =>
           this.#raceUiRevocation(() => ui.select(input), undefined)
         ),
+      status: (message: string) => {
+        if (this.#uiRevokedController.signal.aborted) {
+          return () => undefined;
+        }
+        const dispose = ui.status(message);
+        const tracked = () => {
+          this.#statusDisposers.delete(tracked);
+          dispose();
+        };
+        this.#statusDisposers.add(tracked);
+        return tracked;
+      },
     });
   }
 

--- a/apps/coding-agent/src/extensions/host-services.ts
+++ b/apps/coding-agent/src/extensions/host-services.ts
@@ -107,11 +107,14 @@ export class ExtensionHostServices {
     ).services;
   }
 
-  /** Reject further extension state writes across every service scope. */
-  revokeStateWrites(): void {
-    for (const scope of this.#scopes.values()) {
-      scope.revokeStateWrites();
-    }
+  /**
+   * Reject further extension state writes across every service scope and
+   * drain writes already admitted, so none can land after this resolves.
+   */
+  async revokeStateWrites(): Promise<void> {
+    await Promise.allSettled(
+      [...this.#scopes.values()].map((scope) => scope.revokeStateWrites())
+    );
   }
 
   /**
@@ -225,7 +228,14 @@ export class ExtensionHostServices {
           return () => undefined;
         }
         const dispose = ui.status(message);
+        // Idempotent so a disposer retained by detached cleanup cannot
+        // clear a status the replacement runtime published later.
+        let disposed = false;
         const tracked = () => {
+          if (disposed) {
+            return;
+          }
+          disposed = true;
           this.#statusDisposers.delete(tracked);
           dispose();
         };

--- a/apps/coding-agent/src/extensions/host.ts
+++ b/apps/coding-agent/src/extensions/host.ts
@@ -161,6 +161,14 @@ export class CodingAgentExtensionHost {
     this.#lifecycle.emitHostEvent(type, payload);
   }
 
+  /**
+   * Reject further extension state writes, e.g. after this host's disposal
+   * was detached by a reload timeout and a replacement now owns the state.
+   */
+  revokeExtensionState(): void {
+    this.#lifecycle.revokeExtensionState();
+  }
+
   getToolOwner(name: string): string | undefined {
     return this.#collections.owners.tools.get(name);
   }

--- a/apps/coding-agent/src/extensions/host.ts
+++ b/apps/coding-agent/src/extensions/host.ts
@@ -162,8 +162,9 @@ export class CodingAgentExtensionHost {
   }
 
   /**
-   * Reject further extension state writes, e.g. after this host's disposal
-   * was detached by a reload timeout and a replacement now owns the state.
+   * Reject further extension state writes and release detached interactive
+   * UI work, e.g. after this host's disposal was detached by a reload
+   * timeout and a replacement now owns the state and the terminal.
    */
   revokeExtensionState(): void {
     this.#lifecycle.revokeExtensionState();

--- a/apps/coding-agent/src/extensions/host.ts
+++ b/apps/coding-agent/src/extensions/host.ts
@@ -22,6 +22,7 @@ import type {
   CodingAgentExtensionInput,
   CodingAgentExtensionMode,
   CodingAgentExtensionUi,
+  ExtensionJsonValue,
 } from "./types";
 
 export class CodingAgentExtensionHost {
@@ -149,6 +150,15 @@ export class CodingAgentExtensionHost {
 
   bindUi(ui: CodingAgentExtensionUi): void {
     this.#lifecycle.bindUi(ui);
+  }
+
+  /**
+   * Publish a host-originated bus event (for example `provider:response`).
+   * Extensions subscribe via `services.events.on(...)`; they cannot publish
+   * into host-reserved namespaces themselves.
+   */
+  emitHostEvent(type: string, payload?: ExtensionJsonValue): void {
+    this.#lifecycle.emitHostEvent(type, payload);
   }
 
   getToolOwner(name: string): string | undefined {

--- a/apps/coding-agent/src/extensions/host.ts
+++ b/apps/coding-agent/src/extensions/host.ts
@@ -162,12 +162,13 @@ export class CodingAgentExtensionHost {
   }
 
   /**
-   * Reject further extension state writes and release detached interactive
-   * UI work, e.g. after this host's disposal was detached by a reload
-   * timeout and a replacement now owns the state and the terminal.
+   * Reject further extension state writes (draining already-admitted
+   * writes) and release detached interactive UI work, e.g. after this
+   * host's disposal was detached by a reload timeout and a replacement now
+   * owns the state and the terminal.
    */
-  revokeExtensionState(): void {
-    this.#lifecycle.revokeExtensionState();
+  async revokeExtensionState(): Promise<void> {
+    await this.#lifecycle.revokeExtensionState();
   }
 
   getToolOwner(name: string): string | undefined {

--- a/apps/coding-agent/src/extensions/index.ts
+++ b/apps/coding-agent/src/extensions/index.ts
@@ -54,6 +54,7 @@ export {
   type CodingAgentExtensionCleanup,
   type CodingAgentExtensionEventContext,
   type CodingAgentExtensionEventHandler,
+  type CodingAgentExtensionEvents,
   type CodingAgentExtensionExec,
   type CodingAgentExtensionExecResult,
   type CodingAgentExtensionFactory,

--- a/apps/coding-agent/src/extensions/json-state.ts
+++ b/apps/coding-agent/src/extensions/json-state.ts
@@ -13,6 +13,12 @@ import type { CodingAgentExtensionState, ExtensionJsonValue } from "./types";
 export function createExtensionJsonState(options: {
   readonly extensionId: string;
   readonly root: string;
+  /**
+   * When aborted (host disposal or a runtime swap), writes are rejected so
+   * detached cleanup from a previous runtime cannot overwrite state that a
+   * replacement runtime now owns.
+   */
+  readonly signal?: AbortSignal;
 }): CodingAgentExtensionState {
   const path = join(
     options.root,
@@ -27,23 +33,34 @@ export function createExtensionJsonState(options: {
     );
     return result;
   };
+  const assertWritable = (): void => {
+    if (options.signal?.aborted) {
+      throw new Error(
+        `Extension "${options.extensionId}" state is read-only after its runtime was disposed`
+      );
+    }
+  };
 
   const state: CodingAgentExtensionState = {
     clear: () =>
       enqueue(async () => {
+        assertWritable();
         await assertNotSymbolicLink(path);
         await rm(path, { force: true });
       }),
     get: () => enqueue(() => readState(path)),
     set: (value: ExtensionJsonValue) =>
       enqueue(async () => {
+        assertWritable();
         assertJsonValue(value, "Extension state");
         await writeState(path, value);
       }),
     update: (updater: Parameters<CodingAgentExtensionState["update"]>[0]) =>
       enqueue(async () => {
+        assertWritable();
         const next = await updater(await readState(path));
         assertJsonValue(next, "Extension state");
+        assertWritable();
         await writeState(path, next);
         return next;
       }),

--- a/apps/coding-agent/src/extensions/json-state.ts
+++ b/apps/coding-agent/src/extensions/json-state.ts
@@ -14,11 +14,12 @@ export function createExtensionJsonState(options: {
   readonly extensionId: string;
   readonly root: string;
   /**
-   * When aborted (host disposal or a runtime swap), writes are rejected so
-   * detached cleanup from a previous runtime cannot overwrite state that a
-   * replacement runtime now owns.
+   * Reports whether writes are revoked. Revocation happens after all
+   * registered cleanups ran (or were detached by a timeout), so ordinary
+   * cleanup can persist final state while detached post-disposal work
+   * cannot overwrite state that a replacement runtime now owns.
    */
-  readonly signal?: AbortSignal;
+  readonly isRevoked?: () => boolean;
 }): CodingAgentExtensionState {
   const path = join(
     options.root,
@@ -34,7 +35,7 @@ export function createExtensionJsonState(options: {
     return result;
   };
   const assertWritable = (): void => {
-    if (options.signal?.aborted) {
+    if (options.isRevoked?.()) {
       throw new Error(
         `Extension "${options.extensionId}" state is read-only after its runtime was disposed`
       );

--- a/apps/coding-agent/src/extensions/manager/cli-extensions.ts
+++ b/apps/coding-agent/src/extensions/manager/cli-extensions.ts
@@ -54,15 +54,23 @@ export async function resolveCliExtensionTargets({
 export async function importCliExtensions({
   cacheBust,
   importer,
+  signal,
   targets,
 }: {
   /** Import-cache buster used by `/reload` to re-import changed modules. */
   readonly cacheBust?: string;
   readonly importer?: ImportExtensionModule;
+  /** Aborting stops importing further modules, e.g. after a reload timeout. */
+  readonly signal?: AbortSignal;
   readonly targets: readonly ResolvedCliExtension[];
 }): Promise<readonly CodingAgentExtensionInput[]> {
   const extensions: CodingAgentExtensionInput[] = [];
   for (const target of targets) {
+    if (signal?.aborted) {
+      throw new Error(
+        "Extension loading was cancelled; no further modules were imported"
+      );
+    }
     extensions.push(
       await loadExtensionTarget({
         ...(cacheBust === undefined ? {} : { cacheBust }),

--- a/apps/coding-agent/src/extensions/manager/cli-extensions.ts
+++ b/apps/coding-agent/src/extensions/manager/cli-extensions.ts
@@ -52,9 +52,12 @@ export async function resolveCliExtensionTargets({
  * gating and take precedence over configured extensions with the same id.
  */
 export async function importCliExtensions({
+  cacheBust,
   importer,
   targets,
 }: {
+  /** Import-cache buster used by `/reload` to re-import changed modules. */
+  readonly cacheBust?: string;
   readonly importer?: ImportExtensionModule;
   readonly targets: readonly ResolvedCliExtension[];
 }): Promise<readonly CodingAgentExtensionInput[]> {
@@ -62,6 +65,7 @@ export async function importCliExtensions({
   for (const target of targets) {
     extensions.push(
       await loadExtensionTarget({
+        ...(cacheBust === undefined ? {} : { cacheBust }),
         id: target.id,
         ...(importer === undefined ? {} : { importer }),
         installRoot: dirname(target.path),

--- a/apps/coding-agent/src/extensions/manager/loader.ts
+++ b/apps/coding-agent/src/extensions/manager/loader.ts
@@ -28,6 +28,7 @@ export async function loadConfiguredCodingAgentExtensions({
   excludeIds,
   home,
   importer,
+  signal,
 }: {
   /** Import-cache buster used by `/reload` to re-import changed modules. */
   readonly cacheBust?: string;
@@ -36,6 +37,8 @@ export async function loadConfiguredCodingAgentExtensions({
   readonly excludeIds?: ReadonlySet<string>;
   readonly home: string;
   readonly importer?: ImportExtensionModule;
+  /** Aborting stops importing further modules, e.g. after a reload timeout. */
+  readonly signal?: AbortSignal;
 }): Promise<LoadedConfiguredExtensions> {
   const [globalPaths, trustedProjects, project] = await Promise.all([
     extensionScopePaths({ cwd, home, scope: "global" }),
@@ -88,9 +91,11 @@ export async function loadConfiguredCodingAgentExtensions({
   const shared: {
     readonly cacheBust?: string;
     readonly importer?: ImportExtensionModule;
+    readonly signal?: AbortSignal;
   } = {
     ...(cacheBust === undefined ? {} : { cacheBust }),
     ...(importer === undefined ? {} : { importer }),
+    ...(signal === undefined ? {} : { signal }),
   };
   const globalExtensions = await loadEnabledExtensions({
     ...shared,
@@ -146,6 +151,7 @@ async function loadLocalExtensions(options: {
   readonly importer?: ImportExtensionModule;
   readonly managedIds: ReadonlySet<string>;
   readonly projectInstallRoot?: string | undefined;
+  readonly signal?: AbortSignal;
 }): Promise<{
   readonly globalExtensions: readonly CodingAgentExtensionInput[];
   readonly notices: readonly string[];
@@ -186,11 +192,13 @@ async function loadLocalExtensions(options: {
   const shared: {
     readonly cacheBust?: string;
     readonly importer?: ImportExtensionModule;
+    readonly signal?: AbortSignal;
   } = {
     ...(options.cacheBust === undefined
       ? {}
       : { cacheBust: options.cacheBust }),
     ...(options.importer === undefined ? {} : { importer: options.importer }),
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
   };
   return {
     globalExtensions: await loadLocalCandidates({
@@ -208,6 +216,14 @@ async function loadLocalExtensions(options: {
             installRoot: options.projectInstallRoot,
           }),
   };
+}
+
+function assertLoadNotCancelled(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new Error(
+      "Extension loading was cancelled; no further modules were imported"
+    );
+  }
 }
 
 function selectLocalCandidates(
@@ -231,9 +247,11 @@ async function loadLocalCandidates(options: {
   readonly candidates: readonly LocalExtensionCandidate[];
   readonly importer?: ImportExtensionModule;
   readonly installRoot: string;
+  readonly signal?: AbortSignal;
 }): Promise<readonly CodingAgentExtensionInput[]> {
   const extensions: CodingAgentExtensionInput[] = [];
   for (const candidate of options.candidates) {
+    assertLoadNotCancelled(options.signal);
     extensions.push(
       await loadExtensionTarget({
         ...(options.cacheBust === undefined
@@ -256,9 +274,11 @@ async function loadEnabledExtensions(options: {
   readonly entries: readonly ExtensionSettingsEntry[];
   readonly importer?: ImportExtensionModule;
   readonly installRoot: string;
+  readonly signal?: AbortSignal;
 }): Promise<readonly CodingAgentExtensionInput[]> {
   const extensions: CodingAgentExtensionInput[] = [];
   for (const entry of options.entries) {
+    assertLoadNotCancelled(options.signal);
     if (!entry.enabled) {
       continue;
     }

--- a/apps/coding-agent/src/extensions/manager/loader.ts
+++ b/apps/coding-agent/src/extensions/manager/loader.ts
@@ -23,11 +23,14 @@ import type {
 } from "./types";
 
 export async function loadConfiguredCodingAgentExtensions({
+  cacheBust,
   cwd,
   excludeIds,
   home,
   importer,
 }: {
+  /** Import-cache buster used by `/reload` to re-import changed modules. */
+  readonly cacheBust?: string;
   readonly cwd: string;
   /** IDs supplied via `-e`; matching configured modules are never imported. */
   readonly excludeIds?: ReadonlySet<string>;
@@ -82,27 +85,34 @@ export async function loadConfiguredCodingAgentExtensions({
       .map((entry) => entry.id) ?? []
   );
   const skippedIds = excludeIds ?? new Set<string>();
+  const shared: {
+    readonly cacheBust?: string;
+    readonly importer?: ImportExtensionModule;
+  } = {
+    ...(cacheBust === undefined ? {} : { cacheBust }),
+    ...(importer === undefined ? {} : { importer }),
+  };
   const globalExtensions = await loadEnabledExtensions({
+    ...shared,
     entries: globalSettings.extensions.filter(
       (entry) => !(enabledProjectIds.has(entry.id) || skippedIds.has(entry.id))
     ),
-    ...(importer === undefined ? {} : { importer }),
     installRoot: globalPaths.installRoot,
   });
   const projectExtensions =
     projectConfiguration === undefined
       ? []
       : await loadEnabledExtensions({
+          ...shared,
           entries: projectConfiguration.settings.extensions.filter(
             (entry) => !skippedIds.has(entry.id)
           ),
-          ...(importer === undefined ? {} : { importer }),
           installRoot: projectConfiguration.paths.installRoot,
         });
   const local = await loadLocalExtensions({
+    ...shared,
     excludeIds: skippedIds,
     globalInstallRoot: globalPaths.installRoot,
-    ...(importer === undefined ? {} : { importer }),
     managedIds: new Set(
       [
         ...globalSettings.extensions,
@@ -130,6 +140,7 @@ export async function loadConfiguredCodingAgentExtensions({
 }
 
 async function loadLocalExtensions(options: {
+  readonly cacheBust?: string;
   readonly excludeIds: ReadonlySet<string>;
   readonly globalInstallRoot: string;
   readonly importer?: ImportExtensionModule;
@@ -172,10 +183,19 @@ async function loadLocalExtensions(options: {
     options.managedIds,
     notices
   );
+  const shared: {
+    readonly cacheBust?: string;
+    readonly importer?: ImportExtensionModule;
+  } = {
+    ...(options.cacheBust === undefined
+      ? {}
+      : { cacheBust: options.cacheBust }),
+    ...(options.importer === undefined ? {} : { importer: options.importer }),
+  };
   return {
     globalExtensions: await loadLocalCandidates({
+      ...shared,
       candidates: globalCandidates,
-      ...(options.importer === undefined ? {} : { importer: options.importer }),
       installRoot: options.globalInstallRoot,
     }),
     notices,
@@ -183,10 +203,8 @@ async function loadLocalExtensions(options: {
       options.projectInstallRoot === undefined
         ? []
         : await loadLocalCandidates({
+            ...shared,
             candidates: projectCandidates,
-            ...(options.importer === undefined
-              ? {}
-              : { importer: options.importer }),
             installRoot: options.projectInstallRoot,
           }),
   };
@@ -209,6 +227,7 @@ function selectLocalCandidates(
 }
 
 async function loadLocalCandidates(options: {
+  readonly cacheBust?: string;
   readonly candidates: readonly LocalExtensionCandidate[];
   readonly importer?: ImportExtensionModule;
   readonly installRoot: string;
@@ -217,6 +236,9 @@ async function loadLocalCandidates(options: {
   for (const candidate of options.candidates) {
     extensions.push(
       await loadExtensionTarget({
+        ...(options.cacheBust === undefined
+          ? {}
+          : { cacheBust: options.cacheBust }),
         id: candidate.id,
         ...(options.importer === undefined
           ? {}
@@ -230,6 +252,7 @@ async function loadLocalCandidates(options: {
 }
 
 async function loadEnabledExtensions(options: {
+  readonly cacheBust?: string;
   readonly entries: readonly ExtensionSettingsEntry[];
   readonly importer?: ImportExtensionModule;
   readonly installRoot: string;
@@ -241,6 +264,9 @@ async function loadEnabledExtensions(options: {
     }
     extensions.push(
       await loadExtensionTarget({
+        ...(options.cacheBust === undefined
+          ? {}
+          : { cacheBust: options.cacheBust }),
         ...(entry.config === undefined ? {} : { config: entry.config }),
         id: entry.id,
         ...(options.importer === undefined

--- a/apps/coding-agent/src/extensions/manager/module-loader.test.ts
+++ b/apps/coding-agent/src/extensions/manager/module-loader.test.ts
@@ -1,8 +1,12 @@
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadExtensionTarget } from "./module-loader";
+
+const execFileAsync = promisify(execFile);
 
 const cleanupRoots: string[] = [];
 
@@ -113,6 +117,59 @@ describe("managed package module loading", () => {
     expect(extension).toMatchObject({
       config: { installed: true, moduleDefault: true },
       id: "static-extension",
+    });
+  });
+
+  // Runs in a child Node process because module customization hooks do not
+  // intercept imports issued through vitest's own module runner.
+  it("reloads transitive helper modules when cache busting", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "pss-module-loader-"));
+    cleanupRoots.push(root);
+    const helperPath = join(root, "helper.mjs");
+    const entryPath = join(root, "entry.mjs");
+    await writeFile(helperPath, 'export const marker = "one";\n', "utf8");
+    await writeFile(
+      entryPath,
+      [
+        'import { marker } from "./helper.mjs";',
+        "export default function extension() {}",
+        "extension.marker = marker;",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+    const script = [
+      `import { ensureReloadModuleGraphHooks } from ${JSON.stringify(
+        new URL("./reload-module-graph.ts", import.meta.url).href
+      )};`,
+      'import { writeFile } from "node:fs/promises";',
+      'import { pathToFileURL } from "node:url";',
+      "ensureReloadModuleGraphHooks();",
+      `const entryPath = ${JSON.stringify(entryPath)};`,
+      `const helperPath = ${JSON.stringify(helperPath)};`,
+      "const importBusted = async (cacheBust) => {",
+      "  const url = pathToFileURL(entryPath);",
+      "  url.searchParams.set('pss-extension-update', cacheBust);",
+      "  return await import(url.href);",
+      "};",
+      "const first = await importBusted('1');",
+      "await writeFile(helperPath, 'export const marker = \"two\";\\n');",
+      "const second = await importBusted('2');",
+      "console.log(JSON.stringify({ first: first.default.marker, second: second.default.marker }));",
+    ].join("\n");
+
+    // When
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["--input-type=module", "-e", script],
+      { timeout: 30_000 }
+    );
+
+    // Then
+    expect(JSON.parse(stdout.trim())).toEqual({
+      first: "one",
+      second: "two",
     });
   });
 });

--- a/apps/coding-agent/src/extensions/manager/module-loader.test.ts
+++ b/apps/coding-agent/src/extensions/manager/module-loader.test.ts
@@ -122,6 +122,58 @@ describe("managed package module loading", () => {
 
   // Runs in a child Node process because module customization hooks do not
   // intercept imports issued through vitest's own module runner.
+  it("reloads commonjs helpers when cache busting", async () => {
+    // Given
+    const root = await mkdtemp(join(tmpdir(), "pss-module-loader-"));
+    cleanupRoots.push(root);
+    const helperPath = join(root, "helper.cjs");
+    const entryPath = join(root, "entry.mjs");
+    await writeFile(helperPath, 'module.exports = { marker: "one" };\n');
+    await writeFile(
+      entryPath,
+      [
+        'import helper from "./helper.cjs";',
+        "export default function extension() {}",
+        "extension.marker = helper.marker;",
+        "",
+      ].join("\n")
+    );
+    const script = [
+      `import { ensureReloadModuleGraphHooks, purgeCommonJsCacheUnder } from ${JSON.stringify(
+        new URL("./reload-module-graph.ts", import.meta.url).href
+      )};`,
+      'import { writeFile } from "node:fs/promises";',
+      'import { pathToFileURL } from "node:url";',
+      "ensureReloadModuleGraphHooks();",
+      `const root = ${JSON.stringify(root)};`,
+      `const entryPath = ${JSON.stringify(entryPath)};`,
+      `const helperPath = ${JSON.stringify(helperPath)};`,
+      "const importBusted = async (cacheBust) => {",
+      "  purgeCommonJsCacheUnder([root]);",
+      "  const url = pathToFileURL(entryPath);",
+      "  url.searchParams.set('pss-extension-update', cacheBust);",
+      "  return await import(url.href);",
+      "};",
+      "const first = await importBusted('1');",
+      "await writeFile(helperPath, 'module.exports = { marker: \"two\" };\\n');",
+      "const second = await importBusted('2');",
+      "console.log(JSON.stringify({ first: first.default.marker, second: second.default.marker }));",
+    ].join("\n");
+
+    // When
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["--input-type=module", "-e", script],
+      { timeout: 30_000 }
+    );
+
+    // Then
+    expect(JSON.parse(stdout.trim())).toEqual({
+      first: "one",
+      second: "two",
+    });
+  });
+
   it("reloads transitive helper modules when cache busting", async () => {
     // Given
     const root = await mkdtemp(join(tmpdir(), "pss-module-loader-"));

--- a/apps/coding-agent/src/extensions/manager/module-loader.test.ts
+++ b/apps/coding-agent/src/extensions/manager/module-loader.test.ts
@@ -139,7 +139,7 @@ describe("managed package module loading", () => {
       ].join("\n")
     );
     const script = [
-      `import { ensureReloadModuleGraphHooks, purgeCommonJsCacheUnder } from ${JSON.stringify(
+      `import { ensureReloadModuleGraphHooks, beginCommonJsReloadTransaction } from ${JSON.stringify(
         new URL("./reload-module-graph.ts", import.meta.url).href
       )};`,
       'import { writeFile } from "node:fs/promises";',
@@ -149,7 +149,7 @@ describe("managed package module loading", () => {
       `const entryPath = ${JSON.stringify(entryPath)};`,
       `const helperPath = ${JSON.stringify(helperPath)};`,
       "const importBusted = async (cacheBust) => {",
-      "  purgeCommonJsCacheUnder([root]);",
+      "  beginCommonJsReloadTransaction([root]);",
       "  const url = pathToFileURL(entryPath);",
       "  url.searchParams.set('pss-extension-update', cacheBust);",
       "  return await import(url.href);",

--- a/apps/coding-agent/src/extensions/manager/module-loader.ts
+++ b/apps/coding-agent/src/extensions/manager/module-loader.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type {
   CodingAgentExtension,
@@ -7,7 +7,10 @@ import type {
   CodingAgentExtensionInput,
   ExtensionJsonValue,
 } from "../types";
-import { ensureReloadModuleGraphHooks } from "./reload-module-graph";
+import {
+  ensureReloadModuleGraphHooks,
+  purgeCommonJsCacheUnder,
+} from "./reload-module-graph";
 import type { ExtensionTarget, ImportExtensionModule } from "./types";
 
 const defaultImportModule: ImportExtensionModule = async (specifier) =>
@@ -30,15 +33,15 @@ export async function loadExtensionTarget({
   readonly installRoot: string;
   readonly target: ExtensionTarget;
 }): Promise<CodingAgentExtensionInput> {
-  const url =
+  const entryPath =
     target.kind === "module"
-      ? pathToFileURL(target.path)
-      : pathToFileURL(
-          await resolvePackageImportEntry(installRoot, target.packageName)
-        );
+      ? target.path
+      : await resolvePackageImportEntry(installRoot, target.packageName);
+  const url = pathToFileURL(entryPath);
   if (cacheBust !== undefined) {
     url.searchParams.set("pss-extension-update", cacheBust);
     ensureReloadModuleGraphHooks();
+    purgeCommonJsCacheUnder([installRoot, dirname(entryPath)]);
   }
   const specifier = url.href;
   const namespace = await importer(specifier);

--- a/apps/coding-agent/src/extensions/manager/module-loader.ts
+++ b/apps/coding-agent/src/extensions/manager/module-loader.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type {
   CodingAgentExtension,
@@ -7,10 +7,7 @@ import type {
   CodingAgentExtensionInput,
   ExtensionJsonValue,
 } from "../types";
-import {
-  ensureReloadModuleGraphHooks,
-  purgeCommonJsCacheUnder,
-} from "./reload-module-graph";
+import { ensureReloadModuleGraphHooks } from "./reload-module-graph";
 import type { ExtensionTarget, ImportExtensionModule } from "./types";
 
 const defaultImportModule: ImportExtensionModule = async (specifier) =>
@@ -41,7 +38,6 @@ export async function loadExtensionTarget({
   if (cacheBust !== undefined) {
     url.searchParams.set("pss-extension-update", cacheBust);
     ensureReloadModuleGraphHooks();
-    purgeCommonJsCacheUnder([installRoot, dirname(entryPath)]);
   }
   const specifier = url.href;
   const namespace = await importer(specifier);

--- a/apps/coding-agent/src/extensions/manager/module-loader.ts
+++ b/apps/coding-agent/src/extensions/manager/module-loader.ts
@@ -7,6 +7,7 @@ import type {
   CodingAgentExtensionInput,
   ExtensionJsonValue,
 } from "../types";
+import { ensureReloadModuleGraphHooks } from "./reload-module-graph";
 import type { ExtensionTarget, ImportExtensionModule } from "./types";
 
 const defaultImportModule: ImportExtensionModule = async (specifier) =>
@@ -37,6 +38,7 @@ export async function loadExtensionTarget({
         );
   if (cacheBust !== undefined) {
     url.searchParams.set("pss-extension-update", cacheBust);
+    ensureReloadModuleGraphHooks();
   }
   const specifier = url.href;
   const namespace = await importer(specifier);

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.test.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.test.ts
@@ -1,0 +1,62 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { beginCommonJsReloadTransaction } from "./reload-module-graph";
+
+const require = createRequire(import.meta.url);
+const cleanupRoots: string[] = [];
+
+afterEach(async () => {
+  for (const root of cleanupRoots.splice(0)) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pss-reload-graph-"));
+  cleanupRoots.push(root);
+  return root;
+}
+
+describe("beginCommonJsReloadTransaction", () => {
+  it("evicts extension-owned entries and restores them on rollback", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    const helperPath = join(root, "helper.cjs");
+    await writeFile(helperPath, 'module.exports = { marker: "one" };\n');
+    const original: unknown = require(helperPath);
+    expect(require.cache[helperPath]).toBeDefined();
+
+    // When
+    const transaction = beginCommonJsReloadTransaction([root]);
+    const evicted = require.cache[helperPath];
+    await writeFile(helperPath, 'module.exports = { marker: "two" };\n');
+    const reloaded: unknown = require(helperPath);
+    transaction.rollback();
+    const restored: unknown = require(helperPath);
+
+    // Then
+    expect(evicted).toBeUndefined();
+    expect(reloaded).toMatchObject({ marker: "two" });
+    expect(restored).toBe(original);
+  });
+
+  it("leaves node_modules entries untouched", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    const dependencyDirectory = join(root, "node_modules", "dep");
+    await mkdir(dependencyDirectory, { recursive: true });
+    const dependencyPath = join(dependencyDirectory, "index.cjs");
+    await writeFile(dependencyPath, 'module.exports = { marker: "dep" };\n');
+    const dependency: unknown = require(dependencyPath);
+
+    // When
+    beginCommonJsReloadTransaction([root]);
+
+    // Then
+    expect(require.cache[dependencyPath]).toBeDefined();
+    expect(require(dependencyPath)).toBe(dependency);
+  });
+});

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
@@ -8,17 +8,29 @@ import { sep } from "node:path";
  * entry points while sibling and helper modules stayed pinned in Node's
  * module cache.
  *
- * Dependencies under `node_modules` keep their stable URLs: Node retains
- * every distinct ESM URL for the process lifetime, so re-versioning large
- * dependency graphs on each reload would leak memory. Reload therefore
- * refreshes extension-owned files only; updating a dependency still requires
- * `pss extension update` or a restart.
+ * Managed extensions live at `<installRoot>/node_modules/<package>`, so the
+ * marker follows imports that stay inside the same package (the extension's
+ * own helpers) but stops at imports that cross into a different package
+ * (real dependencies). Node retains every distinct ESM URL for the process
+ * lifetime, so re-versioning dependency graphs on each reload would leak
+ * memory; updating a dependency still requires `pss extension update` or a
+ * restart.
  *
  * The hook is pass-through for every resolution whose parent does not carry
  * the marker parameter, so regular imports keep their normal behavior.
  */
 const HOOK_SOURCE = `
 const MARKER = /[?&]pss-extension-update=([^&#]+)/;
+const packageRootOf = (url) => {
+  const index = url.lastIndexOf("/node_modules/");
+  if (index === -1) {
+    return;
+  }
+  const start = index + "/node_modules/".length;
+  const segments = url.slice(start).split("/");
+  const packageLength = segments[0]?.startsWith("@") ? 2 : 1;
+  return url.slice(0, start) + segments.slice(0, packageLength).join("/");
+};
 export async function resolve(specifier, context, nextResolve) {
   const resolved = await nextResolve(specifier, context);
   const parent = context.parentURL;
@@ -32,7 +44,8 @@ export async function resolve(specifier, context, nextResolve) {
   if (!resolved.url.startsWith("file:")) {
     return resolved;
   }
-  if (resolved.url.includes("/node_modules/")) {
+  const resolvedRoot = packageRootOf(resolved.url);
+  if (resolvedRoot !== undefined && resolvedRoot !== packageRootOf(parent)) {
     return resolved;
   }
   if (MARKER.test(resolved.url)) {
@@ -75,8 +88,9 @@ export interface CommonJsReloadTransaction {
  * evicted entries first. The ESM resolve hook cannot reach the CommonJS
  * cache because Node keys it by filesystem path rather than URL.
  *
- * Entries under `node_modules` are left untouched for the same reasons the
- * ESM hook skips them.
+ * Pass loose-module directories and managed package roots explicitly;
+ * `node_modules` trees nested below a root (real dependencies) are left
+ * untouched for the same reasons the ESM hook skips them.
  */
 export function beginCommonJsReloadTransaction(
   roots: readonly string[]
@@ -86,8 +100,12 @@ export function beginCommonJsReloadTransaction(
     root.endsWith(sep) ? root : `${root}${sep}`
   );
   const owned = (key: string): boolean =>
-    !key.includes(`${sep}node_modules${sep}`) &&
-    prefixes.some((prefix) => key.startsWith(prefix));
+    prefixes.some(
+      (prefix) =>
+        key.startsWith(prefix) &&
+        !key.slice(prefix.length).includes(`${sep}node_modules${sep}`) &&
+        !key.slice(prefix.length).startsWith(`node_modules${sep}`)
+    );
   const snapshot = new Map<string, NodeJS.Module>();
   for (const key of Object.keys(require.cache)) {
     if (!owned(key)) {

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
@@ -3,9 +3,16 @@ import { sep } from "node:path";
 
 /**
  * Module customization hook that propagates the `pss-extension-update`
- * cache-busting parameter from a parent module to every module it imports.
- * Without this, `/reload` would only re-import extension entry points while
- * sibling and helper modules stayed pinned in Node's module cache.
+ * cache-busting parameter from a parent module to every extension-owned
+ * module it imports. Without this, `/reload` would only re-import extension
+ * entry points while sibling and helper modules stayed pinned in Node's
+ * module cache.
+ *
+ * Dependencies under `node_modules` keep their stable URLs: Node retains
+ * every distinct ESM URL for the process lifetime, so re-versioning large
+ * dependency graphs on each reload would leak memory. Reload therefore
+ * refreshes extension-owned files only; updating a dependency still requires
+ * `pss extension update` or a restart.
  *
  * The hook is pass-through for every resolution whose parent does not carry
  * the marker parameter, so regular imports keep their normal behavior.
@@ -23,6 +30,9 @@ export async function resolve(specifier, context, nextResolve) {
     return resolved;
   }
   if (!resolved.url.startsWith("file:")) {
+    return resolved;
+  }
+  if (resolved.url.includes("/node_modules/")) {
     return resolved;
   }
   if (MARKER.test(resolved.url)) {
@@ -53,20 +63,52 @@ export function ensureReloadModuleGraphHooks(): void {
   register(`data:text/javascript,${encodeURIComponent(HOOK_SOURCE)}`);
 }
 
+export interface CommonJsReloadTransaction {
+  /** Restore the pre-reload cache so a failed reload cannot hand the live
+   * runtime freshly re-executed CommonJS helper instances. */
+  rollback(): void;
+}
+
 /**
- * Drop CommonJS modules cached under the given roots so cache-busted ESM
- * imports re-execute `.cjs` helpers and their `require()` descendants. The
- * ESM resolve hook cannot reach the CommonJS cache because Node keys it by
- * filesystem path rather than URL.
+ * Evict extension-owned CommonJS modules cached under the given roots so
+ * cache-busted ESM imports re-execute `.cjs` helpers, snapshotting the
+ * evicted entries first. The ESM resolve hook cannot reach the CommonJS
+ * cache because Node keys it by filesystem path rather than URL.
+ *
+ * Entries under `node_modules` are left untouched for the same reasons the
+ * ESM hook skips them.
  */
-export function purgeCommonJsCacheUnder(roots: readonly string[]): void {
+export function beginCommonJsReloadTransaction(
+  roots: readonly string[]
+): CommonJsReloadTransaction {
   const require = createRequire(import.meta.url);
   const prefixes = roots.map((root) =>
     root.endsWith(sep) ? root : `${root}${sep}`
   );
+  const owned = (key: string): boolean =>
+    !key.includes(`${sep}node_modules${sep}`) &&
+    prefixes.some((prefix) => key.startsWith(prefix));
+  const snapshot = new Map<string, NodeJS.Module>();
   for (const key of Object.keys(require.cache)) {
-    if (prefixes.some((prefix) => key.startsWith(prefix))) {
-      delete require.cache[key];
+    if (!owned(key)) {
+      continue;
     }
+    const entry = require.cache[key];
+    if (entry !== undefined) {
+      snapshot.set(key, entry);
+    }
+    delete require.cache[key];
   }
+  return {
+    rollback: () => {
+      for (const key of Object.keys(require.cache)) {
+        if (owned(key)) {
+          delete require.cache[key];
+        }
+      }
+      for (const [key, entry] of snapshot) {
+        require.cache[key] = entry;
+      }
+    },
+  };
 }

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
@@ -1,0 +1,53 @@
+import { register } from "node:module";
+
+/**
+ * Module customization hook that propagates the `pss-extension-update`
+ * cache-busting parameter from a parent module to every module it imports.
+ * Without this, `/reload` would only re-import extension entry points while
+ * sibling and helper modules stayed pinned in Node's module cache.
+ *
+ * The hook is pass-through for every resolution whose parent does not carry
+ * the marker parameter, so regular imports keep their normal behavior.
+ */
+const HOOK_SOURCE = `
+const MARKER = /[?&]pss-extension-update=([^&#]+)/;
+export async function resolve(specifier, context, nextResolve) {
+  const resolved = await nextResolve(specifier, context);
+  const parent = context.parentURL;
+  if (typeof parent !== "string") {
+    return resolved;
+  }
+  const match = MARKER.exec(parent);
+  if (match === null) {
+    return resolved;
+  }
+  if (!resolved.url.startsWith("file:")) {
+    return resolved;
+  }
+  if (MARKER.test(resolved.url)) {
+    return resolved;
+  }
+  const separator = resolved.url.includes("?") ? "&" : "?";
+  return {
+    ...resolved,
+    url: resolved.url + separator + "pss-extension-update=" + match[1],
+  };
+}
+`;
+
+let registered = false;
+
+/**
+ * Install the graph-propagation hook once per process. Called lazily from
+ * cache-busted extension imports so normal startups never pay for it.
+ */
+export function ensureReloadModuleGraphHooks(): void {
+  if (registered) {
+    return;
+  }
+  registered = true;
+  if (typeof register !== "function") {
+    return;
+  }
+  register(`data:text/javascript,${encodeURIComponent(HOOK_SOURCE)}`);
+}

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
@@ -91,6 +91,13 @@ export interface CommonJsReloadTransaction {
  * Pass loose-module directories and managed package roots explicitly;
  * `node_modules` trees nested below a root (real dependencies) are left
  * untouched for the same reasons the ESM hook skips them.
+ *
+ * Known limitation: the CommonJS cache is process-wide, so between eviction
+ * and a failed reload's rollback the still-active previous runtime could
+ * observe a freshly re-executed helper through a *lazy* `require()` issued
+ * during that window. Modules loaded during activation keep their original
+ * references and are unaffected. Full isolation needs a separate module
+ * context (worker/vm) and is tracked as follow-up work.
  */
 export function beginCommonJsReloadTransaction(
   roots: readonly string[]

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
@@ -1,4 +1,5 @@
-import { register } from "node:module";
+import { createRequire, register } from "node:module";
+import { sep } from "node:path";
 
 /**
  * Module customization hook that propagates the `pss-extension-update`
@@ -50,4 +51,22 @@ export function ensureReloadModuleGraphHooks(): void {
     return;
   }
   register(`data:text/javascript,${encodeURIComponent(HOOK_SOURCE)}`);
+}
+
+/**
+ * Drop CommonJS modules cached under the given roots so cache-busted ESM
+ * imports re-execute `.cjs` helpers and their `require()` descendants. The
+ * ESM resolve hook cannot reach the CommonJS cache because Node keys it by
+ * filesystem path rather than URL.
+ */
+export function purgeCommonJsCacheUnder(roots: readonly string[]): void {
+  const require = createRequire(import.meta.url);
+  const prefixes = roots.map((root) =>
+    root.endsWith(sep) ? root : `${root}${sep}`
+  );
+  for (const key of Object.keys(require.cache)) {
+    if (prefixes.some((prefix) => key.startsWith(prefix))) {
+      delete require.cache[key];
+    }
+  }
 }

--- a/apps/coding-agent/src/extensions/name-validation.ts
+++ b/apps/coding-agent/src/extensions/name-validation.ts
@@ -2,7 +2,7 @@ import { requiredString } from "./data-validation";
 
 const COMMAND_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 const TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
-const RESERVED_COMMAND_NAMES = new Set(["clear", "help", "new"]);
+const RESERVED_COMMAND_NAMES = new Set(["clear", "help", "new", "reload"]);
 const UNSAFE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 
 export function snapshotCommandName(value: unknown): string {

--- a/apps/coding-agent/src/extensions/runtime-services-contract.test.ts
+++ b/apps/coding-agent/src/extensions/runtime-services-contract.test.ts
@@ -247,14 +247,17 @@ describe("extension runtime service contracts", () => {
           cwd: "..",
         })
       ).rejects.toThrow("Extension exec cwd must stay inside the workspace");
+      // The timeout must exceed child Node boot time on a loaded CI runner;
+      // otherwise SIGTERM lands before the handler is registered and the
+      // process exits on SIGTERM without exercising SIGKILL escalation.
       await expect(
         services?.exec.run({
           args: [
             "-e",
-            "process.on('SIGTERM', () => {}); setTimeout(() => process.exit(0), 500)",
+            "process.on('SIGTERM', () => {}); setTimeout(() => process.exit(0), 10000)",
           ],
           command: process.execPath,
-          timeoutMs: 100,
+          timeoutMs: 750,
         })
       ).resolves.toMatchObject({ signal: "SIGKILL", timedOut: true });
     } finally {

--- a/apps/coding-agent/src/extensions/runtime-services.ts
+++ b/apps/coding-agent/src/extensions/runtime-services.ts
@@ -15,6 +15,8 @@ import type {
   ExtensionJsonValue,
 } from "./types";
 
+const STATE_WRITE_FENCE_TIMEOUT_MS = 5000;
+
 export interface ExtensionServiceScope {
   readonly dispose: () => Promise<void>;
   /**
@@ -80,7 +82,15 @@ export function createExtensionServiceScope(options: {
       stateWritesRevoked = true;
       // Reads queue behind admitted writes, so awaiting one fences every
       // write that passed the revocation check before the flag was set.
-      await services.state.get().catch(() => undefined);
+      // The fence is bounded: a never-settling queued updater must not be
+      // able to hang revocation (and with it the whole reload).
+      await Promise.race([
+        services.state.get().catch(() => undefined),
+        new Promise<void>((resolveFence) => {
+          const timer = setTimeout(resolveFence, STATE_WRITE_FENCE_TIMEOUT_MS);
+          timer.unref?.();
+        }),
+      ]);
     },
     dispose: async () => {
       stateWritesRevoked = true;

--- a/apps/coding-agent/src/extensions/runtime-services.ts
+++ b/apps/coding-agent/src/extensions/runtime-services.ts
@@ -17,6 +17,8 @@ import type {
 
 export interface ExtensionServiceScope {
   readonly dispose: () => Promise<void>;
+  /** Reject further state writes; used after cleanup ran or was detached. */
+  readonly revokeStateWrites: () => void;
   readonly services: CodingAgentExtensionServices;
 }
 
@@ -34,6 +36,7 @@ export function createExtensionServiceScope(options: {
 }): ExtensionServiceScope {
   const logger = createExtensionLogger(options.extensionId);
   const children: Agent[] = [];
+  let stateWritesRevoked = false;
   const agents: CodingAgentExtensionAgents = {
     create: async (
       input: Parameters<CodingAgentExtensionAgents["create"]>[0]
@@ -63,13 +66,17 @@ export function createExtensionServiceScope(options: {
     logger,
     state: createExtensionJsonState({
       extensionId: options.extensionId,
+      isRevoked: () => stateWritesRevoked,
       root: options.dataRoot ?? join(homedir(), ".pss", "extension-state"),
-      signal: options.signal,
     }),
     ui: options.ui ?? createNoninteractiveExtensionUi(options.mode, logger),
   });
   return {
+    revokeStateWrites: () => {
+      stateWritesRevoked = true;
+    },
     dispose: async () => {
+      stateWritesRevoked = true;
       const results = await Promise.allSettled(
         children.reverse().map(async (agent) => await agent.dispose())
       );

--- a/apps/coding-agent/src/extensions/runtime-services.ts
+++ b/apps/coding-agent/src/extensions/runtime-services.ts
@@ -17,8 +17,12 @@ import type {
 
 export interface ExtensionServiceScope {
   readonly dispose: () => Promise<void>;
-  /** Reject further state writes; used after cleanup ran or was detached. */
-  readonly revokeStateWrites: () => void;
+  /**
+   * Reject further state writes and drain writes already admitted to the
+   * serial queue, so once this resolves no write from this scope can land
+   * behind a replacement runtime or a restored snapshot.
+   */
+  readonly revokeStateWrites: () => Promise<void>;
   readonly services: CodingAgentExtensionServices;
 }
 
@@ -72,8 +76,11 @@ export function createExtensionServiceScope(options: {
     ui: options.ui ?? createNoninteractiveExtensionUi(options.mode, logger),
   });
   return {
-    revokeStateWrites: () => {
+    revokeStateWrites: async () => {
       stateWritesRevoked = true;
+      // Reads queue behind admitted writes, so awaiting one fences every
+      // write that passed the revocation check before the flag was set.
+      await services.state.get().catch(() => undefined);
     },
     dispose: async () => {
       stateWritesRevoked = true;

--- a/apps/coding-agent/src/extensions/runtime-services.ts
+++ b/apps/coding-agent/src/extensions/runtime-services.ts
@@ -6,6 +6,7 @@ import { assertJsonValue, createExtensionJsonState } from "./json-state";
 import { createExtensionExec } from "./process-exec";
 import type {
   CodingAgentExtensionAgents,
+  CodingAgentExtensionEvents,
   CodingAgentExtensionLogger,
   CodingAgentExtensionMode,
   CodingAgentExtensionModelProvider,
@@ -22,6 +23,7 @@ export interface ExtensionServiceScope {
 export function createExtensionServiceScope(options: {
   readonly config?: Readonly<Record<string, ExtensionJsonValue>>;
   readonly dataRoot?: string;
+  readonly events: CodingAgentExtensionEvents;
   readonly extensionId: string;
   readonly mode: CodingAgentExtensionMode;
   readonly model?: LanguageModel;
@@ -53,6 +55,7 @@ export function createExtensionServiceScope(options: {
   const services: CodingAgentExtensionServices = Object.freeze({
     agents,
     config: snapshotConfig(options.config),
+    events: options.events,
     exec: createExtensionExec({
       signal: options.signal,
       workspace: options.workspace ?? process.cwd(),

--- a/apps/coding-agent/src/extensions/runtime-services.ts
+++ b/apps/coding-agent/src/extensions/runtime-services.ts
@@ -64,6 +64,7 @@ export function createExtensionServiceScope(options: {
     state: createExtensionJsonState({
       extensionId: options.extensionId,
       root: options.dataRoot ?? join(homedir(), ".pss", "extension-state"),
+      signal: options.signal,
     }),
     ui: options.ui ?? createNoninteractiveExtensionUi(options.mode, logger),
   });

--- a/apps/coding-agent/src/extensions/state-lifecycle.test.ts
+++ b/apps/coding-agent/src/extensions/state-lifecycle.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { createAgent } from "@minpeter/pss-runtime";
+import { afterEach, describe, expect, it } from "vitest";
+import { createCodingAgentExtensionHost } from "./host";
+import type { CodingAgentExtensionModule } from "./types";
+
+const readOnlyPattern = /read-only after its runtime was disposed/u;
+const cleanupRoots: string[] = [];
+
+afterEach(async () => {
+  for (const root of cleanupRoots.splice(0)) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+describe("extension state lifecycle across disposal", () => {
+  it("allows cleanup to persist state and revokes writes afterwards", async () => {
+    // Given
+    const dataRoot = await mkdtemp(join(tmpdir(), "pss-state-lifecycle-"));
+    cleanupRoots.push(dataRoot);
+    let services: import("./types").CodingAgentExtensionServices | undefined;
+    const extension: CodingAgentExtensionModule = {
+      default(pss) {
+        pss.on("activate", (context) => {
+          services = context.services;
+          return async () => {
+            await context.services.state.set({ finalized: true });
+          };
+        });
+      },
+      id: "stateful",
+    };
+    const provider = createOpenAICompatible({
+      apiKey: "test",
+      baseURL: "https://example.com/v1",
+      name: "test",
+    });
+    const agent = await createAgent({ model: provider("model") });
+    const host = await createCodingAgentExtensionHost([extension], {
+      dataRoot,
+    });
+    await host.activate(agent, "exec");
+
+    // When — disposal runs the cleanup, which persists final state.
+    await host.dispose();
+    await agent.dispose();
+
+    // Then
+    await expect(services?.state.get()).resolves.toEqual({ finalized: true });
+    await expect(services?.state.set({ late: true })).rejects.toThrow(
+      readOnlyPattern
+    );
+  });
+});

--- a/apps/coding-agent/src/extensions/state-snapshot.test.ts
+++ b/apps/coding-agent/src/extensions/state-snapshot.test.ts
@@ -1,0 +1,78 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { snapshotExtensionState } from "./state-snapshot";
+
+const cleanupRoots: string[] = [];
+
+afterEach(async () => {
+  for (const root of cleanupRoots.splice(0)) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pss-state-snapshot-"));
+  cleanupRoots.push(root);
+  return root;
+}
+
+describe("snapshotExtensionState", () => {
+  it("restores files changed after the snapshot", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    const stateRoot = join(root, "extension-state");
+    await mkdir(stateRoot, { recursive: true });
+    await writeFile(join(stateRoot, "ext.json"), '{"revision":1}');
+
+    // When — the replacement mutates and adds state, then fails.
+    const snapshot = await snapshotExtensionState(stateRoot);
+    await writeFile(join(stateRoot, "ext.json"), '{"revision":2}');
+    await writeFile(join(stateRoot, "new.json"), "{}");
+    await snapshot.restore();
+
+    // Then
+    await expect(readFile(join(stateRoot, "ext.json"), "utf8")).resolves.toBe(
+      '{"revision":1}'
+    );
+    await expect(
+      readFile(join(stateRoot, "new.json"), "utf8")
+    ).rejects.toThrow();
+  });
+
+  it("removes a state directory that did not exist before", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    const stateRoot = join(root, "extension-state");
+
+    // When
+    const snapshot = await snapshotExtensionState(stateRoot);
+    await mkdir(stateRoot, { recursive: true });
+    await writeFile(join(stateRoot, "ext.json"), "{}");
+    await snapshot.restore();
+
+    // Then
+    await expect(
+      readFile(join(stateRoot, "ext.json"), "utf8")
+    ).rejects.toThrow();
+  });
+
+  it("discard keeps the current state untouched", async () => {
+    // Given
+    const root = await temporaryDirectory();
+    const stateRoot = join(root, "extension-state");
+    await mkdir(stateRoot, { recursive: true });
+    await writeFile(join(stateRoot, "ext.json"), '{"revision":1}');
+
+    // When
+    const snapshot = await snapshotExtensionState(stateRoot);
+    await writeFile(join(stateRoot, "ext.json"), '{"revision":2}');
+    await snapshot.discard();
+
+    // Then
+    await expect(readFile(join(stateRoot, "ext.json"), "utf8")).resolves.toBe(
+      '{"revision":2}'
+    );
+  });
+});

--- a/apps/coding-agent/src/extensions/state-snapshot.test.ts
+++ b/apps/coding-agent/src/extensions/state-snapshot.test.ts
@@ -12,66 +12,73 @@ afterEach(async () => {
   }
 });
 
-async function temporaryDirectory(): Promise<string> {
+async function temporaryStateRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "pss-state-snapshot-"));
   cleanupRoots.push(root);
-  return root;
+  const stateRoot = join(root, "extension-state");
+  await mkdir(stateRoot, { recursive: true });
+  return stateRoot;
 }
 
 describe("snapshotExtensionState", () => {
-  it("restores files changed after the snapshot", async () => {
+  it("restores only the listed extensions' files", async () => {
     // Given
-    const root = await temporaryDirectory();
-    const stateRoot = join(root, "extension-state");
-    await mkdir(stateRoot, { recursive: true });
-    await writeFile(join(stateRoot, "ext.json"), '{"revision":1}');
+    const stateRoot = await temporaryStateRoot();
+    await writeFile(join(stateRoot, "guard.json"), '{"revision":1}');
+    await writeFile(join(stateRoot, "other.json"), '{"foreign":1}');
 
-    // When — the replacement mutates and adds state, then fails.
-    const snapshot = await snapshotExtensionState(stateRoot);
-    await writeFile(join(stateRoot, "ext.json"), '{"revision":2}');
-    await writeFile(join(stateRoot, "new.json"), "{}");
+    // When — the replacement mutates listed and unrelated state, then fails.
+    const snapshot = await snapshotExtensionState(
+      ["guard", "fresh"],
+      stateRoot
+    );
+    await writeFile(join(stateRoot, "guard.json"), '{"revision":2}');
+    await writeFile(join(stateRoot, "fresh.json"), "{}");
+    await writeFile(join(stateRoot, "other.json"), '{"foreign":2}');
     await snapshot.restore();
 
-    // Then
-    await expect(readFile(join(stateRoot, "ext.json"), "utf8")).resolves.toBe(
+    // Then — listed files roll back, unrelated files keep their new value.
+    await expect(readFile(join(stateRoot, "guard.json"), "utf8")).resolves.toBe(
       '{"revision":1}'
     );
     await expect(
-      readFile(join(stateRoot, "new.json"), "utf8")
+      readFile(join(stateRoot, "fresh.json"), "utf8")
     ).rejects.toThrow();
+    await expect(readFile(join(stateRoot, "other.json"), "utf8")).resolves.toBe(
+      '{"foreign":2}'
+    );
   });
 
-  it("removes a state directory that did not exist before", async () => {
+  it("handles missing state files and directories", async () => {
     // Given
-    const root = await temporaryDirectory();
-    const stateRoot = join(root, "extension-state");
+    const root = await mkdtemp(join(tmpdir(), "pss-state-snapshot-"));
+    cleanupRoots.push(root);
+    const stateRoot = join(root, "missing-state");
 
-    // When
-    const snapshot = await snapshotExtensionState(stateRoot);
+    // When — the state root does not exist yet.
+    const snapshot = await snapshotExtensionState(["guard"], stateRoot);
     await mkdir(stateRoot, { recursive: true });
-    await writeFile(join(stateRoot, "ext.json"), "{}");
+    await writeFile(join(stateRoot, "guard.json"), "{}");
     await snapshot.restore();
 
     // Then
     await expect(
-      readFile(join(stateRoot, "ext.json"), "utf8")
+      readFile(join(stateRoot, "guard.json"), "utf8")
     ).rejects.toThrow();
   });
 
   it("discard keeps the current state untouched", async () => {
     // Given
-    const root = await temporaryDirectory();
-    const stateRoot = join(root, "extension-state");
-    await mkdir(stateRoot, { recursive: true });
-    await writeFile(join(stateRoot, "ext.json"), '{"revision":1}');
+    const stateRoot = await temporaryStateRoot();
+    await writeFile(join(stateRoot, "guard.json"), '{"revision":1}');
 
     // When
-    const snapshot = await snapshotExtensionState(stateRoot);
-    await writeFile(join(stateRoot, "ext.json"), '{"revision":2}');
+    const snapshot = await snapshotExtensionState(["guard"], stateRoot);
+    await writeFile(join(stateRoot, "guard.json"), '{"revision":2}');
     await snapshot.discard();
 
     // Then
-    await expect(readFile(join(stateRoot, "ext.json"), "utf8")).resolves.toBe(
+    await expect(readFile(join(stateRoot, "guard.json"), "utf8")).resolves.toBe(
       '{"revision":2}'
     );
   });

--- a/apps/coding-agent/src/extensions/state-snapshot.ts
+++ b/apps/coding-agent/src/extensions/state-snapshot.ts
@@ -1,6 +1,6 @@
-import { cp, mkdtemp, rm, stat } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 /** Default directory backing `services.state` JSON files. */
 export function defaultExtensionStateRoot(): string {
@@ -15,40 +15,63 @@ export interface ExtensionStateSnapshot {
 }
 
 /**
- * Snapshot the extension-state directory before a runtime swap activates.
+ * Snapshot the state files of the given extensions before a runtime swap
+ * activates.
  *
  * Replacement activation runs against the same per-extension state files as
  * the runtime it replaces, so a failed activation could leave partially
- * upgraded state behind for the recovered runtime. Restoring this snapshot
- * puts the files back exactly as the previous runtime's cleanup left them.
+ * upgraded state behind for the recovered runtime. Only the listed
+ * extensions' files are captured and restored — state belonging to other
+ * extensions or written by concurrent `pss` sessions stays untouched.
  */
 export async function snapshotExtensionState(
+  extensionIds: readonly string[],
   root: string = defaultExtensionStateRoot()
 ): Promise<ExtensionStateSnapshot> {
   const backupRoot = await mkdtemp(join(tmpdir(), "pss-state-backup-"));
-  const backupPath = join(backupRoot, "state");
-  const rootExists = await directoryExists(root);
-  if (rootExists) {
-    await cp(root, backupPath, { recursive: true });
+  const entries: {
+    readonly backupPath: string;
+    readonly existed: boolean;
+    readonly path: string;
+  }[] = [];
+  for (const [index, extensionId] of extensionIds.entries()) {
+    const path = join(root, `${encodeURIComponent(extensionId)}.json`);
+    const backupPath = join(backupRoot, `${index}.json`);
+    entries.push({
+      backupPath,
+      existed: await tryCopy(path, backupPath),
+      path,
+    });
   }
   return {
     discard: async () => {
       await rm(backupRoot, { force: true, recursive: true });
     },
     restore: async () => {
-      await rm(root, { force: true, recursive: true });
-      if (rootExists) {
-        await cp(backupPath, root, { recursive: true });
+      for (const entry of entries) {
+        if (entry.existed) {
+          await mkdir(dirname(entry.path), { recursive: true });
+          await copyFile(entry.backupPath, entry.path);
+        } else {
+          await rm(entry.path, { force: true });
+        }
       }
       await rm(backupRoot, { force: true, recursive: true });
     },
   };
 }
 
-async function directoryExists(path: string): Promise<boolean> {
+async function tryCopy(source: string, target: string): Promise<boolean> {
   try {
-    return (await stat(path)).isDirectory();
-  } catch {
-    return false;
+    await copyFile(source, target);
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return false;
+    }
+    throw error;
   }
 }

--- a/apps/coding-agent/src/extensions/state-snapshot.ts
+++ b/apps/coding-agent/src/extensions/state-snapshot.ts
@@ -1,0 +1,54 @@
+import { cp, mkdtemp, rm, stat } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Default directory backing `services.state` JSON files. */
+export function defaultExtensionStateRoot(): string {
+  return join(homedir(), ".pss", "extension-state");
+}
+
+export interface ExtensionStateSnapshot {
+  /** Drop the backup after the runtime swap succeeded. */
+  discard(): Promise<void>;
+  /** Restore the snapshotted state files after a failed swap. */
+  restore(): Promise<void>;
+}
+
+/**
+ * Snapshot the extension-state directory before a runtime swap activates.
+ *
+ * Replacement activation runs against the same per-extension state files as
+ * the runtime it replaces, so a failed activation could leave partially
+ * upgraded state behind for the recovered runtime. Restoring this snapshot
+ * puts the files back exactly as the previous runtime's cleanup left them.
+ */
+export async function snapshotExtensionState(
+  root: string = defaultExtensionStateRoot()
+): Promise<ExtensionStateSnapshot> {
+  const backupRoot = await mkdtemp(join(tmpdir(), "pss-state-backup-"));
+  const backupPath = join(backupRoot, "state");
+  const rootExists = await directoryExists(root);
+  if (rootExists) {
+    await cp(root, backupPath, { recursive: true });
+  }
+  return {
+    discard: async () => {
+      await rm(backupRoot, { force: true, recursive: true });
+    },
+    restore: async () => {
+      await rm(root, { force: true, recursive: true });
+      if (rootExists) {
+        await cp(backupPath, root, { recursive: true });
+      }
+      await rm(backupRoot, { force: true, recursive: true });
+    },
+  };
+}
+
+async function directoryExists(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/apps/coding-agent/src/extensions/types.ts
+++ b/apps/coding-agent/src/extensions/types.ts
@@ -88,9 +88,24 @@ export interface CodingAgentExtensionState {
   ): Promise<ExtensionJsonValue>;
 }
 
+/**
+ * Inter-extension publish/subscribe events plus host observations.
+ *
+ * Host-originated events use reserved namespaces (`host:`, `provider:`)
+ * that extensions can subscribe to but never publish.
+ */
+export interface CodingAgentExtensionEvents {
+  emit(type: string, payload?: ExtensionJsonValue): void;
+  on(
+    type: string,
+    handler: (payload: ExtensionJsonValue | undefined) => Promise<void> | void
+  ): () => void;
+}
+
 export interface CodingAgentExtensionServices {
   readonly agents: CodingAgentExtensionAgents;
   readonly config: Readonly<Record<string, ExtensionJsonValue>>;
+  readonly events: CodingAgentExtensionEvents;
   readonly exec: CodingAgentExtensionExec;
   readonly logger: CodingAgentExtensionLogger;
   readonly state: CodingAgentExtensionState;

--- a/apps/coding-agent/src/model.ts
+++ b/apps/coding-agent/src/model.ts
@@ -7,17 +7,22 @@ import {
 } from "./env";
 
 export interface CreateOpenAICompatibleModelFromEnvOptions {
+  /** Custom fetch, e.g. for provider observation. */
+  fetch?: typeof globalThis.fetch;
   providerName?: string;
   runtimeEnv?: CodingAgentRuntimeEnv;
 }
 
 export interface CreateOpenAICompatibleModelFromDotenvOptions {
+  /** Custom fetch, e.g. for provider observation. */
+  fetch?: typeof globalThis.fetch;
   override?: boolean;
   providerName?: string;
   quiet?: boolean;
 }
 
 export function createOpenAICompatibleModelFromEnv({
+  fetch,
   providerName = "custom",
   runtimeEnv = process.env,
 }: CreateOpenAICompatibleModelFromEnvOptions = {}): LanguageModel {
@@ -26,12 +31,14 @@ export function createOpenAICompatibleModelFromEnv({
     name: providerName,
     apiKey: env.AI_API_KEY,
     baseURL: env.AI_BASE_URL,
+    ...(fetch === undefined ? {} : { fetch }),
   });
 
   return provider(env.AI_MODEL);
 }
 
 export function createCodingLanguageModel({
+  fetch,
   override = true,
   providerName = "custom",
   quiet = true,
@@ -39,6 +46,7 @@ export function createCodingLanguageModel({
   config({ override, quiet });
 
   return createOpenAICompatibleModelFromEnv({
+    ...(fetch === undefined ? {} : { fetch }),
     providerName,
   });
 }

--- a/apps/coding-agent/src/provider-observation.test.ts
+++ b/apps/coding-agent/src/provider-observation.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import type { ExtensionJsonValue } from "./extensions";
+import {
+  createProviderObservationFetch,
+  type ProviderObservationEmitter,
+} from "./provider-observation";
+
+interface RecordedEvent {
+  readonly payload: ExtensionJsonValue;
+  readonly type: string;
+}
+
+function createRecorder(): {
+  readonly emitter: ProviderObservationEmitter;
+  readonly events: RecordedEvent[];
+} {
+  const events: RecordedEvent[] = [];
+  return {
+    emitter: {
+      current: (type, payload) => {
+        events.push({ payload, type });
+      },
+    },
+    events,
+  };
+}
+
+describe("provider observation fetch", () => {
+  it("emits redacted request and safelisted response events", async () => {
+    // Given
+    const { emitter, events } = createRecorder();
+    const observed = createProviderObservationFetch(emitter, () =>
+      Promise.resolve(
+        new Response("{}", {
+          headers: {
+            authorization: "Bearer secret",
+            "content-type": "application/json",
+            "set-cookie": "session=1",
+            "x-ratelimit-remaining": "42",
+            "x-request-id": "req-1",
+          },
+          status: 200,
+        })
+      )
+    );
+
+    // When
+    const response = await observed(
+      "https://user:pass@gateway.example/v1/chat?api-key=leak",
+      { body: '{"secret":true}', method: "post" }
+    );
+
+    // Then
+    expect(response.status).toBe(200);
+    expect(events).toEqual([
+      {
+        payload: {
+          method: "POST",
+          url: "https://gateway.example/v1/chat",
+        },
+        type: "provider:request",
+      },
+      {
+        payload: {
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "42",
+            "x-request-id": "req-1",
+          },
+          status: 200,
+          url: "https://gateway.example/v1/chat",
+        },
+        type: "provider:response",
+      },
+    ]);
+  });
+
+  it("emits provider:error and rethrows on network failure", async () => {
+    // Given
+    const { emitter, events } = createRecorder();
+    const observed = createProviderObservationFetch(emitter, () =>
+      Promise.reject(new Error("socket hang up"))
+    );
+
+    // When / Then
+    await expect(observed("https://gateway.example/v1/chat")).rejects.toThrow(
+      "socket hang up"
+    );
+    expect(events).toEqual([
+      {
+        payload: { method: "GET", url: "https://gateway.example/v1/chat" },
+        type: "provider:request",
+      },
+      {
+        payload: {
+          message: "socket hang up",
+          url: "https://gateway.example/v1/chat",
+        },
+        type: "provider:error",
+      },
+    ]);
+  });
+
+  it("never breaks traffic when the emitter is unbound or throws", async () => {
+    // Given
+    const emitter: ProviderObservationEmitter = {};
+    const observed = createProviderObservationFetch(emitter, () =>
+      Promise.resolve(new Response("ok"))
+    );
+
+    // When
+    const unbound = await observed("https://gateway.example/v1/models");
+    emitter.current = () => {
+      throw new Error("observer exploded");
+    };
+    const throwing = await observed("https://gateway.example/v1/models");
+
+    // Then
+    expect(unbound.status).toBe(200);
+    expect(throwing.status).toBe(200);
+  });
+});

--- a/apps/coding-agent/src/provider-observation.test.ts
+++ b/apps/coding-agent/src/provider-observation.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+
+const invalidUrlPattern = /Invalid URL/u;
+
 import type { ExtensionJsonValue } from "./extensions";
 import {
   createProviderObservationFetch,
@@ -99,6 +102,35 @@ describe("provider observation fetch", () => {
         type: "provider:error",
       },
     ]);
+  });
+
+  it("scrubs URL-like tokens from transport error messages", async () => {
+    // Given
+    const { emitter, events } = createRecorder();
+    const observed = createProviderObservationFetch(emitter, () =>
+      Promise.reject(
+        new Error(
+          `Invalid URL: https://user:secret@gateway.example/v1?api-key=leak (${"x".repeat(400)})`
+        )
+      )
+    );
+
+    // When / Then
+    await expect(observed("https://gateway.example/v1/chat")).rejects.toThrow(
+      invalidUrlPattern
+    );
+    const errorEvent = events.find((event) => event.type === "provider:error");
+    const message =
+      errorEvent !== undefined &&
+      typeof errorEvent.payload === "object" &&
+      errorEvent.payload !== null &&
+      "message" in errorEvent.payload
+        ? String(errorEvent.payload.message)
+        : "";
+    expect(message).toContain("<redacted-url>");
+    expect(message).not.toContain("secret");
+    expect(message).not.toContain("api-key=leak");
+    expect(message.length).toBeLessThanOrEqual(256);
   });
 
   it("never breaks traffic when the emitter is unbound or throws", async () => {

--- a/apps/coding-agent/src/provider-observation.test.ts
+++ b/apps/coding-agent/src/provider-observation.test.ts
@@ -46,7 +46,7 @@ describe("provider observation fetch", () => {
 
     // When
     const response = await observed(
-      "https://user:pass@gateway.example/v1/chat?api-key=leak",
+      "https://user:pass@gateway.example/v1/chat?api-key=leak#token=fragment",
       { body: '{"secret":true}', method: "post" }
     );
 

--- a/apps/coding-agent/src/provider-observation.test.ts
+++ b/apps/coding-agent/src/provider-observation.test.ts
@@ -152,6 +152,40 @@ describe("provider observation fetch", () => {
     expect(message.length).toBeLessThanOrEqual(256);
   });
 
+  it("keeps a request bound to the sink captured at its start", async () => {
+    // Given
+    const first: RecordedEvent[] = [];
+    const second: RecordedEvent[] = [];
+    const emitter: ProviderObservationEmitter = {
+      current: (type, payload) => {
+        first.push({ payload, type });
+      },
+    };
+    let releaseResponse: (() => void) | undefined;
+    const observed = createProviderObservationFetch(
+      emitter,
+      () =>
+        new Promise((resolveFetch) => {
+          releaseResponse = () => resolveFetch(new Response("ok"));
+        })
+    );
+
+    // When — a reload rebinds the emitter while the request is in flight.
+    const pending = observed("https://gateway.example/v1/chat");
+    emitter.current = (type, payload) => {
+      second.push({ payload, type });
+    };
+    releaseResponse?.();
+    await pending;
+
+    // Then — both events landed on the original sink.
+    expect(first.map((event) => event.type)).toEqual([
+      "provider:request",
+      "provider:response",
+    ]);
+    expect(second).toEqual([]);
+  });
+
   it("never breaks traffic when the emitter is unbound or throws", async () => {
     // Given
     const emitter: ProviderObservationEmitter = {};

--- a/apps/coding-agent/src/provider-observation.test.ts
+++ b/apps/coding-agent/src/provider-observation.test.ts
@@ -104,6 +104,25 @@ describe("provider observation fetch", () => {
     ]);
   });
 
+  it("scrubs scheme-less query and fragment tokens", async () => {
+    // Given
+    const { emitter, events } = createRecorder();
+    const observed = createProviderObservationFetch(emitter, () =>
+      Promise.reject(
+        new Error(
+          "Failed to parse gateway.example/v1?secret-token and host/path#secret"
+        )
+      )
+    );
+
+    // When / Then
+    await expect(observed("gateway.example/v1?secret-token")).rejects.toThrow();
+    const errorEvent = events.find((event) => event.type === "provider:error");
+    const message = JSON.stringify(errorEvent?.payload ?? "");
+    expect(message).not.toContain("secret-token");
+    expect(message).not.toContain("#secret");
+  });
+
   it("scrubs URL-like tokens from transport error messages", async () => {
     // Given
     const { emitter, events } = createRecorder();

--- a/apps/coding-agent/src/provider-observation.ts
+++ b/apps/coding-agent/src/provider-observation.ts
@@ -1,0 +1,108 @@
+import type { ExtensionJsonValue } from "./extensions";
+
+/**
+ * Late-bound sink for provider observation events. The model (and its fetch
+ * wrapper) is created before the extension host, so the host binds itself
+ * here once it exists; `/reload` rebinds the replacement host the same way.
+ */
+export interface ProviderObservationEmitter {
+  current?: (type: string, payload: ExtensionJsonValue) => void;
+}
+
+const SAFE_RESPONSE_HEADERS = new Set([
+  "content-type",
+  "retry-after",
+  "x-request-id",
+]);
+const SAFE_RESPONSE_HEADER_PREFIXES = ["ratelimit-", "x-ratelimit-"] as const;
+
+/**
+ * Wrap `fetch` so provider HTTP traffic is observable by extensions as
+ * read-only `provider:request` / `provider:response` / `provider:error` bus
+ * events. URLs are stripped of credentials and query strings, request bodies
+ * and headers are never exposed, and response headers pass a safelist.
+ */
+export function createProviderObservationFetch(
+  emitter: ProviderObservationEmitter,
+  baseFetch: typeof globalThis.fetch = globalThis.fetch
+): typeof globalThis.fetch {
+  const emit = (type: string, payload: ExtensionJsonValue): void => {
+    try {
+      emitter.current?.(type, payload);
+    } catch {
+      // Observation must never break provider traffic.
+    }
+  };
+  return async (input, init) => {
+    const url = redactedUrl(input);
+    const method = requestMethod(input, init);
+    emit("provider:request", { method, url });
+    let response: Response;
+    try {
+      response = await baseFetch(input, init);
+    } catch (error) {
+      emit("provider:error", {
+        message: error instanceof Error ? error.message : String(error),
+        url,
+      });
+      throw error;
+    }
+    emit("provider:response", {
+      headers: safeResponseHeaders(response.headers),
+      status: response.status,
+      url,
+    });
+    return response;
+  };
+}
+
+function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method !== undefined) {
+    return init.method.toUpperCase();
+  }
+  if (input instanceof Request) {
+    return input.method.toUpperCase();
+  }
+  return "GET";
+}
+
+function rawUrl(input: RequestInfo | URL): string {
+  if (input instanceof Request) {
+    return input.url;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input;
+}
+
+function redactedUrl(input: RequestInfo | URL): string {
+  const raw = rawUrl(input);
+  try {
+    const url = new URL(raw);
+    url.password = "";
+    url.search = "";
+    url.username = "";
+    return url.href;
+  } catch {
+    return "invalid-url";
+  }
+}
+
+function safeResponseHeaders(
+  headers: Headers
+): Readonly<Record<string, string>> {
+  const safe: Record<string, string> = {};
+  headers.forEach((value, name) => {
+    const normalized = name.toLowerCase();
+    if (
+      SAFE_RESPONSE_HEADERS.has(normalized) ||
+      SAFE_RESPONSE_HEADER_PREFIXES.some((prefix) =>
+        normalized.startsWith(prefix)
+      )
+    ) {
+      safe[normalized] = value;
+    }
+  });
+  return safe;
+}

--- a/apps/coding-agent/src/provider-observation.ts
+++ b/apps/coding-agent/src/provider-observation.ts
@@ -34,14 +34,18 @@ export function createProviderObservationFetch(
   emitter: ProviderObservationEmitter,
   baseFetch: typeof globalThis.fetch = globalThis.fetch
 ): typeof globalThis.fetch {
-  const emit = (type: string, payload: ExtensionJsonValue): void => {
-    try {
-      emitter.current?.(type, payload);
-    } catch {
-      // Observation must never break provider traffic.
-    }
-  };
   return async (input, init) => {
+    // Capture the sink once per request so a `/reload` rebinding mid-flight
+    // cannot split one request's events across different hosts or leak
+    // observations of traffic a runtime never initiated.
+    const sink = emitter.current;
+    const emit = (type: string, payload: ExtensionJsonValue): void => {
+      try {
+        sink?.(type, payload);
+      } catch {
+        // Observation must never break provider traffic.
+      }
+    };
     const url = redactedUrl(input);
     const method = requestMethod(input, init);
     emit("provider:request", { method, url });

--- a/apps/coding-agent/src/provider-observation.ts
+++ b/apps/coding-agent/src/provider-observation.ts
@@ -72,14 +72,30 @@ export function createProviderObservationFetch(
   };
 }
 
+/** Methods that Fetch byte-uppercases; every other token keeps its case. */
+const FETCH_NORMALIZED_METHODS = new Set([
+  "DELETE",
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "POST",
+  "PUT",
+]);
+
 function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
   if (init?.method !== undefined) {
-    return init.method.toUpperCase();
+    return normalizedMethod(init.method);
   }
   if (input instanceof Request) {
-    return input.method.toUpperCase();
+    // Request normalizes standard methods at construction time.
+    return input.method;
   }
   return "GET";
+}
+
+function normalizedMethod(method: string): string {
+  const uppercase = method.toUpperCase();
+  return FETCH_NORMALIZED_METHODS.has(uppercase) ? uppercase : method;
 }
 
 function rawUrl(input: RequestInfo | URL): string {

--- a/apps/coding-agent/src/provider-observation.ts
+++ b/apps/coding-agent/src/provider-observation.ts
@@ -9,6 +9,8 @@ export interface ProviderObservationEmitter {
   current?: (type: string, payload: ExtensionJsonValue) => void;
 }
 
+const URL_LIKE_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^\s"')]+/gi;
+const MAX_ERROR_MESSAGE_LENGTH = 256;
 const SAFE_RESPONSE_HEADERS = new Set([
   "content-type",
   "retry-after",
@@ -42,7 +44,7 @@ export function createProviderObservationFetch(
       response = await baseFetch(input, init);
     } catch (error) {
       emit("provider:error", {
-        message: error instanceof Error ? error.message : String(error),
+        message: redactedErrorMessage(error),
         url,
       });
       throw error;
@@ -88,6 +90,17 @@ function redactedUrl(input: RequestInfo | URL): string {
   } catch {
     return "invalid-url";
   }
+}
+
+/**
+ * Transport errors can embed the raw request URL (including credentials or
+ * query API keys); scrub URL-like tokens before publishing to observers.
+ */
+function redactedErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message
+    .replace(URL_LIKE_PATTERN, "<redacted-url>")
+    .slice(0, MAX_ERROR_MESSAGE_LENGTH);
 }
 
 function safeResponseHeaders(

--- a/apps/coding-agent/src/provider-observation.ts
+++ b/apps/coding-agent/src/provider-observation.ts
@@ -16,6 +16,10 @@ const URL_LIKE_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^\s"')]+/gi;
  * token carrying a `?` or `#` suffix is redacted wholesale.
  */
 const QUERY_TOKEN_PATTERN = /[^\s"')?#]*[?#][^\s"')]+/g;
+/** Credential-bearing authorities (`//user:secret@host`, `user:pw@host`). */
+const AUTHORITY_CREDENTIAL_PATTERN = /[^\s"')@]*@[^\s"')]+/g;
+/** Scheme-relative tokens (`//host/path`) that carry the raw input. */
+const SCHEME_RELATIVE_PATTERN = /\/\/[^\s"')]+/g;
 const MAX_ERROR_MESSAGE_LENGTH = 256;
 const SAFE_RESPONSE_HEADERS = new Set([
   "content-type",
@@ -110,6 +114,8 @@ function redactedErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return message
     .replace(URL_LIKE_PATTERN, "<redacted-url>")
+    .replace(SCHEME_RELATIVE_PATTERN, "<redacted-url>")
+    .replace(AUTHORITY_CREDENTIAL_PATTERN, "<redacted-url>")
     .replace(QUERY_TOKEN_PATTERN, "<redacted-url>")
     .slice(0, MAX_ERROR_MESSAGE_LENGTH);
 }

--- a/apps/coding-agent/src/provider-observation.ts
+++ b/apps/coding-agent/src/provider-observation.ts
@@ -80,6 +80,7 @@ function redactedUrl(input: RequestInfo | URL): string {
   const raw = rawUrl(input);
   try {
     const url = new URL(raw);
+    url.hash = "";
     url.password = "";
     url.search = "";
     url.username = "";

--- a/apps/coding-agent/src/provider-observation.ts
+++ b/apps/coding-agent/src/provider-observation.ts
@@ -10,6 +10,8 @@ export interface ProviderObservationEmitter {
 }
 
 const URL_LIKE_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^\s"')]+/gi;
+/** Scheme-less inputs still leak query secrets through error messages. */
+const QUERY_TOKEN_PATTERN = /[^\s"')?]*\?[^\s"')]*=[^\s"')]*/g;
 const MAX_ERROR_MESSAGE_LENGTH = 256;
 const SAFE_RESPONSE_HEADERS = new Set([
   "content-type",
@@ -100,6 +102,7 @@ function redactedErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return message
     .replace(URL_LIKE_PATTERN, "<redacted-url>")
+    .replace(QUERY_TOKEN_PATTERN, "<redacted-url>")
     .slice(0, MAX_ERROR_MESSAGE_LENGTH);
 }
 

--- a/apps/coding-agent/src/provider-observation.ts
+++ b/apps/coding-agent/src/provider-observation.ts
@@ -10,8 +10,12 @@ export interface ProviderObservationEmitter {
 }
 
 const URL_LIKE_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^\s"')]+/gi;
-/** Scheme-less inputs still leak query secrets through error messages. */
-const QUERY_TOKEN_PATTERN = /[^\s"')?]*\?[^\s"')]*=[^\s"')]*/g;
+/**
+ * Scheme-less inputs still leak query/fragment secrets through error
+ * messages (`gateway.example/v1?secret-token`, `host/path#secret`), so any
+ * token carrying a `?` or `#` suffix is redacted wholesale.
+ */
+const QUERY_TOKEN_PATTERN = /[^\s"')?#]*[?#][^\s"')]+/g;
 const MAX_ERROR_MESSAGE_LENGTH = 256;
 const SAFE_RESPONSE_HEADERS = new Set([
   "content-type",

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -525,7 +525,9 @@ export interface AgentTUIConfig {
   footer?: { text?: string };
   header?: { title: string; subtitle?: string };
   onCommandAction?: (action: TuiCommandAction) => void | Promise<void>;
-  onExtensionUiReady?: (ui: CodingAgentExtensionUi) => void | Promise<void>;
+  onExtensionUiReady?: (
+    createUi: (hostSignal?: AbortSignal) => CodingAgentExtensionUi
+  ) => void | Promise<void>;
   onModelUsage?: (usage: ModelUsage) => void;
   onSetup?: () => void | Promise<void>;
   onStreamStart?: () => void | Promise<void>;
@@ -1198,7 +1200,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   tui.start();
 
   try {
-    await config.onExtensionUiReady?.(
+    await config.onExtensionUiReady?.((hostSignal) =>
       createExtensionUi({
         restoreFocus: clearPromptInput,
         showMessage: (message) => addSystemMessage(chatContainer, message),
@@ -1206,7 +1208,12 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           showLoader(message);
           return clearStatus;
         },
-        signal: extensionUiController.signal,
+        // Host-scoped signals let a runtime swap cancel prompts that a
+        // detached previous host still has on screen.
+        signal:
+          hostSignal === undefined
+            ? extensionUiController.signal
+            : AbortSignal.any([extensionUiController.signal, hostSignal]),
         tui,
       })
     );

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -552,9 +552,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   const markdownTheme =
     config.theme?.markdownTheme ?? createDefaultMarkdownTheme();
   const editorTheme = config.theme?.editorTheme ?? createDefaultEditorTheme();
-  const { commands, commandLookup, commandAliasLookup } = buildTuiCommandSet(
-    config.commands
-  );
+  let commandSet = buildTuiCommandSet(config.commands);
 
   const terminal = new ProcessTerminal();
   const tui = new TUI(terminal);
@@ -603,9 +601,18 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     paddingX: 1,
     autocompleteMaxVisible: 8,
   });
+  const refreshCommandSet = (): void => {
+    commandSet = buildTuiCommandSet(config.commands);
+    editor.setAutocompleteProvider(
+      createAliasAwareAutocompleteProvider({
+        commands: commandSet.commands,
+        basePath: process.cwd(),
+      })
+    );
+  };
   editor.setAutocompleteProvider(
     createAliasAwareAutocompleteProvider({
-      commands,
+      commands: commandSet.commands,
       basePath: process.cwd(),
     })
   );
@@ -943,8 +950,8 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
     const normalizedName = parsed.name.toLowerCase();
     const resolvedName =
-      commandAliasLookup.get(normalizedName) ?? normalizedName;
-    const command = commandLookup.get(resolvedName);
+      commandSet.commandAliasLookup.get(normalizedName) ?? normalizedName;
+    const command = commandSet.commandLookup.get(resolvedName);
     if (!command) {
       return null;
     }
@@ -1017,6 +1024,36 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
 
+    if (commandResult.action.type === "reload") {
+      await handleReloadAction(commandResult);
+      return;
+    }
+
+    if (commandResult.message) {
+      addSystemMessage(chatContainer, commandResult.message);
+    }
+    tui.requestRender();
+  };
+
+  const handleReloadAction = async (
+    commandResult: TuiCommandResult
+  ): Promise<void> => {
+    if (!commandResult.action) {
+      return;
+    }
+    try {
+      await config.onCommandAction?.(commandResult.action);
+    } catch (error) {
+      refreshCommandSet();
+      addSystemMessage(
+        chatContainer,
+        `Reload failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+      tui.requestRender();
+      return;
+    }
+    refreshCommandSet();
+    updateHeader();
     if (commandResult.message) {
       addSystemMessage(chatContainer, commandResult.message);
     }

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -207,10 +207,21 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         CodingAgentExtensionHost
       >({
         activateHost: async (host, nextAgent) => {
-          if (extensionUi !== undefined) {
-            host.bindUi(extensionUi);
+          // Bind provider observations to the replacement host before its
+          // extensions activate so they observe their own model traffic.
+          const previousEmit = providerEmitter.current;
+          providerEmitter.current = (type, payload) => {
+            host.emitHostEvent(type, payload);
+          };
+          try {
+            if (extensionUi !== undefined) {
+              host.bindUi(extensionUi);
+            }
+            await host.activate(nextAgent, "tui");
+          } catch (error) {
+            providerEmitter.current = previousEmit;
+            throw error;
           }
-          await host.activate(nextAgent, "tui");
         },
         createAgent: (host) =>
           Promise.resolve(

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -253,17 +253,21 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       };
       providerEmitter.current = installedEmit;
       let installedUi: CodingAgentExtensionUi | undefined;
+      let installedUiAbort: AbortController | undefined;
       try {
         if (createExtensionUiForHost !== undefined) {
-          extensionUiAbort = new AbortController();
-          installedUi = createExtensionUiForHost(extensionUiAbort.signal);
+          installedUiAbort = new AbortController();
+          extensionUiAbort = installedUiAbort;
+          installedUi = createExtensionUiForHost(installedUiAbort.signal);
           extensionUi = installedUi;
           host.bindUi(installedUi);
         }
         await host.activate(nextAgent, "tui");
       } catch (error) {
-        // A detached activation can reject long after recovery installed a
-        // new runtime; only roll back bindings this attempt still owns.
+        // Cancel any prompt the failed attempt left on screen, then only
+        // roll back bindings this attempt still owns (a detached activation
+        // can reject long after recovery installed a new runtime).
+        installedUiAbort?.abort();
         if (providerEmitter.current === installedEmit) {
           providerEmitter.current = previousEmit;
         }

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -20,6 +20,7 @@ import {
   type CodingAgentExtensionUi,
   createCodingAgentExtensionHost,
 } from "../extensions";
+import { snapshotExtensionState } from "../extensions/state-snapshot";
 import { createCodingLanguageModel } from "../model";
 import {
   createProviderObservationFetch,
@@ -308,6 +309,9 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             host.toolRenderers,
             (name) => host.getToolRendererOwner(name)
           ),
+        // Snapshot shared extension state so a failed activation cannot
+        // leave partially upgraded state for the recovered runtime.
+        snapshotState: () => snapshotExtensionState(),
         // Rebuild a runtime from the previous inputs so the session stays
         // usable when replacement activation fails after old cleanup ran.
         recoverPrevious: async () => {
@@ -344,24 +348,37 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         validateHost: async (host) => {
           // Migration callbacks are extension-controlled; bound them like
           // every other extension operation so a hanging migration fails
-          // the reload instead of freezing the session.
+          // the reload instead of freezing the session. The abort signal is
+          // checked before every durable write, so a timed-out migration
+          // task can never commit after the reload already failed.
+          const commitAbort = new AbortController();
           const committed = await boundedReloadOperation(
             commitThreadStateMigrations({
               migrations: host.threadMigrations,
+              signal: commitAbort.signal,
               store: reloadFileHost.store.threads,
               threadKey: threadStoreKey(threadConfig.key),
             }),
             host.timeoutMs,
             "Thread migration validation"
-          );
-          return committed === undefined
-            ? undefined
-            : () =>
-                boundedReloadOperation(
-                  committed.revert(),
-                  host.timeoutMs,
-                  "Thread migration revert"
-                );
+          ).catch((error: unknown) => {
+            commitAbort.abort();
+            throw error;
+          });
+          if (committed === undefined) {
+            return;
+          }
+          return () => {
+            const revertAbort = new AbortController();
+            return boundedReloadOperation(
+              committed.revert({ signal: revertAbort.signal }),
+              host.timeoutMs,
+              "Thread migration revert"
+            ).catch((error: unknown) => {
+              revertAbort.abort();
+              throw error;
+            });
+          };
         },
       });
       installRuntime(swap.host, swap.agent, swap.commands, swap.toolRenderers);

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -333,8 +333,8 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             // Even when cleanup was detached by the timeout, late writes
             // must not touch state the replacement runtime now owns, and
             // stale prompts must release the terminal.
-            previous.host.revokeExtensionState();
             previous.uiAbort?.abort();
+            await previous.host.revokeExtensionState();
           }
         },
         loadExtensions: reloadExtensions,
@@ -385,7 +385,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
               toolRenderers
             );
           } catch (error) {
-            recoveredHost.revokeExtensionState();
+            await recoveredHost.revokeExtensionState().catch(() => undefined);
             await Promise.allSettled([
               recoveredAgent === undefined
                 ? Promise.resolve()

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -1,7 +1,11 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import type { AgentOptions } from "@minpeter/pss-runtime";
+import {
+  type AgentOptions,
+  threadStoreKey,
+  validateThreadStateMigrations,
+} from "@minpeter/pss-runtime";
 import { createFileHost } from "@minpeter/pss-runtime/platform/file";
 import type { ToolSet } from "ai";
 import { createCodingAgent } from "../coding-agent";
@@ -175,7 +179,18 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       },
       onCommandAction: async (action) => {
         if (action.type === "reload") {
-          await reloadExtensionRuntime();
+          try {
+            await reloadExtensionRuntime();
+          } catch (error) {
+            // Replacement activation may have written to the durable thread
+            // before failing; refresh the handle so the surviving session
+            // re-reads the store instead of committing on a stale revision.
+            const stale = thread;
+            thread = agent.thread(threadConfig.key);
+            stale.interrupt();
+            await stale.dispose().catch(() => undefined);
+            throw error;
+          }
           return;
         }
         if (action.type !== "new-session") {
@@ -202,6 +217,9 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       if (reloadExtensions === undefined) {
         throw new Error("Extension reload is unavailable in this session.");
       }
+      const reloadFileHost = createFileHost({
+        directory: threadConfig.directory,
+      });
       const swap = await buildReloadedExtensionRuntime<
         Awaited<ReturnType<typeof createCodingAgent>>,
         CodingAgentExtensionHost
@@ -228,7 +246,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             createCodingAgent({
               autoCompaction: threadConfig.autoCompaction,
               extensionHost: host,
-              host: createFileHost({ directory: threadConfig.directory }),
+              host: reloadFileHost,
               model,
               tools: options.tools,
               webTools: { onWebToolsDisabled: () => undefined },
@@ -246,6 +264,14 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             host.toolRenderers,
             (name) => host.getToolRendererOwner(name)
           ),
+        // Prove reloaded migrations accept the stored thread before swapping
+        // so a rejecting migration cannot strand the next prompt.
+        validateHost: (host) =>
+          validateThreadStateMigrations({
+            migrations: host.threadMigrations,
+            store: reloadFileHost.store.threads,
+            threadKey: threadStoreKey(threadConfig.key),
+          }),
       });
       const previous = { agent, host: extensionHost, thread };
       agent = swap.agent;

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -284,13 +284,19 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         createAgent: (host) => Promise.resolve(createReplacementAgent(host)),
         createHost: (loaded) =>
           createCodingAgentExtensionHost(loaded.extensions),
-        disposePrevious: () => {
+        disposePrevious: async () => {
           previous.thread.interrupt();
-          return disposePreviousExtensionRuntime({
-            agent: previous.agent,
-            disposeThread: () => previous.thread.dispose(),
-            host: previous.host,
-          });
+          try {
+            return await disposePreviousExtensionRuntime({
+              agent: previous.agent,
+              disposeThread: () => previous.thread.dispose(),
+              host: previous.host,
+            });
+          } finally {
+            // Even when cleanup was detached by the timeout, late writes
+            // must not touch state the replacement runtime now owns.
+            previous.host.revokeExtensionState();
+          }
         },
         loadExtensions: reloadExtensions,
         mergeCommands: (host) =>

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -11,9 +11,17 @@ import {
   readOpenAICompatibleModelEnv,
 } from "../env";
 import {
+  type CodingAgentExtensionHost,
   type CodingAgentExtensionInput,
+  type CodingAgentExtensionUi,
   createCodingAgentExtensionHost,
+  type LoadedConfiguredExtensions,
 } from "../extensions";
+import { createCodingLanguageModel } from "../model";
+import {
+  createProviderObservationFetch,
+  type ProviderObservationEmitter,
+} from "../provider-observation";
 import { resolveCodingAgentThreadConfig } from "../thread-config";
 import { planAutoUpdate, runAutoUpdate } from "../update/auto-update";
 import { UPDATE_CHECK_CACHE_FILENAME } from "../update/check";
@@ -21,13 +29,19 @@ import { cliVersion } from "../update/cli-version";
 import { emitUpdateNotice } from "../update/notifier";
 import { type AgentTUIConfig, createAgentTUI } from "./agent";
 import type { TuiCommand } from "./command";
-import { createClearCommand } from "./command-set";
+import { createClearCommand, createReloadCommand } from "./command-set";
+import {
+  buildReloadedExtensionRuntime,
+  disposePreviousExtensionRuntime,
+} from "./reload";
 import { createToolRenderers } from "./renderers/tool-renderers";
 
 export interface StartTuiOptions {
   readonly extensions?: readonly CodingAgentExtensionInput[];
   /** Overrides the language model (tests and scripted QA). */
   readonly model?: AgentOptions["model"];
+  /** Re-runs extension discovery for `/reload`; absent means unavailable. */
+  readonly reloadExtensions?: () => Promise<LoadedConfiguredExtensions>;
   /** Replaces the TUI's default optional OpenSearch tools. */
   readonly tools?: ToolSet;
 }
@@ -50,16 +64,26 @@ const resolveModelSubtitle = (): string | undefined => {
 export async function startTui(options: StartTuiOptions = {}): Promise<number> {
   const startupNotices: string[] = [];
   const threadConfig = resolveCodingAgentThreadConfig();
-  const extensionHost = await createCodingAgentExtensionHost(
+  const providerEmitter: ProviderObservationEmitter = {};
+  let model: AgentOptions["model"];
+  let extensionHost = await createCodingAgentExtensionHost(
     options.extensions ?? []
   );
+  providerEmitter.current = (type, payload) => {
+    extensionHost.emitHostEvent(type, payload);
+  };
   let agent: Awaited<ReturnType<typeof createCodingAgent>>;
   try {
+    model =
+      options.model ??
+      createCodingLanguageModel({
+        fetch: createProviderObservationFetch(providerEmitter),
+      });
     agent = await createCodingAgent({
       autoCompaction: threadConfig.autoCompaction,
       extensionHost,
       host: createFileHost({ directory: threadConfig.directory }),
-      ...(options.model === undefined ? {} : { model: options.model }),
+      model,
       tools: options.tools,
       webTools: {
         onWebToolsDisabled: (message) => startupNotices.push(message),
@@ -77,9 +101,10 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
   let exitCode = 0;
   try {
     let thread = agent.thread(threadConfig.key);
+    let extensionUi: CodingAgentExtensionUi | undefined;
 
     const noticeLines: string[] = [];
-    const builtInCommands = [createClearCommand()];
+    const builtInCommands = [createClearCommand(), createReloadCommand()];
     const deferredRefreshes: (() => Promise<void>)[] = [];
     const updateNotice = await emitUpdateNotice({
       write: (line) => noticeLines.push(line),
@@ -139,6 +164,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         footer.text = `${formatTokens(usageTotals.totalTokens)} tokens (${formatTokens(usageTotals.inputTokens)} in / ${formatTokens(usageTotals.outputTokens)} out)`;
       },
       onExtensionUiReady: async (ui) => {
+        extensionUi = ui;
         extensionHost.bindUi(ui);
         await extensionHost.activate(agent, "tui");
       },
@@ -148,6 +174,10 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         }
       },
       onCommandAction: async (action) => {
+        if (action.type === "reload") {
+          await reloadExtensionRuntime();
+          return;
+        }
         if (action.type !== "new-session") {
           return;
         }
@@ -165,6 +195,62 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         extensionHost.toolRenderers,
         (toolName) => extensionHost.getToolRendererOwner(toolName)
       ),
+    };
+
+    const reloadExtensionRuntime = async (): Promise<void> => {
+      const reloadExtensions = options.reloadExtensions;
+      if (reloadExtensions === undefined) {
+        throw new Error("Extension reload is unavailable in this session.");
+      }
+      const swap = await buildReloadedExtensionRuntime<
+        Awaited<ReturnType<typeof createCodingAgent>>,
+        CodingAgentExtensionHost
+      >({
+        activateHost: async (host, nextAgent) => {
+          if (extensionUi !== undefined) {
+            host.bindUi(extensionUi);
+          }
+          await host.activate(nextAgent, "tui");
+        },
+        createAgent: (host) =>
+          Promise.resolve(
+            createCodingAgent({
+              autoCompaction: threadConfig.autoCompaction,
+              extensionHost: host,
+              host: createFileHost({ directory: threadConfig.directory }),
+              model,
+              tools: options.tools,
+              webTools: { onWebToolsDisabled: () => undefined },
+              workspace: process.cwd(),
+            })
+          ),
+        createHost: (loaded) =>
+          createCodingAgentExtensionHost(loaded.extensions),
+        loadExtensions: reloadExtensions,
+        mergeCommands: (host) =>
+          guardExtensionCommands(builtInCommands, host.commands),
+        mergeToolRenderers: (host) =>
+          mergeToolRenderers(
+            createToolRenderers(),
+            host.toolRenderers,
+            (name) => host.getToolRendererOwner(name)
+          ),
+      });
+      const previous = { agent, host: extensionHost, thread };
+      agent = swap.agent;
+      extensionHost = swap.host;
+      thread = agent.thread(threadConfig.key);
+      tuiConfig.commands = [...swap.commands];
+      tuiConfig.toolRenderers = swap.toolRenderers;
+      previous.thread.interrupt();
+      const cleanupNotices = await disposePreviousExtensionRuntime({
+        agent: previous.agent,
+        disposeThread: () => previous.thread.dispose(),
+        host: previous.host,
+      });
+      for (const notice of [...swap.notices, ...cleanupNotices]) {
+        extensionUi?.notify(notice);
+      }
     };
 
     try {

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -3,8 +3,8 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   type AgentOptions,
+  commitThreadStateMigrations,
   threadStoreKey,
-  validateThreadStateMigrations,
 } from "@minpeter/pss-runtime";
 import { createFileHost } from "@minpeter/pss-runtime/platform/file";
 import type { ToolSet } from "ai";
@@ -108,7 +108,16 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
     let extensionUi: CodingAgentExtensionUi | undefined;
 
     const noticeLines: string[] = [];
-    const builtInCommands = [createClearCommand(), createReloadCommand()];
+    // `/reload` is only offered when the entrypoint provided a rediscovery
+    // loader; embedded starts without one would advertise a dead command.
+    const builtInCommands = [
+      createClearCommand(),
+      ...(options.reloadExtensions === undefined
+        ? []
+        : [createReloadCommand()]),
+    ];
+    let currentExtensionInputs: readonly CodingAgentExtensionInput[] =
+      options.extensions ?? [];
     const deferredRefreshes: (() => Promise<void>)[] = [];
     const updateNotice = await emitUpdateNotice({
       write: (line) => noticeLines.push(line),
@@ -212,6 +221,51 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       ),
     };
 
+    const activateReplacementHost = async (
+      host: CodingAgentExtensionHost,
+      nextAgent: Awaited<ReturnType<typeof createCodingAgent>>
+    ): Promise<void> => {
+      // Bind provider observations to the replacement host before its
+      // extensions activate so they observe their own model traffic.
+      const previousEmit = providerEmitter.current;
+      providerEmitter.current = (type, payload) => {
+        host.emitHostEvent(type, payload);
+      };
+      try {
+        if (extensionUi !== undefined) {
+          host.bindUi(extensionUi);
+        }
+        await host.activate(nextAgent, "tui");
+      } catch (error) {
+        providerEmitter.current = previousEmit;
+        throw error;
+      }
+    };
+
+    const createReplacementAgent = (host: CodingAgentExtensionHost) =>
+      createCodingAgent({
+        autoCompaction: threadConfig.autoCompaction,
+        extensionHost: host,
+        host: createFileHost({ directory: threadConfig.directory }),
+        model,
+        tools: options.tools,
+        webTools: { onWebToolsDisabled: () => undefined },
+        workspace: process.cwd(),
+      });
+
+    const installRuntime = (
+      host: CodingAgentExtensionHost,
+      nextAgent: Awaited<ReturnType<typeof createCodingAgent>>,
+      commands: readonly TuiCommand[],
+      toolRenderers: NonNullable<AgentTUIConfig["toolRenderers"]>
+    ): void => {
+      agent = nextAgent;
+      extensionHost = host;
+      thread = agent.thread(threadConfig.key);
+      tuiConfig.commands = [...commands];
+      tuiConfig.toolRenderers = toolRenderers;
+    };
+
     const reloadExtensionRuntime = async (): Promise<void> => {
       const reloadExtensions = options.reloadExtensions;
       if (reloadExtensions === undefined) {
@@ -220,41 +274,23 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       const reloadFileHost = createFileHost({
         directory: threadConfig.directory,
       });
+      const previous = { agent, host: extensionHost, thread };
       const swap = await buildReloadedExtensionRuntime<
         Awaited<ReturnType<typeof createCodingAgent>>,
         CodingAgentExtensionHost
       >({
-        activateHost: async (host, nextAgent) => {
-          // Bind provider observations to the replacement host before its
-          // extensions activate so they observe their own model traffic.
-          const previousEmit = providerEmitter.current;
-          providerEmitter.current = (type, payload) => {
-            host.emitHostEvent(type, payload);
-          };
-          try {
-            if (extensionUi !== undefined) {
-              host.bindUi(extensionUi);
-            }
-            await host.activate(nextAgent, "tui");
-          } catch (error) {
-            providerEmitter.current = previousEmit;
-            throw error;
-          }
-        },
-        createAgent: (host) =>
-          Promise.resolve(
-            createCodingAgent({
-              autoCompaction: threadConfig.autoCompaction,
-              extensionHost: host,
-              host: reloadFileHost,
-              model,
-              tools: options.tools,
-              webTools: { onWebToolsDisabled: () => undefined },
-              workspace: process.cwd(),
-            })
-          ),
+        activateHost: activateReplacementHost,
+        createAgent: (host) => Promise.resolve(createReplacementAgent(host)),
         createHost: (loaded) =>
           createCodingAgentExtensionHost(loaded.extensions),
+        disposePrevious: () => {
+          previous.thread.interrupt();
+          return disposePreviousExtensionRuntime({
+            agent: previous.agent,
+            disposeThread: () => previous.thread.dispose(),
+            host: previous.host,
+          });
+        },
         loadExtensions: reloadExtensions,
         mergeCommands: (host) =>
           guardExtensionCommands(builtInCommands, host.commands),
@@ -264,28 +300,48 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             host.toolRenderers,
             (name) => host.getToolRendererOwner(name)
           ),
-        // Prove reloaded migrations accept the stored thread before swapping
-        // so a rejecting migration cannot strand the next prompt.
+        // Rebuild a runtime from the previous inputs so the session stays
+        // usable when replacement activation fails after old cleanup ran.
+        recoverPrevious: async () => {
+          const recoveredHost = await createCodingAgentExtensionHost(
+            currentExtensionInputs
+          );
+          try {
+            const recoveredAgent = await createReplacementAgent(recoveredHost);
+            const commands = guardExtensionCommands(
+              builtInCommands,
+              recoveredHost.commands
+            );
+            const toolRenderers = mergeToolRenderers(
+              createToolRenderers(),
+              recoveredHost.toolRenderers,
+              (name) => recoveredHost.getToolRendererOwner(name)
+            );
+            await activateReplacementHost(recoveredHost, recoveredAgent);
+            installRuntime(
+              recoveredHost,
+              recoveredAgent,
+              commands,
+              toolRenderers
+            );
+          } catch (error) {
+            await recoveredHost.dispose().catch(() => undefined);
+            throw error;
+          }
+        },
+        // Commit reloaded migrations for the stored thread before swapping so
+        // a rejecting migration cannot strand the next prompt and stateful
+        // migrations never re-run on the next load.
         validateHost: (host) =>
-          validateThreadStateMigrations({
+          commitThreadStateMigrations({
             migrations: host.threadMigrations,
             store: reloadFileHost.store.threads,
             threadKey: threadStoreKey(threadConfig.key),
           }),
       });
-      const previous = { agent, host: extensionHost, thread };
-      agent = swap.agent;
-      extensionHost = swap.host;
-      thread = agent.thread(threadConfig.key);
-      tuiConfig.commands = [...swap.commands];
-      tuiConfig.toolRenderers = swap.toolRenderers;
-      previous.thread.interrupt();
-      const cleanupNotices = await disposePreviousExtensionRuntime({
-        agent: previous.agent,
-        disposeThread: () => previous.thread.dispose(),
-        host: previous.host,
-      });
-      for (const notice of [...swap.notices, ...cleanupNotices]) {
+      installRuntime(swap.host, swap.agent, swap.commands, swap.toolRenderers);
+      currentExtensionInputs = swap.loadedExtensions;
+      for (const notice of swap.notices) {
         extensionUi?.notify(notice);
       }
     };

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -35,7 +35,6 @@ import { type AgentTUIConfig, createAgentTUI } from "./agent";
 import type { TuiCommand } from "./command";
 import { createClearCommand, createReloadCommand } from "./command-set";
 import {
-  boundedReloadOperation,
   buildReloadedExtensionRuntime,
   disposePreviousExtensionRuntime,
   type ReloadableExtensions,
@@ -107,7 +106,11 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
   let exitCode = 0;
   try {
     let thread = agent.thread(threadConfig.key);
+    let createExtensionUiForHost:
+      | ((hostSignal?: AbortSignal) => CodingAgentExtensionUi)
+      | undefined;
     let extensionUi: CodingAgentExtensionUi | undefined;
+    let extensionUiAbort: AbortController | undefined;
 
     const noticeLines: string[] = [];
     // `/reload` is only offered when the entrypoint provided a rediscovery
@@ -178,9 +181,11 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
           (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
         footer.text = `${formatTokens(usageTotals.totalTokens)} tokens (${formatTokens(usageTotals.inputTokens)} in / ${formatTokens(usageTotals.outputTokens)} out)`;
       },
-      onExtensionUiReady: async (ui) => {
-        extensionUi = ui;
-        extensionHost.bindUi(ui);
+      onExtensionUiReady: async (createUi) => {
+        createExtensionUiForHost = createUi;
+        extensionUiAbort = new AbortController();
+        extensionUi = createUi(extensionUiAbort.signal);
+        extensionHost.bindUi(extensionUi);
         await extensionHost.activate(agent, "tui");
       },
       onSetup: () => {
@@ -229,18 +234,26 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       nextAgent: Awaited<ReturnType<typeof createCodingAgent>>
     ): Promise<void> => {
       // Bind provider observations to the replacement host before its
-      // extensions activate so they observe their own model traffic.
+      // extensions activate so they observe their own model traffic, and
+      // give the replacement its own host-scoped UI so detached prompts
+      // from a previous runtime can be cancelled independently.
       const previousEmit = providerEmitter.current;
+      const previousUi = extensionUi;
+      const previousUiAbort = extensionUiAbort;
       providerEmitter.current = (type, payload) => {
         host.emitHostEvent(type, payload);
       };
       try {
-        if (extensionUi !== undefined) {
+        if (createExtensionUiForHost !== undefined) {
+          extensionUiAbort = new AbortController();
+          extensionUi = createExtensionUiForHost(extensionUiAbort.signal);
           host.bindUi(extensionUi);
         }
         await host.activate(nextAgent, "tui");
       } catch (error) {
         providerEmitter.current = previousEmit;
+        extensionUi = previousUi;
+        extensionUiAbort = previousUiAbort;
         throw error;
       }
     };
@@ -277,7 +290,12 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       const reloadFileHost = createFileHost({
         directory: threadConfig.directory,
       });
-      const previous = { agent, host: extensionHost, thread };
+      const previous = {
+        agent,
+        host: extensionHost,
+        thread,
+        uiAbort: extensionUiAbort,
+      };
       const swap = await buildReloadedExtensionRuntime<
         Awaited<ReturnType<typeof createCodingAgent>>,
         CodingAgentExtensionHost
@@ -296,8 +314,10 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             });
           } finally {
             // Even when cleanup was detached by the timeout, late writes
-            // must not touch state the replacement runtime now owns.
+            // must not touch state the replacement runtime now owns, and
+            // stale prompts must release the terminal.
             previous.host.revokeExtensionState();
+            previous.uiAbort?.abort();
           }
         },
         loadExtensions: reloadExtensions,
@@ -347,39 +367,17 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         // migrations never re-run on the next load. The returned revert
         // restores the snapshot if a later reload phase fails.
         validateHost: async (host) => {
-          // Migration callbacks are extension-controlled; bound them like
-          // every other extension operation so a hanging migration fails
-          // the reload instead of freezing the session. The abort signal is
-          // checked before every durable write, so a timed-out migration
-          // task can never commit after the reload already failed.
-          const commitAbort = new AbortController();
-          const committed = await boundedReloadOperation(
-            commitThreadStateMigrations({
-              migrations: host.threadMigrations,
-              signal: commitAbort.signal,
-              store: reloadFileHost.store.threads,
-              threadKey: threadStoreKey(threadConfig.key),
-            }),
-            host.timeoutMs,
-            "Thread migration validation"
-          ).catch((error: unknown) => {
-            commitAbort.abort();
-            throw error;
+          // Migration callbacks are extension-controlled and bounded by the
+          // host timeout; the durable commit itself is awaited to
+          // completion so the reported reload outcome always matches the
+          // stored thread state.
+          const committed = await commitThreadStateMigrations({
+            migrations: host.threadMigrations,
+            store: reloadFileHost.store.threads,
+            threadKey: threadStoreKey(threadConfig.key),
+            timeoutMs: host.timeoutMs,
           });
-          if (committed === undefined) {
-            return;
-          }
-          return () => {
-            const revertAbort = new AbortController();
-            return boundedReloadOperation(
-              committed.revert({ signal: revertAbort.signal }),
-              host.timeoutMs,
-              "Thread migration revert"
-            ).catch((error: unknown) => {
-              revertAbort.abort();
-              throw error;
-            });
-          };
+          return committed === undefined ? undefined : () => committed.revert();
         },
       });
       installRuntime(swap.host, swap.agent, swap.commands, swap.toolRenderers);

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -19,7 +19,6 @@ import {
   type CodingAgentExtensionInput,
   type CodingAgentExtensionUi,
   createCodingAgentExtensionHost,
-  type LoadedConfiguredExtensions,
 } from "../extensions";
 import { createCodingLanguageModel } from "../model";
 import {
@@ -37,6 +36,7 @@ import { createClearCommand, createReloadCommand } from "./command-set";
 import {
   buildReloadedExtensionRuntime,
   disposePreviousExtensionRuntime,
+  type ReloadableExtensions,
 } from "./reload";
 import { createToolRenderers } from "./renderers/tool-renderers";
 
@@ -45,7 +45,7 @@ export interface StartTuiOptions {
   /** Overrides the language model (tests and scripted QA). */
   readonly model?: AgentOptions["model"];
   /** Re-runs extension discovery for `/reload`; absent means unavailable. */
-  readonly reloadExtensions?: () => Promise<LoadedConfiguredExtensions>;
+  readonly reloadExtensions?: () => Promise<ReloadableExtensions>;
   /** Replaces the TUI's default optional OpenSearch tools. */
   readonly tools?: ToolSet;
 }

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -35,6 +35,7 @@ import { type AgentTUIConfig, createAgentTUI } from "./agent";
 import type { TuiCommand } from "./command";
 import { createClearCommand, createReloadCommand } from "./command-set";
 import {
+  boundedReloadOperation,
   buildReloadedExtensionRuntime,
   disposePreviousExtensionRuntime,
   type ReloadableExtensions,
@@ -50,6 +51,8 @@ export interface StartTuiOptions {
   /** Replaces the TUI's default optional OpenSearch tools. */
   readonly tools?: ToolSet;
 }
+
+const RECOVERY_ACTIVATION_TIMEOUT_MS = 60_000;
 
 const formatTokens = (n: number): string => {
   if (n >= 1000) {
@@ -353,8 +356,11 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
           const recoveredHost = await createCodingAgentExtensionHost(
             currentExtensionInputs
           );
+          let recoveredAgent:
+            | Awaited<ReturnType<typeof createCodingAgent>>
+            | undefined;
           try {
-            const recoveredAgent = await createReplacementAgent(recoveredHost);
+            recoveredAgent = await createReplacementAgent(recoveredHost);
             const commands = guardExtensionCommands(
               builtInCommands,
               recoveredHost.commands
@@ -364,7 +370,14 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
               recoveredHost.toolRenderers,
               (name) => recoveredHost.getToolRendererOwner(name)
             );
-            await activateReplacementHost(recoveredHost, recoveredAgent);
+            // Recovery activation needs the same boundary as replacement
+            // activation; a hanging recovered cleanup must fail recovery
+            // instead of freezing the session.
+            await boundedReloadOperation(
+              activateReplacementHost(recoveredHost, recoveredAgent),
+              RECOVERY_ACTIVATION_TIMEOUT_MS,
+              "Recovered extension activation"
+            );
             installRuntime(
               recoveredHost,
               recoveredAgent,
@@ -372,7 +385,21 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
               toolRenderers
             );
           } catch (error) {
-            await recoveredHost.dispose().catch(() => undefined);
+            recoveredHost.revokeExtensionState();
+            await Promise.allSettled([
+              recoveredAgent === undefined
+                ? Promise.resolve()
+                : boundedReloadOperation(
+                    recoveredAgent.dispose(),
+                    RECOVERY_ACTIVATION_TIMEOUT_MS,
+                    "Recovered agent disposal"
+                  ),
+              boundedReloadOperation(
+                recoveredHost.dispose(),
+                RECOVERY_ACTIVATION_TIMEOUT_MS,
+                "Recovered host disposal"
+              ),
+            ]);
             throw error;
           }
         },

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -240,20 +240,34 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       const previousEmit = providerEmitter.current;
       const previousUi = extensionUi;
       const previousUiAbort = extensionUiAbort;
-      providerEmitter.current = (type, payload) => {
+      const installedEmit = (
+        type: string,
+        payload: Parameters<
+          NonNullable<ProviderObservationEmitter["current"]>
+        >[1]
+      ) => {
         host.emitHostEvent(type, payload);
       };
+      providerEmitter.current = installedEmit;
+      let installedUi: CodingAgentExtensionUi | undefined;
       try {
         if (createExtensionUiForHost !== undefined) {
           extensionUiAbort = new AbortController();
-          extensionUi = createExtensionUiForHost(extensionUiAbort.signal);
-          host.bindUi(extensionUi);
+          installedUi = createExtensionUiForHost(extensionUiAbort.signal);
+          extensionUi = installedUi;
+          host.bindUi(installedUi);
         }
         await host.activate(nextAgent, "tui");
       } catch (error) {
-        providerEmitter.current = previousEmit;
-        extensionUi = previousUi;
-        extensionUiAbort = previousUiAbort;
+        // A detached activation can reject long after recovery installed a
+        // new runtime; only roll back bindings this attempt still owns.
+        if (providerEmitter.current === installedEmit) {
+          providerEmitter.current = previousEmit;
+        }
+        if (installedUi !== undefined && extensionUi === installedUi) {
+          extensionUi = previousUi;
+          extensionUiAbort = previousUiAbort;
+        }
         throw error;
       }
     };

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -191,13 +191,14 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
           try {
             await reloadExtensionRuntime();
           } catch (error) {
-            // Replacement activation may have written to the durable thread
-            // before failing; refresh the handle so the surviving session
-            // re-reads the store instead of committing on a stale revision.
+            // A failed reload may have touched the durable thread; dispose
+            // the cached handle first (disposal evicts it from the agent),
+            // then request a fresh one that re-reads the store instead of
+            // committing on a stale revision.
             const stale = thread;
-            thread = agent.thread(threadConfig.key);
             stale.interrupt();
             await stale.dispose().catch(() => undefined);
+            thread = agent.thread(threadConfig.key);
             throw error;
           }
           return;
@@ -331,13 +332,16 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         },
         // Commit reloaded migrations for the stored thread before swapping so
         // a rejecting migration cannot strand the next prompt and stateful
-        // migrations never re-run on the next load.
-        validateHost: (host) =>
-          commitThreadStateMigrations({
+        // migrations never re-run on the next load. The returned revert
+        // restores the snapshot if a later reload phase fails.
+        validateHost: async (host) => {
+          const committed = await commitThreadStateMigrations({
             migrations: host.threadMigrations,
             store: reloadFileHost.store.threads,
             threadKey: threadStoreKey(threadConfig.key),
-          }),
+          });
+          return committed === undefined ? undefined : () => committed.revert();
+        },
       });
       installRuntime(swap.host, swap.agent, swap.commands, swap.toolRenderers);
       currentExtensionInputs = swap.loadedExtensions;

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -309,9 +309,10 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             host.toolRenderers,
             (name) => host.getToolRendererOwner(name)
           ),
-        // Snapshot shared extension state so a failed activation cannot
-        // leave partially upgraded state for the recovered runtime.
-        snapshotState: () => snapshotExtensionState(),
+        // Snapshot the replacement extensions' state files so a failed
+        // activation cannot leave partially upgraded state for the
+        // recovered runtime.
+        snapshotState: (extensionIds) => snapshotExtensionState(extensionIds),
         // Rebuild a runtime from the previous inputs so the session stays
         // usable when replacement activation fails after old cleanup ran.
         recoverPrevious: async () => {

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -34,6 +34,7 @@ import { type AgentTUIConfig, createAgentTUI } from "./agent";
 import type { TuiCommand } from "./command";
 import { createClearCommand, createReloadCommand } from "./command-set";
 import {
+  boundedReloadOperation,
   buildReloadedExtensionRuntime,
   disposePreviousExtensionRuntime,
   type ReloadableExtensions,
@@ -341,12 +342,26 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         // migrations never re-run on the next load. The returned revert
         // restores the snapshot if a later reload phase fails.
         validateHost: async (host) => {
-          const committed = await commitThreadStateMigrations({
-            migrations: host.threadMigrations,
-            store: reloadFileHost.store.threads,
-            threadKey: threadStoreKey(threadConfig.key),
-          });
-          return committed === undefined ? undefined : () => committed.revert();
+          // Migration callbacks are extension-controlled; bound them like
+          // every other extension operation so a hanging migration fails
+          // the reload instead of freezing the session.
+          const committed = await boundedReloadOperation(
+            commitThreadStateMigrations({
+              migrations: host.threadMigrations,
+              store: reloadFileHost.store.threads,
+              threadKey: threadStoreKey(threadConfig.key),
+            }),
+            host.timeoutMs,
+            "Thread migration validation"
+          );
+          return committed === undefined
+            ? undefined
+            : () =>
+                boundedReloadOperation(
+                  committed.revert(),
+                  host.timeoutMs,
+                  "Thread migration revert"
+                );
         },
       });
       installRuntime(swap.host, swap.agent, swap.commands, swap.toolRenderers);

--- a/apps/coding-agent/src/tui/command-set.ts
+++ b/apps/coding-agent/src/tui/command-set.ts
@@ -81,3 +81,13 @@ export const createClearCommand = (): TuiCommand => ({
   description: "Start a new session",
   execute: () => newSessionAction(),
 });
+
+export const createReloadCommand = (): TuiCommand => ({
+  name: "reload",
+  description: "Reload extensions from disk",
+  execute: (): TuiCommandResult => ({
+    action: { type: "reload" },
+    message: "Extensions reloaded.",
+    success: true,
+  }),
+});

--- a/apps/coding-agent/src/tui/command.ts
+++ b/apps/coding-agent/src/tui/command.ts
@@ -8,9 +8,7 @@ import type {
  * Local slash-command model for the pss TUI. Mirrors the harness `Command`
  * contract plugsuits used, scoped down to what the interactive session needs.
  */
-export interface TuiCommandAction {
-  type: "new-session";
-}
+export type TuiCommandAction = { type: "new-session" } | { type: "reload" };
 
 export interface TuiCommandResult {
   action?: TuiCommandAction;

--- a/apps/coding-agent/src/tui/reload.test.ts
+++ b/apps/coding-agent/src/tui/reload.test.ts
@@ -61,7 +61,7 @@ function baseOptions(overrides: {
   >;
   readonly mergeCommands?: () => readonly TuiCommand[];
   readonly recoverPrevious?: () => Promise<void>;
-  readonly validateHost?: () => Promise<void>;
+  readonly validateHost?: () => Promise<(() => Promise<void>) | undefined>;
 }) {
   return {
     activateHost: overrides.activateHost ?? (() => Promise.resolve()),
@@ -116,7 +116,7 @@ describe("buildReloadedExtensionRuntime", () => {
         },
         validateHost: () => {
           order.push("validate");
-          return Promise.resolve();
+          return Promise.resolve(undefined);
         },
       })
     );
@@ -165,6 +165,7 @@ describe("buildReloadedExtensionRuntime", () => {
         })
       )
     ).rejects.toThrow("migration rejected history");
+    // Validation itself failed, so there is nothing to revert.
     expect(previousDisposed).toBe(false);
     expect(host.disposed).toEqual([true]);
     expect(rollbacks).toEqual([true]);
@@ -192,6 +193,46 @@ describe("buildReloadedExtensionRuntime", () => {
     ).rejects.toThrow("command conflict");
     expect(agentCreated).toBe(false);
     expect(host.disposed).toEqual([true]);
+  });
+
+  it("reverts committed validation side effects when activation fails", async () => {
+    // Given
+    const reverts: boolean[] = [];
+
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          activateHost: () => Promise.reject(new Error("activation exploded")),
+          validateHost: () =>
+            Promise.resolve(() => {
+              reverts.push(true);
+              return Promise.resolve();
+            }),
+        })
+      )
+    ).rejects.toThrow("activation exploded");
+    expect(reverts).toEqual([true]);
+  });
+
+  it("reverts validation when agent creation fails after the commit", async () => {
+    // Given
+    const reverts: boolean[] = [];
+
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          createAgent: () => Promise.reject(new Error("agent exploded")),
+          validateHost: () =>
+            Promise.resolve(() => {
+              reverts.push(true);
+              return Promise.resolve();
+            }),
+        })
+      )
+    ).rejects.toThrow("agent exploded");
+    expect(reverts).toEqual([true]);
   });
 
   it("recovers the previous runtime when activation fails", async () => {

--- a/apps/coding-agent/src/tui/reload.test.ts
+++ b/apps/coding-agent/src/tui/reload.test.ts
@@ -44,6 +44,7 @@ const loaded: LoadedConfiguredExtensions = {
 };
 
 const recoveryPattern = /could not be recovered/u;
+const revertFailedPattern = /could not be reverted/u;
 
 const command: TuiCommand = {
   description: "noop",
@@ -266,6 +267,29 @@ describe("buildReloadedExtensionRuntime", () => {
     expect(agent.disposed).toEqual([true]);
     expect(host.disposed).toEqual([true]);
     expect(rollbacks).toEqual([true]);
+    expect(recoveries).toEqual([true]);
+  });
+
+  it("recovers the previous runtime even when the migration revert fails", async () => {
+    // Given
+    const recoveries: boolean[] = [];
+
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          activateHost: () => Promise.reject(new Error("activation exploded")),
+          recoverPrevious: () => {
+            recoveries.push(true);
+            return Promise.resolve();
+          },
+          validateHost: () =>
+            Promise.resolve(() =>
+              Promise.reject(new Error("revert conflicted"))
+            ),
+        })
+      )
+    ).rejects.toThrow(revertFailedPattern);
     expect(recoveries).toEqual([true]);
   });
 

--- a/apps/coding-agent/src/tui/reload.test.ts
+++ b/apps/coding-agent/src/tui/reload.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import type { LoadedConfiguredExtensions } from "../extensions";
+import type { TuiCommand } from "./command";
+import {
+  buildReloadedExtensionRuntime,
+  disposePreviousExtensionRuntime,
+} from "./reload";
+
+interface FakeAgent {
+  dispose(): Promise<void>;
+  readonly disposed: boolean[];
+}
+
+interface FakeHost {
+  dispose(): Promise<void>;
+  readonly disposed: boolean[];
+}
+
+function fakeAgent(): FakeAgent {
+  const disposed: boolean[] = [];
+  return {
+    dispose: () => {
+      disposed.push(true);
+      return Promise.resolve();
+    },
+    disposed,
+  };
+}
+
+function fakeHost(): FakeHost {
+  const disposed: boolean[] = [];
+  return {
+    dispose: () => {
+      disposed.push(true);
+      return Promise.resolve();
+    },
+    disposed,
+  };
+}
+
+const loaded: LoadedConfiguredExtensions = {
+  extensions: [],
+  notices: ["notice-a"],
+};
+
+const command: TuiCommand = {
+  description: "noop",
+  execute: () => ({ success: true }),
+  name: "noop",
+};
+
+describe("buildReloadedExtensionRuntime", () => {
+  it("builds and activates the replacement runtime before returning", async () => {
+    // Given
+    const host = fakeHost();
+    const agent = fakeAgent();
+    const order: string[] = [];
+
+    // When
+    const swap = await buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
+      activateHost: (_host, _agent) => {
+        order.push("activate");
+        return Promise.resolve();
+      },
+      createAgent: () => {
+        order.push("agent");
+        return Promise.resolve(agent);
+      },
+      createHost: () => {
+        order.push("host");
+        return Promise.resolve(host);
+      },
+      loadExtensions: () => {
+        order.push("load");
+        return Promise.resolve(loaded);
+      },
+      mergeCommands: () => {
+        order.push("commands");
+        return [command];
+      },
+      mergeToolRenderers: () => {
+        order.push("renderers");
+        return {};
+      },
+    });
+
+    // Then
+    expect(order).toEqual([
+      "load",
+      "host",
+      "commands",
+      "renderers",
+      "agent",
+      "activate",
+    ]);
+    expect(swap.agent).toBe(agent);
+    expect(swap.host).toBe(host);
+    expect(swap.commands).toEqual([command]);
+    expect(swap.notices).toEqual(["notice-a"]);
+    expect(host.disposed).toEqual([]);
+    expect(agent.disposed).toEqual([]);
+  });
+
+  it("disposes partial resources and rethrows when activation fails", async () => {
+    // Given
+    const host = fakeHost();
+    const agent = fakeAgent();
+
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
+        activateHost: () => Promise.reject(new Error("activation exploded")),
+        createAgent: () => Promise.resolve(agent),
+        createHost: () => Promise.resolve(host),
+        loadExtensions: () => Promise.resolve(loaded),
+        mergeCommands: () => [command],
+        mergeToolRenderers: () => ({}),
+      })
+    ).rejects.toThrow("activation exploded");
+    expect(agent.disposed).toEqual([true]);
+    expect(host.disposed).toEqual([true]);
+  });
+
+  it("aborts before creating the agent when command merging fails", async () => {
+    // Given
+    const host = fakeHost();
+    let agentCreated = false;
+
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
+        activateHost: () => Promise.resolve(),
+        createAgent: () => {
+          agentCreated = true;
+          return Promise.resolve(fakeAgent());
+        },
+        createHost: () => Promise.resolve(host),
+        loadExtensions: () => Promise.resolve(loaded),
+        mergeCommands: () => {
+          throw new Error("command conflict");
+        },
+        mergeToolRenderers: () => ({}),
+      })
+    ).rejects.toThrow("command conflict");
+    expect(agentCreated).toBe(false);
+    expect(host.disposed).toEqual([true]);
+  });
+
+  it("keeps nothing when extension loading fails", async () => {
+    // Given
+    let hostCreated = false;
+
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
+        activateHost: () => Promise.resolve(),
+        createAgent: () => Promise.resolve(fakeAgent()),
+        createHost: () => {
+          hostCreated = true;
+          return Promise.resolve(fakeHost());
+        },
+        loadExtensions: () => Promise.reject(new Error("discovery failed")),
+        mergeCommands: () => [command],
+        mergeToolRenderers: () => ({}),
+      })
+    ).rejects.toThrow("discovery failed");
+    expect(hostCreated).toBe(false);
+  });
+});
+
+describe("disposePreviousExtensionRuntime", () => {
+  it("disposes everything and reports failures as notices", async () => {
+    // Given
+    const agent = fakeAgent();
+    const host = fakeHost();
+
+    // When
+    const clean = await disposePreviousExtensionRuntime({
+      agent,
+      disposeThread: () => Promise.resolve(),
+      host,
+    });
+    const failing = await disposePreviousExtensionRuntime({
+      agent: {
+        dispose: () => Promise.reject(new Error("agent stuck")),
+      },
+      disposeThread: () => Promise.reject(new Error("thread stuck")),
+      host: fakeHost(),
+    });
+
+    // Then
+    expect(clean).toEqual([]);
+    expect(agent.disposed).toEqual([true]);
+    expect(host.disposed).toEqual([true]);
+    expect(failing).toHaveLength(2);
+    expect(failing[0]).toContain("thread stuck");
+    expect(failing[1]).toContain("agent stuck");
+  });
+});

--- a/apps/coding-agent/src/tui/reload.test.ts
+++ b/apps/coding-agent/src/tui/reload.test.ts
@@ -171,6 +171,30 @@ describe("buildReloadedExtensionRuntime", () => {
     expect(host.disposed).toEqual([true]);
   });
 
+  it("rolls back the module cache when activation fails", async () => {
+    // Given
+    const rollbacks: boolean[] = [];
+
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
+        activateHost: () => Promise.reject(new Error("activation exploded")),
+        createAgent: () => Promise.resolve(fakeAgent()),
+        createHost: () => Promise.resolve(fakeHost()),
+        loadExtensions: () =>
+          Promise.resolve({
+            ...loaded,
+            rollbackModuleCache: () => {
+              rollbacks.push(true);
+            },
+          }),
+        mergeCommands: () => [command],
+        mergeToolRenderers: () => ({}),
+      })
+    ).rejects.toThrow("activation exploded");
+    expect(rollbacks).toEqual([true]);
+  });
+
   it("keeps nothing when extension loading fails", async () => {
     // Given
     let hostCreated = false;
@@ -194,6 +218,23 @@ describe("buildReloadedExtensionRuntime", () => {
 });
 
 describe("disposePreviousExtensionRuntime", () => {
+  it("detaches never-settling cleanup after the timeout", async () => {
+    // Given
+    const hanging = new Promise<void>(() => undefined);
+
+    // When
+    const notices = await disposePreviousExtensionRuntime({
+      agent: { dispose: () => hanging },
+      disposeThread: () => Promise.resolve(),
+      host: fakeHost(),
+      timeoutMs: 20,
+    });
+
+    // Then
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain("did not settle within 20ms");
+  });
+
   it("disposes everything and reports failures as notices", async () => {
     // Given
     const agent = fakeAgent();

--- a/apps/coding-agent/src/tui/reload.test.ts
+++ b/apps/coding-agent/src/tui/reload.test.ts
@@ -121,6 +121,31 @@ describe("buildReloadedExtensionRuntime", () => {
     expect(host.disposed).toEqual([true]);
   });
 
+  it("aborts before creating the agent when validation fails", async () => {
+    // Given
+    const host = fakeHost();
+    let agentCreated = false;
+
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
+        activateHost: () => Promise.resolve(),
+        createAgent: () => {
+          agentCreated = true;
+          return Promise.resolve(fakeAgent());
+        },
+        createHost: () => Promise.resolve(host),
+        loadExtensions: () => Promise.resolve(loaded),
+        mergeCommands: () => [command],
+        mergeToolRenderers: () => ({}),
+        validateHost: () =>
+          Promise.reject(new Error("migration rejected history")),
+      })
+    ).rejects.toThrow("migration rejected history");
+    expect(agentCreated).toBe(false);
+    expect(host.disposed).toEqual([true]);
+  });
+
   it("aborts before creating the agent when command merging fails", async () => {
     // Given
     const host = fakeHost();

--- a/apps/coding-agent/src/tui/reload.test.ts
+++ b/apps/coding-agent/src/tui/reload.test.ts
@@ -43,107 +43,131 @@ const loaded: LoadedConfiguredExtensions = {
   notices: ["notice-a"],
 };
 
+const recoveryPattern = /could not be recovered/u;
+
 const command: TuiCommand = {
   description: "noop",
   execute: () => ({ success: true }),
   name: "noop",
 };
 
+function baseOptions(overrides: {
+  readonly activateHost?: (host: FakeHost, agent: FakeAgent) => Promise<void>;
+  readonly createAgent?: () => Promise<FakeAgent>;
+  readonly createHost?: () => Promise<FakeHost>;
+  readonly disposePrevious?: () => Promise<readonly string[]>;
+  readonly loadExtensions?: () => Promise<
+    LoadedConfiguredExtensions & { rollbackModuleCache?: () => void }
+  >;
+  readonly mergeCommands?: () => readonly TuiCommand[];
+  readonly recoverPrevious?: () => Promise<void>;
+  readonly validateHost?: () => Promise<void>;
+}) {
+  return {
+    activateHost: overrides.activateHost ?? (() => Promise.resolve()),
+    createAgent: overrides.createAgent ?? (() => Promise.resolve(fakeAgent())),
+    createHost: overrides.createHost ?? (() => Promise.resolve(fakeHost())),
+    disposePrevious:
+      overrides.disposePrevious ??
+      (() => Promise.resolve([] as readonly string[])),
+    loadExtensions: overrides.loadExtensions ?? (() => Promise.resolve(loaded)),
+    mergeCommands: overrides.mergeCommands ?? (() => [command]),
+    mergeToolRenderers: () => ({}),
+    recoverPrevious: overrides.recoverPrevious ?? (() => Promise.resolve()),
+    ...(overrides.validateHost === undefined
+      ? {}
+      : { validateHost: overrides.validateHost }),
+  };
+}
+
 describe("buildReloadedExtensionRuntime", () => {
-  it("builds and activates the replacement runtime before returning", async () => {
+  it("disposes the previous runtime before activating the replacement", async () => {
     // Given
     const host = fakeHost();
     const agent = fakeAgent();
     const order: string[] = [];
 
     // When
-    const swap = await buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
-      activateHost: (_host, _agent) => {
-        order.push("activate");
-        return Promise.resolve();
-      },
-      createAgent: () => {
-        order.push("agent");
-        return Promise.resolve(agent);
-      },
-      createHost: () => {
-        order.push("host");
-        return Promise.resolve(host);
-      },
-      loadExtensions: () => {
-        order.push("load");
-        return Promise.resolve(loaded);
-      },
-      mergeCommands: () => {
-        order.push("commands");
-        return [command];
-      },
-      mergeToolRenderers: () => {
-        order.push("renderers");
-        return {};
-      },
-    });
+    const swap = await buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+      baseOptions({
+        activateHost: () => {
+          order.push("activate");
+          return Promise.resolve();
+        },
+        createAgent: () => {
+          order.push("agent");
+          return Promise.resolve(agent);
+        },
+        createHost: () => {
+          order.push("host");
+          return Promise.resolve(host);
+        },
+        disposePrevious: () => {
+          order.push("dispose-previous");
+          return Promise.resolve(["cleanup-notice"]);
+        },
+        loadExtensions: () => {
+          order.push("load");
+          return Promise.resolve(loaded);
+        },
+        mergeCommands: () => {
+          order.push("commands");
+          return [command];
+        },
+        validateHost: () => {
+          order.push("validate");
+          return Promise.resolve();
+        },
+      })
+    );
 
     // Then
     expect(order).toEqual([
       "load",
       "host",
       "commands",
-      "renderers",
+      "validate",
       "agent",
+      "dispose-previous",
       "activate",
     ]);
     expect(swap.agent).toBe(agent);
     expect(swap.host).toBe(host);
-    expect(swap.commands).toEqual([command]);
-    expect(swap.notices).toEqual(["notice-a"]);
+    expect(swap.notices).toEqual(["notice-a", "cleanup-notice"]);
     expect(host.disposed).toEqual([]);
     expect(agent.disposed).toEqual([]);
   });
 
-  it("disposes partial resources and rethrows when activation fails", async () => {
+  it("keeps the previous runtime when the build phase fails", async () => {
     // Given
     const host = fakeHost();
-    const agent = fakeAgent();
+    const rollbacks: boolean[] = [];
+    let previousDisposed = false;
 
     // When / Then
     await expect(
-      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
-        activateHost: () => Promise.reject(new Error("activation exploded")),
-        createAgent: () => Promise.resolve(agent),
-        createHost: () => Promise.resolve(host),
-        loadExtensions: () => Promise.resolve(loaded),
-        mergeCommands: () => [command],
-        mergeToolRenderers: () => ({}),
-      })
-    ).rejects.toThrow("activation exploded");
-    expect(agent.disposed).toEqual([true]);
-    expect(host.disposed).toEqual([true]);
-  });
-
-  it("aborts before creating the agent when validation fails", async () => {
-    // Given
-    const host = fakeHost();
-    let agentCreated = false;
-
-    // When / Then
-    await expect(
-      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
-        activateHost: () => Promise.resolve(),
-        createAgent: () => {
-          agentCreated = true;
-          return Promise.resolve(fakeAgent());
-        },
-        createHost: () => Promise.resolve(host),
-        loadExtensions: () => Promise.resolve(loaded),
-        mergeCommands: () => [command],
-        mergeToolRenderers: () => ({}),
-        validateHost: () =>
-          Promise.reject(new Error("migration rejected history")),
-      })
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          createHost: () => Promise.resolve(host),
+          disposePrevious: () => {
+            previousDisposed = true;
+            return Promise.resolve([]);
+          },
+          loadExtensions: () =>
+            Promise.resolve({
+              ...loaded,
+              rollbackModuleCache: () => {
+                rollbacks.push(true);
+              },
+            }),
+          validateHost: () =>
+            Promise.reject(new Error("migration rejected history")),
+        })
+      )
     ).rejects.toThrow("migration rejected history");
-    expect(agentCreated).toBe(false);
+    expect(previousDisposed).toBe(false);
     expect(host.disposed).toEqual([true]);
+    expect(rollbacks).toEqual([true]);
   });
 
   it("aborts before creating the agent when command merging fails", async () => {
@@ -153,46 +177,67 @@ describe("buildReloadedExtensionRuntime", () => {
 
     // When / Then
     await expect(
-      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
-        activateHost: () => Promise.resolve(),
-        createAgent: () => {
-          agentCreated = true;
-          return Promise.resolve(fakeAgent());
-        },
-        createHost: () => Promise.resolve(host),
-        loadExtensions: () => Promise.resolve(loaded),
-        mergeCommands: () => {
-          throw new Error("command conflict");
-        },
-        mergeToolRenderers: () => ({}),
-      })
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          createAgent: () => {
+            agentCreated = true;
+            return Promise.resolve(fakeAgent());
+          },
+          createHost: () => Promise.resolve(host),
+          mergeCommands: () => {
+            throw new Error("command conflict");
+          },
+        })
+      )
     ).rejects.toThrow("command conflict");
     expect(agentCreated).toBe(false);
     expect(host.disposed).toEqual([true]);
   });
 
-  it("rolls back the module cache when activation fails", async () => {
+  it("recovers the previous runtime when activation fails", async () => {
     // Given
+    const host = fakeHost();
+    const agent = fakeAgent();
     const rollbacks: boolean[] = [];
+    const recoveries: boolean[] = [];
 
     // When / Then
     await expect(
-      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
-        activateHost: () => Promise.reject(new Error("activation exploded")),
-        createAgent: () => Promise.resolve(fakeAgent()),
-        createHost: () => Promise.resolve(fakeHost()),
-        loadExtensions: () =>
-          Promise.resolve({
-            ...loaded,
-            rollbackModuleCache: () => {
-              rollbacks.push(true);
-            },
-          }),
-        mergeCommands: () => [command],
-        mergeToolRenderers: () => ({}),
-      })
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          activateHost: () => Promise.reject(new Error("activation exploded")),
+          createAgent: () => Promise.resolve(agent),
+          createHost: () => Promise.resolve(host),
+          loadExtensions: () =>
+            Promise.resolve({
+              ...loaded,
+              rollbackModuleCache: () => {
+                rollbacks.push(true);
+              },
+            }),
+          recoverPrevious: () => {
+            recoveries.push(true);
+            return Promise.resolve();
+          },
+        })
+      )
     ).rejects.toThrow("activation exploded");
+    expect(agent.disposed).toEqual([true]);
+    expect(host.disposed).toEqual([true]);
     expect(rollbacks).toEqual([true]);
+    expect(recoveries).toEqual([true]);
+  });
+
+  it("aggregates activation and recovery failures", async () => {
+    // When / Then
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          activateHost: () => Promise.reject(new Error("activation exploded")),
+          recoverPrevious: () => Promise.reject(new Error("recovery exploded")),
+        })
+      )
+    ).rejects.toThrow(recoveryPattern);
   });
 
   it("keeps nothing when extension loading fails", async () => {
@@ -201,17 +246,15 @@ describe("buildReloadedExtensionRuntime", () => {
 
     // When / Then
     await expect(
-      buildReloadedExtensionRuntime<FakeAgent, FakeHost>({
-        activateHost: () => Promise.resolve(),
-        createAgent: () => Promise.resolve(fakeAgent()),
-        createHost: () => {
-          hostCreated = true;
-          return Promise.resolve(fakeHost());
-        },
-        loadExtensions: () => Promise.reject(new Error("discovery failed")),
-        mergeCommands: () => [command],
-        mergeToolRenderers: () => ({}),
-      })
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          createHost: () => {
+            hostCreated = true;
+            return Promise.resolve(fakeHost());
+          },
+          loadExtensions: () => Promise.reject(new Error("discovery failed")),
+        })
+      )
     ).rejects.toThrow("discovery failed");
     expect(hostCreated).toBe(false);
   });

--- a/apps/coding-agent/src/tui/reload.test.ts
+++ b/apps/coding-agent/src/tui/reload.test.ts
@@ -62,6 +62,10 @@ function baseOptions(overrides: {
   >;
   readonly mergeCommands?: () => readonly TuiCommand[];
   readonly recoverPrevious?: () => Promise<void>;
+  readonly snapshotState?: () => Promise<{
+    discard(): Promise<void>;
+    restore(): Promise<void>;
+  }>;
   readonly validateHost?: () => Promise<(() => Promise<void>) | undefined>;
 }) {
   return {
@@ -75,6 +79,9 @@ function baseOptions(overrides: {
     mergeCommands: overrides.mergeCommands ?? (() => [command]),
     mergeToolRenderers: () => ({}),
     recoverPrevious: overrides.recoverPrevious ?? (() => Promise.resolve()),
+    ...(overrides.snapshotState === undefined
+      ? {}
+      : { snapshotState: overrides.snapshotState }),
     ...(overrides.validateHost === undefined
       ? {}
       : { validateHost: overrides.validateHost }),
@@ -291,6 +298,37 @@ describe("buildReloadedExtensionRuntime", () => {
       )
     ).rejects.toThrow(revertFailedPattern);
     expect(recoveries).toEqual([true]);
+  });
+
+  it("restores the state snapshot on activation failure and discards it on success", async () => {
+    // Given
+    const events: string[] = [];
+    const snapshotState = () =>
+      Promise.resolve({
+        discard: () => {
+          events.push("discard");
+          return Promise.resolve();
+        },
+        restore: () => {
+          events.push("restore");
+          return Promise.resolve();
+        },
+      });
+
+    // When — success discards.
+    await buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+      baseOptions({ snapshotState })
+    );
+    // When / Then — activation failure restores.
+    await expect(
+      buildReloadedExtensionRuntime<FakeAgent, FakeHost>(
+        baseOptions({
+          activateHost: () => Promise.reject(new Error("activation exploded")),
+          snapshotState,
+        })
+      )
+    ).rejects.toThrow("activation exploded");
+    expect(events).toEqual(["discard", "restore"]);
   });
 
   it("aggregates activation and recovery failures", async () => {

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -58,6 +58,15 @@ export async function buildReloadedExtensionRuntime<
   /** Rebuild a runtime from the previous inputs after activation failure. */
   readonly recoverPrevious: () => Promise<void>;
   /**
+   * Snapshot shared extension state right before activation so a failed
+   * activation cannot leave partially upgraded state for the recovered
+   * runtime. Returns restore/discard handles.
+   */
+  readonly snapshotState?: () => Promise<{
+    discard(): Promise<void>;
+    restore(): Promise<void>;
+  }>;
+  /**
    * Pre-swap validation, e.g. committing migrations for the stored thread.
    * May return a revert callback invoked when a later phase fails so
    * durable side effects do not outlive a failed reload.
@@ -105,17 +114,27 @@ export async function buildReloadedExtensionRuntime<
     throw error;
   }
   const cleanupNotices = await options.disposePrevious();
+  // Snapshot after old cleanup finished writing and before the replacement
+  // can touch the shared per-extension state files.
+  const stateSnapshot = await options.snapshotState?.();
   try {
     await options.activateHost(host, agent);
   } catch (activationError) {
     await disposeSettled(agent, host);
-    // Recovery must run even when the revert conflicts (for example when
+    // Recovery must run even when the reverts conflict (for example when
     // replacement activation already advanced the stored thread version);
     // the session otherwise stays backed by the disposed old runtime.
-    const revertFailure = await revertSideEffects();
     const failures: unknown[] = [activationError];
+    const revertFailure = await revertSideEffects();
     if (revertFailure !== undefined) {
       failures.push(revertFailure);
+    }
+    if (stateSnapshot !== undefined) {
+      try {
+        await stateSnapshot.restore();
+      } catch (stateRestoreError) {
+        failures.push(stateRestoreError);
+      }
     }
     try {
       await options.recoverPrevious();
@@ -128,11 +147,12 @@ export async function buildReloadedExtensionRuntime<
     if (failures.length > 1) {
       throw new AggregateError(
         failures,
-        "Extension reload failed and its committed migrations could not be reverted; inspect the thread state"
+        "Extension reload failed and some of its side effects could not be reverted; inspect the thread and extension state"
       );
     }
     throw activationError;
   }
+  await stateSnapshot?.discard().catch(() => undefined);
   return {
     agent,
     commands,

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -40,6 +40,8 @@ export async function buildReloadedExtensionRuntime<
   readonly loadExtensions: () => Promise<LoadedConfiguredExtensions>;
   readonly mergeCommands: (host: Host) => readonly TuiCommand[];
   readonly mergeToolRenderers: (host: Host) => ToolRendererMap;
+  /** Pre-swap validation, e.g. proving migrations accept the stored thread. */
+  readonly validateHost?: (host: Host) => Promise<void>;
 }): Promise<ExtensionRuntimeSwap<Agent, Host>> {
   const loaded = await options.loadExtensions();
   const host = await options.createHost(loaded);
@@ -48,6 +50,7 @@ export async function buildReloadedExtensionRuntime<
     // Validate TUI-facing merges before activation so conflicts abort early.
     const commands = options.mergeCommands(host);
     const toolRenderers = options.mergeToolRenderers(host);
+    await options.validateHost?.(host);
     agent = await options.createAgent(host);
     await options.activateHost(host, agent);
     return {

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -21,6 +21,11 @@ export interface ExtensionRuntimeSwap<
   readonly toolRenderers: ToolRendererMap;
 }
 
+/** Reload result plus an optional module-cache rollback for failures. */
+export type ReloadableExtensions = LoadedConfiguredExtensions & {
+  readonly rollbackModuleCache?: () => void;
+};
+
 /**
  * Build a full replacement extension runtime for `/reload`.
  *
@@ -37,7 +42,7 @@ export async function buildReloadedExtensionRuntime<
   readonly activateHost: (host: Host, agent: Agent) => Promise<void>;
   readonly createAgent: (host: Host) => Promise<Agent>;
   readonly createHost: (loaded: LoadedConfiguredExtensions) => Promise<Host>;
-  readonly loadExtensions: () => Promise<LoadedConfiguredExtensions>;
+  readonly loadExtensions: () => Promise<ReloadableExtensions>;
   readonly mergeCommands: (host: Host) => readonly TuiCommand[];
   readonly mergeToolRenderers: (host: Host) => ToolRendererMap;
   /** Pre-swap validation, e.g. proving migrations accept the stored thread. */
@@ -65,6 +70,9 @@ export async function buildReloadedExtensionRuntime<
       agent === undefined ? Promise.resolve() : agent.dispose(),
       host.dispose(),
     ]);
+    // The live runtime keeps running, so hand it back the CommonJS modules
+    // the failed reload evicted.
+    loaded.rollbackModuleCache?.();
     const cleanupFailures = cleanups.flatMap((result) =>
       result.status === "rejected" ? [result.reason] : []
     );
@@ -83,16 +91,22 @@ export async function buildReloadedExtensionRuntime<
  * are reported as notices instead of failing the reload because the
  * replacement runtime is already live.
  */
+const DEFAULT_PREVIOUS_RUNTIME_CLEANUP_TIMEOUT_MS = 10_000;
+
 export async function disposePreviousExtensionRuntime(options: {
   readonly agent: ReloadableAgent;
   readonly disposeThread: () => Promise<void>;
   readonly host: { dispose(): Promise<void> };
+  /** Bounds extension-controlled cleanup so `/reload` cannot hang on it. */
+  readonly timeoutMs?: number;
 }): Promise<readonly string[]> {
+  const timeoutMs =
+    options.timeoutMs ?? DEFAULT_PREVIOUS_RUNTIME_CLEANUP_TIMEOUT_MS;
   const notices: string[] = [];
   const results = await Promise.allSettled([
-    options.disposeThread(),
-    options.agent.dispose(),
-    options.host.dispose(),
+    bounded(options.disposeThread(), timeoutMs),
+    bounded(options.agent.dispose(), timeoutMs),
+    bounded(options.host.dispose(), timeoutMs),
   ]);
   for (const result of results) {
     if (result.status === "rejected") {
@@ -106,4 +120,29 @@ export async function disposePreviousExtensionRuntime(options: {
     }
   }
   return notices;
+}
+
+function bounded(task: Promise<void>, timeoutMs: number): Promise<void> {
+  // Late settlement is intentionally detached; the replacement runtime is
+  // already live and must not wait on abandoned cleanup.
+  task.catch(() => undefined);
+  return new Promise<void>((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      rejectPromise(
+        new Error(`cleanup did not settle within ${timeoutMs}ms; detached`)
+      );
+    }, timeoutMs);
+    task.then(
+      () => {
+        clearTimeout(timer);
+        resolvePromise();
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        rejectPromise(
+          error instanceof Error ? error : new Error(String(error))
+        );
+      }
+    );
+  });
 }

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -58,14 +58,16 @@ export async function buildReloadedExtensionRuntime<
   /** Rebuild a runtime from the previous inputs after activation failure. */
   readonly recoverPrevious: () => Promise<void>;
   /**
-   * Snapshot shared extension state right before activation so a failed
-   * activation cannot leave partially upgraded state for the recovered
-   * runtime. Returns restore/discard handles.
+   * Snapshot the replacement extensions' state files right before
+   * activation so a failed activation cannot leave partially upgraded
+   * state for the recovered runtime. Returns restore/discard handles.
    */
-  readonly snapshotState?: () => Promise<{
+  readonly snapshotState?: (extensionIds: readonly string[]) => Promise<{
     discard(): Promise<void>;
     restore(): Promise<void>;
   }>;
+  /** Bounds replacement activation and failed-replacement disposal. */
+  readonly timeoutMs?: number;
   /**
    * Pre-swap validation, e.g. committing migrations for the stored thread.
    * May return a revert callback invoked when a later phase fails so
@@ -113,14 +115,29 @@ export async function buildReloadedExtensionRuntime<
     }
     throw error;
   }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_RELOAD_PHASE_TIMEOUT_MS;
   const cleanupNotices = await options.disposePrevious();
-  // Snapshot after old cleanup finished writing and before the replacement
-  // can touch the shared per-extension state files.
-  const stateSnapshot = await options.snapshotState?.();
+  let stateSnapshot:
+    | Awaited<ReturnType<NonNullable<typeof options.snapshotState>>>
+    | undefined;
   try {
-    await options.activateHost(host, agent);
+    // Snapshot after old cleanup finished writing and before the
+    // replacement can touch the shared per-extension state files. Snapshot
+    // failures use the same recovery path as activation failures because
+    // the previous runtime is already gone.
+    stateSnapshot = await options.snapshotState?.(
+      loaded.extensions.map((extension) => extension.id)
+    );
+    // Per-extension activation is bounded by the host, but a replacement
+    // cleanup that never settles would otherwise hang the failure path
+    // inside the host's own dispose; bound the whole phase.
+    await boundedReloadOperation(
+      options.activateHost(host, agent),
+      timeoutMs,
+      "Replacement extension activation"
+    );
   } catch (activationError) {
-    await disposeSettled(agent, host);
+    await disposeSettled(agent, host, timeoutMs);
     // Recovery must run even when the reverts conflict (for example when
     // replacement activation already advanced the stored thread version);
     // the session otherwise stays backed by the disposed old runtime.
@@ -163,13 +180,19 @@ export async function buildReloadedExtensionRuntime<
   };
 }
 
+const DEFAULT_RELOAD_PHASE_TIMEOUT_MS = 60_000;
+
 async function disposeSettled(
   agent: ReloadableAgent | undefined,
-  host: ReloadableHost | undefined
+  host: ReloadableHost | undefined,
+  timeoutMs = DEFAULT_RELOAD_PHASE_TIMEOUT_MS
 ): Promise<void> {
   await Promise.allSettled([
-    agent === undefined ? Promise.resolve() : agent.dispose(),
-    host === undefined ? Promise.resolve() : host.dispose(),
+    bounded(
+      agent === undefined ? Promise.resolve() : agent.dispose(),
+      timeoutMs
+    ),
+    bounded(host === undefined ? Promise.resolve() : host.dispose(), timeoutMs),
   ]);
 }
 

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -9,7 +9,7 @@ interface ReloadableAgent {
 interface ReloadableHost {
   dispose(): Promise<void>;
   /** Revoke state/UI access after disposal was detached by a timeout. */
-  revokeExtensionState?(): void;
+  revokeExtensionState?(): Promise<void> | void;
 }
 
 export interface ExtensionRuntimeSwap<
@@ -143,7 +143,7 @@ export async function buildReloadedExtensionRuntime<
     // Disposal may have been detached by its timeout while a replacement
     // cleanup is still live; revoke its state/UI access so it cannot write
     // behind the restored snapshot or the recovered runtime.
-    host.revokeExtensionState?.();
+    await host.revokeExtensionState?.();
     // Recovery must run even when the reverts conflict (for example when
     // replacement activation already advanced the stored thread version);
     // the session otherwise stays backed by the disposed old runtime.

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -184,6 +184,36 @@ export async function disposePreviousExtensionRuntime(options: {
   return notices;
 }
 
+/**
+ * Bound an extension-controlled operation (for example a reloaded thread
+ * migration) so a never-settling callback fails the reload instead of
+ * hanging the session.
+ */
+export function boundedReloadOperation<Value>(
+  task: Promise<Value>,
+  timeoutMs: number,
+  label: string
+): Promise<Value> {
+  task.catch(() => undefined);
+  return new Promise<Value>((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      rejectPromise(new Error(`${label} did not settle within ${timeoutMs}ms`));
+    }, timeoutMs);
+    task.then(
+      (value) => {
+        clearTimeout(timer);
+        resolvePromise(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        rejectPromise(
+          error instanceof Error ? error : new Error(String(error))
+        );
+      }
+    );
+  });
+}
+
 function bounded(task: Promise<void>, timeoutMs: number): Promise<void> {
   // Late settlement is intentionally detached; the replacement runtime is
   // already live and must not wait on abandoned cleanup.

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -8,6 +8,8 @@ interface ReloadableAgent {
 
 interface ReloadableHost {
   dispose(): Promise<void>;
+  /** Revoke state/UI access after disposal was detached by a timeout. */
+  revokeExtensionState?(): void;
 }
 
 export interface ExtensionRuntimeSwap<
@@ -138,6 +140,10 @@ export async function buildReloadedExtensionRuntime<
     );
   } catch (activationError) {
     await disposeSettled(agent, host, timeoutMs);
+    // Disposal may have been detached by its timeout while a replacement
+    // cleanup is still live; revoke its state/UI access so it cannot write
+    // behind the restored snapshot or the recovered runtime.
+    host.revokeExtensionState?.();
     // Recovery must run even when the reverts conflict (for example when
     // replacement activation already advanced the stored thread version);
     // the session otherwise stays backed by the disposed old runtime.

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -1,0 +1,106 @@
+import type { LoadedConfiguredExtensions } from "../extensions";
+import type { TuiCommand } from "./command";
+import type { ToolRendererMap } from "./tool-call-view";
+
+interface ReloadableAgent {
+  dispose(): Promise<void>;
+}
+
+interface ReloadableHost {
+  dispose(): Promise<void>;
+}
+
+export interface ExtensionRuntimeSwap<
+  Agent extends ReloadableAgent,
+  Host extends ReloadableHost,
+> {
+  readonly agent: Agent;
+  readonly commands: readonly TuiCommand[];
+  readonly host: Host;
+  readonly notices: readonly string[];
+  readonly toolRenderers: ToolRendererMap;
+}
+
+/**
+ * Build a full replacement extension runtime for `/reload`.
+ *
+ * Ordering is fail-safe: the replacement host, agent, command set, and
+ * renderer set are fully constructed and activated before the caller swaps
+ * anything, so a failing reload leaves the current session untouched. On
+ * failure every partially created resource is disposed and the original
+ * error is rethrown.
+ */
+export async function buildReloadedExtensionRuntime<
+  Agent extends ReloadableAgent,
+  Host extends ReloadableHost,
+>(options: {
+  readonly activateHost: (host: Host, agent: Agent) => Promise<void>;
+  readonly createAgent: (host: Host) => Promise<Agent>;
+  readonly createHost: (loaded: LoadedConfiguredExtensions) => Promise<Host>;
+  readonly loadExtensions: () => Promise<LoadedConfiguredExtensions>;
+  readonly mergeCommands: (host: Host) => readonly TuiCommand[];
+  readonly mergeToolRenderers: (host: Host) => ToolRendererMap;
+}): Promise<ExtensionRuntimeSwap<Agent, Host>> {
+  const loaded = await options.loadExtensions();
+  const host = await options.createHost(loaded);
+  let agent: Agent | undefined;
+  try {
+    // Validate TUI-facing merges before activation so conflicts abort early.
+    const commands = options.mergeCommands(host);
+    const toolRenderers = options.mergeToolRenderers(host);
+    agent = await options.createAgent(host);
+    await options.activateHost(host, agent);
+    return {
+      agent,
+      commands,
+      host,
+      notices: loaded.notices,
+      toolRenderers,
+    };
+  } catch (error) {
+    const cleanups = await Promise.allSettled([
+      agent === undefined ? Promise.resolve() : agent.dispose(),
+      host.dispose(),
+    ]);
+    const cleanupFailures = cleanups.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : []
+    );
+    if (cleanupFailures.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupFailures],
+        "Extension reload and cleanup failed"
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Dispose the previous extension runtime after a successful swap. Failures
+ * are reported as notices instead of failing the reload because the
+ * replacement runtime is already live.
+ */
+export async function disposePreviousExtensionRuntime(options: {
+  readonly agent: ReloadableAgent;
+  readonly disposeThread: () => Promise<void>;
+  readonly host: { dispose(): Promise<void> };
+}): Promise<readonly string[]> {
+  const notices: string[] = [];
+  const results = await Promise.allSettled([
+    options.disposeThread(),
+    options.agent.dispose(),
+    options.host.dispose(),
+  ]);
+  for (const result of results) {
+    if (result.status === "rejected") {
+      notices.push(
+        `Previous extension runtime cleanup failed: ${
+          result.reason instanceof Error
+            ? result.reason.message
+            : String(result.reason)
+        }`
+      );
+    }
+  }
+  return notices;
+}

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -17,6 +17,7 @@ export interface ExtensionRuntimeSwap<
   readonly agent: Agent;
   readonly commands: readonly TuiCommand[];
   readonly host: Host;
+  readonly loadedExtensions: LoadedConfiguredExtensions["extensions"];
   readonly notices: readonly string[];
   readonly toolRenderers: ToolRendererMap;
 }
@@ -27,13 +28,20 @@ export type ReloadableExtensions = LoadedConfiguredExtensions & {
 };
 
 /**
- * Build a full replacement extension runtime for `/reload`.
+ * Build and install a full replacement extension runtime for `/reload`.
  *
- * Ordering is fail-safe: the replacement host, agent, command set, and
- * renderer set are fully constructed and activated before the caller swaps
- * anything, so a failing reload leaves the current session untouched. On
- * failure every partially created resource is disposed and the original
- * error is rethrown.
+ * Phases and failure semantics:
+ *
+ * 1. Discovery, host configuration, TUI merges, validation, and agent
+ *    construction all happen while the previous runtime keeps running; any
+ *    failure here disposes the partial replacement, rolls back the module
+ *    cache, and leaves the session untouched.
+ * 2. The previous runtime is then disposed *before* the replacement
+ *    activates so old cleanup can never write extension state behind the
+ *    already-active replacement.
+ * 3. If replacement activation fails after that point, the replacement is
+ *    disposed, the module cache rolls back, and `recoverPrevious` rebuilds a
+ *    runtime from the previous extension inputs so the session stays usable.
  */
 export async function buildReloadedExtensionRuntime<
   Agent extends ReloadableAgent,
@@ -42,55 +50,71 @@ export async function buildReloadedExtensionRuntime<
   readonly activateHost: (host: Host, agent: Agent) => Promise<void>;
   readonly createAgent: (host: Host) => Promise<Agent>;
   readonly createHost: (loaded: LoadedConfiguredExtensions) => Promise<Host>;
+  /** Bounded cleanup of the previous runtime; returns cleanup notices. */
+  readonly disposePrevious: () => Promise<readonly string[]>;
   readonly loadExtensions: () => Promise<ReloadableExtensions>;
   readonly mergeCommands: (host: Host) => readonly TuiCommand[];
   readonly mergeToolRenderers: (host: Host) => ToolRendererMap;
-  /** Pre-swap validation, e.g. proving migrations accept the stored thread. */
+  /** Rebuild a runtime from the previous inputs after activation failure. */
+  readonly recoverPrevious: () => Promise<void>;
+  /** Pre-swap validation, e.g. committing migrations for the stored thread. */
   readonly validateHost?: (host: Host) => Promise<void>;
 }): Promise<ExtensionRuntimeSwap<Agent, Host>> {
   const loaded = await options.loadExtensions();
-  const host = await options.createHost(loaded);
+  let host: Host | undefined;
   let agent: Agent | undefined;
+  let commands: readonly TuiCommand[];
+  let toolRenderers: ToolRendererMap;
   try {
+    host = await options.createHost(loaded);
     // Validate TUI-facing merges before activation so conflicts abort early.
-    const commands = options.mergeCommands(host);
-    const toolRenderers = options.mergeToolRenderers(host);
+    commands = options.mergeCommands(host);
+    toolRenderers = options.mergeToolRenderers(host);
     await options.validateHost?.(host);
     agent = await options.createAgent(host);
-    await options.activateHost(host, agent);
-    return {
-      agent,
-      commands,
-      host,
-      notices: loaded.notices,
-      toolRenderers,
-    };
   } catch (error) {
-    const cleanups = await Promise.allSettled([
-      agent === undefined ? Promise.resolve() : agent.dispose(),
-      host.dispose(),
-    ]);
+    await disposeSettled(agent, host);
     // The live runtime keeps running, so hand it back the CommonJS modules
     // the failed reload evicted.
     loaded.rollbackModuleCache?.();
-    const cleanupFailures = cleanups.flatMap((result) =>
-      result.status === "rejected" ? [result.reason] : []
-    );
-    if (cleanupFailures.length > 0) {
-      throw new AggregateError(
-        [error, ...cleanupFailures],
-        "Extension reload and cleanup failed"
-      );
-    }
     throw error;
   }
+  const cleanupNotices = await options.disposePrevious();
+  try {
+    await options.activateHost(host, agent);
+  } catch (activationError) {
+    await disposeSettled(agent, host);
+    loaded.rollbackModuleCache?.();
+    try {
+      await options.recoverPrevious();
+    } catch (recoveryError) {
+      throw new AggregateError(
+        [activationError, recoveryError],
+        "Extension reload activation failed and the previous runtime could not be recovered; restart pss"
+      );
+    }
+    throw activationError;
+  }
+  return {
+    agent,
+    commands,
+    host,
+    loadedExtensions: loaded.extensions,
+    notices: [...loaded.notices, ...cleanupNotices],
+    toolRenderers,
+  };
 }
 
-/**
- * Dispose the previous extension runtime after a successful swap. Failures
- * are reported as notices instead of failing the reload because the
- * replacement runtime is already live.
- */
+async function disposeSettled(
+  agent: ReloadableAgent | undefined,
+  host: ReloadableHost | undefined
+): Promise<void> {
+  await Promise.allSettled([
+    agent === undefined ? Promise.resolve() : agent.dispose(),
+    host === undefined ? Promise.resolve() : host.dispose(),
+  ]);
+}
+
 const DEFAULT_PREVIOUS_RUNTIME_CLEANUP_TIMEOUT_MS = 10_000;
 
 export async function disposePreviousExtensionRuntime(options: {

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -72,7 +72,7 @@ export async function buildReloadedExtensionRuntime<
   let commands: readonly TuiCommand[];
   let toolRenderers: ToolRendererMap;
   let revertValidation: (() => Promise<void>) | undefined;
-  const revertSideEffects = async (cause: unknown): Promise<void> => {
+  const revertSideEffects = async (): Promise<unknown | undefined> => {
     // The live runtime keeps running (or is being recovered), so hand back
     // the CommonJS modules and durable state the failed reload changed.
     loaded.rollbackModuleCache?.();
@@ -81,11 +81,9 @@ export async function buildReloadedExtensionRuntime<
     }
     try {
       await revertValidation();
+      return;
     } catch (revertError) {
-      throw new AggregateError(
-        [cause, revertError],
-        "Extension reload failed and its committed migrations could not be reverted; manual inspection required"
-      );
+      return revertError;
     }
   };
   try {
@@ -97,7 +95,13 @@ export async function buildReloadedExtensionRuntime<
     agent = await options.createAgent(host);
   } catch (error) {
     await disposeSettled(agent, host);
-    await revertSideEffects(error);
+    const revertFailure = await revertSideEffects();
+    if (revertFailure !== undefined) {
+      throw new AggregateError(
+        [error, revertFailure],
+        "Extension reload failed and its committed migrations could not be reverted; manual inspection required"
+      );
+    }
     throw error;
   }
   const cleanupNotices = await options.disposePrevious();
@@ -105,13 +109,26 @@ export async function buildReloadedExtensionRuntime<
     await options.activateHost(host, agent);
   } catch (activationError) {
     await disposeSettled(agent, host);
-    await revertSideEffects(activationError);
+    // Recovery must run even when the revert conflicts (for example when
+    // replacement activation already advanced the stored thread version);
+    // the session otherwise stays backed by the disposed old runtime.
+    const revertFailure = await revertSideEffects();
+    const failures: unknown[] = [activationError];
+    if (revertFailure !== undefined) {
+      failures.push(revertFailure);
+    }
     try {
       await options.recoverPrevious();
     } catch (recoveryError) {
       throw new AggregateError(
-        [activationError, recoveryError],
+        [...failures, recoveryError],
         "Extension reload activation failed and the previous runtime could not be recovered; restart pss"
+      );
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(
+        failures,
+        "Extension reload failed and its committed migrations could not be reverted; inspect the thread state"
       );
     }
     throw activationError;

--- a/apps/coding-agent/src/tui/reload.ts
+++ b/apps/coding-agent/src/tui/reload.ts
@@ -57,26 +57,47 @@ export async function buildReloadedExtensionRuntime<
   readonly mergeToolRenderers: (host: Host) => ToolRendererMap;
   /** Rebuild a runtime from the previous inputs after activation failure. */
   readonly recoverPrevious: () => Promise<void>;
-  /** Pre-swap validation, e.g. committing migrations for the stored thread. */
-  readonly validateHost?: (host: Host) => Promise<void>;
+  /**
+   * Pre-swap validation, e.g. committing migrations for the stored thread.
+   * May return a revert callback invoked when a later phase fails so
+   * durable side effects do not outlive a failed reload.
+   */
+  readonly validateHost?: (
+    host: Host
+  ) => Promise<(() => Promise<void>) | undefined>;
 }): Promise<ExtensionRuntimeSwap<Agent, Host>> {
   const loaded = await options.loadExtensions();
   let host: Host | undefined;
   let agent: Agent | undefined;
   let commands: readonly TuiCommand[];
   let toolRenderers: ToolRendererMap;
+  let revertValidation: (() => Promise<void>) | undefined;
+  const revertSideEffects = async (cause: unknown): Promise<void> => {
+    // The live runtime keeps running (or is being recovered), so hand back
+    // the CommonJS modules and durable state the failed reload changed.
+    loaded.rollbackModuleCache?.();
+    if (revertValidation === undefined) {
+      return;
+    }
+    try {
+      await revertValidation();
+    } catch (revertError) {
+      throw new AggregateError(
+        [cause, revertError],
+        "Extension reload failed and its committed migrations could not be reverted; manual inspection required"
+      );
+    }
+  };
   try {
     host = await options.createHost(loaded);
     // Validate TUI-facing merges before activation so conflicts abort early.
     commands = options.mergeCommands(host);
     toolRenderers = options.mergeToolRenderers(host);
-    await options.validateHost?.(host);
+    revertValidation = await options.validateHost?.(host);
     agent = await options.createAgent(host);
   } catch (error) {
     await disposeSettled(agent, host);
-    // The live runtime keeps running, so hand it back the CommonJS modules
-    // the failed reload evicted.
-    loaded.rollbackModuleCache?.();
+    await revertSideEffects(error);
     throw error;
   }
   const cleanupNotices = await options.disposePrevious();
@@ -84,7 +105,7 @@ export async function buildReloadedExtensionRuntime<
     await options.activateHost(host, agent);
   } catch (activationError) {
     await disposeSettled(agent, host);
-    loaded.rollbackModuleCache?.();
+    await revertSideEffects(activationError);
     try {
       await options.recoverPrevious();
     } catch (recoveryError) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -152,7 +152,7 @@ export type {
   CompactionContextMessage,
   ThreadContextMessage,
 } from "./thread/state/context";
-export { validateThreadStateMigrations } from "./thread/state/migration-validation";
+export { commitThreadStateMigrations } from "./thread/state/migration-validation";
 export {
   type ThreadMigrationContext,
   ThreadMigrationError,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -152,7 +152,10 @@ export type {
   CompactionContextMessage,
   ThreadContextMessage,
 } from "./thread/state/context";
-export { commitThreadStateMigrations } from "./thread/state/migration-validation";
+export {
+  type CommittedThreadMigrations,
+  commitThreadStateMigrations,
+} from "./thread/state/migration-validation";
 export {
   type ThreadMigrationContext,
   ThreadMigrationError,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -152,6 +152,7 @@ export type {
   CompactionContextMessage,
   ThreadContextMessage,
 } from "./thread/state/context";
+export { validateThreadStateMigrations } from "./thread/state/migration-validation";
 export {
   type ThreadMigrationContext,
   ThreadMigrationError,

--- a/packages/runtime/src/thread/state/migration-validation.test.ts
+++ b/packages/runtime/src/thread/state/migration-validation.test.ts
@@ -1,15 +1,45 @@
 import { describe, expect, it } from "vitest";
-import type { StoredThread } from "../store/types";
-import { validateThreadStateMigrations } from "./migration-validation";
-import { ThreadMigrationError } from "./migrations";
+import type {
+  CommitResult,
+  StoredThread,
+  ThreadStoreCommit,
+} from "../store/types";
+import { commitThreadStateMigrations } from "./migration-validation";
+import {
+  ThreadMigrationError,
+  type ThreadMigrationSnapshot,
+} from "./migrations";
 
-function storeWith(stored: StoredThread | null): {
+const conflictPattern = /changed while committing migrations/u;
+
+function storeWith(
+  stored: StoredThread | null,
+  commitResult: CommitResult = { ok: true, version: "v2" }
+): {
+  commit(
+    key: string,
+    next: ThreadStoreCommit,
+    options: { expectedVersion: string | null }
+  ): Promise<CommitResult>;
+  readonly commits: {
+    readonly expectedVersion: string | null;
+    readonly state: unknown;
+  }[];
   load(key: string): Promise<StoredThread | null>;
   readonly loads: string[];
 } {
   const loads: string[] = [];
+  const commits: { expectedVersion: string | null; state: unknown }[] = [];
   return {
-    load: (key: string) => {
+    commit: (_key, next, options) => {
+      commits.push({
+        expectedVersion: options.expectedVersion,
+        state: next.state,
+      });
+      return Promise.resolve(commitResult);
+    },
+    commits,
+    load: (key) => {
       loads.push(key);
       return Promise.resolve(stored);
     },
@@ -25,13 +55,13 @@ const storedThread: StoredThread = {
   version: "v1",
 };
 
-describe("validateThreadStateMigrations", () => {
+describe("commitThreadStateMigrations", () => {
   it("skips loading when no migrations are configured", async () => {
     // Given
     const store = storeWith(storedThread);
 
     // When
-    await validateThreadStateMigrations({
+    await commitThreadStateMigrations({
       migrations: [],
       store,
       threadKey: "thread-1",
@@ -39,47 +69,96 @@ describe("validateThreadStateMigrations", () => {
 
     // Then
     expect(store.loads).toEqual([]);
+    expect(store.commits).toEqual([]);
   });
 
-  it("accepts missing threads and passing migrations without committing", async () => {
+  it("commits migrated state with applied markers exactly once", async () => {
     // Given
-    const empty = storeWith(null);
     const store = storeWith(storedThread);
-    const seen: unknown[] = [];
+    const runs: unknown[] = [];
     const migration = {
       id: "sanitize",
-      migrate: (snapshot: unknown) => {
-        seen.push(snapshot);
-        return snapshot as never;
+      migrate: (snapshot: ThreadMigrationSnapshot) => {
+        runs.push(snapshot);
+        return {
+          compactions: snapshot.compactions,
+          history: [{ content: "sanitized", role: "user" as const }],
+        };
       },
       version: 1,
     };
 
     // When
-    await validateThreadStateMigrations({
-      migrations: [migration],
-      store: empty,
-      threadKey: "thread-1",
-    });
-    await validateThreadStateMigrations({
+    await commitThreadStateMigrations({
       migrations: [migration],
       store,
       threadKey: "thread-1",
     });
 
     // Then
-    expect(empty.loads).toEqual(["thread-1"]);
-    expect(store.loads).toEqual(["thread-1"]);
-    expect(seen).toHaveLength(1);
+    expect(runs).toHaveLength(1);
+    expect(store.commits).toHaveLength(1);
+    expect(store.commits[0]?.expectedVersion).toBe("v1");
+    expect(store.commits[0]?.state).toMatchObject({
+      appliedMigrations: { sanitize: 1 },
+      history: [{ content: "sanitized", role: "user" }],
+    });
   });
 
-  it("surfaces rejecting migrations as ThreadMigrationError", async () => {
+  it("does not commit when nothing changes or the thread is missing", async () => {
+    // Given
+    const empty = storeWith(null);
+    const alreadyApplied = storeWith({
+      state: {
+        appliedMigrations: { sanitize: 1 },
+        compactions: [],
+        history: [],
+        schemaVersion: 3,
+      },
+      version: "v3",
+    });
+    const migration = {
+      id: "sanitize",
+      migrate: (snapshot: ThreadMigrationSnapshot) => snapshot,
+      version: 1,
+    };
+
+    // When
+    await commitThreadStateMigrations({
+      migrations: [migration],
+      store: empty,
+      threadKey: "thread-1",
+    });
+    await commitThreadStateMigrations({
+      migrations: [migration],
+      store: alreadyApplied,
+      threadKey: "thread-1",
+    });
+
+    // Then
+    expect(empty.commits).toEqual([]);
+    expect(alreadyApplied.commits).toEqual([]);
+  });
+
+  it("surfaces rejecting migrations and commit conflicts", async () => {
     // Given
     const store = storeWith(storedThread);
+    const conflicted = storeWith(storedThread, {
+      ok: false,
+      reason: "conflict",
+    });
+    const passing = {
+      id: "pass",
+      migrate: (snapshot: ThreadMigrationSnapshot) => ({
+        compactions: snapshot.compactions,
+        history: [],
+      }),
+      version: 1,
+    };
 
     // When / Then
     await expect(
-      validateThreadStateMigrations({
+      commitThreadStateMigrations({
         migrations: [
           {
             id: "rejects",
@@ -93,5 +172,12 @@ describe("validateThreadStateMigrations", () => {
         threadKey: "thread-1",
       })
     ).rejects.toBeInstanceOf(ThreadMigrationError);
+    await expect(
+      commitThreadStateMigrations({
+        migrations: [passing],
+        store: conflicted,
+        threadKey: "thread-1",
+      })
+    ).rejects.toThrow(conflictPattern);
   });
 });

--- a/packages/runtime/src/thread/state/migration-validation.test.ts
+++ b/packages/runtime/src/thread/state/migration-validation.test.ts
@@ -89,7 +89,7 @@ describe("commitThreadStateMigrations", () => {
     };
 
     // When
-    await commitThreadStateMigrations({
+    const committed = await commitThreadStateMigrations({
       migrations: [migration],
       store,
       threadKey: "thread-1",
@@ -103,6 +103,14 @@ describe("commitThreadStateMigrations", () => {
       appliedMigrations: { sanitize: 1 },
       history: [{ content: "sanitized", role: "user" }],
     });
+
+    // When — reverting restores the pre-migration snapshot.
+    await committed?.revert();
+
+    // Then
+    expect(store.commits).toHaveLength(2);
+    expect(store.commits[1]?.expectedVersion).toBe("v2");
+    expect(store.commits[1]?.state).toBe(storedThread.state);
   });
 
   it("does not commit when nothing changes or the thread is missing", async () => {
@@ -138,6 +146,27 @@ describe("commitThreadStateMigrations", () => {
     // Then
     expect(empty.commits).toEqual([]);
     expect(alreadyApplied.commits).toEqual([]);
+  });
+
+  it("returns no revert handle when nothing was committed", async () => {
+    // Given
+    const store = storeWith(null);
+
+    // When
+    const committed = await commitThreadStateMigrations({
+      migrations: [
+        {
+          id: "sanitize",
+          migrate: (snapshot: ThreadMigrationSnapshot) => snapshot,
+          version: 1,
+        },
+      ],
+      store,
+      threadKey: "thread-1",
+    });
+
+    // Then
+    expect(committed).toBeUndefined();
   });
 
   it("surfaces rejecting migrations and commit conflicts", async () => {

--- a/packages/runtime/src/thread/state/migration-validation.test.ts
+++ b/packages/runtime/src/thread/state/migration-validation.test.ts
@@ -12,6 +12,7 @@ import {
 
 const conflictPattern = /changed while committing migrations/u;
 const abortedPattern = /migration was aborted/u;
+const timeoutPattern = /did not settle within/u;
 
 function storeWith(
   stored: StoredThread | null,
@@ -168,6 +169,28 @@ describe("commitThreadStateMigrations", () => {
 
     // Then
     expect(committed).toBeUndefined();
+  });
+
+  it("times out hanging migrations without writing", async () => {
+    // Given
+    const store = storeWith(storedThread);
+
+    // When / Then
+    await expect(
+      commitThreadStateMigrations({
+        migrations: [
+          {
+            id: "hangs",
+            migrate: () => new Promise<never>(() => undefined),
+            version: 1,
+          },
+        ],
+        store,
+        threadKey: "thread-1",
+        timeoutMs: 20,
+      })
+    ).rejects.toThrow(timeoutPattern);
+    expect(store.commits).toEqual([]);
   });
 
   it("never writes once the abort signal fires", async () => {

--- a/packages/runtime/src/thread/state/migration-validation.test.ts
+++ b/packages/runtime/src/thread/state/migration-validation.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./migrations";
 
 const conflictPattern = /changed while committing migrations/u;
+const abortedPattern = /migration was aborted/u;
 
 function storeWith(
   stored: StoredThread | null,
@@ -167,6 +168,59 @@ describe("commitThreadStateMigrations", () => {
 
     // Then
     expect(committed).toBeUndefined();
+  });
+
+  it("never writes once the abort signal fires", async () => {
+    // Given
+    const store = storeWith(storedThread);
+    const controller = new AbortController();
+    const migration = {
+      id: "slow",
+      migrate: (snapshot: ThreadMigrationSnapshot) => {
+        // The host stops waiting (timeout) while the migration still runs.
+        controller.abort();
+        return { compactions: snapshot.compactions, history: [] };
+      },
+      version: 1,
+    };
+
+    // When / Then
+    await expect(
+      commitThreadStateMigrations({
+        migrations: [migration],
+        signal: controller.signal,
+        store,
+        threadKey: "thread-1",
+      })
+    ).rejects.toThrow(abortedPattern);
+    expect(store.commits).toEqual([]);
+  });
+
+  it("never reverts once the revert abort signal fires", async () => {
+    // Given
+    const store = storeWith(storedThread);
+    const committed = await commitThreadStateMigrations({
+      migrations: [
+        {
+          id: "pass",
+          migrate: (snapshot: ThreadMigrationSnapshot) => ({
+            compactions: snapshot.compactions,
+            history: [],
+          }),
+          version: 1,
+        },
+      ],
+      store,
+      threadKey: "thread-1",
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    // When / Then
+    await expect(
+      committed?.revert({ signal: controller.signal })
+    ).rejects.toThrow(abortedPattern);
+    expect(store.commits).toHaveLength(1);
   });
 
   it("surfaces rejecting migrations and commit conflicts", async () => {

--- a/packages/runtime/src/thread/state/migration-validation.test.ts
+++ b/packages/runtime/src/thread/state/migration-validation.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { StoredThread } from "../store/types";
+import { validateThreadStateMigrations } from "./migration-validation";
+import { ThreadMigrationError } from "./migrations";
+
+function storeWith(stored: StoredThread | null): {
+  load(key: string): Promise<StoredThread | null>;
+  readonly loads: string[];
+} {
+  const loads: string[] = [];
+  return {
+    load: (key: string) => {
+      loads.push(key);
+      return Promise.resolve(stored);
+    },
+    loads,
+  };
+}
+
+const storedThread: StoredThread = {
+  state: {
+    history: [{ content: "hello", role: "user" }],
+    schemaVersion: 1,
+  },
+  version: "v1",
+};
+
+describe("validateThreadStateMigrations", () => {
+  it("skips loading when no migrations are configured", async () => {
+    // Given
+    const store = storeWith(storedThread);
+
+    // When
+    await validateThreadStateMigrations({
+      migrations: [],
+      store,
+      threadKey: "thread-1",
+    });
+
+    // Then
+    expect(store.loads).toEqual([]);
+  });
+
+  it("accepts missing threads and passing migrations without committing", async () => {
+    // Given
+    const empty = storeWith(null);
+    const store = storeWith(storedThread);
+    const seen: unknown[] = [];
+    const migration = {
+      id: "sanitize",
+      migrate: (snapshot: unknown) => {
+        seen.push(snapshot);
+        return snapshot as never;
+      },
+      version: 1,
+    };
+
+    // When
+    await validateThreadStateMigrations({
+      migrations: [migration],
+      store: empty,
+      threadKey: "thread-1",
+    });
+    await validateThreadStateMigrations({
+      migrations: [migration],
+      store,
+      threadKey: "thread-1",
+    });
+
+    // Then
+    expect(empty.loads).toEqual(["thread-1"]);
+    expect(store.loads).toEqual(["thread-1"]);
+    expect(seen).toHaveLength(1);
+  });
+
+  it("surfaces rejecting migrations as ThreadMigrationError", async () => {
+    // Given
+    const store = storeWith(storedThread);
+
+    // When / Then
+    await expect(
+      validateThreadStateMigrations({
+        migrations: [
+          {
+            id: "rejects",
+            migrate: () => {
+              throw new Error("history not supported");
+            },
+            version: 1,
+          },
+        ],
+        store,
+        threadKey: "thread-1",
+      })
+    ).rejects.toBeInstanceOf(ThreadMigrationError);
+  });
+});

--- a/packages/runtime/src/thread/state/migration-validation.ts
+++ b/packages/runtime/src/thread/state/migration-validation.ts
@@ -13,7 +13,7 @@ export interface CommittedThreadMigrations {
    * the history it was built for and a corrected retry re-runs the
    * migration instead of skipping its applied-version marker.
    */
-  revert(): Promise<void>;
+  revert(options?: { readonly signal?: AbortSignal }): Promise<void>;
 }
 
 /**
@@ -34,10 +34,17 @@ export interface CommittedThreadMigrations {
  */
 export async function commitThreadStateMigrations({
   migrations,
+  signal,
   store,
   threadKey,
 }: {
   readonly migrations: readonly ThreadStateMigration[];
+  /**
+   * Checked immediately before each durable write. Hosts abort the signal
+   * when they stop waiting (for example a reload timeout) so a detached
+   * migration task can never commit after its reload already failed.
+   */
+  readonly signal?: AbortSignal;
   readonly store: Pick<ThreadStore, "commit" | "load">;
   readonly threadKey: string;
 }): Promise<CommittedThreadMigrations | undefined> {
@@ -57,6 +64,7 @@ export async function commitThreadStateMigrations({
   if (!migrated.changed) {
     return;
   }
+  assertNotAborted(signal, threadKey, "committing");
   const result = await store.commit(
     threadKey,
     {
@@ -75,7 +83,8 @@ export async function commitThreadStateMigrations({
   }
   const committedVersion = result.version;
   return {
-    revert: async () => {
+    revert: async (options?: { readonly signal?: AbortSignal }) => {
+      assertNotAborted(options?.signal, threadKey, "reverting");
       const restored = await store.commit(
         threadKey,
         { state: stored.state },
@@ -88,4 +97,16 @@ export async function commitThreadStateMigrations({
       }
     },
   };
+}
+
+function assertNotAborted(
+  signal: AbortSignal | undefined,
+  threadKey: string,
+  phase: string
+): void {
+  if (signal?.aborted) {
+    throw new Error(
+      `Thread "${threadKey}" migration was aborted before ${phase}; no state was written`
+    );
+  }
 }

--- a/packages/runtime/src/thread/state/migration-validation.ts
+++ b/packages/runtime/src/thread/state/migration-validation.ts
@@ -4,25 +4,30 @@ import {
   normalizeThreadStateMigrations,
   type ThreadStateMigration,
 } from "./migrations";
-import { decodeStoredThreadState } from "./snapshot";
+import { decodeStoredThreadState, encodeThreadSnapshot } from "./snapshot";
 
 /**
- * Run the configured migrations against a stored thread snapshot without
- * committing anything.
+ * Run the configured migrations against a stored thread snapshot and commit
+ * the migrated state, preserving exactly-once semantics.
  *
  * Hosts that hot-swap agents (for example the coding-agent `/reload`
  * command) use this to prove that newly registered migrations accept the
- * current durable history before the replacement runtime goes live. Throws
- * `ThreadMigrationError` when a migration rejects the snapshot; resolves
- * without side effects otherwise.
+ * current durable history before the replacement runtime goes live. Because
+ * the migrated snapshot is committed together with its applied-version
+ * markers, migration callbacks never re-run on the next thread load; a
+ * dry-run would execute stateful migrations twice.
+ *
+ * Throws `ThreadMigrationError` when a migration rejects the snapshot and a
+ * plain `Error` when a concurrent writer wins the commit; resolves without
+ * writing when no migration changes the snapshot.
  */
-export async function validateThreadStateMigrations({
+export async function commitThreadStateMigrations({
   migrations,
   store,
   threadKey,
 }: {
   readonly migrations: readonly ThreadStateMigration[];
-  readonly store: Pick<ThreadStore, "load">;
+  readonly store: Pick<ThreadStore, "commit" | "load">;
   readonly threadKey: string;
 }): Promise<void> {
   const normalized = normalizeThreadStateMigrations(migrations);
@@ -33,9 +38,28 @@ export async function validateThreadStateMigrations({
   if (stored === null) {
     return;
   }
-  await applyThreadStateMigrations({
+  const migrated = await applyThreadStateMigrations({
     migrations: normalized,
     state: decodeStoredThreadState(stored),
     threadKey,
   });
+  if (!migrated.changed) {
+    return;
+  }
+  const result = await store.commit(
+    threadKey,
+    {
+      state: encodeThreadSnapshot(
+        migrated.history,
+        migrated.compactions,
+        migrated.appliedMigrations
+      ),
+    },
+    { expectedVersion: stored.version }
+  );
+  if (!result.ok) {
+    throw new Error(
+      `Thread "${threadKey}" changed while committing migrations; retry the operation`
+    );
+  }
 }

--- a/packages/runtime/src/thread/state/migration-validation.ts
+++ b/packages/runtime/src/thread/state/migration-validation.ts
@@ -1,0 +1,41 @@
+import type { ThreadStore } from "../store/types";
+import {
+  applyThreadStateMigrations,
+  normalizeThreadStateMigrations,
+  type ThreadStateMigration,
+} from "./migrations";
+import { decodeStoredThreadState } from "./snapshot";
+
+/**
+ * Run the configured migrations against a stored thread snapshot without
+ * committing anything.
+ *
+ * Hosts that hot-swap agents (for example the coding-agent `/reload`
+ * command) use this to prove that newly registered migrations accept the
+ * current durable history before the replacement runtime goes live. Throws
+ * `ThreadMigrationError` when a migration rejects the snapshot; resolves
+ * without side effects otherwise.
+ */
+export async function validateThreadStateMigrations({
+  migrations,
+  store,
+  threadKey,
+}: {
+  readonly migrations: readonly ThreadStateMigration[];
+  readonly store: Pick<ThreadStore, "load">;
+  readonly threadKey: string;
+}): Promise<void> {
+  const normalized = normalizeThreadStateMigrations(migrations);
+  if (normalized.length === 0) {
+    return;
+  }
+  const stored = await store.load(threadKey);
+  if (stored === null) {
+    return;
+  }
+  await applyThreadStateMigrations({
+    migrations: normalized,
+    state: decodeStoredThreadState(stored),
+    threadKey,
+  });
+}

--- a/packages/runtime/src/thread/state/migration-validation.ts
+++ b/packages/runtime/src/thread/state/migration-validation.ts
@@ -6,6 +6,16 @@ import {
 } from "./migrations";
 import { decodeStoredThreadState, encodeThreadSnapshot } from "./snapshot";
 
+export interface CommittedThreadMigrations {
+  /**
+   * Restore the pre-migration snapshot. Hosts call this when the runtime
+   * swap fails after the commit so the surviving runtime resumes against
+   * the history it was built for and a corrected retry re-runs the
+   * migration instead of skipping its applied-version marker.
+   */
+  revert(): Promise<void>;
+}
+
 /**
  * Run the configured migrations against a stored thread snapshot and commit
  * the migrated state, preserving exactly-once semantics.
@@ -17,9 +27,10 @@ import { decodeStoredThreadState, encodeThreadSnapshot } from "./snapshot";
  * markers, migration callbacks never re-run on the next thread load; a
  * dry-run would execute stateful migrations twice.
  *
- * Throws `ThreadMigrationError` when a migration rejects the snapshot and a
- * plain `Error` when a concurrent writer wins the commit; resolves without
- * writing when no migration changes the snapshot.
+ * Returns a revert handle when a migration changed the snapshot and
+ * `undefined` otherwise. Throws `ThreadMigrationError` when a migration
+ * rejects the snapshot and a plain `Error` when a concurrent writer wins
+ * the commit.
  */
 export async function commitThreadStateMigrations({
   migrations,
@@ -29,7 +40,7 @@ export async function commitThreadStateMigrations({
   readonly migrations: readonly ThreadStateMigration[];
   readonly store: Pick<ThreadStore, "commit" | "load">;
   readonly threadKey: string;
-}): Promise<void> {
+}): Promise<CommittedThreadMigrations | undefined> {
   const normalized = normalizeThreadStateMigrations(migrations);
   if (normalized.length === 0) {
     return;
@@ -62,4 +73,19 @@ export async function commitThreadStateMigrations({
       `Thread "${threadKey}" changed while committing migrations; retry the operation`
     );
   }
+  const committedVersion = result.version;
+  return {
+    revert: async () => {
+      const restored = await store.commit(
+        threadKey,
+        { state: stored.state },
+        { expectedVersion: committedVersion }
+      );
+      if (!restored.ok) {
+        throw new Error(
+          `Thread "${threadKey}" changed while reverting migrations; manual inspection required`
+        );
+      }
+    },
+  };
 }

--- a/packages/runtime/src/thread/state/migration-validation.ts
+++ b/packages/runtime/src/thread/state/migration-validation.ts
@@ -37,16 +37,25 @@ export async function commitThreadStateMigrations({
   signal,
   store,
   threadKey,
+  timeoutMs,
 }: {
   readonly migrations: readonly ThreadStateMigration[];
   /**
    * Checked immediately before each durable write. Hosts abort the signal
-   * when they stop waiting (for example a reload timeout) so a detached
-   * migration task can never commit after its reload already failed.
+   * when they stop waiting so a detached migration task can never commit
+   * after its reload already failed.
    */
   readonly signal?: AbortSignal;
   readonly store: Pick<ThreadStore, "commit" | "load">;
   readonly threadKey: string;
+  /**
+   * Bounds migration callback execution only. The durable commit itself is
+   * intentionally unbounded: once every callback settled inside the budget
+   * the write is awaited to completion, so the reported outcome always
+   * matches the stored state and a timed-out validation can never commit
+   * in the background after failure was reported.
+   */
+  readonly timeoutMs?: number;
 }): Promise<CommittedThreadMigrations | undefined> {
   const normalized = normalizeThreadStateMigrations(migrations);
   if (normalized.length === 0) {
@@ -56,11 +65,15 @@ export async function commitThreadStateMigrations({
   if (stored === null) {
     return;
   }
-  const migrated = await applyThreadStateMigrations({
-    migrations: normalized,
-    state: decodeStoredThreadState(stored),
+  const migrated = await boundedMigrationRun(
+    applyThreadStateMigrations({
+      migrations: normalized,
+      state: decodeStoredThreadState(stored),
+      threadKey,
+    }),
     threadKey,
-  });
+    timeoutMs
+  );
   if (!migrated.changed) {
     return;
   }
@@ -109,4 +122,36 @@ function assertNotAborted(
       `Thread "${threadKey}" migration was aborted before ${phase}; no state was written`
     );
   }
+}
+
+function boundedMigrationRun<Value>(
+  task: Promise<Value>,
+  threadKey: string,
+  timeoutMs: number | undefined
+): Promise<Value> {
+  if (timeoutMs === undefined) {
+    return task;
+  }
+  task.catch(() => undefined);
+  return new Promise<Value>((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      rejectPromise(
+        new Error(
+          `Thread "${threadKey}" migrations did not settle within ${timeoutMs}ms; no state was written`
+        )
+      );
+    }, timeoutMs);
+    task.then(
+      (value) => {
+        clearTimeout(timer);
+        resolvePromise(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        rejectPromise(
+          error instanceof Error ? error : new Error(String(error))
+        );
+      }
+    );
+  });
 }


### PR DESCRIPTION
Closes the remaining items of #257 (extension developer experience).

## Summary

### `/reload` (item 3)
- new TUI command rebuilds the extension runtime from disk without restarting the session: managed installs, local modules, and `-e` paths are rediscovered and re-imported past the module cache (cache-busted specifiers), then activated against a replacement agent while the durable thread keeps its history
- fail-safe swap: the replacement host, agent, command set, and renderer set are fully constructed, merged, and activated **before** anything is swapped — a failing reload leaves the current session untouched and reports the error in chat
- command set and autocomplete rebuild after reload; tool renderers are re-read per turn; `reload` joins the reserved command names extensions cannot register
- orchestration lives in a dependency-injected `tui/reload.ts` module with full unit coverage of ordering and failure paths

### Inter-extension event bus (item 4)
- `services.events` — `emit(type, payload)` / `on(type, handler)` with unsubscribe
- payloads are JSON values cloned per delivery; handlers run under the host timeout/abort boundary; failures are attributed to the subscribing extension without affecting the publisher or other subscribers
- `host:` and `provider:` namespaces are reserved: extensions can subscribe but publishing into them throws

### Provider observations (item 5, read-only)
- host publishes `provider:request` / `provider:response` / `provider:error` bus events from a fetch wrapper installed in both the TUI and headless exec
- URLs are stripped of credentials and query strings, request bodies/headers are never exposed, response headers pass a safelist (`content-type`, `retry-after`, `x-request-id`, rate-limit headers)
- observation failures never interrupt provider traffic; the emitter is late-bound so `/reload` rebinds the replacement host automatically

## Verification

- `pnpm lint` / `pnpm typecheck` / `pnpm test` (9/9 tasks; 482 coding-agent tests, 17 new)
- `pnpm build`
- built CLI smoke: `pss exec -e ./observer.ts` against a live model — the extension received `provider:response` with a redacted URL and safelisted headers end-to-end
- Tegami patch letter queued for `@minpeter/pss-coding-agent`; README documents all three surfaces

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TUI `/reload` command, an inter‑extension event bus, and provider HTTP observation events to help extension developers iterate faster without losing session history. Completes #257.

- **New Features**
  - `/reload`: Rebuilds the extension runtime from disk with cache‑busted re‑imports through each extension’s own module graph (ESM and transactional CommonJS eviction with rollback; skips cross‑package deps; includes the current `cwd`; canonicalizes cache roots so symlinked `-e` helpers evict their real CJS entries). Staged swap: build replacement host/commands/renderers; commit thread migrations exactly once with a revert handle; snapshot only the replacement extensions’ state files; dispose the previous runtime first (bounded; cancel its prompts via host‑scoped UI abort; gate/clear statuses; revoke state writes and drain them with a bounded fence; release detached UI); then activate the replacement (bounded). On activation failure or timeout, abort the failed replacement’s UI controller, revoke its state/UI access, restore the snapshot (or recover from previous inputs if snapshotting failed), revert migrations when possible and report conflicts, roll back the CJS cache, rebuild the previous runtime within the reload boundary, dispose the recovery agent (with revocation) if that activation fails, and refresh the surviving thread handle if activation wrote. Extension imports are bounded; on timeout, further imports stop so a rolled‑back CJS cache cannot be repopulated. The command appears only when the session was started via the `pss` CLI; `reload` is reserved.
  - Event bus: `services.events.emit(type, payload)` / `on(type, handler)` with payloads snapshotted at emit‑time (publisher mutations and cloning errors surface to the publisher), deferred delivery with a disposal recheck, host timeout/abort boundaries, isolated subscriber failures, draining of in‑flight deliveries (bounded by the host timeout) before host cleanup, and unsubscribe. `host:` and `provider:` namespaces are reserved (subscribe allowed, publishing blocked).
  - Provider observations: Host emits `provider:request`, `provider:response`, and `provider:error` with credential‑, query‑, and fragment‑stripped URLs; error messages also scrub URL‑like tokens, scheme‑relative tokens, scheme‑less query/fragment tokens, and credential‑bearing authorities; response headers are safelisted; request methods follow Fetch’s normalization rules. Wired in both TUI and headless `exec`. During `/reload`, the emitter binds to the replacement host before activation and is restored if activation fails; each request binds to the sink captured at its start so mid‑reload rebinding cannot split one request’s events; the exec host is disposed if binding throws; and emitter/UI rollbacks are guarded so a detached activation that rejects after recovery cannot overwrite the recovered runtime’s bindings.

- **Migration**
  - Extensions cannot register a `reload` command.
  - Extensions may subscribe to `provider:` events but cannot emit into `host:` or `provider:`. No other changes required.

<sup>Written for commit 5fd0236977db62c73c1b81aa0a1b41c3041dee9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

