### PR TITLE
feat(coding-agent): stage /reload extension imports in an isolated module context

### DIFF
--- a/.tegami/2026-07-28-reload-staging-isolation.md
+++ b/.tegami/2026-07-28-reload-staging-isolation.md
@@ -1,0 +1,26 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Stage /reload extension imports in an isolated module context
+
+`/reload` now evaluates every replacement extension candidate in a
+worker-thread module context before anything in the live process is
+touched. A candidate that throws at module scope, or exports the wrong
+shape, fails the reload during staging — so the live runtime's ESM module
+graph and CommonJS cache are only modified once all candidates load
+cleanly, and a rolled-back reload can no longer leave freshly re-executed
+helper instances observable to the still-running previous runtime through
+that window. The staging worker reports the observed export shape
+(factory, extension object, or invalid), letting loader validation fail at
+staging time exactly as the commit-time import would.
+
+Module side effects run once in the discarded worker context and once more
+at commit time; staging trades that repeat execution for keeping the live
+module graph untouched on failure. The staging worker keeps the process
+alive only while imports are in flight and is terminated when the staging
+session ends, and remaining commit-time failures (for example an
+activation error after a clean import) continue to use the transactional
+CommonJS snapshot/rollback.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -230,6 +230,13 @@ dependency still requires `pss extension update` or a restart. The command
 appears only when the session was started through the `pss` CLI, which can
 rediscover extensions.
 
+Before anything in the live process is touched, every reload candidate is
+first imported in an isolated worker-thread module context (staging). A
+candidate that throws at module scope or exports the wrong shape fails the
+reload during staging, so the live runtime's module graph and CommonJS
+cache stay untouched. Staging runs module side effects once in the
+discarded worker context before the real import at commit time.
+
 ### Inter-extension events
 
 `services.events` is a shared bus for extension-to-extension communication:

--- a/apps/coding-agent/src/cli-reload-staging.test.ts
+++ b/apps/coding-agent/src/cli-reload-staging.test.ts
@@ -1,0 +1,75 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTuiExtensionReloader } from "./cli";
+
+const STAGED_FAILURE = /Staged extension import failed/;
+const INVALID_EXPORT = /default export must be a function/;
+
+let root: string;
+let cwd: string;
+let home: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "pss-cli-reload-staging-"));
+  cwd = join(root, "project");
+  home = join(root, "home");
+  await Promise.all([
+    mkdir(cwd, { recursive: true }),
+    mkdir(home, { recursive: true }),
+  ]);
+});
+
+afterEach(async () => {
+  await rm(root, { force: true, recursive: true });
+});
+
+describe("createTuiExtensionReloader", () => {
+  it("reloads healthy -e extensions through staging and commit", async () => {
+    const extensionPath = join(cwd, "sample.mjs");
+    await writeFile(
+      extensionPath,
+      "export default (pss) => { pss.provide({ kind: 'instructions', fragments: ['hi'] }); };"
+    );
+    const reload = createTuiExtensionReloader({
+      cwd,
+      extensionPaths: [extensionPath],
+      home,
+    });
+    const result = await reload();
+    expect(result.extensions.map((extension) => extension.id)).toEqual([
+      "sample",
+    ]);
+    result.rollbackModuleCache();
+  });
+
+  it("fails a broken candidate at staging time, before the main context imports it", async () => {
+    const marker = `pss-reload-staging-main-${Date.now()}`;
+    const extensionPath = join(cwd, "broken.mjs");
+    await writeFile(
+      extensionPath,
+      `globalThis[${JSON.stringify(marker)}] = true;\nthrow new Error("broken at import");`
+    );
+    const reload = createTuiExtensionReloader({
+      cwd,
+      extensionPaths: [extensionPath],
+      home,
+    });
+    await expect(reload()).rejects.toThrow(STAGED_FAILURE);
+    // The staged failure ran only in the worker context: the live module
+    // graph never executed the candidate.
+    expect(Reflect.get(globalThis, marker)).toBeUndefined();
+  });
+
+  it("fails invalid export shapes at staging time", async () => {
+    const extensionPath = join(cwd, "invalid.mjs");
+    await writeFile(extensionPath, "export default 42;");
+    const reload = createTuiExtensionReloader({
+      cwd,
+      extensionPaths: [extensionPath],
+      home,
+    });
+    await expect(reload()).rejects.toThrow(INVALID_EXPORT);
+  });
+});

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -15,6 +15,7 @@ import {
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
 import { extensionScopePaths } from "./extensions/manager/paths";
 import { beginCommonJsReloadTransaction } from "./extensions/manager/reload-module-graph";
+import { beginExtensionStagingSession } from "./extensions/manager/reload-staging";
 import { readExtensionSettings } from "./extensions/manager/settings";
 import {
   activeSessionKey,
@@ -181,15 +182,76 @@ async function runTuiCommand({
       return 1;
     }
   }
-  const reloadExtensions = async (): Promise<
-    LoadedConfiguredExtensions & { rollbackModuleCache(): void }
-  > => {
+  const reloadExtensions = createTuiExtensionReloader({
+    cwd,
+    extensionPaths,
+    home,
+  });
+  return await (
+    start ??
+    ((loaded: readonly CodingAgentExtensionInput[]) =>
+      startTui({
+        extensions: loaded,
+        reloadExtensions,
+        ...(sessionName === undefined ? {} : { sessionName }),
+      }))
+  )(extensions);
+}
+
+/**
+ * Build the `/reload` loader for a TUI session. Exported for tests: the
+ * staged-then-commit ordering (worker staging before any main-context
+ * import or CommonJS eviction) is the reload-isolation contract from #262.
+ */
+export function createTuiExtensionReloader({
+  cwd,
+  extensionPaths,
+  home,
+}: {
+  readonly cwd: string;
+  readonly extensionPaths: readonly string[];
+  readonly home: string;
+}): () => Promise<
+  LoadedConfiguredExtensions & { rollbackModuleCache(): void }
+> {
+  return async () => {
     const cacheBust = Date.now().toString(36);
     const targets = await resolveCliExtensionTargets({
       cwd,
       paths: extensionPaths,
     });
     const targetIds = new Set(targets.map((target) => target.id));
+    // Stage every candidate in an isolated worker module context first: a
+    // candidate that fails to import (or exports the wrong shape) fails the
+    // reload here, before the live runtime's module graph or CommonJS cache
+    // is touched at all.
+    const staging = beginExtensionStagingSession();
+    const stagingAbort = new AbortController();
+    try {
+      await boundedReloadOperation(
+        (async () => {
+          await importCliExtensions({
+            importer: staging.importer,
+            signal: stagingAbort.signal,
+            targets,
+          });
+          await loadConfiguredCodingAgentExtensions({
+            cwd,
+            ...(targetIds.size === 0 ? {} : { excludeIds: targetIds }),
+            home,
+            importer: staging.importer,
+            signal: stagingAbort.signal,
+          });
+        })(),
+        RELOAD_IMPORT_TIMEOUT_MS,
+        "Extension reload staging"
+      );
+    } catch (error) {
+      stagingAbort.abort();
+      throw error;
+    } finally {
+      await staging.dispose();
+    }
     // Evict extension-owned CommonJS modules so cache-busted imports
     // re-execute helpers; the snapshot restores them if the reload fails.
     const transaction = beginCommonJsReloadTransaction(
@@ -230,15 +292,6 @@ async function runTuiCommand({
       throw error;
     }
   };
-  return await (
-    start ??
-    ((loaded: readonly CodingAgentExtensionInput[]) =>
-      startTui({
-        extensions: loaded,
-        reloadExtensions,
-        ...(sessionName === undefined ? {} : { sessionName }),
-      }))
-  )(extensions);
 }
 
 const RELOAD_IMPORT_TIMEOUT_MS = 30_000;

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
@@ -96,8 +96,12 @@ export interface CommonJsReloadTransaction {
  * and a failed reload's rollback the still-active previous runtime could
  * observe a freshly re-executed helper through a *lazy* `require()` issued
  * during that window. Modules loaded during activation keep their original
- * references and are unaffected. Full isolation needs a separate module
- * context (worker/vm) and is tracked as follow-up work.
+ * references and are unaffected. The staging pass in `reload-staging.ts`
+ * narrows the window to commit-time failures: candidates are first imported
+ * in an isolated worker module context, so a candidate that cannot even
+ * load never triggers eviction here at all. Remaining commit-time failures
+ * (for example an activation error after a clean import) still rely on the
+ * snapshot/rollback below.
  */
 export function beginCommonJsReloadTransaction(
   roots: readonly string[]

--- a/apps/coding-agent/src/extensions/manager/reload-staging.test.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-staging.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  beginExtensionStagingSession,
+  type ExtensionStagingSession,
+} from "./reload-staging";
+
+const STAGED_IMPORT_FAILURE = /Staged extension import failed .*boom at import/;
+const DISPOSED = /disposed/;
+const DISPOSED_OR_EXITED = /disposed|exited/;
+
+let root: string;
+let session: ExtensionStagingSession;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "pss-reload-staging-"));
+  session = beginExtensionStagingSession();
+});
+
+afterEach(async () => {
+  await session.dispose();
+  await rm(root, { force: true, recursive: true });
+});
+
+async function writeModule(name: string, source: string): Promise<string> {
+  const path = join(root, name);
+  await writeFile(path, source);
+  return pathToFileURL(path).href;
+}
+
+describe("beginExtensionStagingSession", () => {
+  it("reports factory-shaped default exports with a callable stub", async () => {
+    const specifier = await writeModule(
+      "factory.mjs",
+      "export default () => {};"
+    );
+    const namespace = (await session.importer(specifier)) as {
+      default: unknown;
+    };
+    expect(typeof namespace.default).toBe("function");
+  });
+
+  it("reports extension-shaped exports with their id", async () => {
+    const specifier = await writeModule(
+      "extension.mjs",
+      'export default { id: "sample", configure: () => {} };'
+    );
+    const namespace = (await session.importer(specifier)) as {
+      default: { configure: unknown; id: string };
+    };
+    expect(namespace.default.id).toBe("sample");
+    expect(typeof namespace.default.configure).toBe("function");
+  });
+
+  it("mirrors invalid exports so loader validation fails at staging time", async () => {
+    const specifier = await writeModule("invalid.mjs", "export default 42;");
+    const namespace = (await session.importer(specifier)) as {
+      default: unknown;
+    };
+    expect(namespace.default).toBeUndefined();
+  });
+
+  it("fails staged imports of modules that throw at module scope", async () => {
+    const specifier = await writeModule(
+      "broken.mjs",
+      'throw new Error("boom at import");'
+    );
+    await expect(session.importer(specifier)).rejects.toThrow(
+      STAGED_IMPORT_FAILURE
+    );
+  });
+
+  it("keeps module side effects isolated from the main context", async () => {
+    const marker = `pss-staging-isolated-${Date.now()}`;
+    const specifier = await writeModule(
+      "side-effect.mjs",
+      `globalThis[${JSON.stringify(marker)}] = true; export default () => {};`
+    );
+    await session.importer(specifier);
+    expect(Reflect.get(globalThis, marker)).toBeUndefined();
+  });
+
+  it("rejects imports after disposal", async () => {
+    const specifier = await writeModule("late.mjs", "export default () => {};");
+    await session.dispose();
+    await expect(session.importer(specifier)).rejects.toThrow(DISPOSED);
+  });
+
+  it("fails pending imports when the session is disposed mid-flight", async () => {
+    const specifier = await writeModule(
+      "hang.mjs",
+      "await new Promise(() => {}); export default () => {};"
+    );
+    const pending = session.importer(specifier);
+    const raced = expect(pending).rejects.toThrow(DISPOSED_OR_EXITED);
+    await session.dispose();
+    await raced;
+  });
+});

--- a/apps/coding-agent/src/extensions/manager/reload-staging.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-staging.ts
@@ -1,0 +1,177 @@
+import { Worker } from "node:worker_threads";
+import type { ImportExtensionModule } from "./types";
+
+/**
+ * Reload staging (#262): before `/reload` re-imports replacement extensions
+ * into the live process, every candidate module graph is evaluated in a
+ * separate worker-thread module context. Only when the staged graph loads
+ * cleanly does the reload proceed to the main-context import and swap, so a
+ * candidate that throws at module scope (or exports the wrong shape) can
+ * never leave superseded module instances, half-populated CommonJS caches,
+ * or side effects behind in the runtime that keeps running after the failed
+ * reload.
+ *
+ * The staging importer returns a stub namespace that mirrors the shape the
+ * worker observed (factory / extension object / invalid), which is enough
+ * for the loader's validation to pass or fail exactly like the later
+ * main-context import would. Module side effects run once in the discarded
+ * worker context and once more at commit time; staging trades that repeat
+ * execution for keeping the live module graph untouched on failure.
+ */
+export interface ExtensionStagingSession {
+  /** Terminates the staging worker. Safe to call multiple times. */
+  dispose(): Promise<void>;
+  /** Imports a specifier in the staging worker and returns a stub. */
+  readonly importer: ImportExtensionModule;
+}
+
+interface StagingResponse {
+  readonly id?: string;
+  readonly message?: string;
+  readonly ok: boolean;
+  readonly requestId: number;
+  readonly shape?: "extension" | "factory" | "invalid";
+}
+
+const STAGING_WORKER_SOURCE = `
+const { parentPort } = require("node:worker_threads");
+parentPort.on("message", ({ requestId, specifier }) => {
+  import(specifier).then((namespace) => {
+    const candidate =
+      namespace !== null && typeof namespace === "object" && "default" in namespace
+        ? namespace.default
+        : namespace;
+    if (typeof candidate === "function") {
+      parentPort.postMessage({ ok: true, requestId, shape: "factory" });
+      return;
+    }
+    if (
+      candidate !== null &&
+      typeof candidate === "object" &&
+      typeof candidate.id === "string" &&
+      typeof candidate.configure === "function"
+    ) {
+      parentPort.postMessage({
+        id: candidate.id,
+        ok: true,
+        requestId,
+        shape: "extension",
+      });
+      return;
+    }
+    parentPort.postMessage({ ok: true, requestId, shape: "invalid" });
+  }, (error) => {
+    parentPort.postMessage({
+      message:
+        error instanceof Error ? (error.message ?? String(error)) : String(error),
+      ok: false,
+      requestId,
+    });
+  });
+});
+`;
+
+export function beginExtensionStagingSession(): ExtensionStagingSession {
+  const worker = new Worker(STAGING_WORKER_SOURCE, { eval: true });
+  // A leaked idle session must never keep the process alive on its own,
+  // but in-flight staged imports must: `syncRef` refs the worker while
+  // requests are pending and unrefs it when the session goes idle.
+  worker.unref();
+  const pending = new Map<
+    number,
+    {
+      reject: (error: Error) => void;
+      resolve: (response: StagingResponse) => void;
+    }
+  >();
+  let nextRequestId = 0;
+  let terminated = false;
+
+  const syncRef = (): void => {
+    if (terminated) {
+      return;
+    }
+    if (pending.size > 0) {
+      worker.ref();
+    } else {
+      worker.unref();
+    }
+  };
+
+  const failAllPending = (error: Error): void => {
+    for (const [, entry] of pending) {
+      entry.reject(error);
+    }
+    pending.clear();
+  };
+
+  worker.on("message", (response: StagingResponse) => {
+    const entry = pending.get(response.requestId);
+    if (entry === undefined) {
+      return;
+    }
+    pending.delete(response.requestId);
+    syncRef();
+    entry.resolve(response);
+  });
+  worker.on("error", (error: unknown) => {
+    terminated = true;
+    failAllPending(
+      new Error(
+        `Extension staging worker failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    );
+  });
+  worker.on("exit", () => {
+    terminated = true;
+    failAllPending(new Error("Extension staging worker exited"));
+  });
+
+  const importer: ImportExtensionModule = async (specifier) => {
+    if (terminated) {
+      throw new Error("Extension staging session is disposed");
+    }
+    const requestId = nextRequestId;
+    nextRequestId += 1;
+    const response = await new Promise<StagingResponse>((resolve, reject) => {
+      pending.set(requestId, { reject, resolve });
+      syncRef();
+      worker.postMessage({ requestId, specifier });
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Staged extension import failed for ${specifier}: ${response.message ?? "unknown error"}`
+      );
+    }
+    return stubNamespace(response);
+  };
+
+  return {
+    dispose: async () => {
+      terminated = true;
+      failAllPending(new Error("Extension staging session is disposed"));
+      await worker.terminate();
+    },
+    importer,
+  };
+}
+
+function stubNamespace(response: StagingResponse): Record<string, unknown> {
+  switch (response.shape) {
+    case "factory":
+      return { default: () => undefined };
+    case "extension":
+      return {
+        default: {
+          configure: () => undefined,
+          id: response.id ?? "",
+        },
+      };
+    default:
+      // Mirrors an invalid export so the loader raises the same error the
+      // main-context import would, still without touching the live graph.
+      return { default: undefined };
+  }
+}


### PR DESCRIPTION
Closes #262. Follow-up to #261.

## Summary

`/reload` now evaluates every replacement extension candidate in a worker-thread module context (staging) before anything in the live process is touched:

- Candidates are imported in a dedicated `Worker`; the worker reports the observed export shape (factory / extension object / invalid) and the staging importer returns a matching stub so loader validation fails at staging time exactly as the commit-time import would.
- A candidate that throws at module scope or exports the wrong shape fails the reload during staging, so the live runtime's ESM module graph and CommonJS cache are only modified once all candidates load cleanly — closing the window where a rolled-back reload could hand the still-running previous runtime freshly re-executed CJS helper instances through a lazy `require()`.
- Module side effects run once in the discarded worker context and once more at commit; staging trades that repeat execution for keeping the live graph untouched on failure.
- The staging worker refs the process only while imports are in flight, is terminated when the session ends, and pending imports fail cleanly on disposal. Remaining commit-time failures keep using the transactional CommonJS snapshot/rollback (documented in `reload-module-graph.ts`).
- The reload loader is extracted as `createTuiExtensionReloader` and covered by tests asserting the staged-then-commit contract (a broken candidate never executes in the main context, verified via a global side-effect marker).

## Verification

- `pnpm lint` / `pnpm typecheck` / `pnpm test` (662 coding-agent tests) / `pnpm build`
- Tegami patch letter: `.tegami/2026-07-28-reload-staging-isolation.md` (`@minpeter/pss-coding-agent`, patch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stages `/reload` extension imports in an isolated worker-thread module context to keep the live module graph untouched until all candidates pass. This prevents partial reload leaks and fails broken candidates early with clear errors.

- New Features
  - Import all candidates in a dedicated Worker that reports the export shape (factory, extension object, or invalid) so loader validation happens at staging time.
  - Modify the live ESM graph and CommonJS cache only after staging succeeds, closing the window where rollback could expose re-executed CJS helpers via lazy require().
  - Run side effects in the worker and again at commit; the worker refs only while imports are in flight, terminates on session end, and pending imports fail cleanly on dispose. Commit-time failures still use the transactional CJS snapshot/rollback.

- Refactors
  - Extracted the reload loader as `createTuiExtensionReloader`.
  - Added tests covering staged-then-commit behavior and isolation, plus CLI reload tests.
  - Updated `README` to document reload staging.

<sup>Written for commit 7c86839a9ad4e2daaad3ff783c6749878d839b00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

