### PR TITLE
docs: trim root README, add banner, default to MiniMax-M3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 AI_API_KEY=
 AI_BASE_URL=https://apis.opengateway.ai/v1
-AI_MODEL=minimax/MiniMax-M2.7
+AI_MODEL=minimax/MiniMax-M3
 PSS_BENCH_MODEL=qwen3.8-max-preview
 # Pinned for reproducibility: canary.92+ ERESOLVE-conflicts with the pinned fixture.
 PSS_BENCH_NEXT_VERSION=16.3.0-canary.89

--- a/.tegami/2026-07-29-default-model-minimax-m3.md
+++ b/.tegami/2026-07-29-default-model-minimax-m3.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Default to minimax/MiniMax-M3
+
+The fallback model id used when `AI_MODEL` is unset moves from
+`minimax/MiniMax-M2.7` to `minimax/MiniMax-M3`. Set `AI_MODEL` to pin the
+previous model.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const provider = createOpenAICompatible({
 
 const agent = await createAgent({
   instructions: "Keep every answer under 3 lines.",
-  model: provider(process.env.AI_MODEL ?? "minimax/MiniMax-M2.7"),
+  model: provider(process.env.AI_MODEL ?? "minimax/MiniMax-M3"),
 });
 
 const thread = agent.thread("default");

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/runtime-banner.png" alt="Plugsuits next banner" width="100%" />
 </p>
 
-# Plugsuits <sub><sup>next</sup></sub>
+# Plugsuits <sup>[\*next](https://github.com/minpeter/plugsuits)</sup>
 
 > Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
 > opens with the install steps for the `pss` TUI and the `pss exec` runner.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ for Plugsuits.
   model loop, core hooks, storage, and instrumentation.
 - [`@minpeter/pss-coding-agent`](apps/coding-agent/README.md): model wiring,
   workspace coding tools, the `pss` TUI, and the `pss exec` headless runner.
-- [`examples/`](examples): runnable setups, from a basic CLI to subagents and
-  evals.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 > Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
 > opens with the install steps for the `pss` TUI and the `pss exec` runner.
 
-Small agent runtime workspace.
+Small agent runtime workspace. Everything ships under the `pss` prefix, short
+for Plugsuits.
 
-- `@minpeter/pss-runtime`: runtime, threads, model loop, core hooks, and instrumentation.
+- `@minpeter/pss-runtime`: runtime, threads, model loop, core hooks, and
+  instrumentation.
 - `@minpeter/pss-coding-agent`: model wiring, workspace coding tools, the `pss`
   TUI, and the `pss exec` headless runner, with OpenSearch-backed `web_search`
   and `web_fetch` tools enabled by default.
@@ -60,6 +62,7 @@ events. Deltas are never persisted and bypass `AgentHooks` interception; live
 stream consumers and instrumentation can still observe them. The committed
 events remain the durable record. See the streaming deltas section of
 [`packages/runtime/README.md`](packages/runtime/README.md#streaming-deltas).
+
 Use `thread.send(input)` for a new user turn. If a turn is already active, the
 new turn is queued until the active turn finishes. Use `thread.steer(input)` when
 the input should steer the active turn; if no turn is active, it starts a normal
@@ -137,12 +140,8 @@ Run the TUI:
 pnpm dlx @minpeter/pss-coding-agent
 ```
 
-or install it:
-
-```sh
-pnpm add -g @minpeter/pss-coding-agent
-pss
-```
+See [`apps/coding-agent`](apps/coding-agent/README.md) for global installs,
+updates, and the `pss exec` runner.
 
 In the `pss` TUI, submitting while a run is active steers the current run.
 Submitting while idle starts a normal new turn.

--- a/README.md
+++ b/README.md
@@ -21,174 +21,35 @@ for Plugsuits.
 ```ts
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createAgent } from "@minpeter/pss-runtime";
-import { createEnv } from "@t3-oss/env-core";
-import { config as loadEnv } from "dotenv";
-import { z } from "zod";
-
-loadEnv({ path: ".env", quiet: true, override: true });
-const env = createEnv({
-  runtimeEnv: process.env,
-  server: {
-    AI_API_KEY: z.string().trim().min(1),
-    AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
-    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
-  },
-});
 
 const provider = createOpenAICompatible({
   name: "custom",
-  apiKey: env.AI_API_KEY,
-  baseURL: env.AI_BASE_URL,
+  apiKey: process.env.AI_API_KEY,
+  baseURL: process.env.AI_BASE_URL,
 });
 
 const agent = await createAgent({
   instructions: "Keep every answer under 3 lines.",
-  model: provider(env.AI_MODEL),
+  model: provider(process.env.AI_MODEL ?? "minimax/MiniMax-M2.7"),
 });
-const turn = await agent.send("Hello");
+
+const thread = agent.thread("default");
+const turn = await thread.send("Hello");
+
 for await (const event of turn.events()) {
   console.dir(event, { depth: null });
 }
 ```
 
-`turn.events()` is synchronized and drives the turn. Consume it to let the
-runtime cross lifecycle boundaries such as `turn-start`, `step-start`, and
-`step-end`.
+`turn.events()` drives the turn. The runtime waits at `turn-start`,
+`step-start`, and `step-end` until the consumer continues, so consume the
+events to let the turn progress.
 
-`turn.events()` also emits ephemeral streaming deltas
-(`assistant-output-delta`, `assistant-reasoning-delta`, and three
-`tool-call-input-*` kinds) between `step-start` and a step's committed
-events. Deltas are never persisted and bypass `AgentHooks` interception; live
-stream consumers and instrumentation can still observe them. The committed
-events remain the durable record. See the streaming deltas section of
-[`packages/runtime/README.md`](packages/runtime/README.md#streaming-deltas).
-
-Use `thread.send(input)` for a new user turn. If a turn is already active, the
-new turn is queued until the active turn finishes. Use `thread.steer(input)` when
-the input should steer the active turn; if no turn is active, it starts a normal
-turn.
-
-```ts
-const thread = agent.thread("default");
-const turn = await thread.send("Write a two sentence summary.");
-let addedConstraint = false;
-
-for await (const event of turn.events()) {
-  if (event.type === "step-end" && !addedConstraint) {
-    addedConstraint = true;
-    await thread.steer("Keep the second sentence under 10 words.");
-  }
-}
-```
-
-The guard matters. `step-end` runtime input asks the runtime to continue the
-current turn before the next model snapshot, even after final-looking assistant
-text. Adding input on every `step-end` can keep a turn running indefinitely.
-
-Steering additions appear as `runtime-input` events: runtime/API-originated input
-mapped internally to the model's user role, separate from human `user-input`
-events.
-
-## Runtime hooks and coding-agent extensions
-
-The runtime accepts one headless `AgentHooks` object. Application hosts own
-extension identity, ordering, lifecycle, tools, commands, and UI:
-
-```ts
-import { type AgentHooks, createAgent } from "@minpeter/pss-runtime";
-
-const hooks: AgentHooks = {
-  beforeToolExecution(checkpoint) {
-    if (checkpoint.toolName === "delete_file") {
-      return {
-        output: "delete_file is disabled",
-        status: "blocked",
-      };
-    }
-  },
-};
-
-const agent = await createAgent({ hooks, model, tools });
-```
-
-`@minpeter/pss-coding-agent/extension` provides the higher-level extension host
-for runtime hooks, tools, instruction fragments, commands, and TUI renderers.
-See [`packages/runtime/README.md`](packages/runtime/README.md#host-hooks) for
-the atomic callback contract.
-
-The runtime `send` API also accepts JSON-serializable multimodal content parts
-for model providers that support them:
-
-```ts
-await agent.send([
-  { type: "text", text: "What changed in this screenshot?" },
-  { type: "file", data: "data:image/png;base64,...", mediaType: "image/png" },
-]);
-```
-
-Inline image/file bytes and base64 data URLs are staged into the runtime's
-`attachmentStore` before thread state is committed. Durable events and snapshots
-store only internal `pss-attachment:` refs, and the runtime hydrates those refs
-back into bytes immediately before calling the model. Custom hosts that accept
-byte inputs must provide an `attachmentStore` with `put`, `get`, and `delete`;
-remote `http(s)` media stays as a provider URL/reference and is not fetched by
-the runtime.
-
-Run the TUI:
-
-```sh
-pnpm dlx @minpeter/pss-coding-agent
-```
-
-See [`apps/coding-agent`](apps/coding-agent/README.md) for global installs,
-updates, and the `pss exec` runner.
-
-In the `pss` TUI, submitting while a run is active steers the current run.
-Submitting while idle starts a normal new turn.
-
-## Develop
-
-Use Node.js 24 or later. The repository's supported development version is
-recorded in `.node-version`.
-
-```sh
-pnpm install
-pnpm dev
-pnpm dev:tui
-pnpm test
-pnpm typecheck
-pnpm lint
-pnpm build
-```
-
-## Env
-
-Copy `.env.example` to `.env`.
-
-```env
-AI_API_KEY=...
-AI_BASE_URL=...
-AI_MODEL=...
-```
-
-The `pss` TUI enables OpenSearch-backed `web_search` and `web_fetch` tools by
-default. Applications can still provide their own tools explicitly to the runtime
-or TUI entrypoint.
-
-The `pss` TUI stores threads in `~/.pss/threads` by default. Override with
-`PSS_THREAD_DIR` and `PSS_THREAD_KEY` when you want repo-local storage or a
-shared conversation key.
-
-## Release
-
-```sh
-pnpm tegami
-```
-
-Commit the generated `.tegami/*.md` changelog with the feature or fix. On
-`main`, `pnpm tegami ci` opens or updates the Version Packages pull request.
-After that PR merges, the next release run publishes from the committed Tegami
-publish lock using npm Trusted Publishing.
+The rest lives next to the code it describes:
+[`packages/runtime/README.md`](packages/runtime/README.md) for hooks, streaming
+deltas, storage, and subagents; [`apps/coding-agent/README.md`](apps/coding-agent/README.md)
+for the CLI, extensions, and environment variables; `examples/` for runnable
+setups.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/runtime-banner.png" alt="Plugsuits next banner" width="100%" />
 </p>
 
-# Plugsuits <sub><sup>next <sup>[\*](https://github.com/minpeter/plugsuits)</sup></sup></sub>
+# Plugsuits <sub><sup>(next)<sup>[\*](https://github.com/minpeter/plugsuits)</sup></sup></sub>
 
 > Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
 > opens with the install steps for the `pss` TUI and the `pss exec` runner.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="assets/runtime-banner.png" alt="Plugsuits (Next) banner" width="100%" />
+  <img src="assets/runtime-banner.png" alt="Plugsuits next banner" width="100%" />
 </p>
 
-# Plugsuits (Next)
+# Plugsuits <sub><sup>next</sup></sub>
 
 > Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
 > opens with the install steps for the `pss` TUI and the `pss exec` runner.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# pss-next
+<p align="center">
+  <img src="assets/runtime-banner.png" alt="pss-runtime banner" width="100%" />
+</p>
+
+# pss-runtime
 
 Small agent runtime workspace.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Small agent runtime workspace.
   TUI, and the `pss exec` headless runner, with OpenSearch-backed `web_search`
   and `web_fetch` tools enabled by default.
 
+> Just want the terminal agent? Head to [`apps/coding-agent`](apps/coding-agent/README.md)
+> for the `pss` TUI, the `pss exec` runner, and how to install them.
+
 ## Use
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 <p align="center">
-  <img src="assets/runtime-banner.png" alt="pss-runtime banner" width="100%" />
+  <img src="assets/runtime-banner.png" alt="Plugsuits (Next) banner" width="100%" />
 </p>
 
-# pss-runtime
+# Plugsuits (Next)
+
+> Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
+> opens with the install steps for the `pss` TUI and the `pss exec` runner.
 
 Small agent runtime workspace.
 
@@ -10,9 +13,6 @@ Small agent runtime workspace.
 - `@minpeter/pss-coding-agent`: model wiring, workspace coding tools, the `pss`
   TUI, and the `pss exec` headless runner, with OpenSearch-backed `web_search`
   and `web_fetch` tools enabled by default.
-
-> Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
-> opens with the install steps for the `pss` TUI and the `pss exec` runner.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 <p align="center">
-  <img src="assets/runtime-banner.png" alt="Plugsuits next banner" width="100%" />
+  <img src="assets/runtime-banner.png" alt="Plugsuits banner" width="100%" />
 </p>
 
-# Plugsuits <sub><sup>(next)<sup>[\*](https://github.com/minpeter/plugsuits)</sup></sup></sub>
+# Plugsuits
 
 > Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
 > opens with the install steps for the `pss` TUI and the `pss exec` runner.
 
-Small agent runtime workspace. Everything ships under the `pss` prefix, short
-for Plugsuits.
+Small agent runtime workspace, and the successor to
+[minpeter/plugsuits](https://github.com/minpeter/plugsuits). Everything ships
+under the `pss` prefix, short for Plugsuits.
 
 - [`@minpeter/pss-runtime`](packages/runtime/README.md): runtime, threads,
   model loop, core hooks, storage, and instrumentation.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ Small agent runtime workspace.
 - `@minpeter/pss-coding-agent`: model wiring, workspace coding tools, the `pss`
   TUI, and the `pss exec` headless runner, with OpenSearch-backed `web_search`
   and `web_fetch` tools enabled by default.
-- `@minpeter/pss-benchmark-nextjs` (private): Next.js AI Agent Evals harness
-  that runs the coding agent in Docker and produces leaderboard-comparable
-  scores. See `benchmarks/nextjs/README.md`.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@
 Small agent runtime workspace. Everything ships under the `pss` prefix, short
 for Plugsuits.
 
-- `@minpeter/pss-runtime`: runtime, threads, model loop, core hooks, and
-  instrumentation.
-- `@minpeter/pss-coding-agent`: model wiring, workspace coding tools, the `pss`
-  TUI, and the `pss exec` headless runner, with OpenSearch-backed `web_search`
-  and `web_fetch` tools enabled by default.
+- [`@minpeter/pss-runtime`](packages/runtime/README.md): runtime, threads,
+  model loop, core hooks, storage, and instrumentation.
+- [`@minpeter/pss-coding-agent`](apps/coding-agent/README.md): model wiring,
+  workspace coding tools, the `pss` TUI, and the `pss exec` headless runner.
+- [`examples/`](examples): runnable setups, from a basic CLI to subagents and
+  evals.
 
 ## Use
 
@@ -44,12 +45,6 @@ for await (const event of turn.events()) {
 `turn.events()` drives the turn. The runtime waits at `turn-start`,
 `step-start`, and `step-end` until the consumer continues, so consume the
 events to let the turn progress.
-
-The rest lives next to the code it describes:
-[`packages/runtime/README.md`](packages/runtime/README.md) for hooks, streaming
-deltas, storage, and subagents; [`apps/coding-agent/README.md`](apps/coding-agent/README.md)
-for the CLI, extensions, and environment variables; `examples/` for runnable
-setups.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/runtime-banner.png" alt="Plugsuits next banner" width="100%" />
 </p>
 
-# Plugsuits <sup>[\*next](https://github.com/minpeter/plugsuits)</sup>
+# Plugsuits <sub><sup>next <sup>[\*](https://github.com/minpeter/plugsuits)</sup></sup></sub>
 
 > Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
 > opens with the install steps for the `pss` TUI and the `pss exec` runner.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Small agent runtime workspace.
   TUI, and the `pss exec` headless runner, with OpenSearch-backed `web_search`
   and `web_fetch` tools enabled by default.
 
-> Just want the terminal agent? Head to [`apps/coding-agent`](apps/coding-agent/README.md)
-> for the `pss` TUI, the `pss exec` runner, and how to install them.
+> Just want the terminal agent? [`apps/coding-agent`](apps/coding-agent/README.md)
+> opens with the install steps for the `pss` TUI and the `pss exec` runner.
 
 ## Use
 

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -1,9 +1,30 @@
 # @minpeter/pss-coding-agent
 
-Model wiring and the `pss` TUI for pss-next. The TUI includes
+Model wiring and the `pss` TUI for pss-runtime. The TUI includes
 `@minpeter/opensearch`-backed `web_search` and `web_fetch` tools by default;
 OpenSearch picks its search/fetch providers from the environment and falls
 back to keyless engines when no provider API key is configured.
+
+## Install
+
+```sh
+pnpm add -g @minpeter/pss-coding-agent
+pss
+```
+
+Run it once without installing:
+
+```sh
+pnpm dlx @minpeter/pss-coding-agent
+```
+
+Set `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL` before the first run (a `.env`
+next to the working directory is picked up automatically). The installed
+binaries are `pss` and `pss-coding-agent`; for one headless task use `pss exec
+--workspace . --prompt "..."`. See [CLI](#cli) for updates, `pss exec` flags,
+and thread inspection, and [Env](#env) for the full variable list.
+
+## Library use
 
 ```ts
 import { createCodingLanguageModel } from "@minpeter/pss-coding-agent/model";
@@ -361,17 +382,6 @@ metadata remain readable as a generic `Request failed` message without
 speculative guidance.
 
 ## CLI
-
-```sh
-pnpm dlx @minpeter/pss-coding-agent
-```
-
-```sh
-pnpm add -g @minpeter/pss-coding-agent
-pss
-```
-
-CLI commands: `pss`, `pss-coding-agent`.
 
 Update a global install, or preview what an update would do:
 

--- a/apps/coding-agent/src/env.ts
+++ b/apps/coding-agent/src/env.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 export const DEFAULT_OPENAI_COMPATIBLE_BASE_URL =
   "https://apis.opengateway.ai/v1";
-export const DEFAULT_OPENAI_COMPATIBLE_MODEL_ID = "minimax/MiniMax-M2.7";
+export const DEFAULT_OPENAI_COMPATIBLE_MODEL_ID = "minimax/MiniMax-M3";
 
 /**
  * Keyless fallback provider: OpenCode Zen's free tier. `public` is Zen's

--- a/apps/coding-agent/src/model.test.ts
+++ b/apps/coding-agent/src/model.test.ts
@@ -93,7 +93,7 @@ describe("createOpenAICompatibleModelFromEnv", () => {
       runtimeEnv: {
         AI_API_KEY: " ai-token-1;ai-token-2 ",
         AI_BASE_URL: " https://llm.test/v1 ",
-        AI_MODEL: " minimax/MiniMax-M2.7 ",
+        AI_MODEL: " minimax/MiniMax-M3 ",
       },
     });
 
@@ -104,7 +104,7 @@ describe("createOpenAICompatibleModelFromEnv", () => {
       baseURL: "https://llm.test/v1",
       includeUsage: true,
     });
-    expect(providerMock).toHaveBeenCalledWith("minimax/MiniMax-M2.7");
+    expect(providerMock).toHaveBeenCalledWith("minimax/MiniMax-M3");
     expect(model).toMatchObject({ provider: "test" });
   });
 

--- a/apps/worker-agent/.dev.vars.example
+++ b/apps/worker-agent/.dev.vars.example
@@ -1,7 +1,7 @@
 # pnpm ship → wrangler secret bulk .dev.vars (whole file)
 AI_API_KEY=...
 AI_BASE_URL=https://apis.opengateway.ai/v1
-AI_MODEL=minimax/MiniMax-M2.7
+AI_MODEL=minimax/MiniMax-M3
 TELEGRAM_BOT_TOKEN=...
 TELEGRAM_BOT_USERNAME=your_bot
 # Separate from TELEGRAM_BOT_TOKEN. Allowed: A-Z a-z 0-9 _ -

--- a/apps/worker-agent/src/agent/agent.ts
+++ b/apps/worker-agent/src/agent/agent.ts
@@ -30,7 +30,7 @@ const DEFAULT_BASE_URL = "https://apis.opengateway.ai/v1";
 export const WORKER_AGENT_NAMESPACE = "worker-agent";
 
 /** Default model id when `AI_MODEL` is unset (also used on wide-event `ai.model`). */
-export const DEFAULT_MODEL = "minimax/MiniMax-M2.7";
+export const DEFAULT_MODEL = "minimax/MiniMax-M3";
 
 export const WORKER_AGENT_AUTO_COMPACTION: AgentAutoCompactionOptions = {
   maxInputTokens: 128_000,

--- a/apps/worker-agent/src/evals/thread.ts
+++ b/apps/worker-agent/src/evals/thread.ts
@@ -28,7 +28,7 @@ import { createWorkerAgentTools } from "../tools";
 import { loadWorkerAgentEvalEnv } from "./eval-env";
 import { createScriptedModel, type ScriptedResult } from "./scripted-model";
 
-const DEFAULT_MODEL = "minimax/MiniMax-M2.7";
+const DEFAULT_MODEL = "minimax/MiniMax-M3";
 const REAL_ENV_FLAG = "PSS_WORKER_AGENT_EVAL_REAL";
 const EvalModelEnvSchema = z.looseObject({
   AI_API_KEY: z.string().trim().min(1),

--- a/examples/background-subagent/src/setup.ts
+++ b/examples/background-subagent/src/setup.ts
@@ -15,7 +15,7 @@ const env = createEnv({
   server: {
     AI_API_KEY: z.string().trim().min(1),
     AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
-    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
+    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M3"),
   },
 });
 

--- a/examples/basic/src/setup.ts
+++ b/examples/basic/src/setup.ts
@@ -11,7 +11,7 @@ const env = createEnv({
   server: {
     AI_API_KEY: z.string().trim().min(1),
     AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
-    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
+    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M3"),
   },
 });
 

--- a/examples/evals/.env.example
+++ b/examples/evals/.env.example
@@ -1,3 +1,3 @@
 AI_API_KEY=
 AI_BASE_URL=https://apis.opengateway.ai/v1
-AI_MODEL=minimax/MiniMax-M2.7
+AI_MODEL=minimax/MiniMax-M3

--- a/examples/evals/src/real-model.ts
+++ b/examples/evals/src/real-model.ts
@@ -20,7 +20,7 @@ export function realModel() {
     server: {
       AI_API_KEY: z.string().trim().min(1),
       AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
-      AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
+      AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M3"),
     },
   });
   cached = createOpenAICompatible({

--- a/examples/hooks/src/index.ts
+++ b/examples/hooks/src/index.ts
@@ -10,7 +10,7 @@ const env = createEnv({
   server: {
     AI_API_KEY: z.string().trim().min(1),
     AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
-    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
+    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M3"),
   },
 });
 

--- a/examples/local-file-agent/src/setup.ts
+++ b/examples/local-file-agent/src/setup.ts
@@ -12,7 +12,7 @@ const env = createEnv({
   server: {
     AI_API_KEY: z.string().trim().min(1),
     AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
-    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
+    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M3"),
     PSS_EXAMPLE_THREAD_DIR: z
       .string()
       .trim()

--- a/examples/sync-subagent/src/setup.ts
+++ b/examples/sync-subagent/src/setup.ts
@@ -12,7 +12,7 @@ const env = createEnv({
   server: {
     AI_API_KEY: z.string().trim().min(1),
     AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
-    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
+    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M3"),
   },
 });
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -22,7 +22,7 @@ const env = createEnv({
   server: {
     AI_API_KEY: z.string().trim().min(1),
     AI_BASE_URL: z.url().trim().default("https://apis.opengateway.ai/v1"),
-    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M2.7"),
+    AI_MODEL: z.string().trim().min(1).default("minimax/MiniMax-M3"),
   },
 });
 

--- a/scripts/runtime-docs.test.mjs
+++ b/scripts/runtime-docs.test.mjs
@@ -18,13 +18,19 @@ describe("runtime docs", () => {
     );
     expect(readme).toContain("const agent = await createAgent({");
     expect(readme).toContain('const thread = agent.thread("default")');
-    expect(readme).toContain("PSS_THREAD_DIR");
-    expect(readme).toContain("PSS_THREAD_KEY");
     expect(readme).not.toContain(
       'import { Agent } from "@minpeter/pss-runtime"'
     );
     expect(readme).not.toContain("new Agent({");
     expect(readme).not.toContain("agent.session(");
+    expect(readme).not.toContain("~/.pss/sessions");
+  });
+
+  it("documents thread storage env vars next to the CLI", () => {
+    const readme = readRepoFile("apps/coding-agent/README.md");
+
+    expect(readme).toContain("PSS_THREAD_DIR");
+    expect(readme).toContain("PSS_THREAD_KEY");
     expect(readme).not.toContain("~/.pss/sessions");
   });
 


### PR DESCRIPTION
## Summary

**Root README**

- Add the existing `assets/runtime-banner.png` banner, matching how `packages/runtime/README.md` presents it. Image path reused as-is.
- Retitle to `Plugsuits (Next)`, with a note that the `pss` package prefix is short for Plugsuits.
- Trim 189 lines down to ~54: one quick-start block, plus links to the package READMEs that own the detail. Removed the streaming-delta, steering, hooks, and multimodal blocks along with the Develop / Env / Release sections; all of that already lives in `packages/runtime/README.md` and `apps/coding-agent/README.md`.
- Drop the private `@minpeter/pss-benchmark-nextjs` entry.

**`apps/coding-agent/README.md`**

- Open with an `Install` section so the install steps are the first thing on the page. The duplicate snippet that was buried under `CLI` is gone, and the SDK example moved under `Library use`.

**Default model**

- `minimax/MiniMax-M2.7` -> `minimax/MiniMax-M3` across all 15 files that pinned it: the coding-agent and worker-agent defaults, `.env.example` files, examples, and the two READMEs. Verified `minimax/MiniMax-M3` is active on the default gateway's `/v1/models`. Historical benchmark evidence under `examples/evals/evidence/` is untouched.

**Test**

- `scripts/runtime-docs.test.mjs` asserted the root README documents `PSS_THREAD_DIR` / `PSS_THREAD_KEY`. Those env vars are now documented only in `apps/coding-agent/README.md`, so the assertion moved to a case targeting that file rather than being dropped.

## Test

- `vitest run apps/coding-agent/src/model.test.ts src/env.test.ts` (24 passed)
- `vitest run scripts/runtime-docs.test.mjs scripts/examples.test.mjs scripts/workspace-config.test.mjs scripts/tegami-config.test.mjs` (15 passed)

Full `pnpm typecheck` was not run in the worktree (no installed `node_modules` there, so unrelated `Cannot find module` errors dominate). The changes outside the READMEs are string-constant replacements with no type surface.

## Note

The project name now appears three ways: README title `Plugsuits (Next)`, repo `pss-runtime`, and `package.json` name `pss-next`. Left as-is here since the release scripts reference `pss-next`; worth a follow-up if you want them unified.
