### PR TITLE
refactor(coding-agent): delegate web tool providers to OpenSearch

### DIFF
--- a/.tegami/2026-07-27-opensearch-keyless-web-tools.md
+++ b/.tegami/2026-07-27-opensearch-keyless-web-tools.md
@@ -1,0 +1,21 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Delegate web tool providers to OpenSearch instead of gating on TinyFish
+
+`createCodingAgentTools()` no longer gates `web_search`/`web_fetch` behind
+`TINYFISH_API_KEY`. Provider selection is delegated to
+`@minpeter/opensearch`, which resolves keyed engines (TinyFish, Exa, Brave,
+Tavily, ...) from the environment and always has keyless fallbacks such as
+DuckDuckGo search and local fetch, so the tools register whenever
+`webToolsAvailability` is not `disabled`.
+
+The now-dead missing-key surface is removed: `WEB_TOOLS_DISABLED_MESSAGE`,
+`CodingAgentWebToolsUnavailableError`, and the `onWebToolsDisabled` option are
+gone, and the TUI no longer emits a startup notice for a missing key. The
+`webToolsAvailability` type and the `pss exec --web-tools` flag keep accepting
+`disabled|optional|required` (`optional` and `required` now behave the same),
+and `pss exec` still defaults to `disabled`.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -1,8 +1,9 @@
 # @minpeter/pss-coding-agent
 
-Model wiring and the `pss` TUI for pss-next. The TUI includes OpenSearch-backed
-`web_search` and `web_fetch` tools by default when `TINYFISH_API_KEY` is
-configured.
+Model wiring and the `pss` TUI for pss-next. The TUI includes
+`@minpeter/opensearch`-backed `web_search` and `web_fetch` tools by default;
+OpenSearch picks its search/fetch providers from the environment and falls
+back to keyless engines when no provider API key is configured.
 
 ```ts
 import { createCodingLanguageModel } from "@minpeter/pss-coding-agent/model";
@@ -374,25 +375,19 @@ auto-update as well.
 
 ## Web tools availability
 
-The web tools are backed by `@minpeter/opensearch` and need `TINYFISH_API_KEY`
-(one or more `;`-separated keys). `createCodingAgentTools()` gates on the key
-before wiring the OpenSearch client, controlled by `webToolsAvailability`:
+The web tools are backed by `@minpeter/opensearch`, which resolves its own
+search and fetch providers from the environment (keyed engines such as
+TinyFish, Exa, Brave, Tavily, ... via their respective API key variables, plus
+keyless fallbacks like DuckDuckGo). No provider API key is required for the
+tools to register; `webToolsAvailability` only controls registration:
 
-- `optional` (default): when the key is missing, the web tools are omitted
-  instead of advertised, and the omission is reported through
-  `onWebToolsDisabled` (default: `console.warn` logs
-  `web tools disabled: missing TINYFISH_API_KEY`; the `pss` TUI overrides the
-  handler and renders the message as a dim scrollback line at startup).
-  Startup still succeeds, so environments without a key behave exactly as
-  before minus the unusable tools.
-- `required`: throw `CodingAgentWebToolsUnavailableError` during tool/agent
-  initialization when the key is missing, so a model can never be offered a
-  tool that cannot execute.
+- `optional` (default) and `required`: register the web tools and let
+  OpenSearch pick the best available provider per call.
 - `disabled`: never register the web tools.
 
-The key is read from `openSearchOptions.env` when provided, otherwise from
-`process.env`. An injected `client` counts as provider configuration in
-`optional` and `required` modes.
+Provider configuration is read from `openSearchOptions.env` when provided,
+otherwise from `process.env`. An injected `client` replaces the OpenSearch
+client entirely.
 
 ```ts
 const tools = createCodingAgentTools({ webToolsAvailability: "required" });

--- a/apps/coding-agent/src/index.ts
+++ b/apps/coding-agent/src/index.ts
@@ -45,9 +45,7 @@ export type {
 export {
   CodingAgentToolAbortError,
   CodingAgentToolsConfigError,
-  CodingAgentWebToolsUnavailableError,
   createCodingAgentTools,
-  WEB_TOOLS_DISABLED_MESSAGE,
 } from "./tools";
 export { type StartTuiOptions, startTui } from "./tui/app";
 export {

--- a/apps/coding-agent/src/tools-errors.ts
+++ b/apps/coding-agent/src/tools-errors.ts
@@ -1,5 +1,3 @@
-export const TINYFISH_API_KEY_ENV = "TINYFISH_API_KEY";
-
 type CodingAgentToolName = "web_fetch" | "web_search";
 
 export class CodingAgentToolsConfigError extends Error {
@@ -8,15 +6,6 @@ export class CodingAgentToolsConfigError extends Error {
   constructor() {
     super("Provide either client or openSearchOptions, not both.");
     this.name = "CodingAgentToolsConfigError";
-  }
-}
-
-export class CodingAgentWebToolsUnavailableError extends Error {
-  readonly code = "web-tools-config-missing";
-
-  constructor() {
-    super(`web tools required: missing ${TINYFISH_API_KEY_ENV}`);
-    this.name = "CodingAgentWebToolsUnavailableError";
   }
 }
 

--- a/apps/coding-agent/src/tools.test.ts
+++ b/apps/coding-agent/src/tools.test.ts
@@ -1,13 +1,10 @@
 import type { ToolExecutionOptions } from "ai";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  CodingAgentWebToolsUnavailableError,
+  CodingAgentToolsConfigError,
   createCodingAgentTools,
   resolveStartTuiTools,
-  WEB_TOOLS_DISABLED_MESSAGE,
 } from "./tools";
-
-const tinyfishApiKeyPattern = /TINYFISH_API_KEY/;
 
 const toolExecutionOptions: ToolExecutionOptions<Record<string, unknown>> = {
   context: {},
@@ -78,8 +75,6 @@ describe("coding-agent web tools", () => {
   });
 
   it("uses OpenSearch tools by default for the TUI and preserves overrides", () => {
-    vi.stubEnv("TINYFISH_API_KEY", "test-key");
-
     const defaultTools = resolveStartTuiTools();
     const overrideTools = { custom_tool: defaultTools.web_search };
 
@@ -89,89 +84,51 @@ describe("coding-agent web tools", () => {
     ]);
     expect(resolveStartTuiTools(overrideTools)).toBe(overrideTools);
   });
+
+  it("rejects providing both client and openSearchOptions", () => {
+    expect(() =>
+      createCodingAgentTools({
+        client: createStubClient(),
+        openSearchOptions: {},
+      })
+    ).toThrowError(CodingAgentToolsConfigError);
+  });
 });
 
 describe("web tools availability modes", () => {
-  beforeEach(() => {
+  it("registers web tools by default without any provider API key", () => {
     vi.stubEnv("TINYFISH_API_KEY", undefined);
-  });
-
-  it("registers web tools by default when TINYFISH_API_KEY is present", () => {
-    const tools = createCodingAgentTools({
-      openSearchOptions: { env: { TINYFISH_API_KEY: "test-key" } },
-    });
-
-    expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
-  });
-
-  it("reads TINYFISH_API_KEY from process.env by default", () => {
-    vi.stubEnv("TINYFISH_API_KEY", "test-key");
 
     const tools = createCodingAgentTools();
 
     expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
   });
 
-  it("omits web tools in default optional mode when TINYFISH_API_KEY is missing and reports it", () => {
-    const onWebToolsDisabled = vi.fn();
+  it("registers web tools in required mode without any provider API key", () => {
+    vi.stubEnv("TINYFISH_API_KEY", undefined);
 
-    const tools = createCodingAgentTools({ onWebToolsDisabled });
-
-    expect(Object.keys(tools)).toStrictEqual([]);
-    expect(onWebToolsDisabled).toHaveBeenCalledTimes(1);
-    expect(onWebToolsDisabled).toHaveBeenCalledWith(WEB_TOOLS_DISABLED_MESSAGE);
-    expect(WEB_TOOLS_DISABLED_MESSAGE).toBe(
-      "web tools disabled: missing TINYFISH_API_KEY"
-    );
-  });
-
-  it("warns by default when optional mode omits web tools", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-    const tools = createCodingAgentTools();
-
-    expect(Object.keys(tools)).toStrictEqual([]);
-    expect(warn).toHaveBeenCalledWith(WEB_TOOLS_DISABLED_MESSAGE);
-  });
-
-  it("registers web tools in required mode when TINYFISH_API_KEY is present", () => {
     const tools = createCodingAgentTools({
-      openSearchOptions: { env: { TINYFISH_API_KEY: "test-key" } },
       webToolsAvailability: "required",
     });
 
     expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
   });
 
-  it("fails fast in required mode when TINYFISH_API_KEY is missing", () => {
-    expect(() =>
-      createCodingAgentTools({ webToolsAvailability: "required" })
-    ).toThrowError(CodingAgentWebToolsUnavailableError);
-    expect(() =>
-      createCodingAgentTools({ webToolsAvailability: "required" })
-    ).toThrowError(tinyfishApiKeyPattern);
+  it("registers web tools with an OpenSearch env override", () => {
+    const tools = createCodingAgentTools({
+      openSearchOptions: { env: { TINYFISH_API_KEY: "test-key" } },
+    });
+
+    expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
   });
 
-  it("never registers web tools in disabled mode, even when configured", () => {
-    const onWebToolsDisabled = vi.fn();
-
+  it("never registers web tools in disabled mode", () => {
     const tools = createCodingAgentTools({
-      onWebToolsDisabled,
       openSearchOptions: { env: { TINYFISH_API_KEY: "test-key" } },
       webToolsAvailability: "disabled",
     });
 
     expect(Object.keys(tools)).toStrictEqual([]);
-    expect(onWebToolsDisabled).not.toHaveBeenCalled();
-  });
-
-  it("treats an injected client as configured in required mode", () => {
-    const tools = createCodingAgentTools({
-      client: createStubClient(),
-      webToolsAvailability: "required",
-    });
-
-    expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
   });
 
   it("omits web tools in disabled mode even with an injected client", () => {
@@ -182,76 +139,23 @@ describe("web tools availability modes", () => {
 
     expect(Object.keys(tools)).toStrictEqual([]);
   });
-
-  it("parses semicolon-separated TINYFISH_API_KEY pools like OpenSearch", () => {
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-    expect(
-      Object.keys(
-        createCodingAgentTools({
-          openSearchOptions: {
-            env: { TINYFISH_API_KEY: " ; key-a ;; key-b ; " },
-          },
-        })
-      )
-    ).toStrictEqual(["web_search", "web_fetch"]);
-    expect(
-      Object.keys(
-        createCodingAgentTools({
-          openSearchOptions: { env: { TINYFISH_API_KEY: " ; ; " } },
-        })
-      )
-    ).toStrictEqual([]);
-    expect(
-      Object.keys(
-        createCodingAgentTools({
-          openSearchOptions: { env: { TINYFISH_API_KEY: "" } },
-        })
-      )
-    ).toStrictEqual([]);
-  });
-
-  it("gates on the OpenSearch env override instead of process.env", () => {
-    vi.stubEnv("TINYFISH_API_KEY", "process-env-key");
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-    const tools = createCodingAgentTools({ openSearchOptions: { env: {} } });
-
-    expect(Object.keys(tools)).toStrictEqual([]);
-    expect(warn).toHaveBeenCalledWith(WEB_TOOLS_DISABLED_MESSAGE);
-  });
 });
 
 describe("resolveStartTuiTools availability", () => {
-  beforeEach(() => {
+  it("starts the TUI with web tools even without a provider API key", () => {
     vi.stubEnv("TINYFISH_API_KEY", undefined);
-  });
-
-  it("starts the TUI without web tools and warns when TINYFISH_API_KEY is missing", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     const tools = resolveStartTuiTools();
 
-    expect(Object.keys(tools)).toStrictEqual([]);
-    expect(warn).toHaveBeenCalledWith(WEB_TOOLS_DISABLED_MESSAGE);
+    expect(Object.keys(tools)).toStrictEqual(["web_search", "web_fetch"]);
   });
 
-  it("fails TUI tool resolution in required mode when TINYFISH_API_KEY is missing", () => {
-    expect(() =>
-      resolveStartTuiTools(undefined, { webToolsAvailability: "required" })
-    ).toThrowError(CodingAgentWebToolsUnavailableError);
-  });
-
-  it("omits TUI web tools in disabled mode even when TINYFISH_API_KEY is present", () => {
-    vi.stubEnv("TINYFISH_API_KEY", "test-key");
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
+  it("omits TUI web tools in disabled mode", () => {
     const tools = resolveStartTuiTools(undefined, {
       webToolsAvailability: "disabled",
     });
 
     expect(Object.keys(tools)).toStrictEqual([]);
-    expect(warn).not.toHaveBeenCalled();
   });
 
   it("returns override tools unchanged regardless of availability mode", () => {

--- a/apps/coding-agent/src/tools.ts
+++ b/apps/coding-agent/src/tools.ts
@@ -2,17 +2,12 @@ import {
   createOpenSearch,
   type FetchOptions,
   type FetchResult,
-  type OpenSearchEnvironment,
   type OpenSearchOptions,
   type SearchResult,
 } from "@minpeter/opensearch/node";
 import type { ToolSet } from "ai";
 
-import {
-  CodingAgentToolsConfigError,
-  CodingAgentWebToolsUnavailableError,
-  TINYFISH_API_KEY_ENV,
-} from "./tools-errors";
+import { CodingAgentToolsConfigError } from "./tools-errors";
 import { createWebFetchTool, type WebFetchTool } from "./tools-web-fetch";
 import { createWebSearchTool, type WebSearchTool } from "./tools-web-search";
 
@@ -20,21 +15,17 @@ import { createWebSearchTool, type WebSearchTool } from "./tools-web-search";
 export {
   CodingAgentToolAbortError,
   CodingAgentToolsConfigError,
-  CodingAgentWebToolsUnavailableError,
 } from "./tools-errors";
 export type { WebFetchInput } from "./tools-web-fetch";
 export type { WebSearchInput } from "./tools-web-search";
 
-export const WEB_TOOLS_DISABLED_MESSAGE = `web tools disabled: missing ${TINYFISH_API_KEY_ENV}`;
-
 /**
- * Availability mode for the provider-backed web tools:
+ * Availability mode for the OpenSearch-backed web tools:
  *
- * - `required`: fail fast during tool/agent initialization when the provider
- *   configuration (TINYFISH_API_KEY) is missing.
- * - `optional` (default): omit the web tools when the provider configuration
- *   is missing and report the omission through `onWebToolsDisabled`
- *   (default: `console.warn`).
+ * - `optional`/`required` (default: `optional`): register the web tools.
+ *   `@minpeter/opensearch` resolves its own providers from the environment
+ *   (keyed engines such as TinyFish, Exa, Brave, ... plus keyless fallbacks
+ *   like DuckDuckGo), so no provider API key is required up front.
  * - `disabled`: never register the web tools.
  */
 export type WebToolsAvailability = "disabled" | "optional" | "required";
@@ -49,7 +40,6 @@ export interface CodingAgentOpenSearchClient {
 
 export interface CreateCodingAgentToolsOptions {
   readonly client?: CodingAgentOpenSearchClient;
-  readonly onWebToolsDisabled?: (message: string) => void;
   readonly openSearchOptions?: OpenSearchOptions;
   readonly webToolsAvailability?: WebToolsAvailability;
 }
@@ -60,16 +50,13 @@ export interface CodingAgentToolSet extends ToolSet {
 }
 
 /**
- * Create the provider-backed web tools, gated on TINYFISH_API_KEY before the
- * OpenSearch client is wired. An injected `client` counts as provider
- * configuration in `optional` and `required` modes; `disabled` always returns
- * an empty tool set. Defaults to `optional`, so startup succeeds without a
- * key and the omission is reported instead of advertising tools that can only
- * fail at execution time.
+ * Create the OpenSearch-backed web tools. Provider selection is delegated to
+ * `@minpeter/opensearch`, which picks search/fetch engines from the
+ * environment and always has keyless fallbacks, so the tools are registered
+ * whenever the availability mode is not `disabled`.
  */
 export function createCodingAgentTools(
   options: CreateCodingAgentToolsOptions & {
-    readonly client: CodingAgentOpenSearchClient;
     readonly webToolsAvailability?: "optional" | "required";
   }
 ): CodingAgentToolSet;
@@ -81,18 +68,6 @@ export function createCodingAgentTools(
 ): ToolSet {
   const availability = options.webToolsAvailability ?? "optional";
   if (availability === "disabled") {
-    return {};
-  }
-
-  if (
-    options.client === undefined &&
-    !hasTinyFishApiKey(options.openSearchOptions?.env ?? process.env)
-  ) {
-    if (availability === "required") {
-      throw new CodingAgentWebToolsUnavailableError();
-    }
-
-    (options.onWebToolsDisabled ?? console.warn)(WEB_TOOLS_DISABLED_MESSAGE);
     return {};
   }
 
@@ -108,12 +83,6 @@ export function resolveStartTuiTools(
   options?: CreateCodingAgentToolsOptions
 ): ToolSet {
   return tools ?? createCodingAgentTools(options);
-}
-
-function hasTinyFishApiKey(env: OpenSearchEnvironment): boolean {
-  return (env[TINYFISH_API_KEY_ENV] ?? "")
-    .split(";")
-    .some((apiKey) => apiKey.trim().length > 0);
 }
 
 function resolveOpenSearchClient({

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -70,7 +70,6 @@ const resolveModelSubtitle = (): string | undefined => {
 };
 
 export async function startTui(options: StartTuiOptions = {}): Promise<number> {
-  const startupNotices: string[] = [];
   const threadConfig = resolveCodingAgentThreadConfig();
   const providerEmitter: ProviderObservationEmitter = {};
   let model: AgentOptions["model"];
@@ -93,9 +92,6 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       host: createFileHost({ directory: threadConfig.directory }),
       model,
       tools: options.tools,
-      webTools: {
-        onWebToolsDisabled: (message) => startupNotices.push(message),
-      },
       workspace: process.cwd(),
     });
   } catch (error) {
@@ -222,7 +218,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         thread = agent.thread(threadConfig.key);
         resetUsageTotals();
       },
-      setupMessages: [...startupNotices, ...noticeLines],
+      setupMessages: noticeLines,
       toolRenderers: mergeToolRenderers(
         createToolRenderers(),
         extensionHost.toolRenderers,
@@ -284,7 +280,6 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         host: createFileHost({ directory: threadConfig.directory }),
         model,
         tools: options.tools,
-        webTools: { onWebToolsDisabled: () => undefined },
         workspace: process.cwd(),
       });
 


### PR DESCRIPTION
## Summary

Use `@minpeter/opensearch`'s own provider resolution in the coding-agent instead of gating the web tools on TinyFish.

- `createCodingAgentTools()` no longer checks `TINYFISH_API_KEY`; OpenSearch resolves keyed engines (TinyFish, Exa, Brave, Tavily, ...) from the environment and always has keyless fallbacks (DuckDuckGo search, local fetch), so `web_search`/`web_fetch` register whenever `webToolsAvailability` is not `disabled`.
- Remove the now-dead missing-key surface: `WEB_TOOLS_DISABLED_MESSAGE`, `CodingAgentWebToolsUnavailableError`, `TINYFISH_API_KEY_ENV`, and the `onWebToolsDisabled` option, plus the TUI startup-notice wiring (and the now-always-empty `startupNotices` array).
- Keep `WebToolsAvailability` (`disabled|optional|required`) and the `pss exec --web-tools` flag for compatibility; `optional` and `required` now behave identically and `pss exec` still defaults to `disabled`.
- Update README and tests; add a patch-level tegami changeset for `@minpeter/pss-coding-agent`.

## Testing

- `pnpm typecheck` (coding-agent)
- `pnpm test` — 77 files, 495 tests passed
- `pnpm lint` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delegates web tool provider selection to `@minpeter/opensearch`, removing the `TINYFISH_API_KEY` gate so `web_search` and `web_fetch` register whenever web tools are not disabled. This reduces setup and enables keyless fallbacks by default.

- **Refactors**
  - `createCodingAgentTools()` no longer checks `TINYFISH_API_KEY`; `@minpeter/opensearch` picks keyed providers from env and falls back to DuckDuckGo/local fetch.
  - Removed `WEB_TOOLS_DISABLED_MESSAGE`, `CodingAgentWebToolsUnavailableError`, and `onWebToolsDisabled`; dropped the TUI startup notice.
  - Kept `WebToolsAvailability` and `pss exec --web-tools`; `optional` and `required` now behave the same, default remains `disabled`.
  - Updated README and tests; added a patch changeset for `@minpeter/pss-coding-agent`.

<sup>Written for commit 337868ebe3726e2e8298dd589192d2fd6e5fa179. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

