### PR TITLE
chore: license the workspace under the Sustainable Use License

### DIFF
--- a/.tegami/2026-07-29-sustainable-use-license.md
+++ b/.tegami/2026-07-29-sustainable-use-license.md
@@ -1,0 +1,19 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## License the workspace under the Sustainable Use License
+
+The repository previously shipped without a license file, leaving published
+packages with no stated terms. `LICENSE.md` now declares the Sustainable Use
+License 1.0 at the workspace root and is mirrored into the two published
+packages, which set `"license": "SEE LICENSE IN LICENSE.md"` and include the
+file in their published `files` list.
+
+Internal business, non-commercial, and personal use stay free, including
+modification and free redistribution. Reselling the software or offering it as
+a paid product or service requires a separate commercial license.

--- a/.tegami/2026-07-29-sustainable-use-license.md
+++ b/.tegami/2026-07-29-sustainable-use-license.md
@@ -17,3 +17,7 @@ file in their published `files` list.
 Internal business, non-commercial, and personal use stay free, including
 modification and free redistribution. Reselling the software or offering it as
 a paid product or service requires a separate commercial license.
+
+The license applies retroactively to every earlier release, including the ones
+published with no license field, so previously installed versions are covered by
+the same terms instead of being left unlicensed.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,84 @@
+# License
+
+Copyright 2025 Woonggi Min (https://github.com/minpeter)
+
+Portions of this software are licensed as follows:
+
+- All third party components incorporated into the pss-runtime Software are licensed under the original
+  license provided by the owner of the applicable component.
+- Content outside of the above mentioned files or restrictions is available under the "Sustainable Use
+  License" as defined below.
+
+## Sustainable Use License
+
+Version 1.0
+
+### Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+### Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license
+to use, copy, distribute, make available, and prepare derivative works of the software, in each case subject
+to the limitations below.
+
+### Limitations
+
+You may use or modify the software only for your own internal business purposes or for non-commercial or
+personal use. You may distribute the software or provide it to others only if you do so free of charge for
+non-commercial purposes. You may not alter, remove, or obscure any licensing, copyright, or other notices of
+the licensor in the software. Any use of the licensor's trademarks is subject to applicable law.
+
+### Patents
+
+The licensor grants you a license, under any patent claims the licensor can license, or becomes able to
+license, to make, have made, use, sell, offer for sale, import and have imported the software, in each case
+subject to the limitations and conditions in this license. This license does not cover any patent claims that
+you cause to be infringed by modifications or additions to the software. If you or your company make any
+written claim that the software infringes or contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+### Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these
+terms. If you modify the software, you must include in any modified copies of the software a prominent notice
+stating that you have modified the software.
+
+### No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in these terms.
+
+### Termination
+
+If you use the software in violation of these terms, such use is not licensed, and your license will
+automatically terminate. If the licensor provides you with a notice of your violation, and you cease all
+violation of this license no later than 30 days after you receive that notice, your license will be reinstated
+retroactively. However, if you violate these terms after such reinstatement, any additional violation of these
+terms will cause your license to terminate automatically and permanently.
+
+### No Liability
+
+As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will
+not be liable to you for any damages arising out of these terms or the use or nature of the software, under
+any kind of legal claim.
+
+### Definitions
+
+The "licensor" is the entity offering these terms.
+
+The "software" is the software the licensor makes available under these terms, including any portion of it.
+
+"You" refers to the individual or entity agreeing to these terms.
+
+"Your company" is any legal entity, sole proprietorship, or other kind of organization that you work for, plus
+all organizations that have control over, are under the control of, or are under common control with that
+organization. Control means ownership of substantially all the assets of an entity, or the power to direct its
+management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+"Your license" is the license granted to you for the software under these terms.
+
+"Use" means anything you do with the software requiring your license.
+
+"Trademark" means trademarks, service marks, and similar rights.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,6 +9,10 @@ Portions of this software are licensed as follows:
 - Content outside of the above mentioned files or restrictions is available under the "Sustainable Use
   License" as defined below.
 
+These terms also apply retroactively to every earlier release of this software, including releases
+published before this license file was added and releases that declared no license at all. Those releases
+are covered by the Sustainable Use License below on the same terms as current releases.
+
 ## Sustainable Use License
 
 Version 1.0

--- a/README.md
+++ b/README.md
@@ -186,3 +186,11 @@ Commit the generated `.tegami/*.md` changelog with the feature or fix. On
 `main`, `pnpm tegami ci` opens or updates the Version Packages pull request.
 After that PR merges, the next release run publishes from the committed Tegami
 publish lock using npm Trusted Publishing.
+
+## License
+
+This project is licensed under the [Sustainable Use License](LICENSE.md).
+
+You can use, modify, and distribute it for free for internal business,
+non-commercial, or personal use. Reselling it or offering it as a paid product
+or service requires a separate commercial license.

--- a/apps/coding-agent/LICENSE.md
+++ b/apps/coding-agent/LICENSE.md
@@ -1,0 +1,84 @@
+# License
+
+Copyright 2025 Woonggi Min (https://github.com/minpeter)
+
+Portions of this software are licensed as follows:
+
+- All third party components incorporated into the pss-runtime Software are licensed under the original
+  license provided by the owner of the applicable component.
+- Content outside of the above mentioned files or restrictions is available under the "Sustainable Use
+  License" as defined below.
+
+## Sustainable Use License
+
+Version 1.0
+
+### Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+### Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license
+to use, copy, distribute, make available, and prepare derivative works of the software, in each case subject
+to the limitations below.
+
+### Limitations
+
+You may use or modify the software only for your own internal business purposes or for non-commercial or
+personal use. You may distribute the software or provide it to others only if you do so free of charge for
+non-commercial purposes. You may not alter, remove, or obscure any licensing, copyright, or other notices of
+the licensor in the software. Any use of the licensor's trademarks is subject to applicable law.
+
+### Patents
+
+The licensor grants you a license, under any patent claims the licensor can license, or becomes able to
+license, to make, have made, use, sell, offer for sale, import and have imported the software, in each case
+subject to the limitations and conditions in this license. This license does not cover any patent claims that
+you cause to be infringed by modifications or additions to the software. If you or your company make any
+written claim that the software infringes or contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+### Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these
+terms. If you modify the software, you must include in any modified copies of the software a prominent notice
+stating that you have modified the software.
+
+### No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in these terms.
+
+### Termination
+
+If you use the software in violation of these terms, such use is not licensed, and your license will
+automatically terminate. If the licensor provides you with a notice of your violation, and you cease all
+violation of this license no later than 30 days after you receive that notice, your license will be reinstated
+retroactively. However, if you violate these terms after such reinstatement, any additional violation of these
+terms will cause your license to terminate automatically and permanently.
+
+### No Liability
+
+As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will
+not be liable to you for any damages arising out of these terms or the use or nature of the software, under
+any kind of legal claim.
+
+### Definitions
+
+The "licensor" is the entity offering these terms.
+
+The "software" is the software the licensor makes available under these terms, including any portion of it.
+
+"You" refers to the individual or entity agreeing to these terms.
+
+"Your company" is any legal entity, sole proprietorship, or other kind of organization that you work for, plus
+all organizations that have control over, are under the control of, or are under common control with that
+organization. Control means ownership of substantially all the assets of an entity, or the power to direct its
+management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+"Your license" is the license granted to you for the software under these terms.
+
+"Use" means anything you do with the software requiring your license.
+
+"Trademark" means trademarks, service marks, and similar rights.

--- a/apps/coding-agent/LICENSE.md
+++ b/apps/coding-agent/LICENSE.md
@@ -9,6 +9,10 @@ Portions of this software are licensed as follows:
 - Content outside of the above mentioned files or restrictions is available under the "Sustainable Use
   License" as defined below.
 
+These terms also apply retroactively to every earlier release of this software, including releases
+published before this license file was added and releases that declared no license at all. Those releases
+are covered by the Sustainable Use License below on the same terms as current releases.
+
 ## Sustainable Use License
 
 Version 1.0

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -2,6 +2,7 @@
   "name": "@minpeter/pss-coding-agent",
   "version": "0.0.14-next.5",
   "description": "Code at the speed of thought",
+  "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "engines": {
     "node": ">=24"
@@ -57,7 +58,8 @@
   "files": [
     "dist",
     "bin",
-    "README.md"
+    "README.md",
+    "LICENSE.md"
   ],
   "repository": {
     "type": "git",

--- a/packages/runtime/LICENSE.md
+++ b/packages/runtime/LICENSE.md
@@ -1,0 +1,84 @@
+# License
+
+Copyright 2025 Woonggi Min (https://github.com/minpeter)
+
+Portions of this software are licensed as follows:
+
+- All third party components incorporated into the pss-runtime Software are licensed under the original
+  license provided by the owner of the applicable component.
+- Content outside of the above mentioned files or restrictions is available under the "Sustainable Use
+  License" as defined below.
+
+## Sustainable Use License
+
+Version 1.0
+
+### Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+### Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license
+to use, copy, distribute, make available, and prepare derivative works of the software, in each case subject
+to the limitations below.
+
+### Limitations
+
+You may use or modify the software only for your own internal business purposes or for non-commercial or
+personal use. You may distribute the software or provide it to others only if you do so free of charge for
+non-commercial purposes. You may not alter, remove, or obscure any licensing, copyright, or other notices of
+the licensor in the software. Any use of the licensor's trademarks is subject to applicable law.
+
+### Patents
+
+The licensor grants you a license, under any patent claims the licensor can license, or becomes able to
+license, to make, have made, use, sell, offer for sale, import and have imported the software, in each case
+subject to the limitations and conditions in this license. This license does not cover any patent claims that
+you cause to be infringed by modifications or additions to the software. If you or your company make any
+written claim that the software infringes or contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+### Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these
+terms. If you modify the software, you must include in any modified copies of the software a prominent notice
+stating that you have modified the software.
+
+### No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in these terms.
+
+### Termination
+
+If you use the software in violation of these terms, such use is not licensed, and your license will
+automatically terminate. If the licensor provides you with a notice of your violation, and you cease all
+violation of this license no later than 30 days after you receive that notice, your license will be reinstated
+retroactively. However, if you violate these terms after such reinstatement, any additional violation of these
+terms will cause your license to terminate automatically and permanently.
+
+### No Liability
+
+As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will
+not be liable to you for any damages arising out of these terms or the use or nature of the software, under
+any kind of legal claim.
+
+### Definitions
+
+The "licensor" is the entity offering these terms.
+
+The "software" is the software the licensor makes available under these terms, including any portion of it.
+
+"You" refers to the individual or entity agreeing to these terms.
+
+"Your company" is any legal entity, sole proprietorship, or other kind of organization that you work for, plus
+all organizations that have control over, are under the control of, or are under common control with that
+organization. Control means ownership of substantially all the assets of an entity, or the power to direct its
+management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+"Your license" is the license granted to you for the software under these terms.
+
+"Use" means anything you do with the software requiring your license.
+
+"Trademark" means trademarks, service marks, and similar rights.

--- a/packages/runtime/LICENSE.md
+++ b/packages/runtime/LICENSE.md
@@ -9,6 +9,10 @@ Portions of this software are licensed as follows:
 - Content outside of the above mentioned files or restrictions is available under the "Sustainable Use
   License" as defined below.
 
+These terms also apply retroactively to every earlier release of this software, including releases
+published before this license file was added and releases that declared no license at all. Those releases
+are covered by the Sustainable Use License below on the same terms as current releases.
+
 ## Sustainable Use License
 
 Version 1.0

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -2,6 +2,7 @@
   "name": "@minpeter/pss-runtime",
   "version": "0.3.0-next.4",
   "description": "Generic agent runtime for threads, model loops, and synchronized run events.",
+  "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "engines": {
     "node": ">=24"
@@ -75,7 +76,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE.md"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

The repo shipped without a license file, so both published packages had no stated terms. This adds the Sustainable Use License 1.0, the same license n8n uses.

- `LICENSE.md` at the workspace root, mirrored into `packages/runtime/` and `apps/coding-agent/`
- Both published packages declare `"license": "SEE LICENSE IN LICENSE.md"` and add `LICENSE.md` to `files` so it lands in the npm tarball
- README gains a License section
- Tegami changelog entry (patch for both published packages)

Internal business, non-commercial, and personal use stay free, including modification and free redistribution. Reselling or offering it as a paid product or service needs a separate commercial license.

## Earlier releases

Every version published so far shipped with no `license` field, which defaults to all rights reserved. `LICENSE.md` states that the Sustainable Use License applies retroactively to those releases, so anything already installed is licensed on the same terms rather than left ambiguous. Granting terms where none existed only adds permissions, so there is nothing to revoke and no other copyright holder to get agreement from.

## Notes

`"SEE LICENSE IN LICENSE.md"` is used instead of a bare `SUL-1.0` identifier because SUL is not a registered SPDX id, and npm rejects unknown identifiers. SUL is source-available, not OSI-approved open source, so GitHub will show the repo as "unlicensed" in the sidebar rather than detecting a license.

Only the two currently published packages are touched. Private workspace packages (benchmarks, examples, experimental) are covered by the root `LICENSE.md`.

## Testing

- `ultracite check` on the changed files: clean
- `vitest run scripts/runtime-docs.test.mjs`: 3 passed

Full `vitest run scripts/*.test.mjs` was not run to completion in the worktree since it has no installed `node_modules` of its own; the one failure seen was a missing `fast-png` resolution from that setup, unrelated to these changes.
