### PR TITLE
feat: session management — lifecycle events, resume/fork/naming in the TUI

### DIFF
--- a/.tegami/2026-07-28-session-management.md
+++ b/.tegami/2026-07-28-session-management.md
@@ -1,0 +1,44 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Manage named, resumable, forkable sessions with lifecycle events
+
+The TUI now manages sessions per working directory. Metadata — display
+names, fork parentage, and the active session resumed on the next startup —
+lives in a fail-safe sidecar index next to the thread files; a corrupt
+index degrades to an empty one with a notice and never touches durable
+thread state. Session recency bumps on every completed turn, so pickers
+sort by actual use. `PSS_THREAD_KEY` still forces a key; the forced key is
+registered (naming and forking work) but never clobbers the active pointer
+for regular startups, and `pss inspect-thread` follows the active session
+unless the key is forced.
+
+Commands: `/new [name]` starts a new empty session. `/resume` opens an
+interactive picker to switch, rename, or delete a session (deleting the
+live session is blocked); `/resume <key|name>` switches directly with
+argument completions. `/name <name>` and the `--name` startup flag set the
+display name shown in the header. `/fork` offers branch points: the latest
+state or before any earlier user message — the fork keeps the truncated
+history, drops compaction records that extend past the cut, seeds
+`appliedMigrations` so migrations never re-run, and records the parent
+thread key; a fork whose registration fails deletes its copied thread.
+`/clear` keeps its wipe-in-place meaning and loses its `new` alias to the
+dedicated command. `new`, `resume`, `name`, `fork`, and `model` join the
+reserved command names.
+
+Extensions observe the lifecycle through host bus events:
+`host:session-start` (reasons `startup`/`new`/`resume`/`fork`/`clear`),
+`host:session-switch`, and `host:session-shutdown`. The new `sessionGuard`
+capability adds cancelable pre-switch/pre-fork decision points; guard
+errors, timeouts, malformed decisions, and explicit `null` returns fail
+closed, consistent with strict hook decisions.
+
+`@minpeter/pss-runtime` exports the thread snapshot codecs
+(`decodeStoredThreadState`, `encodeThreadSnapshot`, and their types and
+validation errors) so hosts can implement branch-before-message forks over
+validated state instead of parsing stored snapshots by hand.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -284,6 +284,46 @@ Context resources are discovered at session startup and re-discovered by
 contributed extension resource roots apply without a restart; a failed
 reload keeps the previous resources with the previous runtime.
 
+### Sessions
+
+The TUI manages named, resumable, forkable sessions per working directory.
+Metadata (names, fork parentage, the active session) lives in a sidecar
+`sessions.json` next to the thread files:
+
+- `/new [name]` — start a new empty session
+- `/resume` — interactive picker (switch, rename, or delete a session;
+  deleting the live session is blocked — switch away first);
+  `/resume <key|name>` switches directly (with completions)
+- `/name <name>` — name the current session (also `pss --name <name>` at
+  startup)
+- `/fork` — pick a branch point: the latest state or *before an earlier
+  user message* (the fork keeps the truncated history and only the
+  compaction records that fit it); `/fork <name>` forks at the latest
+  state under that name. Applied thread migrations carry over so they
+  never re-run on the fork, and the parent thread key is recorded
+- `/clear` — wipe the current session in place (legacy behavior)
+
+Session recency updates on every completed turn, so the `/resume` picker
+sorts by actual use.
+
+Extensions observe the lifecycle through host bus events
+(`host:session-start` with reason `startup` | `new` | `resume` | `fork` |
+`clear`, `host:session-switch`, `host:session-shutdown`) and can veto
+switches and forks with the `sessionGuard` capability:
+
+```ts
+import { sessionGuard } from "@minpeter/pss-coding-agent/extension";
+pss.provide(
+  sessionGuard({
+    beforeSwitch: ({ fromKey, toKey, reason }) =>
+      hasUnsavedWork(fromKey) ? { cancel: true, reason: "unsaved work" } : undefined,
+  })
+);
+```
+
+Guard errors, timeouts, and malformed decisions fail closed (the change is
+cancelled). See `docs/rfc/session-lifecycle.md` for the full design.
+
 ### Provider observations
 
 The host publishes read-only provider HTTP observations on the bus:

--- a/apps/coding-agent/src/cli.test.ts
+++ b/apps/coding-agent/src/cli.test.ts
@@ -103,6 +103,40 @@ describe("coding-agent CLI", () => {
     }
   });
 
+  it("accepts --name and starts the TUI", async () => {
+    let started = 0;
+
+    const exitCode = await runCodingAgentCli({
+      argv: ["--name", "spike"],
+      loadExtensions: () => Promise.resolve({ extensions: [], notices: [] }),
+      start: () => {
+        started += 1;
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(started).toBe(1);
+  });
+
+  it("rejects --name without a value", async () => {
+    let output = "";
+
+    const exitCode = await runCodingAgentCli({
+      argv: ["--name"],
+      start: () =>
+        Promise.reject(new Error("TUI should not start for bad flags")),
+      stdout: {
+        write(text: string): void {
+          output += text;
+        },
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(output).toContain("--name requires a value.");
+  });
+
   it("rejects -e without a path value", async () => {
     let output = "";
 
@@ -189,6 +223,46 @@ describe("coding-agent CLI", () => {
       expect(exitCode).toBe(0);
       expect(output).toContain("threadKey: workspace:demo\n");
       expect(output).toContain("messageCount: 0\n");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("inspects the active session unless PSS_THREAD_KEY forces a key", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pss-coding-agent-cli-"));
+    let output = "";
+
+    try {
+      await writeFile(
+        join(directory, "sessions.json"),
+        JSON.stringify({
+          active: { "/repo/demo": "cwd:/repo/demo#abc" },
+          schemaVersion: 1,
+          sessions: [
+            {
+              createdAt: "2026-01-01T00:00:00.000Z",
+              cwd: "/repo/demo",
+              key: "cwd:/repo/demo#abc",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        })
+      );
+
+      const exitCode = await runCodingAgentCli({
+        argv: ["inspect-thread"],
+        cwd: "/repo/demo",
+        env: { PSS_THREAD_DIR: directory },
+        home: "/home/me",
+        stdout: {
+          write(text: string): void {
+            output += text;
+          },
+        },
+      });
+
+      expect(exitCode).toBe(0);
+      expect(output).toContain("threadKey: cwd:/repo/demo#abc\n");
     } finally {
       await rm(directory, { force: true, recursive: true });
     }

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -16,7 +16,15 @@ import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader
 import { extensionScopePaths } from "./extensions/manager/paths";
 import { beginCommonJsReloadTransaction } from "./extensions/manager/reload-module-graph";
 import { readExtensionSettings } from "./extensions/manager/settings";
-import { resolveCodingAgentThreadConfig } from "./thread-config";
+import {
+  activeSessionKey,
+  readSessionIndex,
+  sessionIndexPath,
+} from "./sessions/session-index";
+import {
+  type CodingAgentThreadConfig,
+  resolveCodingAgentThreadConfig,
+} from "./thread-config";
 import {
   formatThreadInspectionReport,
   inspectCodingAgentThread,
@@ -63,7 +71,7 @@ export async function runCodingAgentCli({
 }: RunCodingAgentCliOptions = {}): Promise<number> {
   const command = argv[0];
 
-  if (command === undefined || isExtensionFlag(command)) {
+  if (command === undefined || isTuiFlag(command)) {
     return await runTuiCommand({
       argv,
       cwd,
@@ -97,7 +105,10 @@ export async function runCodingAgentCli({
 
   if (command === "inspect-thread") {
     const config = resolveCodingAgentThreadConfig(env, cwd, home);
-    const report = await inspectCodingAgentThread(config);
+    const report = await inspectCodingAgentThread({
+      ...config,
+      key: await resolveInspectionThreadKey(config, cwd),
+    });
     stdout.write(`${formatThreadInspectionReport(report)}\n`);
     return 0;
   }
@@ -128,8 +139,9 @@ async function runTuiCommand({
   readonly stdout: { write(text: string): void };
 }): Promise<number> {
   let extensionPaths: readonly string[];
+  let sessionName: string | undefined;
   try {
-    extensionPaths = parseTuiExtensionPaths(argv);
+    ({ extensionPaths, sessionName } = parseTuiArguments(argv));
   } catch (error) {
     stdout.write(`${errorMessage(error)}\n\n${formatUsage()}\n`);
     return 1;
@@ -221,11 +233,31 @@ async function runTuiCommand({
   return await (
     start ??
     ((loaded: readonly CodingAgentExtensionInput[]) =>
-      startTui({ extensions: loaded, reloadExtensions }))
+      startTui({
+        extensions: loaded,
+        reloadExtensions,
+        ...(sessionName === undefined ? {} : { sessionName }),
+      }))
   )(extensions);
 }
 
 const RELOAD_IMPORT_TIMEOUT_MS = 30_000;
+
+/**
+ * Inspect the thread the TUI would actually resume: the session index's
+ * active pointer for this directory, unless PSS_THREAD_KEY forces a key.
+ * A missing or unreadable index falls back to the legacy per-cwd key.
+ */
+async function resolveInspectionThreadKey(
+  config: CodingAgentThreadConfig,
+  cwd: string
+): Promise<string> {
+  if (config.keyFromEnv) {
+    return config.key;
+  }
+  const index = await readSessionIndex(sessionIndexPath(config.directory));
+  return activeSessionKey(index, cwd) ?? config.key;
+}
 
 async function reloadCacheRoots({
   cwd,
@@ -291,10 +323,30 @@ function isExtensionFlag(value: string): boolean {
   return value === "-e" || value === "--extension";
 }
 
-function parseTuiExtensionPaths(argv: readonly string[]): readonly string[] {
+function isTuiFlag(value: string): boolean {
+  return isExtensionFlag(value) || value === "--name";
+}
+
+function parseTuiArguments(argv: readonly string[]): {
+  readonly extensionPaths: readonly string[];
+  readonly sessionName?: string;
+} {
   const paths: string[] = [];
+  let sessionName: string | undefined;
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index] ?? "";
+    if (flag === "--name") {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith("-")) {
+        throw new Error("--name requires a value.");
+      }
+      if (sessionName !== undefined) {
+        throw new Error("--name may only be provided once.");
+      }
+      sessionName = value;
+      index += 1;
+      continue;
+    }
     if (!isExtensionFlag(flag)) {
       throw new Error(`Unknown pss option: ${flag}`);
     }
@@ -305,7 +357,10 @@ function parseTuiExtensionPaths(argv: readonly string[]): readonly string[] {
     paths.push(value);
     index += 1;
   }
-  return paths;
+  return {
+    extensionPaths: paths,
+    ...(sessionName === undefined ? {} : { sessionName }),
+  };
 }
 
 function formatUsage(): string {
@@ -314,7 +369,8 @@ function formatUsage(): string {
     "",
     "Commands:",
     "  (no command)     Start the interactive TUI",
-    "                   (-e/--extension <path> loads an extension for this run)",
+    "                   (-e/--extension <path> loads an extension for this run,",
+    "                    --name <name> names the startup session)",
     "  exec             Run one headless coding task",
     "  extension        Manage coding-agent extensions",
     "  inspect-thread   Print a report for the configured thread",

--- a/apps/coding-agent/src/extensions/capabilities.ts
+++ b/apps/coding-agent/src/extensions/capabilities.ts
@@ -1,5 +1,6 @@
 import type { ThreadStateMigration } from "@minpeter/pss-runtime";
 import type { ToolSet } from "ai";
+import type { CodingAgentSessionGuard } from "../sessions/session-guards";
 import type { TuiCommand } from "../tui/command";
 import type { ToolRendererMap } from "../tui/tool-call-view";
 import type { CodingAgentExtensionModelProvider } from "./types";
@@ -37,6 +38,10 @@ export interface ModelProviderCapability extends Capability<"model-provider"> {
   readonly provider: CodingAgentExtensionModelProvider;
 }
 
+export interface SessionGuardCapability extends Capability<"session-guard"> {
+  readonly guard: CodingAgentSessionGuard;
+}
+
 export interface ResourcesCapability extends Capability<"resources"> {
   /** Absolute directories containing `*.md` prompt templates. */
   readonly prompts: readonly string[];
@@ -49,6 +54,7 @@ export type ExtensionCapability =
   | InstructionsCapability
   | ModelProviderCapability
   | ResourcesCapability
+  | SessionGuardCapability
   | ThreadMigrationCapability
   | ToolRendererCapability
   | ToolsCapability;
@@ -81,6 +87,15 @@ export function modelProvider(
     kind: "model-provider",
     provider,
   }) as ModelProviderCapability;
+}
+
+export function sessionGuard(
+  guard: CodingAgentSessionGuard
+): SessionGuardCapability {
+  return Object.freeze({
+    guard,
+    kind: "session-guard",
+  }) as SessionGuardCapability;
 }
 
 export function resources(options: {

--- a/apps/coding-agent/src/extensions/capability-resources.test.ts
+++ b/apps/coding-agent/src/extensions/capability-resources.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { resources } from "./capabilities";
+import { resources, sessionGuard } from "./capabilities";
 import { createCodingAgentExtensionHost } from "./host";
 import type { CodingAgentExtensionApi } from "./types";
 
 const ABSOLUTE_PATHS = /must be absolute paths/;
 const AT_LEAST_ONE_DIRECTORY = /at least one directory/;
+const GUARD_HANDLERS = /beforeFork or beforeSwitch/;
+const MUST_BE_FUNCTION = /must be a function/;
 
 function extensionWith(
   configure: (pss: CodingAgentExtensionApi) => void,
@@ -61,5 +63,43 @@ describe("resources capability", () => {
         pss.provide(resources({}));
       })
     ).toMatch(AT_LEAST_ONE_DIRECTORY);
+  });
+});
+
+describe("session-guard capability", () => {
+  it("exposes registered guards with their owning extension", async () => {
+    const guard = { beforeSwitch: () => undefined };
+    const host = await createCodingAgentExtensionHost([
+      extensionWith((pss) => {
+        pss.provide(sessionGuard(guard));
+      }, "guarding"),
+    ]);
+    try {
+      expect(host.sessionGuards).toHaveLength(1);
+      expect(host.sessionGuards[0]?.extensionId).toBe("guarding");
+      expect(typeof host.sessionGuards[0]?.guard.beforeSwitch).toBe("function");
+    } finally {
+      await host.dispose();
+    }
+  });
+
+  it("rejects guards without any handler", async () => {
+    expect(
+      await configureFailureCause((pss) => {
+        pss.provide(sessionGuard({}));
+      })
+    ).toMatch(GUARD_HANDLERS);
+  });
+
+  it("rejects non-function guard handlers", async () => {
+    expect(
+      await configureFailureCause((pss) => {
+        pss.provide(
+          sessionGuard({
+            beforeSwitch: true as unknown as () => undefined,
+          })
+        );
+      })
+    ).toMatch(MUST_BE_FUNCTION);
   });
 });

--- a/apps/coding-agent/src/extensions/capability-validation.ts
+++ b/apps/coding-agent/src/extensions/capability-validation.ts
@@ -1,6 +1,7 @@
 import { isAbsolute } from "node:path";
 import type { ThreadStateMigration } from "@minpeter/pss-runtime";
 import type { ToolSet } from "ai";
+import type { CodingAgentSessionGuard } from "../sessions/session-guards";
 import type { TuiCommand } from "../tui/command";
 import type { ToolRendererMap } from "../tui/tool-call-view";
 import {
@@ -31,6 +32,10 @@ export type ValidatedCapability =
       readonly kind: "resources";
       readonly prompts: readonly string[];
       readonly skills: readonly string[];
+    }
+  | {
+      readonly guard: CodingAgentSessionGuard;
+      readonly kind: "session-guard";
     }
   | {
       readonly kind: "thread-migration";
@@ -98,6 +103,9 @@ export function validateExtensionCapability(
       }
       return { kind, prompts, skills };
     }
+    case "session-guard":
+      assertKeys(capability, ["guard", "kind"], "Extension capability");
+      return { guard: snapshotSessionGuard(capability.guard), kind };
     case "thread-migration":
       assertKeys(capability, ["kind", "migration"], "Extension capability");
       return {
@@ -231,6 +239,40 @@ export function snapshotThreadMigration(
     id: qualifiedId,
     migrate: migration.migrate as ThreadStateMigration["migrate"],
     version: migration.version as number,
+  });
+}
+
+function snapshotSessionGuard(value: unknown): CodingAgentSessionGuard {
+  const guard = snapshotDataRecord(value, "Session guard");
+  assertKeys(guard, ["beforeFork", "beforeSwitch"], "Session guard", []);
+  let handlers = 0;
+  for (const name of ["beforeFork", "beforeSwitch"] as const) {
+    const handler = guard[name];
+    if (handler === undefined) {
+      continue;
+    }
+    if (typeof handler !== "function") {
+      throw new TypeError(`Session guard "${name}" must be a function`);
+    }
+    handlers += 1;
+  }
+  if (handlers === 0) {
+    throw new TypeError(
+      "Session guard must provide beforeFork or beforeSwitch"
+    );
+  }
+  return Object.freeze({
+    ...(guard.beforeFork === undefined
+      ? {}
+      : {
+          beforeFork: guard.beforeFork as CodingAgentSessionGuard["beforeFork"],
+        }),
+    ...(guard.beforeSwitch === undefined
+      ? {}
+      : {
+          beforeSwitch:
+            guard.beforeSwitch as CodingAgentSessionGuard["beforeSwitch"],
+        }),
   });
 }
 

--- a/apps/coding-agent/src/extensions/host.ts
+++ b/apps/coding-agent/src/extensions/host.ts
@@ -5,6 +5,7 @@ import type {
   ThreadStateMigration,
 } from "@minpeter/pss-runtime";
 import type { ToolSet } from "ai";
+import type { RegisteredSessionGuard } from "../sessions/session-guards";
 import type { TuiCommand } from "../tui/command";
 import type { ToolRendererMap } from "../tui/tool-call-view";
 import { composeAgentHooks, type RegisteredAgentHooks } from "./compose-hooks";
@@ -135,6 +136,11 @@ export class CodingAgentExtensionHost {
 
   get tools(): ToolSet {
     return { ...this.#collections.tools };
+  }
+
+  /** Cancelable pre-switch/pre-fork session decision points (#258). */
+  get sessionGuards(): readonly RegisteredSessionGuard[] {
+    return [...this.#collections.sessionGuards];
   }
 
   /** Extension-contributed prompt/skill resource directories. */

--- a/apps/coding-agent/src/extensions/index.ts
+++ b/apps/coding-agent/src/extensions/index.ts
@@ -5,6 +5,12 @@ export type {
   ThreadStateMigration,
 } from "@minpeter/pss-runtime";
 export type {
+  CodingAgentSessionGuard,
+  SessionChangeEvent,
+  SessionGuardDecision,
+} from "../sessions/session-guards";
+export type { SessionLifecycleReason } from "../sessions/session-manager";
+export type {
   TuiCommand,
   TuiCommandAction,
   TuiCommandResult,
@@ -19,6 +25,7 @@ export type {
   InstructionsCapability,
   ModelProviderCapability,
   ResourcesCapability,
+  SessionGuardCapability,
   ThreadMigrationCapability,
   ToolRendererCapability,
   ToolsCapability,
@@ -28,6 +35,7 @@ export {
   instructions,
   modelProvider,
   resources,
+  sessionGuard,
   threadMigration,
   toolRenderer,
   tools,

--- a/apps/coding-agent/src/extensions/name-validation.ts
+++ b/apps/coding-agent/src/extensions/name-validation.ts
@@ -2,7 +2,16 @@ import { requiredString } from "./data-validation";
 
 const COMMAND_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 const TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
-const RESERVED_COMMAND_NAMES = new Set(["clear", "help", "new", "reload"]);
+const RESERVED_COMMAND_NAMES = new Set([
+  "clear",
+  "fork",
+  "help",
+  "model",
+  "name",
+  "new",
+  "reload",
+  "resume",
+]);
 const UNSAFE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 
 export function snapshotCommandName(value: unknown): string {

--- a/apps/coding-agent/src/extensions/registry-collections.ts
+++ b/apps/coding-agent/src/extensions/registry-collections.ts
@@ -1,5 +1,6 @@
 import type { ThreadStateMigration } from "@minpeter/pss-runtime";
 import type { ToolSet } from "ai";
+import type { RegisteredSessionGuard } from "../sessions/session-guards";
 import type { TuiCommand } from "../tui/command";
 import type { ToolRendererMap } from "../tui/tool-call-view";
 import type { RegisteredAgentHooks } from "./compose-hooks";
@@ -21,6 +22,7 @@ export interface ExtensionRegistryCollections {
   readonly owners: ExtensionContributionOwners;
   readonly renderers: ToolRendererMap;
   readonly resourceRoots: { prompts: string[]; skills: string[] };
+  readonly sessionGuards: RegisteredSessionGuard[];
   readonly tools: ToolSet;
 }
 
@@ -49,6 +51,7 @@ export function createExtensionRegistryCollections(): ExtensionRegistryCollectio
     },
     renderers: Object.create(null) as ToolRendererMap,
     resourceRoots: { prompts: [], skills: [] },
+    sessionGuards: [],
     tools: Object.create(null) as ToolSet,
   };
 }
@@ -102,6 +105,7 @@ export function commitExtensionRegistryCollections(
   target.migrations.push(...staged.migrations);
   target.resourceRoots.prompts.push(...staged.resourceRoots.prompts);
   target.resourceRoots.skills.push(...staged.resourceRoots.skills);
+  target.sessionGuards.push(...staged.sessionGuards);
   for (const [id, provider] of staged.modelProviders) {
     target.modelProviders.set(id, provider);
     target.owners.modelProviders.set(id, extensionId);

--- a/apps/coding-agent/src/extensions/registry.ts
+++ b/apps/coding-agent/src/extensions/registry.ts
@@ -167,6 +167,12 @@ export function createCodingAgentExtensionRegistry({
         collections.resourceRoots.prompts.push(...validated.prompts);
         collections.resourceRoots.skills.push(...validated.skills);
         return;
+      case "session-guard":
+        collections.sessionGuards.push({
+          extensionId,
+          guard: validated.guard,
+        });
+        return;
       case "thread-migration":
         if (
           collections.migrations.some(({ id }) => id === validated.migration.id)

--- a/apps/coding-agent/src/sessions/session-guards.test.ts
+++ b/apps/coding-agent/src/sessions/session-guards.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  approveSessionChange,
+  type RegisteredSessionGuard,
+} from "./session-guards";
+
+const event = { fromKey: "a", reason: "resume" as const, toKey: "b" };
+
+describe("approveSessionChange", () => {
+  it("approves when no guard objects", async () => {
+    const approval = await approveSessionChange({
+      event,
+      guards: [],
+      kind: "switch",
+    });
+    expect(approval).toEqual({ approved: true });
+  });
+
+  it("approves when guards allow explicitly or implicitly", async () => {
+    const guards: RegisteredSessionGuard[] = [
+      { extensionId: "a", guard: { beforeSwitch: () => undefined } },
+      { extensionId: "b", guard: { beforeSwitch: () => ({ cancel: false }) } },
+      { extensionId: "c", guard: { beforeFork: () => ({ cancel: true }) } },
+    ];
+    const approval = await approveSessionChange({
+      event,
+      guards,
+      kind: "switch",
+    });
+    expect(approval).toEqual({ approved: true });
+  });
+
+  it("cancels with the first cancelling guard's reason", async () => {
+    const guards: RegisteredSessionGuard[] = [
+      { extensionId: "a", guard: { beforeSwitch: () => undefined } },
+      {
+        extensionId: "b",
+        guard: {
+          beforeSwitch: () => ({ cancel: true, reason: "unsaved work" }),
+        },
+      },
+    ];
+    const approval = await approveSessionChange({
+      event,
+      guards,
+      kind: "switch",
+    });
+    expect(approval).toEqual({
+      approved: false,
+      extensionId: "b",
+      reason: "unsaved work",
+    });
+  });
+
+  it("consults beforeFork for fork decisions", async () => {
+    const guards: RegisteredSessionGuard[] = [
+      { extensionId: "a", guard: { beforeFork: () => ({ cancel: true }) } },
+    ];
+    const approval = await approveSessionChange({
+      event: { fromKey: "a", reason: "fork" },
+      guards,
+      kind: "fork",
+    });
+    expect(approval).toMatchObject({ approved: false, extensionId: "a" });
+  });
+
+  it("fails closed when a guard throws", async () => {
+    const guards: RegisteredSessionGuard[] = [
+      {
+        extensionId: "boomer",
+        guard: {
+          beforeSwitch: () => {
+            throw new Error("boom");
+          },
+        },
+      },
+    ];
+    const approval = await approveSessionChange({
+      event,
+      guards,
+      kind: "switch",
+    });
+    expect(approval).toMatchObject({ approved: false, extensionId: "boomer" });
+  });
+
+  it("fails closed on an explicit null decision", async () => {
+    const guards: RegisteredSessionGuard[] = [
+      {
+        extensionId: "nully",
+        guard: {
+          beforeSwitch: () => null as unknown as undefined,
+        },
+      },
+    ];
+    const approval = await approveSessionChange({
+      event,
+      guards,
+      kind: "switch",
+    });
+    expect(approval).toMatchObject({ approved: false, extensionId: "nully" });
+  });
+
+  it("fails closed on malformed decisions", async () => {
+    const guards: RegisteredSessionGuard[] = [
+      {
+        extensionId: "weird",
+        guard: {
+          beforeSwitch: () =>
+            ({ cancel: "yes" }) as unknown as { cancel: boolean },
+        },
+      },
+    ];
+    const approval = await approveSessionChange({
+      event,
+      guards,
+      kind: "switch",
+    });
+    expect(approval).toMatchObject({
+      approved: false,
+      extensionId: "weird",
+      reason: expect.stringContaining("invalid session guard decision"),
+    });
+  });
+
+  it("fails closed when a guard exceeds the host timeout", async () => {
+    const guards: RegisteredSessionGuard[] = [
+      {
+        extensionId: "slow",
+        guard: {
+          beforeSwitch: () => new Promise(() => undefined),
+        },
+      },
+    ];
+    const approval = await approveSessionChange({
+      event,
+      guards,
+      kind: "switch",
+      timeoutMs: 20,
+    });
+    expect(approval).toMatchObject({ approved: false, extensionId: "slow" });
+  });
+});

--- a/apps/coding-agent/src/sessions/session-guards.ts
+++ b/apps/coding-agent/src/sessions/session-guards.ts
@@ -1,0 +1,150 @@
+import { raceWithExtensionTimeout } from "../extensions/operation-timeout";
+import type { SessionLifecycleReason } from "./session-manager";
+
+/**
+ * Session lifecycle for extensions (#258, phase 1).
+ *
+ * Host-published bus events (subscribe via `services.events.on`):
+ * - `host:session-start`    `{ key, name?, reason }` — a session became
+ *   active (`startup` | `new` | `resume` | `fork` | `clear`).
+ * - `host:session-switch`   `{ fromKey, toKey, reason }` — the active
+ *   thread handle was replaced.
+ * - `host:session-shutdown` `{ key }` — the interactive session is ending.
+ *
+ * Cancelable decision points use registered session guards instead of bus
+ * events so the decision model stays strict: a guard either explicitly
+ * cancels, or the change proceeds. Guard failures and timeouts fail closed
+ * (the change is cancelled) and are attributed to the owning extension.
+ */
+export interface SessionChangeEvent {
+  readonly fromKey: string;
+  readonly reason: SessionLifecycleReason;
+  /** Absent for pre-fork decisions: the fork target does not exist yet. */
+  readonly toKey?: string;
+}
+
+export type SessionGuardDecision =
+  | undefined
+  | { readonly cancel?: boolean; readonly reason?: string };
+
+export interface CodingAgentSessionGuard {
+  beforeFork?(
+    event: SessionChangeEvent
+  ): Promise<SessionGuardDecision> | SessionGuardDecision;
+  beforeSwitch?(
+    event: SessionChangeEvent
+  ): Promise<SessionGuardDecision> | SessionGuardDecision;
+}
+
+export interface RegisteredSessionGuard {
+  readonly extensionId: string;
+  readonly guard: CodingAgentSessionGuard;
+}
+
+export type SessionChangeApproval =
+  | { readonly approved: true }
+  | {
+      readonly approved: false;
+      readonly extensionId: string;
+      readonly reason: string;
+    };
+
+/**
+ * Consult every registered guard for a pending switch/fork. The first
+ * cancellation wins; guard errors and timeouts cancel as well (fail
+ * closed), attributed to the owning extension.
+ */
+export async function approveSessionChange({
+  event,
+  guards,
+  kind,
+  signal,
+  timeoutMs,
+}: {
+  readonly event: SessionChangeEvent;
+  readonly guards: readonly RegisteredSessionGuard[];
+  readonly kind: "fork" | "switch";
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}): Promise<SessionChangeApproval> {
+  for (const { extensionId, guard } of guards) {
+    const handler = kind === "fork" ? guard.beforeFork : guard.beforeSwitch;
+    if (handler === undefined) {
+      continue;
+    }
+    let decision: SessionGuardDecision;
+    try {
+      decision = await raceWithExtensionTimeout(
+        extensionId,
+        "hook",
+        Promise.resolve(handler({ ...event })),
+        {
+          ...(signal === undefined ? {} : { signal }),
+          ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        }
+      );
+    } catch (error) {
+      return {
+        approved: false,
+        extensionId,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+    const validated = validateDecision(decision);
+    if (validated.valid) {
+      if (validated.cancel) {
+        return {
+          approved: false,
+          extensionId,
+          reason: validated.reason ?? "cancelled by extension",
+        };
+      }
+      continue;
+    }
+    // Malformed decisions fail closed, consistent with strict hooks.
+    return {
+      approved: false,
+      extensionId,
+      reason: `invalid session guard decision from extension "${extensionId}"`,
+    };
+  }
+  return { approved: true };
+}
+
+function validateDecision(decision: unknown):
+  | { readonly valid: false }
+  | {
+      readonly cancel: boolean;
+      readonly reason?: string;
+      readonly valid: true;
+    } {
+  if (decision === undefined) {
+    return { cancel: false, valid: true };
+  }
+  // Anything other than undefined or a plain decision object (including an
+  // explicit null) fails closed, consistent with strict hook decisions.
+  if (
+    decision === null ||
+    typeof decision !== "object" ||
+    Array.isArray(decision)
+  ) {
+    return { valid: false };
+  }
+  const record = decision as { cancel?: unknown; reason?: unknown };
+  for (const key of Object.keys(record)) {
+    if (key !== "cancel" && key !== "reason") {
+      return { valid: false };
+    }
+  }
+  if (record.cancel !== undefined && typeof record.cancel !== "boolean") {
+    return { valid: false };
+  }
+  if (record.reason !== undefined && typeof record.reason !== "string") {
+    return { valid: false };
+  }
+  return {
+    cancel: record.cancel === true,
+    ...(record.reason === undefined ? {} : { reason: record.reason }),
+    valid: true,
+  };
+}

--- a/apps/coding-agent/src/sessions/session-index.test.ts
+++ b/apps/coding-agent/src/sessions/session-index.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  activeSessionKey,
+  emptySessionIndex,
+  listSessionsForCwd,
+  readSessionIndex,
+  removeSession,
+  renameSession,
+  type SessionIndexEntry,
+  sessionIndexPath,
+  setActiveSession,
+  upsertSession,
+  writeSessionIndex,
+} from "./session-index";
+
+let directory: string;
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "pss-session-index-"));
+});
+
+afterEach(async () => {
+  await rm(directory, { force: true, recursive: true });
+});
+
+const entry = (key: string, overrides?: Partial<SessionIndexEntry>) =>
+  ({
+    createdAt: "2026-01-01T00:00:00.000Z",
+    cwd: "/work",
+    key,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  }) as SessionIndexEntry;
+
+describe("session index persistence", () => {
+  it("round-trips through the index file", async () => {
+    const path = sessionIndexPath(directory);
+    let document = emptySessionIndex();
+    document = upsertSession(document, entry("cwd:/work"));
+    document = setActiveSession(document, "/work", "cwd:/work");
+    await writeSessionIndex(path, document);
+
+    const loaded = await readSessionIndex(path);
+    expect(loaded.sessions).toHaveLength(1);
+    expect(activeSessionKey(loaded, "/work")).toBe("cwd:/work");
+  });
+
+  it("returns an empty index for missing files", async () => {
+    const loaded = await readSessionIndex(join(directory, "none.json"));
+    expect(loaded).toEqual(emptySessionIndex());
+  });
+
+  it("fails safe on malformed content", async () => {
+    const path = sessionIndexPath(directory);
+    await writeFile(path, "{broken", "utf8");
+    expect(await readSessionIndex(path)).toEqual(emptySessionIndex());
+  });
+
+  it("drops malformed entries and duplicate keys while parsing", async () => {
+    const path = sessionIndexPath(directory);
+    await writeFile(
+      path,
+      JSON.stringify({
+        active: { "/work": 5 },
+        schemaVersion: 1,
+        sessions: [entry("a"), entry("a"), { key: "b" }, "junk"],
+      }),
+      "utf8"
+    );
+    const loaded = await readSessionIndex(path);
+    expect(loaded.sessions.map((session) => session.key)).toEqual(["a"]);
+    expect(loaded.active).toEqual({});
+  });
+
+  it("writes atomically without leaving temp files", async () => {
+    const path = sessionIndexPath(directory);
+    await writeSessionIndex(path, emptySessionIndex());
+    const raw = await readFile(path, "utf8");
+    expect(raw.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("session index operations", () => {
+  it("removes sessions and clears dangling active pointers", () => {
+    let document = upsertSession(emptySessionIndex(), entry("a"));
+    document = setActiveSession(document, "/work", "a");
+    document = removeSession(document, "a");
+    expect(document.sessions).toEqual([]);
+    expect(activeSessionKey(document, "/work")).toBeUndefined();
+  });
+
+  it("ignores active pointers to unknown sessions", () => {
+    const document = setActiveSession(emptySessionIndex(), "/work", "ghost");
+    expect(activeSessionKey(document, "/work")).toBeUndefined();
+  });
+
+  it("renames sessions", () => {
+    let document = upsertSession(emptySessionIndex(), entry("a"));
+    document = renameSession(
+      document,
+      "a",
+      "spike",
+      "2026-01-02T00:00:00.000Z"
+    );
+    expect(document.sessions[0]).toMatchObject({
+      name: "spike",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+  });
+
+  it("lists sessions for a cwd sorted by recency", () => {
+    let document = emptySessionIndex();
+    document = upsertSession(
+      document,
+      entry("old", { updatedAt: "2026-01-01T00:00:00.000Z" })
+    );
+    document = upsertSession(
+      document,
+      entry("new", { updatedAt: "2026-01-03T00:00:00.000Z" })
+    );
+    document = upsertSession(document, entry("other", { cwd: "/elsewhere" }));
+    expect(listSessionsForCwd(document, "/work").map((s) => s.key)).toEqual([
+      "new",
+      "old",
+    ]);
+  });
+});

--- a/apps/coding-agent/src/sessions/session-index.ts
+++ b/apps/coding-agent/src/sessions/session-index.ts
@@ -1,0 +1,219 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/**
+ * Durable metadata for coding-agent sessions (threads). The runtime's
+ * thread store only persists opaque state, so display names, fork
+ * parentage, and the per-directory "active session" pointer live in this
+ * sidecar index next to the thread files.
+ */
+export interface SessionIndexEntry {
+  readonly createdAt: string;
+  readonly cwd: string;
+  readonly key: string;
+  readonly name?: string;
+  /** Thread key of the session this one was forked from. */
+  readonly parentKey?: string;
+  readonly updatedAt: string;
+}
+
+export interface SessionIndexDocument {
+  /** Maps a working directory to the thread key resumed on startup. */
+  readonly active: Readonly<Record<string, string>>;
+  readonly schemaVersion: 1;
+  readonly sessions: readonly SessionIndexEntry[];
+}
+
+export const SESSION_INDEX_FILENAME = "sessions.json";
+
+export function sessionIndexPath(threadDirectory: string): string {
+  return join(threadDirectory, SESSION_INDEX_FILENAME);
+}
+
+export function emptySessionIndex(): SessionIndexDocument {
+  return { active: {}, schemaVersion: 1, sessions: [] };
+}
+
+/**
+ * Read the session index. A missing file yields an empty index; a
+ * malformed file fails safe to an empty index as well (the durable thread
+ * state itself is never touched by index corruption).
+ */
+export async function readSessionIndex(
+  path: string
+): Promise<SessionIndexDocument> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return emptySessionIndex();
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parseSessionIndex(parsed);
+  } catch {
+    return emptySessionIndex();
+  }
+}
+
+export async function writeSessionIndex(
+  path: string,
+  document: SessionIndexDocument
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(
+      temporary,
+      `${JSON.stringify(document, null, 2)}\n`,
+      "utf8"
+    );
+    await rename(temporary, path);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export function upsertSession(
+  document: SessionIndexDocument,
+  entry: SessionIndexEntry
+): SessionIndexDocument {
+  const existing = document.sessions.find(
+    (session) => session.key === entry.key
+  );
+  const sessions =
+    existing === undefined
+      ? [...document.sessions, entry]
+      : document.sessions.map((session) =>
+          session.key === entry.key ? { ...existing, ...entry } : session
+        );
+  return { ...document, sessions };
+}
+
+export function touchSession(
+  document: SessionIndexDocument,
+  key: string,
+  updatedAt: string
+): SessionIndexDocument {
+  return {
+    ...document,
+    sessions: document.sessions.map((session) =>
+      session.key === key ? { ...session, updatedAt } : session
+    ),
+  };
+}
+
+export function renameSession(
+  document: SessionIndexDocument,
+  key: string,
+  name: string,
+  updatedAt: string
+): SessionIndexDocument {
+  return {
+    ...document,
+    sessions: document.sessions.map((session) =>
+      session.key === key ? { ...session, name, updatedAt } : session
+    ),
+  };
+}
+
+export function removeSession(
+  document: SessionIndexDocument,
+  key: string
+): SessionIndexDocument {
+  const active = Object.fromEntries(
+    Object.entries(document.active).filter(([, value]) => value !== key)
+  );
+  return {
+    ...document,
+    active,
+    sessions: document.sessions.filter((session) => session.key !== key),
+  };
+}
+
+export function setActiveSession(
+  document: SessionIndexDocument,
+  cwd: string,
+  key: string
+): SessionIndexDocument {
+  return { ...document, active: { ...document.active, [cwd]: key } };
+}
+
+export function activeSessionKey(
+  document: SessionIndexDocument,
+  cwd: string
+): string | undefined {
+  const key = document.active[cwd];
+  if (key === undefined) {
+    return;
+  }
+  return document.sessions.some((session) => session.key === key)
+    ? key
+    : undefined;
+}
+
+export function listSessionsForCwd(
+  document: SessionIndexDocument,
+  cwd: string
+): readonly SessionIndexEntry[] {
+  return document.sessions
+    .filter((session) => session.cwd === cwd)
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+function parseSessionIndex(value: unknown): SessionIndexDocument {
+  if (!isRecord(value) || value.schemaVersion !== 1) {
+    return emptySessionIndex();
+  }
+  const active: Record<string, string> = {};
+  if (isRecord(value.active)) {
+    for (const [cwd, key] of Object.entries(value.active)) {
+      if (typeof key === "string") {
+        active[cwd] = key;
+      }
+    }
+  }
+  const sessions: SessionIndexEntry[] = [];
+  if (Array.isArray(value.sessions)) {
+    for (const candidate of value.sessions) {
+      const entry = parseSessionEntry(candidate);
+      if (
+        entry !== undefined &&
+        !sessions.some((session) => session.key === entry.key)
+      ) {
+        sessions.push(entry);
+      }
+    }
+  }
+  return { active, schemaVersion: 1, sessions };
+}
+
+function parseSessionEntry(value: unknown): SessionIndexEntry | undefined {
+  if (
+    !(
+      isRecord(value) &&
+      typeof value.key === "string" &&
+      typeof value.cwd === "string" &&
+      typeof value.createdAt === "string" &&
+      typeof value.updatedAt === "string"
+    )
+  ) {
+    return;
+  }
+  return {
+    createdAt: value.createdAt,
+    cwd: value.cwd,
+    key: value.key,
+    ...(typeof value.name === "string" ? { name: value.name } : {}),
+    ...(typeof value.parentKey === "string"
+      ? { parentKey: value.parentKey }
+      : {}),
+    updatedAt: value.updatedAt,
+  };
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/coding-agent/src/sessions/session-manager.test.ts
+++ b/apps/coding-agent/src/sessions/session-manager.test.ts
@@ -1,0 +1,258 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ThreadStore } from "@minpeter/pss-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createSessionManager } from "./session-manager";
+
+const UNKNOWN_SESSION = /Unknown session/;
+const NOT_A_USER_MESSAGE = /does not reference a user message/;
+
+let directory: string;
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "pss-session-manager-"));
+});
+
+afterEach(async () => {
+  await rm(directory, { force: true, recursive: true });
+});
+
+function memoryThreadStore(): ThreadStore & {
+  readonly stored: Map<string, unknown>;
+} {
+  const stored = new Map<string, unknown>();
+  return {
+    commit: (key, next, options) => {
+      const exists = stored.has(key);
+      if (
+        (options.expectedVersion === null && exists) ||
+        (options.expectedVersion !== null && !exists)
+      ) {
+        return Promise.resolve({ ok: false, reason: "conflict" as const });
+      }
+      stored.set(key, next.state);
+      return Promise.resolve({ ok: true, version: "1" });
+    },
+    delete: (key) => {
+      stored.delete(key);
+      return Promise.resolve();
+    },
+    load: (key) =>
+      Promise.resolve(
+        stored.has(key) ? { state: stored.get(key), version: "1" } : null
+      ),
+    stored,
+  };
+}
+
+function manager(threads = memoryThreadStore()) {
+  return {
+    manager: createSessionManager({ cwd: "/work", directory, threads }),
+    threads,
+  };
+}
+
+describe("createSessionManager", () => {
+  it("registers the legacy key on first startup", async () => {
+    const { manager: sessions } = manager();
+    const entry = await sessions.resolveStartupSession();
+    expect(entry.key).toBe("cwd:/work");
+    expect(await sessions.listSessions()).toHaveLength(1);
+  });
+
+  it("resumes the recorded active session on the next startup", async () => {
+    const { manager: sessions } = manager();
+    await sessions.resolveStartupSession();
+    const created = await sessions.createSession("spike");
+    const next = createSessionManager({ cwd: "/work", directory });
+    const resumed = await next.resolveStartupSession();
+    expect(resumed.key).toBe(created.key);
+    expect(resumed.name).toBe("spike");
+  });
+
+  it("prefers an explicit override key and records a startup name", async () => {
+    const { manager: sessions } = manager();
+    const entry = await sessions.resolveStartupSession({
+      name: "ci",
+      overrideKey: "custom:key",
+    });
+    expect(entry).toMatchObject({ key: "custom:key", name: "ci" });
+  });
+
+  it("does not let an override key clobber the active pointer", async () => {
+    const { manager: sessions } = manager();
+    const regular = await sessions.resolveStartupSession();
+    await sessions.resolveStartupSession({ overrideKey: "ci:forced" });
+
+    const next = createSessionManager({ cwd: "/work", directory });
+    expect((await next.resolveStartupSession()).key).toBe(regular.key);
+    // The forced key is still registered for /name and /fork.
+    expect((await next.findSession("ci:forced"))?.key).toBe("ci:forced");
+  });
+
+  it("creates uniquely keyed sessions and marks them active", async () => {
+    const { manager: sessions } = manager();
+    const first = await sessions.createSession();
+    const second = await sessions.createSession();
+    expect(first.key).not.toBe(second.key);
+    const next = createSessionManager({ cwd: "/work", directory });
+    expect((await next.resolveStartupSession()).key).toBe(second.key);
+  });
+
+  it("forks durable state and records the parent-thread reference", async () => {
+    const { manager: sessions, threads } = manager();
+    const source = await sessions.resolveStartupSession();
+    threads.stored.set(source.key, { history: [], schemaVersion: 1 });
+
+    const fork = await sessions.forkSession(source.key, {
+      name: "experiment",
+    });
+    expect(fork.parentKey).toBe(source.key);
+    expect(fork.name).toBe("experiment");
+    expect(threads.stored.get(fork.key)).toEqual({
+      history: [],
+      schemaVersion: 1,
+    });
+    // The source thread stays untouched.
+    expect(threads.stored.get(source.key)).toEqual({
+      history: [],
+      schemaVersion: 1,
+    });
+  });
+
+  it("forks sessions without durable state as empty sessions", async () => {
+    const { manager: sessions, threads } = manager();
+    const source = await sessions.resolveStartupSession();
+    const fork = await sessions.forkSession(source.key);
+    expect(threads.stored.has(fork.key)).toBe(false);
+    expect(fork.parentKey).toBe(source.key);
+  });
+
+  it("forks before an earlier user message with truncated history", async () => {
+    const { manager: sessions, threads } = manager();
+    const source = await sessions.resolveStartupSession();
+    threads.stored.set(source.key, {
+      appliedMigrations: { "ext/migration": 1 },
+      compactions: [],
+      history: [
+        { content: "first ask", role: "user" },
+        { content: "first answer", role: "assistant" },
+        { content: "second ask", role: "user" },
+        { content: "second answer", role: "assistant" },
+      ],
+      schemaVersion: 3,
+    });
+
+    const fork = await sessions.forkSession(source.key, {
+      beforeHistoryIndex: 2,
+    });
+    const forked = threads.stored.get(fork.key) as {
+      appliedMigrations: Record<string, number>;
+      history: { content: string }[];
+    };
+    expect(forked.history.map((message) => message.content)).toEqual([
+      "first ask",
+      "first answer",
+    ]);
+    // Applied migrations are seeded so they never re-run on the fork.
+    expect(forked.appliedMigrations).toEqual({ "ext/migration": 1 });
+  });
+
+  it("rejects fork points that are not user messages", async () => {
+    const { manager: sessions, threads } = manager();
+    const source = await sessions.resolveStartupSession();
+    threads.stored.set(source.key, {
+      history: [
+        { content: "ask", role: "user" },
+        { content: "answer", role: "assistant" },
+      ],
+      schemaVersion: 1,
+    });
+    await expect(
+      sessions.forkSession(source.key, { beforeHistoryIndex: 1 })
+    ).rejects.toThrow(NOT_A_USER_MESSAGE);
+    await expect(
+      sessions.forkSession(source.key, { beforeHistoryIndex: 9 })
+    ).rejects.toThrow(NOT_A_USER_MESSAGE);
+  });
+
+  it("lists user messages as fork points with previews", async () => {
+    const { manager: sessions, threads } = manager();
+    const source = await sessions.resolveStartupSession();
+    threads.stored.set(source.key, {
+      history: [
+        { content: "  first\n ask ", role: "user" },
+        { content: "answer", role: "assistant" },
+        {
+          content: [{ text: "second ask", type: "text" }],
+          role: "user",
+        },
+        {
+          content: [{ data: "aGk=", mediaType: "image/png", type: "image" }],
+          role: "user",
+        },
+      ],
+      schemaVersion: 1,
+    });
+    expect(await sessions.listForkPoints(source.key)).toEqual([
+      { historyIndex: 0, preview: "first ask" },
+      { historyIndex: 2, preview: "second ask" },
+      { historyIndex: 3, preview: "(no text)" },
+    ]);
+  });
+
+  it("touches recency without failing for unknown keys", async () => {
+    const { manager: sessions } = manager();
+    const source = await sessions.resolveStartupSession();
+    const before = (await sessions.getSession(source.key))?.updatedAt;
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await sessions.touchSession(source.key);
+    const after = (await sessions.getSession(source.key))?.updatedAt;
+    expect(after).not.toBe(before);
+    await expect(sessions.touchSession("ghost")).resolves.toBeUndefined();
+  });
+
+  it("renames and finds sessions by name, key, and unique prefix", async () => {
+    const { manager: sessions } = manager();
+    const entry = await sessions.resolveStartupSession();
+    await sessions.renameSession(entry.key, "bugfix");
+    expect((await sessions.findSession("bugfix"))?.key).toBe(entry.key);
+    expect((await sessions.findSession(entry.key))?.key).toBe(entry.key);
+    expect((await sessions.findSession("bug"))?.key).toBe(entry.key);
+    expect(await sessions.findSession("nope")).toBeUndefined();
+  });
+
+  it("rejects renames of unknown sessions", async () => {
+    const { manager: sessions } = manager();
+    await expect(sessions.renameSession("ghost", "x")).rejects.toThrow(
+      UNKNOWN_SESSION
+    );
+  });
+
+  it("removes sessions along with their durable thread state", async () => {
+    const { manager: sessions, threads } = manager();
+    const entry = await sessions.resolveStartupSession();
+    threads.stored.set(entry.key, { messages: [] });
+    await sessions.removeSession(entry.key);
+    expect(threads.stored.has(entry.key)).toBe(false);
+    expect(await sessions.listSessions()).toEqual([]);
+  });
+
+  it("switches between recorded sessions", async () => {
+    const { manager: sessions } = manager();
+    const first = await sessions.resolveStartupSession();
+    await sessions.createSession();
+    const switched = await sessions.switchToSession(first.key);
+    expect(switched.key).toBe(first.key);
+    const next = createSessionManager({ cwd: "/work", directory });
+    expect((await next.resolveStartupSession()).key).toBe(first.key);
+  });
+
+  it("rejects switching to unknown sessions", async () => {
+    const { manager: sessions } = manager();
+    await expect(sessions.switchToSession("ghost")).rejects.toThrow(
+      UNKNOWN_SESSION
+    );
+  });
+});

--- a/apps/coding-agent/src/sessions/session-manager.ts
+++ b/apps/coding-agent/src/sessions/session-manager.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+import {
+  decodeStoredThreadState,
+  encodeThreadSnapshot,
+  type ThreadStore,
+} from "@minpeter/pss-runtime";
+import type { ModelMessage } from "ai";
+import {
+  activeSessionKey,
+  listSessionsForCwd,
+  readSessionIndex,
+  removeSession,
+  renameSession,
+  type SessionIndexDocument,
+  type SessionIndexEntry,
+  sessionIndexPath,
+  setActiveSession,
+  touchSession,
+  upsertSession,
+  writeSessionIndex,
+} from "./session-index";
+
+/** Why a session became (or is becoming) the active one. */
+export type SessionLifecycleReason =
+  | "clear"
+  | "fork"
+  | "new"
+  | "resume"
+  | "startup";
+
+/** A user message in the source thread that a fork can branch before. */
+export interface SessionForkPoint {
+  /** Index of the user message in the stored history. */
+  readonly historyIndex: number;
+  /** Single-line text preview of the user message. */
+  readonly preview: string;
+}
+
+export interface SessionForkOptions {
+  /**
+   * Branch before this user message: the fork keeps the history strictly
+   * before `historyIndex` (which must reference a user message). Without
+   * it the fork branches at the latest committed state.
+   */
+  readonly beforeHistoryIndex?: number;
+  readonly name?: string;
+}
+
+export interface SessionManagerOptions {
+  readonly cwd: string;
+  /** Thread storage directory; the index lives next to the thread files. */
+  readonly directory: string;
+  readonly now?: () => Date;
+  /** Durable thread store used to copy state when forking. */
+  readonly threads?: ThreadStore;
+}
+
+export interface SessionManager {
+  /** Create a new empty session and mark it active. */
+  createSession(name?: string): Promise<SessionIndexEntry>;
+  readonly cwd: string;
+  /** Find a session for this cwd by exact key, name, or unique prefix. */
+  findSession(query: string): Promise<SessionIndexEntry | undefined>;
+  /**
+   * Fork `fromKey` into a new session and record the parent-thread
+   * reference. By default the fork copies the latest committed state
+   * (including applied migrations); `beforeHistoryIndex` branches before an
+   * earlier user message instead, keeping compaction records that fit the
+   * truncated history.
+   */
+  forkSession(
+    fromKey: string,
+    options?: SessionForkOptions
+  ): Promise<SessionIndexEntry>;
+  getSession(key: string): Promise<SessionIndexEntry | undefined>;
+  /** List the user messages of a stored thread a fork can branch before. */
+  listForkPoints(fromKey: string): Promise<readonly SessionForkPoint[]>;
+  listSessions(): Promise<readonly SessionIndexEntry[]>;
+  /** Delete a session's metadata and its durable thread state. */
+  removeSession(key: string): Promise<void>;
+  renameSession(key: string, name: string): Promise<SessionIndexEntry>;
+  /**
+   * Resolve which thread key this startup should use: an explicit override
+   * wins, then the recorded active session, then the legacy per-cwd key.
+   * The resolved session is registered; it is also marked active unless an
+   * override forced it (an env-forced run must not change what the next
+   * plain startup resumes).
+   */
+  resolveStartupSession(options?: {
+    readonly name?: string;
+    readonly overrideKey?: string;
+  }): Promise<SessionIndexEntry>;
+  /** Mark an existing session active (e.g. after `/resume`). */
+  switchToSession(key: string): Promise<SessionIndexEntry>;
+  /** Bump a session's recency (no-op for unknown keys). */
+  touchSession(key: string): Promise<void>;
+}
+
+export function createSessionManager(
+  options: SessionManagerOptions
+): SessionManager {
+  const { cwd, directory, threads } = options;
+  const now = options.now ?? (() => new Date());
+  const indexPath = sessionIndexPath(directory);
+  // Serialize read-modify-write cycles so concurrent commands cannot drop
+  // one another's index updates.
+  let queue: Promise<unknown> = Promise.resolve();
+  const enqueue = <Result>(
+    task: (document: SessionIndexDocument) => Promise<{
+      readonly document: SessionIndexDocument;
+      readonly result: Result;
+    }>
+  ): Promise<Result> => {
+    const run = queue.then(async () => {
+      const document = await readSessionIndex(indexPath);
+      const { document: next, result } = await task(document);
+      if (next !== document) {
+        await writeSessionIndex(indexPath, next);
+      }
+      return result;
+    });
+    queue = run.catch(() => undefined);
+    return run;
+  };
+
+  const timestamp = (): string => now().toISOString();
+
+  const registerActive = (
+    document: SessionIndexDocument,
+    entry: SessionIndexEntry
+  ): SessionIndexDocument =>
+    setActiveSession(upsertSession(document, entry), cwd, entry.key);
+
+  return {
+    createSession: (name) =>
+      enqueue((document) => {
+        const at = timestamp();
+        const entry: SessionIndexEntry = {
+          createdAt: at,
+          cwd,
+          key: newSessionKey(cwd),
+          ...(name === undefined ? {} : { name }),
+          updatedAt: at,
+        };
+        return Promise.resolve({
+          document: registerActive(document, entry),
+          result: entry,
+        });
+      }),
+    cwd,
+    findSession: (query) =>
+      enqueue((document) =>
+        Promise.resolve({
+          document,
+          result: matchSession(listSessionsForCwd(document, cwd), query),
+        })
+      ),
+    forkSession: async (fromKey, forkOptions = {}) => {
+      if (threads === undefined) {
+        throw new Error("Forking requires thread storage.");
+      }
+      const source = await threads.load(fromKey);
+      const forkState = resolveForkState(source, forkOptions);
+      const at = timestamp();
+      const entry: SessionIndexEntry = {
+        createdAt: at,
+        cwd,
+        key: newSessionKey(cwd),
+        ...(forkOptions.name === undefined ? {} : { name: forkOptions.name }),
+        parentKey: fromKey,
+        updatedAt: at,
+      };
+      if (forkState !== undefined) {
+        const committed = await threads.commit(
+          entry.key,
+          { state: forkState },
+          { expectedVersion: null }
+        );
+        if (!committed.ok) {
+          throw new Error(
+            `Fork target thread ${JSON.stringify(entry.key)} already exists`
+          );
+        }
+      }
+      try {
+        return await enqueue((document) =>
+          Promise.resolve({
+            document: registerActive(document, entry),
+            result: entry,
+          })
+        );
+      } catch (error) {
+        // Never leave an orphaned thread copy behind when the metadata
+        // registration fails.
+        if (forkState !== undefined) {
+          await threads.delete(entry.key).catch(() => undefined);
+        }
+        throw error;
+      }
+    },
+    getSession: (key) =>
+      enqueue((document) =>
+        Promise.resolve({
+          document,
+          result: document.sessions.find((session) => session.key === key),
+        })
+      ),
+    listForkPoints: async (fromKey) => {
+      if (threads === undefined) {
+        return [];
+      }
+      const state = decodeStoredThreadState(await threads.load(fromKey));
+      const points: SessionForkPoint[] = [];
+      for (const [index, message] of state.history.entries()) {
+        if (message.role !== "user") {
+          continue;
+        }
+        points.push({
+          historyIndex: index,
+          preview: previewOfMessage(message),
+        });
+      }
+      return points;
+    },
+    listSessions: () =>
+      enqueue((document) =>
+        Promise.resolve({
+          document,
+          result: listSessionsForCwd(document, cwd),
+        })
+      ),
+    removeSession: async (key) => {
+      await enqueue((document) =>
+        Promise.resolve({
+          document: removeSession(document, key),
+          result: undefined,
+        })
+      );
+      await threads?.delete(key);
+    },
+    renameSession: (key, name) =>
+      enqueue((document) => {
+        const existing = document.sessions.find(
+          (session) => session.key === key
+        );
+        if (existing === undefined) {
+          return Promise.reject(
+            new Error(`Unknown session ${JSON.stringify(key)}`)
+          );
+        }
+        const at = timestamp();
+        const next = renameSession(document, key, name, at);
+        return Promise.resolve({
+          document: next,
+          result: { ...existing, name, updatedAt: at },
+        });
+      }),
+    resolveStartupSession: ({ name, overrideKey } = {}) =>
+      enqueue((document) => {
+        const key =
+          overrideKey ?? activeSessionKey(document, cwd) ?? `cwd:${cwd}`;
+        const existing = document.sessions.find(
+          (session) => session.key === key
+        );
+        const at = timestamp();
+        const resolvedName = name ?? existing?.name;
+        const entry: SessionIndexEntry = {
+          createdAt: existing?.createdAt ?? at,
+          cwd,
+          key,
+          ...(resolvedName === undefined ? {} : { name: resolvedName }),
+          ...(existing?.parentKey === undefined
+            ? {}
+            : { parentKey: existing.parentKey }),
+          updatedAt: at,
+        };
+        // An env-forced key is registered (so /name and /fork work) but
+        // must not clobber the active pointer for regular startups.
+        const next =
+          overrideKey === undefined
+            ? registerActive(document, entry)
+            : upsertSession(document, entry);
+        return Promise.resolve({ document: next, result: entry });
+      }),
+    touchSession: (key) =>
+      enqueue((document) => {
+        const exists = document.sessions.some((session) => session.key === key);
+        return Promise.resolve({
+          document: exists
+            ? touchSession(document, key, timestamp())
+            : document,
+          result: undefined,
+        });
+      }),
+    switchToSession: (key) =>
+      enqueue((document) => {
+        const existing = document.sessions.find(
+          (session) => session.key === key
+        );
+        if (existing === undefined) {
+          return Promise.reject(
+            new Error(`Unknown session ${JSON.stringify(key)}`)
+          );
+        }
+        const at = timestamp();
+        const next = setActiveSession(
+          touchSession(document, key, at),
+          cwd,
+          key
+        );
+        return Promise.resolve({
+          document: next,
+          result: { ...existing, updatedAt: at },
+        });
+      }),
+  };
+}
+
+export function describeSession(entry: SessionIndexEntry): string {
+  const name = entry.name === undefined ? "" : ` "${entry.name}"`;
+  const fork = entry.parentKey === undefined ? "" : " (fork)";
+  return `${entry.key}${name}${fork}`;
+}
+
+function matchSession(
+  sessions: readonly SessionIndexEntry[],
+  query: string
+): SessionIndexEntry | undefined {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return;
+  }
+  const exactKey = sessions.find((session) => session.key === trimmed);
+  if (exactKey !== undefined) {
+    return exactKey;
+  }
+  const lower = trimmed.toLowerCase();
+  const byName = sessions.filter(
+    (session) => session.name?.toLowerCase() === lower
+  );
+  if (byName.length === 1) {
+    return byName[0];
+  }
+  const byPrefix = sessions.filter(
+    (session) =>
+      session.key.toLowerCase().startsWith(lower) ||
+      session.name?.toLowerCase().startsWith(lower)
+  );
+  return byPrefix.length === 1 ? byPrefix[0] : undefined;
+}
+
+function newSessionKey(cwd: string): string {
+  return `cwd:${cwd}#${randomUUID().slice(0, 8)}`;
+}
+
+const FORK_PREVIEW_LENGTH = 64;
+const WHITESPACE_RUN = /\s+/g;
+
+/**
+ * Compute the state a fork starts from. A head fork copies the stored
+ * state verbatim (no decode/re-encode round trip); a fork before an
+ * earlier user message re-encodes the truncated history, keeping only
+ * compaction records that fit inside it and the applied-migration seed.
+ * Returns `undefined` when there is nothing to copy.
+ */
+function resolveForkState(
+  source: Awaited<ReturnType<ThreadStore["load"]>>,
+  options: SessionForkOptions
+): unknown {
+  if (options.beforeHistoryIndex === undefined) {
+    return source?.state;
+  }
+  const index = options.beforeHistoryIndex;
+  const state = decodeStoredThreadState(source);
+  if (
+    !Number.isInteger(index) ||
+    index < 0 ||
+    index >= state.history.length ||
+    state.history[index]?.role !== "user"
+  ) {
+    throw new Error(
+      `Fork point ${String(index)} does not reference a user message`
+    );
+  }
+  return encodeThreadSnapshot(
+    state.history.slice(0, index),
+    state.compactions.filter((record) => record.endSeqExclusive <= index),
+    state.appliedMigrations
+  );
+}
+
+function previewOfMessage(message: ModelMessage): string {
+  const text =
+    typeof message.content === "string"
+      ? message.content
+      : message.content
+          .map((part) =>
+            typeof part === "object" && part !== null && "text" in part
+              ? String(part.text)
+              : ""
+          )
+          .join(" ");
+  const collapsed = text.replace(WHITESPACE_RUN, " ").trim();
+  if (collapsed.length === 0) {
+    // e.g. attachment-only user messages still need a legible fork label.
+    return "(no text)";
+  }
+  if (collapsed.length <= FORK_PREVIEW_LENGTH) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, FORK_PREVIEW_LENGTH - 1)}…`;
+}

--- a/apps/coding-agent/src/thread-config.test.ts
+++ b/apps/coding-agent/src/thread-config.test.ts
@@ -9,6 +9,7 @@ describe("resolveCodingAgentThreadConfig", () => {
       autoCompaction: undefined,
       directory: "/home/me/.pss/threads",
       key: "cwd:/repo/demo",
+      keyFromEnv: false,
     });
   });
 
@@ -26,6 +27,7 @@ describe("resolveCodingAgentThreadConfig", () => {
       autoCompaction: undefined,
       directory: ".pss/threads",
       key: "workspace:demo",
+      keyFromEnv: true,
     });
   });
 
@@ -40,6 +42,7 @@ describe("resolveCodingAgentThreadConfig", () => {
       autoCompaction: undefined,
       directory: "/home/me/.pss/threads",
       key: "cwd:/repo/demo",
+      keyFromEnv: false,
     });
   });
 
@@ -54,6 +57,7 @@ describe("resolveCodingAgentThreadConfig", () => {
       autoCompaction: { maxInputTokens: 64_000 },
       directory: "/home/me/.pss/threads",
       key: "cwd:/repo/demo",
+      keyFromEnv: false,
     });
   });
 

--- a/apps/coding-agent/src/thread-config.ts
+++ b/apps/coding-agent/src/thread-config.ts
@@ -6,6 +6,8 @@ export interface CodingAgentThreadConfig {
   readonly autoCompaction: AgentOptions["autoCompaction"];
   readonly directory: string;
   readonly key: string;
+  /** True when PSS_THREAD_KEY forced the key (session index is bypassed). */
+  readonly keyFromEnv: boolean;
 }
 
 export function resolveCodingAgentThreadConfig(
@@ -13,10 +15,12 @@ export function resolveCodingAgentThreadConfig(
   cwd = process.cwd(),
   home = homedir()
 ): CodingAgentThreadConfig {
+  const envKey = nonEmpty(env.PSS_THREAD_KEY);
   return {
     autoCompaction: resolveAutoCompaction(env),
     directory: nonEmpty(env.PSS_THREAD_DIR) ?? join(home, ".pss", "threads"),
-    key: nonEmpty(env.PSS_THREAD_KEY) ?? `cwd:${cwd}`,
+    key: envKey ?? `cwd:${cwd}`,
+    keyFromEnv: envKey !== undefined,
   };
 }
 

--- a/apps/coding-agent/src/thread-inspect.test.ts
+++ b/apps/coding-agent/src/thread-inspect.test.ts
@@ -54,6 +54,7 @@ describe("thread inspection", () => {
         autoCompaction: { maxInputTokens: 64_000 },
         directory,
         key,
+        keyFromEnv: false,
       });
 
       expect(formatThreadInspectionReport(report)).toBe(`threadKey: inspect:key
@@ -79,6 +80,7 @@ autoCompaction: auto max=64000`);
         autoCompaction: undefined,
         directory,
         key,
+        keyFromEnv: false,
       });
 
       expect(formatThreadInspectionReport(report)).toBe(`threadKey: missing:key

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -1264,11 +1264,34 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
 
+    if (commandResult.action.type === "session") {
+      handleSessionAction(commandResult, commandResult.action.clear);
+      return;
+    }
+
     if (commandResult.action.type === "refresh-header") {
       await config.onCommandAction?.(commandResult.action);
       updateHeader();
     }
 
+    if (commandResult.message) {
+      addSystemMessage(chatContainer, commandResult.message);
+    }
+    tui.requestRender();
+  };
+
+  const handleSessionAction = (
+    commandResult: TuiCommandResult,
+    clear: boolean
+  ): void => {
+    // Session commands already swapped the thread handle; the TUI only
+    // resets the transcript view and refreshes the header.
+    if (clear) {
+      clearStatus();
+      chatContainer.clear();
+      addNewSessionMessage(chatContainer);
+    }
+    updateHeader();
     if (commandResult.message) {
       addSystemMessage(chatContainer, commandResult.message);
     }

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -32,6 +32,15 @@ import {
   createProviderObservationFetch,
   type ProviderObservationEmitter,
 } from "../provider-observation";
+import {
+  approveSessionChange,
+  type SessionChangeEvent,
+} from "../sessions/session-guards";
+import type { SessionIndexEntry } from "../sessions/session-index";
+import {
+  createSessionManager,
+  type SessionLifecycleReason,
+} from "../sessions/session-manager";
 import { resolveCodingAgentThreadConfig } from "../thread-config";
 import { planAutoUpdate, runAutoUpdate } from "../update/auto-update";
 import { UPDATE_CHECK_CACHE_FILENAME } from "../update/check";
@@ -48,6 +57,7 @@ import {
   type ReloadableExtensions,
 } from "./reload";
 import { createToolRenderers } from "./renderers/tool-renderers";
+import { createSessionCommands } from "./session-commands";
 import { TokenUsageTracker } from "./usage-footer";
 
 export interface StartTuiOptions {
@@ -56,11 +66,46 @@ export interface StartTuiOptions {
   readonly model?: AgentOptions["model"];
   /** Re-runs extension discovery for `/reload`; absent means unavailable. */
   readonly reloadExtensions?: () => Promise<ReloadableExtensions>;
+  /** Display name recorded for the startup session (`--name`). */
+  readonly sessionName?: string;
   /** Replaces the TUI's default optional OpenSearch tools. */
   readonly tools?: ToolSet;
 }
 
 const RECOVERY_ACTIVATION_TIMEOUT_MS = 60_000;
+
+/**
+ * Resolve (and record) the session this startup drives. The session index
+ * must never block startup: on failure the legacy per-directory key is
+ * used without recording metadata, and a notice is surfaced.
+ */
+async function resolveStartupSessionEntry(
+  sessionManager: ReturnType<typeof createSessionManager>,
+  threadConfig: ReturnType<typeof resolveCodingAgentThreadConfig>,
+  sessionName: string | undefined
+): Promise<{ entry: SessionIndexEntry; notice?: string }> {
+  try {
+    return {
+      entry: await sessionManager.resolveStartupSession({
+        ...(sessionName === undefined ? {} : { name: sessionName }),
+        ...(threadConfig.keyFromEnv ? { overrideKey: threadConfig.key } : {}),
+      }),
+    };
+  } catch (error) {
+    const at = new Date().toISOString();
+    return {
+      entry: {
+        createdAt: at,
+        cwd: process.cwd(),
+        key: threadConfig.key,
+        updatedAt: at,
+      },
+      notice: `Session index unavailable: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
 
 const resolveModelSubtitle = (): string | undefined => {
   try {
@@ -133,7 +178,20 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
   }
   let exitCode = 0;
   try {
-    let thread = agent.thread(threadConfig.key);
+    const sessionManager = createSessionManager({
+      cwd: process.cwd(),
+      directory: threadConfig.directory,
+      threads: createFileHost({ directory: threadConfig.directory }).store
+        .threads,
+    });
+    const startupSession = await resolveStartupSessionEntry(
+      sessionManager,
+      threadConfig,
+      options.sessionName
+    );
+    let currentSession = startupSession.entry;
+    const sessionIndexNotice = startupSession.notice;
+    let thread = agent.thread(currentSession.key);
     let createExtensionUiForHost:
       | ((hostSignal?: AbortSignal) => CodingAgentExtensionUi)
       | undefined;
@@ -141,6 +199,9 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
     let extensionUiAbort: AbortController | undefined;
 
     const noticeLines: string[] = [...contextResources.notices];
+    if (sessionIndexNotice !== undefined) {
+      noticeLines.push(sessionIndexNotice);
+    }
     if (modelSession?.isFreeTier) {
       noticeLines.push(
         `No AI_API_KEY configured — using the OpenCode Zen free tier (model ${modelSession.currentModelId()}). Free models are rate-limited and may change; set AI_API_KEY to use your own provider.`
@@ -153,6 +214,20 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
     const activeModelSession = modelSession;
     const builtInCommands = [
       createClearCommand(),
+      // Session commands close over helpers defined below; the wrappers
+      // defer evaluation to call time.
+      ...createSessionCommands({
+        currentSession: () => currentSession,
+        ensureApproved: (kind, event) =>
+          ensureSessionChangeApproved(kind, event),
+        manager: sessionManager,
+        onRenamed: (entry) => {
+          currentSession = entry;
+          header.subtitle = buildSubtitle();
+        },
+        switchThread: (entry, reason) => switchThread(entry, reason),
+        ui: () => extensionUi,
+      }),
       ...(activeModelSession === undefined
         ? []
         : [
@@ -217,9 +292,67 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
       renderUsageFooter();
     };
 
-    const buildSubtitle = (): string =>
-      `${modelSubtitleLabel(modelSession)}\n${process.cwd()}`;
+    const buildSubtitle = (): string => {
+      const base = `${modelSubtitleLabel(modelSession)}\n${process.cwd()}`;
+      return currentSession.name === undefined
+        ? base
+        : `${base}\nsession: ${currentSession.name}`;
+    };
     const header = { title: "pss", subtitle: buildSubtitle() };
+
+    const emitSessionEvent = (
+      type: string,
+      payload: Parameters<CodingAgentExtensionHost["emitHostEvent"]>[1]
+    ): void => {
+      extensionHost.emitHostEvent(type, payload);
+    };
+
+    // Cancelable pre-switch/pre-fork decision points (#258): any
+    // registered extension session guard can cancel the change; guard
+    // failures fail closed.
+    const ensureSessionChangeApproved = async (
+      kind: "fork" | "switch",
+      event: SessionChangeEvent
+    ): Promise<void> => {
+      const approval = await approveSessionChange({
+        event,
+        guards: extensionHost.sessionGuards,
+        kind,
+        signal: extensionHost.signal,
+        timeoutMs: extensionHost.timeoutMs,
+      });
+      if (!approval.approved) {
+        throw new Error(
+          `Session change cancelled by extension "${approval.extensionId}": ${approval.reason}`
+        );
+      }
+    };
+
+    const switchThread = async (
+      entry: SessionIndexEntry,
+      reason: SessionLifecycleReason
+    ): Promise<void> => {
+      const fromKey = currentSession.key;
+      const previous = thread;
+      previous.interrupt();
+      // Best-effort: a failing disposal of the outgoing handle must not
+      // strand the switch half-way (disposal evicts it from the agent).
+      await previous.dispose().catch(() => undefined);
+      thread = agent.thread(entry.key);
+      currentSession = entry;
+      resetUsageTotals();
+      header.subtitle = buildSubtitle();
+      emitSessionEvent("host:session-switch", {
+        fromKey,
+        reason,
+        toKey: entry.key,
+      });
+      emitSessionEvent("host:session-start", {
+        key: entry.key,
+        ...(entry.name === undefined ? {} : { name: entry.name }),
+        reason,
+      });
+    };
 
     const tuiConfig: AgentTUIConfig = {
       thread: {
@@ -254,12 +387,24 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         usageTracker.beginTurn();
         renderUsageFooter();
       },
+      onTurnComplete: () => {
+        // Keep /resume recency meaningful: every completed turn bumps the
+        // session's updatedAt (best-effort; never surfaces to the user).
+        sessionManager.touchSession(currentSession.key).catch(() => undefined);
+      },
       onExtensionUiReady: async (createUi) => {
         createExtensionUiForHost = createUi;
         extensionUiAbort = new AbortController();
         extensionUi = createUi(extensionUiAbort.signal);
         extensionHost.bindUi(extensionUi);
         await extensionHost.activate(agent, "tui");
+        emitSessionEvent("host:session-start", {
+          key: currentSession.key,
+          ...(currentSession.name === undefined
+            ? {}
+            : { name: currentSession.name }),
+          reason: "startup",
+        });
       },
       onSetup: () => {
         for (const refresh of deferredRefreshes) {
@@ -278,7 +423,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             const stale = thread;
             stale.interrupt();
             await stale.dispose().catch(() => undefined);
-            thread = agent.thread(threadConfig.key);
+            thread = agent.thread(currentSession.key);
             throw error;
           }
           return;
@@ -291,8 +436,13 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
         previous.interrupt();
         await previous.delete();
         await previous.dispose();
-        thread = agent.thread(threadConfig.key);
+        thread = agent.thread(currentSession.key);
         resetUsageTotals();
+        sessionManager.touchSession(currentSession.key).catch(() => undefined);
+        emitSessionEvent("host:session-start", {
+          key: currentSession.key,
+          reason: "clear",
+        });
       },
       setupMessages: noticeLines,
       toolRenderers: mergeToolRenderers(
@@ -370,7 +520,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
     ): void => {
       agent = nextAgent;
       extensionHost = host;
-      thread = agent.thread(threadConfig.key);
+      thread = agent.thread(currentSession.key);
       tuiConfig.commands = [...commands];
       tuiConfig.toolRenderers = toolRenderers;
     };
@@ -519,7 +669,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
             const committed = await commitThreadStateMigrations({
               migrations: host.threadMigrations,
               store: reloadFileHost.store.threads,
-              threadKey: threadStoreKey(threadConfig.key),
+              threadKey: threadStoreKey(currentSession.key),
               timeoutMs: host.timeoutMs,
             });
             return committed === undefined
@@ -550,6 +700,7 @@ export async function startTui(options: StartTuiOptions = {}): Promise<number> {
     try {
       await createAgentTUI(tuiConfig);
     } finally {
+      emitSessionEvent("host:session-shutdown", { key: currentSession.key });
       thread.interrupt();
       await thread.dispose().catch(() => undefined);
     }

--- a/apps/coding-agent/src/tui/command-set.ts
+++ b/apps/coding-agent/src/tui/command-set.ts
@@ -44,9 +44,7 @@ const newSessionAction = (): TuiCommandResult => ({
 
 export const createClearCommand = (): TuiCommand => ({
   name: "clear",
-  displayName: "clear (new)",
-  aliases: ["new"],
-  description: "Start a new session",
+  description: "Clear the current session history",
   execute: () => newSessionAction(),
 });
 

--- a/apps/coding-agent/src/tui/command.ts
+++ b/apps/coding-agent/src/tui/command.ts
@@ -12,6 +12,7 @@ export type TuiCommandAction =
   | { type: "new-session" }
   | { type: "refresh-header" }
   | { type: "reload" }
+  | { clear: boolean; type: "session" }
   | { prompt: string; type: "submit-prompt" }
   | { type: "select-model"; query?: string };
 

--- a/apps/coding-agent/src/tui/session-commands.test.ts
+++ b/apps/coding-agent/src/tui/session-commands.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CodingAgentExtensionUi } from "../extensions/types";
+import type { SessionIndexEntry } from "../sessions/session-index";
+import type { SessionManager } from "../sessions/session-manager";
+import {
+  createSessionCommands,
+  type SessionCommandContext,
+} from "./session-commands";
+
+const entry = (
+  key: string,
+  overrides?: Partial<SessionIndexEntry>
+): SessionIndexEntry => ({
+  createdAt: "2026-01-01T00:00:00.000Z",
+  cwd: "/work",
+  key,
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+interface FakeUiScript {
+  readonly confirms?: boolean[];
+  readonly inputs?: (string | undefined)[];
+  readonly selects?: (string | undefined)[];
+}
+
+function fakeUi(script: FakeUiScript): {
+  selectLabels: string[];
+  selectOptions: { label: string; value: string }[][];
+  ui: CodingAgentExtensionUi;
+} {
+  const selects = [...(script.selects ?? [])];
+  const inputs = [...(script.inputs ?? [])];
+  const confirms = [...(script.confirms ?? [])];
+  const selectLabels: string[] = [];
+  const selectOptions: { label: string; value: string }[][] = [];
+  const ui: CodingAgentExtensionUi = {
+    confirm: () => Promise.resolve(confirms.shift() ?? false),
+    input: () => Promise.resolve(inputs.shift()),
+    notify: () => undefined,
+    select: ({ label, options }) => {
+      selectLabels.push(label);
+      selectOptions.push(
+        options.map(({ label: optionLabel, value }) => ({
+          label: optionLabel,
+          value,
+        }))
+      );
+      return Promise.resolve(selects.shift());
+    },
+    status: () => () => undefined,
+  };
+  return { selectLabels, selectOptions, ui };
+}
+
+function createContext(overrides?: Partial<SessionCommandContext>): {
+  context: SessionCommandContext;
+  manager: SessionManager;
+  switched: [SessionIndexEntry, string][];
+} {
+  const switched: [SessionIndexEntry, string][] = [];
+  const manager = {
+    createSession: vi.fn((name?: string) =>
+      Promise.resolve(
+        entry("cwd:/work#new", name === undefined ? {} : { name })
+      )
+    ),
+    cwd: "/work",
+    findSession: vi.fn(() => Promise.resolve(undefined)),
+    forkSession: vi.fn(
+      (
+        fromKey: string,
+        options?: { beforeHistoryIndex?: number; name?: string }
+      ) =>
+        Promise.resolve(
+          entry("cwd:/work#fork", {
+            parentKey: fromKey,
+            ...(options?.name === undefined ? {} : { name: options.name }),
+          })
+        )
+    ),
+    getSession: vi.fn(() => Promise.resolve(undefined)),
+    listForkPoints: vi.fn(() => Promise.resolve([])),
+    listSessions: vi.fn(() => Promise.resolve([])),
+    removeSession: vi.fn(() => Promise.resolve()),
+    renameSession: vi.fn((key: string, name: string) =>
+      Promise.resolve(entry(key, { name }))
+    ),
+    resolveStartupSession: vi.fn(() => Promise.resolve(entry("cwd:/work"))),
+    switchToSession: vi.fn((key: string) => Promise.resolve(entry(key))),
+    touchSession: vi.fn(() => Promise.resolve()),
+  } as unknown as SessionManager;
+  const context: SessionCommandContext = {
+    currentSession: () => entry("cwd:/work"),
+    ensureApproved: vi.fn(() => Promise.resolve()),
+    manager,
+    onRenamed: vi.fn(),
+    switchThread: (target, reason) => {
+      switched.push([target, reason]);
+      return Promise.resolve();
+    },
+    ...overrides,
+  };
+  return { context, manager, switched };
+}
+
+function command(context: SessionCommandContext, name: string) {
+  const found = createSessionCommands(context).find(
+    (candidate) => candidate.name === name
+  );
+  if (found === undefined) {
+    throw new Error(`missing command ${name}`);
+  }
+  return found;
+}
+
+describe("/new", () => {
+  it("creates a named session and switches to it", async () => {
+    const { context, manager, switched } = createContext();
+    const result = await command(context, "new").execute({
+      args: ["spike", "work"],
+    });
+    expect(manager.createSession).toHaveBeenCalledWith("spike work");
+    expect(switched).toHaveLength(1);
+    expect(switched[0]?.[1]).toBe("new");
+    expect(result).toMatchObject({
+      action: { clear: true, type: "session" },
+      success: true,
+    });
+  });
+
+  it("reports guard cancellations without switching", async () => {
+    const { context, switched } = createContext({
+      ensureApproved: () => Promise.reject(new Error("cancelled by extension")),
+    });
+    const result = await command(context, "new").execute({ args: [] });
+    expect(result).toMatchObject({
+      message: "cancelled by extension",
+      success: false,
+    });
+    expect(switched).toEqual([]);
+  });
+});
+
+describe("/resume", () => {
+  it("lists sessions when no interactive UI is bound", async () => {
+    const { context, manager } = createContext();
+    (manager.listSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      entry("cwd:/work", { name: "main" }),
+      entry("cwd:/work#2", { updatedAt: "2026-01-02T00:00:00.000Z" }),
+    ]);
+    const result = await command(context, "resume").execute({ args: [] });
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("cwd:/work#2");
+    expect(result.message).toContain('* cwd:/work "main"');
+  });
+
+  it("switches to a matching session", async () => {
+    const { context, manager, switched } = createContext();
+    (manager.findSession as ReturnType<typeof vi.fn>).mockResolvedValue(
+      entry("cwd:/work#2")
+    );
+    const result = await command(context, "resume").execute({
+      args: ["cwd:/work#2"],
+    });
+    expect(manager.switchToSession).toHaveBeenCalledWith("cwd:/work#2");
+    expect(switched[0]?.[1]).toBe("resume");
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown queries", async () => {
+    const { context, switched } = createContext();
+    const result = await command(context, "resume").execute({
+      args: ["ghost"],
+    });
+    expect(result.success).toBe(false);
+    expect(switched).toEqual([]);
+  });
+
+  it("is a no-op when already on the target session", async () => {
+    const { context, manager, switched } = createContext();
+    (manager.findSession as ReturnType<typeof vi.fn>).mockResolvedValue(
+      entry("cwd:/work")
+    );
+    const result = await command(context, "resume").execute({
+      args: ["cwd:/work"],
+    });
+    expect(result).toMatchObject({ success: true });
+    expect(switched).toEqual([]);
+  });
+
+  it("offers completions excluding the current session", async () => {
+    const { context, manager } = createContext();
+    (manager.listSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      entry("cwd:/work"),
+      entry("cwd:/work#2", { name: "spike" }),
+    ]);
+    const completions = await command(
+      context,
+      "resume"
+    ).getArgumentCompletions?.("sp");
+    expect(completions).toEqual([expect.objectContaining({ value: "spike" })]);
+  });
+
+  it("switches through the interactive picker", async () => {
+    const { selectOptions, ui } = fakeUi({
+      selects: ["cwd:/work#2", "switch"],
+    });
+    const { context, manager, switched } = createContext({ ui: () => ui });
+    (manager.listSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      entry("cwd:/work"),
+      entry("cwd:/work#2"),
+    ]);
+    const result = await command(context, "resume").execute({ args: [] });
+    expect(manager.switchToSession).toHaveBeenCalledWith("cwd:/work#2");
+    expect(switched[0]?.[1]).toBe("resume");
+    expect(result).toMatchObject({
+      action: { clear: true, type: "session" },
+      success: true,
+    });
+    // The current session is marked and its action list omits switch/delete.
+    expect(selectOptions[0]?.[0]?.label).toContain("(current)");
+  });
+
+  it("renames through the picker and syncs the header for the current session", async () => {
+    const { ui } = fakeUi({
+      inputs: ["renamed"],
+      selects: ["cwd:/work", "rename"],
+    });
+    const { context, manager } = createContext({ ui: () => ui });
+    (manager.listSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      entry("cwd:/work"),
+    ]);
+    const result = await command(context, "resume").execute({ args: [] });
+    expect(manager.renameSession).toHaveBeenCalledWith("cwd:/work", "renamed");
+    expect(context.onRenamed).toHaveBeenCalled();
+    expect(result).toMatchObject({ success: true });
+  });
+
+  it("deletes non-current sessions after confirmation", async () => {
+    const { selectOptions, ui } = fakeUi({
+      confirms: [true],
+      selects: ["cwd:/work#2", "delete"],
+    });
+    const { context, manager } = createContext({ ui: () => ui });
+    (manager.listSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      entry("cwd:/work"),
+      entry("cwd:/work#2"),
+    ]);
+    const result = await command(context, "resume").execute({ args: [] });
+    expect(manager.removeSession).toHaveBeenCalledWith("cwd:/work#2");
+    expect(result.message).toContain("Deleted");
+    // The non-current target offers switch and delete.
+    expect(selectOptions[1]?.map((option) => option.value)).toEqual([
+      "switch",
+      "rename",
+      "delete",
+      "cancel",
+    ]);
+  });
+
+  it("never offers delete for the current session", async () => {
+    const { selectOptions, ui } = fakeUi({ selects: ["cwd:/work", "cancel"] });
+    const { context, manager } = createContext({ ui: () => ui });
+    (manager.listSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      entry("cwd:/work"),
+    ]);
+    await command(context, "resume").execute({ args: [] });
+    expect(selectOptions[1]?.map((option) => option.value)).toEqual([
+      "rename",
+      "cancel",
+    ]);
+  });
+
+  it("cancels cleanly when the picker is dismissed", async () => {
+    const { ui } = fakeUi({ selects: [undefined] });
+    const { context, manager, switched } = createContext({ ui: () => ui });
+    (manager.listSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      entry("cwd:/work"),
+    ]);
+    const result = await command(context, "resume").execute({ args: [] });
+    expect(result).toMatchObject({ success: true });
+    expect(switched).toEqual([]);
+  });
+});
+
+describe("/fork", () => {
+  it("consults the fork guard and switches to the fork", async () => {
+    const { context, manager, switched } = createContext();
+    const result = await command(context, "fork").execute({
+      args: ["experiment"],
+    });
+    expect(context.ensureApproved).toHaveBeenCalledWith("fork", {
+      fromKey: "cwd:/work",
+      reason: "fork",
+    });
+    expect(manager.forkSession).toHaveBeenCalledWith("cwd:/work", {
+      name: "experiment",
+    });
+    expect(switched[0]?.[1]).toBe("fork");
+    expect(result.success).toBe(true);
+  });
+
+  it("forks at head without a UI or fork points", async () => {
+    const { context, manager } = createContext();
+    const result = await command(context, "fork").execute({ args: [] });
+    expect(manager.forkSession).toHaveBeenCalledWith("cwd:/work", {});
+    expect(result.success).toBe(true);
+  });
+
+  it("offers earlier user messages recent-first and forks before one", async () => {
+    const { selectOptions, ui } = fakeUi({ selects: ["2"] });
+    const { context, manager, switched } = createContext({ ui: () => ui });
+    (manager.listForkPoints as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { historyIndex: 0, preview: "first ask" },
+      { historyIndex: 2, preview: "second ask" },
+    ]);
+    const result = await command(context, "fork").execute({ args: [] });
+    expect(manager.forkSession).toHaveBeenCalledWith("cwd:/work", {
+      beforeHistoryIndex: 2,
+    });
+    expect(switched[0]?.[1]).toBe("fork");
+    expect(result.message).toContain("before user message #3");
+    expect(selectOptions[0]?.map((option) => option.value)).toEqual([
+      "head",
+      "2",
+      "0",
+    ]);
+  });
+
+  it("cancels the fork when the picker is dismissed", async () => {
+    const { ui } = fakeUi({ selects: [undefined] });
+    const { context, manager } = createContext({ ui: () => ui });
+    (manager.listForkPoints as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { historyIndex: 0, preview: "first ask" },
+    ]);
+    const result = await command(context, "fork").execute({ args: [] });
+    expect(manager.forkSession).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ message: "Fork cancelled.", success: true });
+  });
+});
+
+describe("/name", () => {
+  it("renames the current session", async () => {
+    const { context, manager } = createContext();
+    const result = await command(context, "name").execute({
+      args: ["my", "session"],
+    });
+    expect(manager.renameSession).toHaveBeenCalledWith(
+      "cwd:/work",
+      "my session"
+    );
+    expect(context.onRenamed).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: { type: "refresh-header" },
+      success: true,
+    });
+  });
+
+  it("requires a name argument", async () => {
+    const { context } = createContext();
+    const result = await command(context, "name").execute({ args: [] });
+    expect(result).toMatchObject({ success: false });
+  });
+});

--- a/apps/coding-agent/src/tui/session-commands.ts
+++ b/apps/coding-agent/src/tui/session-commands.ts
@@ -1,0 +1,368 @@
+import type { CodingAgentExtensionUi } from "../extensions/types";
+import type { SessionChangeEvent } from "../sessions/session-guards";
+import type { SessionIndexEntry } from "../sessions/session-index";
+import {
+  describeSession,
+  type SessionLifecycleReason,
+  type SessionManager,
+} from "../sessions/session-manager";
+import type {
+  TuiCommand,
+  TuiCommandArgumentCompletion,
+  TuiCommandResult,
+} from "./command";
+
+/** Extension-UI select is capped at 100 options. */
+const MAX_PICKER_OPTIONS = 100;
+
+/**
+ * Dependencies the session commands need from the interactive session.
+ * Injected so command behavior is unit-testable without a live TUI.
+ */
+export interface SessionCommandContext {
+  /** The session whose thread handle is currently driving the TUI. */
+  currentSession(): SessionIndexEntry;
+  /**
+   * Consult extension session guards; throws when an extension cancels the
+   * change.
+   */
+  ensureApproved(
+    kind: "fork" | "switch",
+    event: SessionChangeEvent
+  ): Promise<void>;
+  readonly manager: SessionManager;
+  /** Update TUI state after the current session was renamed. */
+  onRenamed(entry: SessionIndexEntry): void;
+  /** Replace the active thread handle and emit lifecycle events. */
+  switchThread(
+    entry: SessionIndexEntry,
+    reason: SessionLifecycleReason
+  ): Promise<void>;
+  /** Interactive prompts for pickers; absent in embedded hosts. */
+  ui?(): CodingAgentExtensionUi | undefined;
+}
+
+export function createSessionCommands(
+  context: SessionCommandContext
+): TuiCommand[] {
+  return [
+    createNewCommand(context),
+    createResumeCommand(context),
+    createForkCommand(context),
+    createNameCommand(context),
+  ];
+}
+
+function createNewCommand(context: SessionCommandContext): TuiCommand {
+  return {
+    description: "Start a new session: /new [name]",
+    execute: (input) =>
+      runSessionCommand(async () => {
+        const name = optionalName(input.args);
+        await context.ensureApproved("switch", {
+          fromKey: context.currentSession().key,
+          reason: "new",
+        });
+        const entry = await context.manager.createSession(name);
+        await context.switchThread(entry, "new");
+        return {
+          action: { clear: true, type: "session" },
+          message: `Started new session ${describeSession(entry)}.`,
+          success: true,
+        };
+      }),
+    name: "new",
+  };
+}
+
+function createResumeCommand(context: SessionCommandContext): TuiCommand {
+  return {
+    description:
+      "Resume, rename, or delete a session: /resume [key|name] (no argument opens the picker)",
+    execute: (input) =>
+      runSessionCommand(async () => {
+        if (input.args.length === 0) {
+          return await runSessionPicker(context);
+        }
+        const query = input.args.join(" ");
+        const entry = await context.manager.findSession(query);
+        if (entry === undefined) {
+          return {
+            message: `No session matches ${JSON.stringify(query)}. Use /resume to list sessions.`,
+            success: false,
+          };
+        }
+        return await resumeSession(context, entry);
+      }),
+    getArgumentCompletions: async (argumentPrefix) => {
+      const sessions = await context.manager.listSessions();
+      const prefix = argumentPrefix.toLowerCase();
+      const completions: TuiCommandArgumentCompletion[] = [];
+      for (const session of sessions) {
+        if (session.key === context.currentSession().key) {
+          continue;
+        }
+        const value = session.name ?? session.key;
+        if (prefix.length > 0 && !value.toLowerCase().startsWith(prefix)) {
+          continue;
+        }
+        completions.push({
+          description: `updated ${session.updatedAt}`,
+          label: describeSession(session),
+          value,
+        });
+      }
+      return completions;
+    },
+    name: "resume",
+  };
+}
+
+function createForkCommand(context: SessionCommandContext): TuiCommand {
+  return {
+    description:
+      "Fork the current session: /fork [name] (no argument offers earlier fork points)",
+    execute: (input) =>
+      runSessionCommand(async () => {
+        const name = optionalName(input.args);
+        const fromKey = context.currentSession().key;
+        let beforeHistoryIndex: number | undefined;
+        if (name === undefined) {
+          const point = await pickForkPoint(context, fromKey);
+          if (point.kind === "cancelled") {
+            return { message: "Fork cancelled.", success: true };
+          }
+          beforeHistoryIndex = point.beforeHistoryIndex;
+        }
+        await context.ensureApproved("fork", { fromKey, reason: "fork" });
+        const entry = await context.manager.forkSession(fromKey, {
+          ...(beforeHistoryIndex === undefined ? {} : { beforeHistoryIndex }),
+          ...(name === undefined ? {} : { name }),
+        });
+        await context.switchThread(entry, "fork");
+        const suffix =
+          beforeHistoryIndex === undefined
+            ? ""
+            : ` (before user message #${beforeHistoryIndex + 1})`;
+        return {
+          action: { clear: true, type: "session" },
+          message: `Forked into session ${describeSession(entry)}${suffix}.`,
+          success: true,
+        };
+      }),
+    name: "fork",
+  };
+}
+
+function createNameCommand(context: SessionCommandContext): TuiCommand {
+  return {
+    description: "Name the current session: /name <name>",
+    execute: (input) =>
+      runSessionCommand(async () => {
+        const name = input.args.join(" ").trim();
+        if (name.length === 0) {
+          return { message: "Usage: /name <name>", success: false };
+        }
+        const entry = await context.manager.renameSession(
+          context.currentSession().key,
+          name
+        );
+        context.onRenamed(entry);
+        return {
+          action: { type: "refresh-header" },
+          message: `Session named ${JSON.stringify(name)}.`,
+          success: true,
+        };
+      }),
+    name: "name",
+  };
+}
+
+async function resumeSession(
+  context: SessionCommandContext,
+  entry: SessionIndexEntry
+): Promise<TuiCommandResult> {
+  if (entry.key === context.currentSession().key) {
+    return { message: "Already on that session.", success: true };
+  }
+  await context.ensureApproved("switch", {
+    fromKey: context.currentSession().key,
+    reason: "resume",
+    toKey: entry.key,
+  });
+  const switched = await context.manager.switchToSession(entry.key);
+  await context.switchThread(switched, "resume");
+  return {
+    action: { clear: true, type: "session" },
+    message: `Resumed session ${describeSession(switched)}.`,
+    success: true,
+  };
+}
+
+/**
+ * Interactive `/resume` picker: choose a session, then switch, rename, or
+ * delete it. Falls back to a plain listing when no interactive UI is bound
+ * (embedded hosts).
+ */
+async function runSessionPicker(
+  context: SessionCommandContext
+): Promise<TuiCommandResult> {
+  const sessions = await context.manager.listSessions();
+  if (sessions.length === 0) {
+    return {
+      message: "No sessions recorded for this directory yet.",
+      success: true,
+    };
+  }
+  const ui = context.ui?.();
+  if (ui === undefined) {
+    return { message: formatSessionList(context, sessions), success: true };
+  }
+  const currentKey = context.currentSession().key;
+  const selectedKey = await ui.select({
+    label: "Sessions (Enter to choose, Esc to cancel)",
+    options: sessions.slice(0, MAX_PICKER_OPTIONS).map((session) => ({
+      description: `updated ${session.updatedAt}`,
+      label:
+        session.key === currentKey
+          ? `${describeSession(session)} (current)`
+          : describeSession(session),
+      value: session.key,
+    })),
+  });
+  const target = sessions.find((session) => session.key === selectedKey);
+  if (target === undefined) {
+    return { message: "Resume cancelled.", success: true };
+  }
+  return await runSessionAction(context, ui, target);
+}
+
+async function runSessionAction(
+  context: SessionCommandContext,
+  ui: CodingAgentExtensionUi,
+  target: SessionIndexEntry
+): Promise<TuiCommandResult> {
+  const isCurrent = target.key === context.currentSession().key;
+  const action = await ui.select({
+    label: `Session ${describeSession(target)}`,
+    options: [
+      ...(isCurrent ? [] : [{ label: "Switch to it", value: "switch" }]),
+      { label: "Rename", value: "rename" },
+      // Deleting the session that drives the live thread would strand the
+      // active handle; switch away first.
+      ...(isCurrent ? [] : [{ label: "Delete", value: "delete" }]),
+      { label: "Cancel", value: "cancel" },
+    ],
+  });
+  if (action === "switch") {
+    return await resumeSession(context, target);
+  }
+  if (action === "rename") {
+    const name = await ui.input({
+      ...(target.name === undefined ? {} : { initialValue: target.name }),
+      label: "New session name",
+    });
+    if (name === undefined || name.trim().length === 0) {
+      return { message: "Rename cancelled.", success: true };
+    }
+    const renamed = await context.manager.renameSession(
+      target.key,
+      name.trim()
+    );
+    if (target.key === context.currentSession().key) {
+      context.onRenamed(renamed);
+    }
+    return {
+      action: { type: "refresh-header" },
+      message: `Session named ${JSON.stringify(name.trim())}.`,
+      success: true,
+    };
+  }
+  if (action === "delete") {
+    const confirmed = await ui.confirm(
+      `Delete session ${describeSession(target)}? This removes its stored history.`
+    );
+    if (!confirmed) {
+      return { message: "Delete cancelled.", success: true };
+    }
+    await context.manager.removeSession(target.key);
+    return {
+      message: `Deleted session ${describeSession(target)}.`,
+      success: true,
+    };
+  }
+  return { message: "Resume cancelled.", success: true };
+}
+
+type ForkPointChoice =
+  | { readonly beforeHistoryIndex?: number; readonly kind: "chosen" }
+  | { readonly kind: "cancelled" };
+
+/**
+ * Offer earlier user messages as fork points. Without an interactive UI or
+ * without any stored user messages the fork branches at the latest state.
+ */
+async function pickForkPoint(
+  context: SessionCommandContext,
+  fromKey: string
+): Promise<ForkPointChoice> {
+  const ui = context.ui?.();
+  if (ui === undefined) {
+    return { kind: "chosen" };
+  }
+  const points = await context.manager.listForkPoints(fromKey);
+  if (points.length === 0) {
+    return { kind: "chosen" };
+  }
+  const recentFirst = [...points].reverse().slice(0, MAX_PICKER_OPTIONS - 1);
+  const value = await ui.select({
+    label: "Fork from (Esc to cancel)",
+    options: [
+      { label: "The latest state", value: "head" },
+      ...recentFirst.map((point) => ({
+        label: `Before user message #${point.historyIndex + 1}: ${point.preview}`,
+        value: String(point.historyIndex),
+      })),
+    ],
+  });
+  if (value === undefined) {
+    return { kind: "cancelled" };
+  }
+  if (value === "head") {
+    return { kind: "chosen" };
+  }
+  return { beforeHistoryIndex: Number(value), kind: "chosen" };
+}
+
+function formatSessionList(
+  context: SessionCommandContext,
+  sessions: readonly SessionIndexEntry[]
+): string {
+  const currentKey = context.currentSession().key;
+  const lines = sessions.map((session) => {
+    const marker = session.key === currentKey ? "* " : "  ";
+    return `${marker}${describeSession(session)} — updated ${session.updatedAt}`;
+  });
+  return [
+    "Sessions for this directory (/resume <key|name> to switch):",
+    ...lines,
+  ].join("\n");
+}
+
+async function runSessionCommand(
+  task: () => Promise<TuiCommandResult>
+): Promise<TuiCommandResult> {
+  try {
+    return await task();
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}
+
+function optionalName(args: readonly string[]): string | undefined {
+  const name = args.join(" ").trim();
+  return name.length === 0 ? undefined : name;
+}

--- a/docs/rfc/session-lifecycle.md
+++ b/docs/rfc/session-lifecycle.md
@@ -1,0 +1,113 @@
+# RFC: Coding-agent session lifecycle
+
+Status: implemented (initial cut) — tracks issue #258.
+
+## Motivation
+
+The coding agent originally pinned one durable thread per working directory
+(`cwd:<path>`), with `/clear` as the only lifecycle operation (delete and
+recreate the same key). Multiple parallel sessions, resuming older work,
+naming, and branching all require explicit session management, and
+extensions need lifecycle visibility so their state does not silently
+outlive the thread it belongs to.
+
+## Concepts
+
+- **Session** — a durable thread plus sidecar metadata. The runtime's
+  `ThreadStore` persists opaque state only; metadata lives in
+  `<thread-dir>/sessions.json` (the *session index*):
+  `key`, `cwd`, optional `name`, optional `parentKey` (fork parentage),
+  `createdAt`, `updatedAt`, and a per-cwd `active` pointer that decides what
+  the next startup resumes.
+- **Lifecycle reason** — why a session became active:
+  `startup` | `new` | `resume` | `fork` | `clear`.
+
+The index fails safe: a missing or malformed file degrades to an empty
+index (with a startup notice) and never blocks the session or touches
+durable thread state. Writes are atomic (temp + rename) and serialized
+within a process; across processes the index is last-writer-wins metadata
+only — concurrent TUIs can overwrite each other's name/active updates, but
+durable thread state stays consistent because the thread files themselves
+are lock-protected by the runtime store. `PSS_THREAD_KEY` still forces an
+explicit key and bypasses the active pointer (the forced key is still
+registered so naming and forking work).
+
+## Phase 1 — runtime lifecycle events
+
+Host-published bus events (extensions subscribe via `services.events.on`;
+the `host:` namespace stays publish-reserved):
+
+| Event | Payload | When |
+| --- | --- | --- |
+| `host:session-start` | `{ key, name?, reason }` | a session became active (emitted after extension activation for `startup`) |
+| `host:session-switch` | `{ fromKey, toKey, reason }` | the active thread handle was replaced |
+| `host:session-shutdown` | `{ key }` | the interactive session is ending |
+
+### Cancelable decision points
+
+Pre-switch and pre-fork decisions use **session guards**, a capability
+(`sessionGuard({ beforeSwitch?, beforeFork? })`), not bus events, so the
+decision model stays strict and synchronous-in-order like `AgentHooks`:
+
+- guards run sequentially; the first cancellation wins;
+- a guard returns `undefined` / `{ cancel?: false }` to allow or
+  `{ cancel: true, reason? }` to cancel;
+- malformed decisions, thrown errors, and host-timeout expiries **fail
+  closed** (the change is cancelled) and are attributed to the owning
+  extension;
+- `beforeFork` receives `{ fromKey, reason: "fork" }`; `beforeSwitch`
+  receives `{ fromKey, toKey?, reason }`. `toKey` is present for `resume`
+  (the target session exists) and absent when the target has not been
+  created yet (`new`, and forks by definition).
+
+### Replacement semantics (what a switch invalidates)
+
+To avoid pi's documented "session replacement footguns", the swap is
+narrow and explicit:
+
+- the extension host, agent, tools, hooks, and per-extension JSON state are
+  **host-scoped, not thread-scoped**: they survive a switch unchanged;
+- only the TUI's thread handle is replaced (`interrupt → dispose → rebind`);
+  in-flight turns of the previous session are interrupted before disposal;
+- an extension that caches the thread key (or per-thread data) must resubscribe
+  on `host:session-start` / `host:session-switch`; those events are the
+  invalidation signal;
+- `/reload` continues to rebuild the host against the *current* session key.
+
+## Phase 2 — TUI
+
+- `/new [name]` — new empty session (fresh key `cwd:<path>#<id>`), guard-
+  checked, recorded active.
+- `/resume` — opens an interactive picker (switch, rename, delete —
+  deleting the session driving the live thread is blocked); with an
+  argument it switches directly by exact key, unique name, or unique
+  prefix, with argument completions backed by the index. Embedded hosts
+  without an interactive UI fall back to a plain listing.
+- Session recency (`updatedAt`) bumps on every completed turn and on
+  `/clear`, so picker ordering reflects actual use.
+- `/name <name>` and the `--name <name>` startup flag — display name,
+  shown in the header subtitle.
+- `/fork` — branches the source thread into a new key and records
+  `parentKey`. Without arguments an interactive picker offers the latest
+  state plus every stored user message as a branch point; branching before
+  a message re-encodes the truncated history and keeps only compaction
+  records that fit inside it. Either way `appliedMigrations` carries over,
+  so #256 migrations never re-run on the fork. `/fork <name>` forks at the
+  latest state under that name.
+- `/clear` keeps its legacy meaning (wipe the current session in place) and
+  emits `host:session-start` with reason `clear`. Its `new` alias moved to
+  the dedicated `/new` command.
+- `new`, `resume`, `name`, `fork` (plus the previously reserved names) are
+  reserved: extensions cannot register them.
+
+## Fork semantics
+
+A head fork copies the stored thread state verbatim to the new key. A fork
+*before an earlier user message* uses the runtime's snapshot codecs
+(`decodeStoredThreadState` / `encodeThreadSnapshot`, exported for this) to
+re-encode the validated history prefix: the fork keeps messages strictly
+before the chosen user message, drops compaction records that extend past
+the cut, and seeds `appliedMigrations` unchanged. The fork point must
+reference a user message; anything else is rejected before any state is
+written, and a fork whose metadata registration fails deletes its copied
+thread so no orphan state remains.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -181,6 +181,15 @@ export {
   type ThreadMigrationSnapshot,
   type ThreadStateMigration,
 } from "./thread/state/migrations";
+export {
+  type AgentThreadSnapshot,
+  type DecodedThreadState,
+  decodeStoredThreadState,
+  encodeThreadSnapshot,
+  type ThreadCompactionRecord,
+  ThreadCompactionValidationError,
+  ThreadStateValidationError,
+} from "./thread/state/snapshot";
 export type {
   CommitResult,
   ExpectedThreadVersion,


### PR DESCRIPTION
Closes #258. Design doc: `docs/rfc/session-lifecycle.md`.

## Summary

### Runtime session lifecycle
- Host bus events for extensions: `host:session-start` (reasons `startup` | `new` | `resume` | `fork` | `clear`), `host:session-switch`, `host:session-shutdown`.
- Cancelable pre-switch/pre-fork decision points via the new `sessionGuard({ beforeSwitch?, beforeFork? })` capability — guard errors, timeouts, malformed decisions, and explicit `null` returns fail closed, consistent with the strict `AgentHooks` decision model.
- Thread metadata (display name, fork `parentKey`, per-cwd active pointer) lives in a fail-safe sidecar `sessions.json` next to the thread files; a corrupt index degrades to empty with a notice and never touches durable state. Recency bumps on every completed turn.
- Replacement semantics documented: the extension host/agent/state are host-scoped and survive a switch; only the thread handle is replaced, with lifecycle events as the invalidation signal.

### TUI
- `/new [name]`, `/resume` (interactive picker: switch / rename / delete — deleting the live session is blocked; `/resume <key|name>` switches directly with completions), `/name <name>` + `--name` startup flag, `/fork` (branch at the latest state or *before an earlier user message*: truncated history re-encoded via the runtime snapshot codecs, compaction records that fit are kept, `appliedMigrations` seeds so migrations never re-run on the fork; failed registration deletes the copied thread).
- `PSS_THREAD_KEY` is registered but never clobbers the active pointer; `pss inspect-thread` follows the active session unless the key is forced.
- `new`, `resume`, `name`, `fork`, `model` join the reserved command names; `/clear` keeps its wipe-in-place meaning and loses its `new` alias.

### Runtime
- Exports the thread snapshot codecs (`decodeStoredThreadState`, `encodeThreadSnapshot`, types, validation errors) so hosts fork over validated state.

## Verification

- `pnpm lint` / `pnpm typecheck` / `pnpm test` (652 coding-agent tests) / `pnpm build`
- Tegami patch letter: `.tegami/2026-07-28-session-management.md` (`@minpeter/pss-runtime` patch + `@minpeter/pss-coding-agent` patch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full session management to the coding agent: named sessions you can resume, fork, and rename, plus lifecycle events for extensions. The TUI gets `/new`, `/resume`, `/name`, and `/fork`, and the runtime exports snapshot codecs for safe forking.

- New Features
  - Sessions per directory with a safe `sessions.json` index (names, parentage, active pointer; recency bumps; corrupt index degrades to empty without touching threads).
  - TUI commands:
    - `/new [name]`
    - `/resume [key|name]` with picker (switch/rename/delete; cannot delete the live session)
    - `/name <name>` and CLI `--name`
    - `/fork` from latest or before an earlier user message
    - Reserved names: `new`, `resume`, `name`, `fork`, `model`, `clear` (`/clear` now only clears history).
  - Extension lifecycle:
    - Events: `host:session-start`, `host:session-switch`, `host:session-shutdown`
    - Cancelable guards via `sessionGuard({ beforeSwitch?, beforeFork? })` with strict, fail-closed decisions and timeouts.
  - Runtime (`@minpeter/pss-runtime`): export `decodeStoredThreadState`, `encodeThreadSnapshot`, types, and validation errors to enable validated forks.
  - Env/inspect behavior: `PSS_THREAD_KEY` registers a session but never overwrites the active pointer; `pss inspect-thread` follows the active session unless a key is forced.

- Migration
  - Use `/new` to start a new session; `/clear` no longer creates one.
  - Avoid custom commands named `new`, `resume`, `name`, `fork`, `model`, or `clear`.
  - Extensions that need to veto switches/forks should adopt the `session-guard` capability.

<sup>Written for commit 6f54b5825b70d2eca0787a8a79cb92e7206ea4ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

