### PR TITLE
Harden runtime ownership and extension transactions

### DIFF
--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -262,10 +262,11 @@ export function createTuiExtensionReloader({
     } finally {
       await staging.dispose();
     }
-    // Evict extension-owned CommonJS modules so cache-busted imports
-    // re-execute helpers; the snapshot restores them if the reload fails.
+    // Refuse to disturb extension-owned process-wide CommonJS cache entries;
+    // those extensions require a restart. ESM graphs remain reloadable.
     const transaction = beginCommonJsReloadTransaction(
-      await reloadCacheRoots({ cwd, home, targets })
+      await reloadCacheRoots({ cwd, home, targets }),
+      staging.commonJsPaths()
     );
     // Bound imports so an edited extension with a never-settling top-level
     // await fails the reload instead of freezing the session; the abort

--- a/apps/coding-agent/src/extensions/manager/activation.ts
+++ b/apps/coding-agent/src/extensions/manager/activation.ts
@@ -1,10 +1,11 @@
 import { realpath } from "node:fs/promises";
 import { extensionScopePaths, extensionTrustPath } from "./paths";
 import {
+  addTrustedProject,
   readExtensionSettings,
   readTrustedProjects,
   updateExtensionSettings,
-  writeTrustedProjects,
+  withExtensionOperationLock,
 } from "./settings";
 import type {
   ExtensionManagerContext,
@@ -60,11 +61,31 @@ export async function setExtensionEnabled(
     throw new TypeError("Provide extension ids or --all");
   }
   const paths = await extensionScopePaths(context);
+  return await withExtensionOperationLock(paths.installRoot, async () =>
+    setExtensionEnabledOwned(context, paths)
+  );
+}
+
+async function setExtensionEnabledOwned(
+  context: ExtensionManagerContext & {
+    readonly all: boolean;
+    readonly enabled: boolean;
+    readonly ids: readonly string[];
+    readonly scope: ExtensionScope;
+  },
+  paths: Awaited<ReturnType<typeof extensionScopePaths>>
+): Promise<readonly ExtensionSettingsEntry[]> {
   const selected = context.all ? null : new Set(context.ids);
+  const previousEnabled = new Map<string, boolean>();
   const next = await updateExtensionSettings(paths.settingsPath, (document) => {
     const ids =
       selected ?? new Set(document.extensions.map((entry) => entry.id));
     assertIdsExist(document.extensions, ids);
+    for (const entry of document.extensions) {
+      if (ids.has(entry.id)) {
+        previousEnabled.set(entry.id, entry.enabled);
+      }
+    }
     return {
       ...document,
       extensions: document.extensions.map((entry) =>
@@ -73,7 +94,26 @@ export async function setExtensionEnabled(
     };
   });
   if (context.enabled && context.scope === "project") {
-    await trustProject(context);
+    try {
+      await trustProject(context);
+    } catch (error) {
+      try {
+        await updateExtensionSettings(paths.settingsPath, (latest) => ({
+          ...latest,
+          extensions: latest.extensions.map((entry) =>
+            previousEnabled.has(entry.id)
+              ? { ...entry, enabled: previousEnabled.get(entry.id) ?? false }
+              : entry
+          ),
+        }));
+      } catch (restoreError) {
+        throw new AggregateError(
+          [error, restoreError],
+          "Project trust and extension enable restore both failed"
+        );
+      }
+      throw error;
+    }
   }
   const ids = selected ?? new Set(next.extensions.map((entry) => entry.id));
   return next.extensions.filter((entry) => ids.has(entry.id));
@@ -84,10 +124,7 @@ export async function trustProject(
 ): Promise<void> {
   const project = await realpath(context.cwd);
   const path = extensionTrustPath(context.home);
-  const projects = await readTrustedProjects(path);
-  if (!projects.includes(project)) {
-    await writeTrustedProjects(path, [...projects, project]);
-  }
+  await addTrustedProject(path, project);
 }
 
 async function isProjectTrusted(

--- a/apps/coding-agent/src/extensions/manager/install-trust.test.ts
+++ b/apps/coding-agent/src/extensions/manager/install-trust.test.ts
@@ -1,8 +1,19 @@
-import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { setExtensionEnabled } from "./activation";
 import { installExtension } from "./install";
+import { extensionScopePaths, extensionTrustPath } from "./paths";
+import { readExtensionSettings, writeExtensionSettings } from "./settings";
+import type { RunExtensionCommand } from "./types";
 
 const cleanupRoots: string[] = [];
 
@@ -46,5 +57,107 @@ describe("project extension trust transaction", () => {
     await expect(
       access(join(home, ".pss", "trusted-projects.json"))
     ).rejects.toThrow();
+  });
+
+  it("restores disabled state when project trust cannot be persisted", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-enable-trust-"));
+    cleanupRoots.push(root);
+    const cwd = join(root, "project");
+    const home = join(root, "home");
+    await mkdir(cwd, { recursive: true });
+    const context = { cwd, home, scope: "project" as const };
+    const paths = await extensionScopePaths(context);
+    await writeExtensionSettings(paths.settingsPath, {
+      extensions: [
+        {
+          enabled: false,
+          id: "demo",
+          installedAt: "2026-08-03T00:00:00.000Z",
+          source: "./demo.mjs",
+          sourceKind: "local",
+          target: { kind: "module", path: "./demo.mjs" },
+        },
+      ],
+      values: {},
+    });
+    await mkdir(extensionTrustPath(home), { recursive: true });
+
+    await expect(
+      setExtensionEnabled({
+        ...context,
+        all: false,
+        enabled: true,
+        ids: ["demo"],
+      })
+    ).rejects.toThrow();
+
+    await expect(
+      readExtensionSettings(paths.settingsPath)
+    ).resolves.toMatchObject({ extensions: [{ enabled: false, id: "demo" }] });
+  });
+});
+
+describe("extension installation transaction", () => {
+  it("serializes duplicate installs before mutating the shared package root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-install-race-"));
+    cleanupRoots.push(root);
+    const cwd = join(root, "project");
+    const home = join(root, "home");
+    await mkdir(cwd, { recursive: true });
+    let commandCount = 0;
+    const runCommand: RunExtensionCommand = async (_command, args) => {
+      commandCount += 1;
+      const prefixIndex = args.indexOf("--prefix");
+      const installRoot = args[prefixIndex + 1];
+      if (!installRoot) {
+        throw new Error("expected npm --prefix");
+      }
+      const packageJsonPath = join(installRoot, "package.json");
+      const packageJson = JSON.parse(
+        await readFile(packageJsonPath, "utf8")
+      ) as Record<string, unknown>;
+      await writeFile(
+        packageJsonPath,
+        JSON.stringify({
+          ...packageJson,
+          dependencies: { demo: "1.0.0" },
+        })
+      );
+      const packageRoot = join(installRoot, "node_modules", "demo");
+      await mkdir(packageRoot, { recursive: true });
+      await writeFile(
+        join(packageRoot, "package.json"),
+        JSON.stringify({ main: "index.js" })
+      );
+      return { code: 0, stderr: "", stdout: "" };
+    };
+    const context = {
+      cwd,
+      enabled: true,
+      home,
+      importer: async () => ({ default: () => undefined }),
+      runCommand,
+      scope: "global" as const,
+      source: "demo@1.0.0",
+    };
+
+    const results = await Promise.allSettled([
+      installExtension(context),
+      installExtension(context),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === "fulfilled")
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "rejected")
+    ).toHaveLength(1);
+    expect(commandCount).toBe(1);
+    const paths = await extensionScopePaths(context);
+    await expect(
+      readExtensionSettings(paths.settingsPath)
+    ).resolves.toMatchObject({
+      extensions: [{ id: "demo" }],
+    });
   });
 });

--- a/apps/coding-agent/src/extensions/manager/install.ts
+++ b/apps/coding-agent/src/extensions/manager/install.ts
@@ -10,6 +10,7 @@ import {
   type ExtensionSettingsDocument,
   readExtensionSettings,
   updateExtensionSettings,
+  withExtensionOperationLock,
   writeExtensionSettings,
 } from "./settings";
 import { type ParsedExtensionSource, parseExtensionSource } from "./source";
@@ -34,6 +35,15 @@ export async function installExtension(
   context: InstallExtensionContext
 ): Promise<ExtensionSettingsEntry> {
   const paths = await extensionScopePaths(context);
+  return await withExtensionOperationLock(paths.installRoot, async () =>
+    installExtensionOwned(context, paths)
+  );
+}
+
+async function installExtensionOwned(
+  context: InstallExtensionContext,
+  paths: Awaited<ReturnType<typeof extensionScopePaths>>
+): Promise<ExtensionSettingsEntry> {
   const document = await readExtensionSettings(paths.settingsPath);
   const parsedSource = await parseExtensionSource(context.source, context.cwd);
   const knownId =

--- a/apps/coding-agent/src/extensions/manager/manager-remove.test.ts
+++ b/apps/coding-agent/src/extensions/manager/manager-remove.test.ts
@@ -1,4 +1,11 @@
-import { chmod, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -66,6 +73,57 @@ describe("managed extension removal", () => {
 
     // Then
     expect(invocations).toEqual([]);
+    const persisted = JSON.parse(await readFile(paths.settingsPath, "utf8"));
+    expect(persisted.extensions).toEqual([
+      expect.objectContaining({ id: "demo" }),
+    ]);
+  });
+
+  it("restores package bytes before settings after a partial uninstall failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-remove-partial-"));
+    cleanupRoots.push(root);
+    const cwd = join(root, "project");
+    const home = join(root, "home");
+    await mkdir(cwd, { recursive: true });
+    const paths = await extensionScopePaths({ cwd, home, scope: "global" });
+    const packageRoot = join(paths.installRoot, "node_modules", "demo");
+    await mkdir(packageRoot, { recursive: true });
+    await writeFile(join(packageRoot, "index.js"), "original\n");
+    await writeFile(
+      join(paths.installRoot, "package.json"),
+      JSON.stringify({ dependencies: { demo: "1.0.0" } })
+    );
+    await writeExtensionSettings(paths.settingsPath, {
+      extensions: [
+        {
+          enabled: true,
+          id: "demo",
+          installedAt: "2026-08-03T00:00:00.000Z",
+          source: "demo@1.0.0",
+          sourceKind: "npm",
+          target: { kind: "package", packageName: "demo" },
+        },
+      ],
+      values: {},
+    });
+    const runCommand: RunExtensionCommand = async () => {
+      await rm(packageRoot, { force: true, recursive: true });
+      return { code: 1, stderr: "partial failure", stdout: "" };
+    };
+
+    await expect(
+      removeExtension({
+        cwd,
+        home,
+        id: "demo",
+        runCommand,
+        scope: "global",
+      })
+    ).rejects.toThrow("partial failure");
+
+    await expect(readFile(join(packageRoot, "index.js"), "utf8")).resolves.toBe(
+      "original\n"
+    );
     const persisted = JSON.parse(await readFile(paths.settingsPath, "utf8"));
     expect(persisted.extensions).toEqual([
       expect.objectContaining({ id: "demo" }),

--- a/apps/coding-agent/src/extensions/manager/manager.ts
+++ b/apps/coding-agent/src/extensions/manager/manager.ts
@@ -8,7 +8,11 @@ import {
   removeExtensionPackage,
 } from "./package-installer";
 import { extensionScopePaths } from "./paths";
-import { readExtensionSettings, updateExtensionSettings } from "./settings";
+import {
+  readExtensionSettings,
+  updateExtensionSettings,
+  withExtensionOperationLock,
+} from "./settings";
 import { parseExtensionSource } from "./source";
 import type {
   ExtensionManagerContext,
@@ -23,6 +27,15 @@ export async function removeExtension(
   }
 ): Promise<ExtensionSettingsEntry> {
   const paths = await extensionScopePaths(context);
+  return await withExtensionOperationLock(paths.installRoot, async () =>
+    removeExtensionOwned(context, paths)
+  );
+}
+
+async function removeExtensionOwned(
+  context: ExtensionManagerContext & { readonly id: string },
+  paths: Awaited<ReturnType<typeof extensionScopePaths>>
+): Promise<ExtensionSettingsEntry> {
   let removed: ExtensionSettingsEntry | undefined;
   let remainingPackages: readonly ExtensionSettingsEntry[] = [];
   await updateExtensionSettings(paths.settingsPath, (document) => {
@@ -49,13 +62,36 @@ export async function removeExtension(
           item.target.packageName === packageName
       )
     ) {
-      await removeExtensionPackage({
-        installRoot: paths.installRoot,
-        packageName,
-        ...(context.runCommand === undefined
-          ? {}
-          : { runCommand: context.runCommand }),
-      });
+      const backup = await snapshotInstallRoot(paths.installRoot);
+      try {
+        await removeExtensionPackage({
+          installRoot: paths.installRoot,
+          packageName,
+          ...(context.runCommand === undefined
+            ? {}
+            : { runCommand: context.runCommand }),
+        });
+      } catch (error) {
+        try {
+          await restoreInstallRoot(paths.installRoot, backup.root);
+          await updateExtensionSettings(paths.settingsPath, (latest) => ({
+            ...latest,
+            extensions: latest.extensions.some(
+              (candidate) => candidate.id === entry.id
+            )
+              ? latest.extensions
+              : [...latest.extensions, entry],
+          }));
+        } catch (restoreError) {
+          throw new AggregateError(
+            [error, restoreError],
+            `Extension "${entry.id}" removal and settings restore both failed`
+          );
+        }
+        throw error;
+      } finally {
+        await rm(backup.parent, { force: true, recursive: true });
+      }
     }
   }
   return entry;
@@ -69,14 +105,87 @@ export async function updateExtensions(
   }
 ): Promise<readonly ExtensionSettingsEntry[]> {
   const paths = await extensionScopePaths(context);
+  return await withExtensionOperationLock(paths.installRoot, async () =>
+    updateExtensionsOwned(context, paths)
+  );
+}
+
+async function updateExtensionsOwned(
+  context: ExtensionManagerContext & {
+    readonly all: boolean;
+    readonly ids: readonly string[];
+  },
+  paths: Awaited<ReturnType<typeof extensionScopePaths>>
+): Promise<readonly ExtensionSettingsEntry[]> {
   const document = await readExtensionSettings(paths.settingsPath);
   const selected =
     context.all || context.ids.length === 0
       ? new Set(document.extensions.map((entry) => entry.id))
       : new Set(context.ids);
   assertIdsExist(document.extensions, selected);
+  const { packageUpdates, updated } = await prepareExtensionUpdates(
+    context,
+    document.extensions,
+    selected,
+    paths.installRoot
+  );
+  const byId = new Map(updated.map((entry) => [entry.id, entry]));
+  const commitSettings = () =>
+    updateExtensionSettings(paths.settingsPath, (latest) => ({
+      ...latest,
+      extensions: latest.extensions.map((entry) => byId.get(entry.id) ?? entry),
+    }));
+  if (packageUpdates.length === 0) {
+    await commitSettings();
+    return updated;
+  }
+
+  const backup = await snapshotInstallRoot(paths.installRoot);
+  try {
+    for (const update of packageUpdates) {
+      await applyManagedPackageUpdate(
+        context,
+        update.entry.id,
+        update.target,
+        update.installSpec,
+        paths.installRoot
+      );
+    }
+    await commitSettings();
+  } catch (error) {
+    try {
+      await restoreInstallRoot(paths.installRoot, backup.root);
+    } catch (restoreError) {
+      throw new AggregateError(
+        [error, restoreError],
+        "Extension update and package root restore both failed"
+      );
+    }
+    throw error;
+  } finally {
+    await rm(backup.parent, { force: true, recursive: true });
+  }
+  return updated;
+}
+
+interface PreparedPackageUpdate {
+  readonly entry: ExtensionSettingsEntry;
+  readonly installSpec: string;
+  readonly target: { readonly kind: "package"; readonly packageName: string };
+}
+
+async function prepareExtensionUpdates(
+  context: ExtensionManagerContext,
+  entries: readonly ExtensionSettingsEntry[],
+  selected: ReadonlySet<string>,
+  installRoot: string
+): Promise<{
+  readonly packageUpdates: readonly PreparedPackageUpdate[];
+  readonly updated: readonly ExtensionSettingsEntry[];
+}> {
+  const packageUpdates: PreparedPackageUpdate[] = [];
   const updated: ExtensionSettingsEntry[] = [];
-  for (const entry of document.extensions) {
+  for (const entry of entries) {
     if (!selected.has(entry.id)) {
       continue;
     }
@@ -90,13 +199,17 @@ export async function updateExtensions(
           `Extension "${entry.id}" no longer resolves to a package`
         );
       }
-      await updateManagedPackage(
+      await validatePackageUpdate(
         context,
         entry.id,
         entry.target,
-        parsedSource.installSpec,
-        paths.installRoot
+        parsedSource.installSpec
       );
+      packageUpdates.push({
+        entry,
+        installSpec: parsedSource.installSpec,
+        target: entry.target,
+      });
     } else {
       await loadExtensionTarget({
         cacheBust: (context.now?.() ?? new Date()).toISOString(),
@@ -104,7 +217,7 @@ export async function updateExtensions(
         ...(context.importer === undefined
           ? {}
           : { importer: context.importer }),
-        installRoot: paths.installRoot,
+        installRoot,
         target: entry.target,
       });
     }
@@ -113,57 +226,48 @@ export async function updateExtensions(
       updatedAt: (context.now?.() ?? new Date()).toISOString(),
     });
   }
-  const byId = new Map(updated.map((entry) => [entry.id, entry]));
-  await updateExtensionSettings(paths.settingsPath, (latest) => ({
-    ...latest,
-    extensions: latest.extensions.map((entry) => byId.get(entry.id) ?? entry),
-  }));
-  return updated;
+  return { packageUpdates, updated };
 }
 
-async function updateManagedPackage(
+async function applyManagedPackageUpdate(
   context: ExtensionManagerContext,
   id: string,
   target: { readonly kind: "package"; readonly packageName: string },
   installSpec: string,
   installRoot: string
 ): Promise<void> {
-  await validatePackageUpdate(context, id, target, installSpec);
-  const backupParent = await mkdtemp(
-    join(tmpdir(), "pss-extension-update-backup-")
-  );
-  const backupRoot = join(backupParent, "managed");
-  await cp(installRoot, backupRoot, { recursive: true });
-  try {
-    await installExtensionPackage({
-      installRoot,
-      installSpec,
-      packageName: target.packageName,
-      ...(context.runCommand === undefined
-        ? {}
-        : { runCommand: context.runCommand }),
-    });
-    await loadExtensionTarget({
-      cacheBust: randomUUID(),
-      id,
-      ...(context.importer === undefined ? {} : { importer: context.importer }),
-      installRoot,
-      target,
-    });
-  } catch (error) {
-    try {
-      await rm(installRoot, { force: true, recursive: true });
-      await cp(backupRoot, installRoot, { recursive: true });
-    } catch (restoreError) {
-      throw new AggregateError(
-        [error, restoreError],
-        `Extension "${id}" update and restore both failed`
-      );
-    }
-    throw error;
-  } finally {
-    await rm(backupParent, { force: true, recursive: true });
-  }
+  await installExtensionPackage({
+    installRoot,
+    installSpec,
+    packageName: target.packageName,
+    ...(context.runCommand === undefined
+      ? {}
+      : { runCommand: context.runCommand }),
+  });
+  await loadExtensionTarget({
+    cacheBust: randomUUID(),
+    id,
+    ...(context.importer === undefined ? {} : { importer: context.importer }),
+    installRoot,
+    target,
+  });
+}
+
+async function snapshotInstallRoot(
+  installRoot: string
+): Promise<{ readonly parent: string; readonly root: string }> {
+  const parent = await mkdtemp(join(tmpdir(), "pss-extension-backup-"));
+  const root = join(parent, "managed");
+  await cp(installRoot, root, { recursive: true });
+  return { parent, root };
+}
+
+async function restoreInstallRoot(
+  installRoot: string,
+  backupRoot: string
+): Promise<void> {
+  await rm(installRoot, { force: true, recursive: true });
+  await cp(backupRoot, installRoot, { recursive: true });
 }
 
 async function validatePackageUpdate(

--- a/apps/coding-agent/src/extensions/manager/module-loader.test.ts
+++ b/apps/coding-agent/src/extensions/manager/module-loader.test.ts
@@ -9,6 +9,7 @@ import { loadExtensionTarget } from "./module-loader";
 const execFileAsync = promisify(execFile);
 
 const cleanupRoots: string[] = [];
+const restartRequiredPattern = /requires a restart.*CommonJS/u;
 
 afterEach(async () => {
   for (const root of cleanupRoots.splice(0)) {
@@ -122,7 +123,7 @@ describe("managed package module loading", () => {
 
   // Runs in a child Node process because module customization hooks do not
   // intercept imports issued through vitest's own module runner.
-  it("reloads commonjs helpers when cache busting", async () => {
+  it("requires a restart instead of mutating cached commonjs helpers", async () => {
     // Given
     const root = await mkdtemp(join(tmpdir(), "pss-module-loader-"));
     cleanupRoots.push(root);
@@ -161,17 +162,14 @@ describe("managed package module loading", () => {
     ].join("\n");
 
     // When
-    const { stdout } = await execFileAsync(
+    const reload = execFileAsync(
       process.execPath,
       ["--input-type=module", "-e", script],
       { timeout: 30_000 }
     );
 
     // Then
-    expect(JSON.parse(stdout.trim())).toEqual({
-      first: "one",
-      second: "two",
-    });
+    await expect(reload).rejects.toThrow(restartRequiredPattern);
   });
 
   it("reloads transitive helper modules when cache busting", async () => {

--- a/apps/coding-agent/src/extensions/manager/package-installer.test.ts
+++ b/apps/coding-agent/src/extensions/manager/package-installer.test.ts
@@ -3,12 +3,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  defaultRunExtensionCommand,
   installExtensionPackage,
   rollbackExtensionPackage,
 } from "./package-installer";
 import type { RunExtensionCommand } from "./types";
 
 const cleanupRoots: string[] = [];
+const commandTimeoutPattern = /timed out/u;
 
 afterEach(async () => {
   for (const root of cleanupRoots.splice(0)) {
@@ -117,5 +119,35 @@ describe("managed extension package installation", () => {
 
     // Then
     expect(specs).toEqual(["demo@1.0.0"]);
+  });
+
+  it("bounds output captured from the package manager", async () => {
+    const result = await defaultRunExtensionCommand(process.execPath, [
+      "-e",
+      "process.stdout.write('x'.repeat(2_000_100))",
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toHaveLength(2_000_000);
+  });
+
+  it("terminates a package manager command after its deadline", async () => {
+    const previousTimeout = process.env.PSS_EXTENSION_NPM_TIMEOUT_MS;
+    process.env.PSS_EXTENSION_NPM_TIMEOUT_MS = "20";
+    try {
+      const result = await defaultRunExtensionCommand(process.execPath, [
+        "-e",
+        "setInterval(() => undefined, 1000)",
+      ]);
+
+      expect(result.code).toBe(1);
+      expect(result.stderr).toMatch(commandTimeoutPattern);
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.PSS_EXTENSION_NPM_TIMEOUT_MS;
+      } else {
+        process.env.PSS_EXTENSION_NPM_TIMEOUT_MS = previousTimeout;
+      }
+    }
   });
 });

--- a/apps/coding-agent/src/extensions/manager/package-installer.ts
+++ b/apps/coding-agent/src/extensions/manager/package-installer.ts
@@ -8,30 +8,91 @@ export interface InstalledExtensionPackage {
   readonly previousSpec?: string;
 }
 
+const DEFAULT_NPM_TIMEOUT_MS = 120_000;
+const MAX_COMMAND_OUTPUT = 2_000_000;
+const TERMINATION_GRACE_MS = 1000;
+
 export const defaultRunExtensionCommand: RunExtensionCommand = (
   command,
   args
 ) =>
   new Promise((resolvePromise) => {
+    const configuredTimeout = Number.parseInt(
+      process.env.PSS_EXTENSION_NPM_TIMEOUT_MS ?? "",
+      10
+    );
+    const timeoutMs =
+      Number.isSafeInteger(configuredTimeout) && configuredTimeout > 0
+        ? configuredTimeout
+        : DEFAULT_NPM_TIMEOUT_MS;
     const child = spawn(command, [...args], {
+      detached: process.platform !== "win32",
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let forceTimer: ReturnType<typeof setTimeout> | undefined;
+    const append = (current: string, chunk: string): string =>
+      (current + chunk).slice(-MAX_COMMAND_OUTPUT);
+    const kill = (signal: NodeJS.Signals) => {
+      if (child.pid === undefined) {
+        return;
+      }
+      try {
+        process.kill(-child.pid, signal);
+      } catch {
+        child.kill(signal);
+      }
+    };
+    const terminate = () => {
+      kill("SIGTERM");
+      forceTimer = setTimeout(() => {
+        kill("SIGKILL");
+        settle({
+          code: 1,
+          stderr: stderr || `npm command timed out after ${timeoutMs}ms`,
+          stdout,
+        });
+      }, TERMINATION_GRACE_MS);
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminate();
+    }, timeoutMs);
+    const settle = (result: CommandResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (forceTimer !== undefined) {
+        clearTimeout(forceTimer);
+      }
+      resolvePromise(result);
+    };
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
+      stdout = append(stdout, chunk);
     });
     child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
+      stderr = append(stderr, chunk);
     });
     child.on("error", (error) => {
-      resolvePromise({ code: 1, stderr: error.message, stdout });
+      settle({ code: 1, stderr: error.message, stdout });
     });
     child.on("close", (code) => {
-      resolvePromise({ code: code ?? 1, stderr, stdout });
+      if (timedOut) {
+        return;
+      }
+      settle({
+        code: code ?? 1,
+        stderr,
+        stdout,
+      });
     });
   });
 

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.test.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.test.ts
@@ -7,6 +7,7 @@ import { beginCommonJsReloadTransaction } from "./reload-module-graph";
 
 const require = createRequire(import.meta.url);
 const cleanupRoots: string[] = [];
+const restartRequiredPattern = /requires a restart.*CommonJS/u;
 
 afterEach(async () => {
   for (const root of cleanupRoots.splice(0)) {
@@ -21,7 +22,7 @@ async function temporaryDirectory(): Promise<string> {
 }
 
 describe("beginCommonJsReloadTransaction", () => {
-  it("evicts extension-owned entries and restores them on rollback", async () => {
+  it("requires a restart when an extension-owned CommonJS entry is loaded", async () => {
     // Given
     const root = await temporaryDirectory();
     const helperPath = join(root, "helper.cjs");
@@ -30,17 +31,12 @@ describe("beginCommonJsReloadTransaction", () => {
     expect(require.cache[helperPath]).toBeDefined();
 
     // When
-    const transaction = beginCommonJsReloadTransaction([root]);
-    const evicted = require.cache[helperPath];
-    await writeFile(helperPath, 'module.exports = { marker: "two" };\n');
-    const reloaded: unknown = require(helperPath);
-    transaction.rollback();
-    const restored: unknown = require(helperPath);
+    const reload = () => beginCommonJsReloadTransaction([root]);
 
     // Then
-    expect(evicted).toBeUndefined();
-    expect(reloaded).toMatchObject({ marker: "two" });
-    expect(restored).toBe(original);
+    expect(reload).toThrow(restartRequiredPattern);
+    expect(require.cache[helperPath]).toBeDefined();
+    expect(require(helperPath)).toBe(original);
   });
 
   it("leaves node_modules entries untouched", async () => {
@@ -58,5 +54,15 @@ describe("beginCommonJsReloadTransaction", () => {
     // Then
     expect(require.cache[dependencyPath]).toBeDefined();
     expect(require(dependencyPath)).toBe(dependency);
+  });
+
+  it("requires a restart for CommonJS loaded only by the staged candidate", async () => {
+    const root = await temporaryDirectory();
+    const candidatePath = join(root, "candidate.cjs");
+
+    expect(() =>
+      beginCommonJsReloadTransaction([root], [candidatePath])
+    ).toThrow(restartRequiredPattern);
+    expect(require.cache[candidatePath]).toBeUndefined();
   });
 });

--- a/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-module-graph.ts
@@ -77,34 +77,24 @@ export function ensureReloadModuleGraphHooks(): void {
 }
 
 export interface CommonJsReloadTransaction {
-  /** Restore the pre-reload cache so a failed reload cannot hand the live
-   * runtime freshly re-executed CommonJS helper instances. */
+  /** Kept for the reload transaction API; CommonJS cache is never mutated. */
   rollback(): void;
 }
 
 /**
- * Evict extension-owned CommonJS modules cached under the given roots so
- * cache-busted ESM imports re-execute `.cjs` helpers, snapshotting the
- * evicted entries first. The ESM resolve hook cannot reach the CommonJS
- * cache because Node keys it by filesystem path rather than URL.
+ * Refuse a live reload when extension-owned CommonJS modules are cached.
+ * Evicting process-wide `require.cache` entries can contaminate the still
+ * active runtime, so CommonJS changes require a process restart. ESM reload
+ * remains supported by the graph-propagation hook above.
  *
  * Pass loose-module directories and managed package roots explicitly;
  * `node_modules` trees nested below a root (real dependencies) are left
  * untouched for the same reasons the ESM hook skips them.
  *
- * Known limitation: the CommonJS cache is process-wide, so between eviction
- * and a failed reload's rollback the still-active previous runtime could
- * observe a freshly re-executed helper through a *lazy* `require()` issued
- * during that window. Modules loaded during activation keep their original
- * references and are unaffected. The staging pass in `reload-staging.ts`
- * narrows the window to commit-time failures: candidates are first imported
- * in an isolated worker module context, so a candidate that cannot even
- * load never triggers eviction here at all. Remaining commit-time failures
- * (for example an activation error after a clean import) still rely on the
- * snapshot/rollback below.
  */
 export function beginCommonJsReloadTransaction(
-  roots: readonly string[]
+  roots: readonly string[],
+  candidateCommonJsPaths: readonly string[] = []
 ): CommonJsReloadTransaction {
   const require = createRequire(import.meta.url);
   const prefixes = roots.map((root) =>
@@ -117,27 +107,17 @@ export function beginCommonJsReloadTransaction(
         !key.slice(prefix.length).includes(`${sep}node_modules${sep}`) &&
         !key.slice(prefix.length).startsWith(`node_modules${sep}`)
     );
-  const snapshot = new Map<string, NodeJS.Module>();
-  for (const key of Object.keys(require.cache)) {
-    if (!owned(key)) {
-      continue;
+  for (const key of [
+    ...Object.keys(require.cache),
+    ...candidateCommonJsPaths,
+  ]) {
+    if (owned(key)) {
+      throw new Error(
+        `Extension reload requires a restart because CommonJS module "${key}" is loaded`
+      );
     }
-    const entry = require.cache[key];
-    if (entry !== undefined) {
-      snapshot.set(key, entry);
-    }
-    delete require.cache[key];
   }
   return {
-    rollback: () => {
-      for (const key of Object.keys(require.cache)) {
-        if (owned(key)) {
-          delete require.cache[key];
-        }
-      }
-      for (const [key, entry] of snapshot) {
-        require.cache[key] = entry;
-      }
-    },
+    rollback: () => undefined,
   };
 }

--- a/apps/coding-agent/src/extensions/manager/reload-staging.test.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-staging.test.ts
@@ -83,6 +83,18 @@ describe("beginExtensionStagingSession", () => {
     expect(Reflect.get(globalThis, marker)).toBeUndefined();
   });
 
+  it("reports CommonJS modules introduced by a candidate graph", async () => {
+    await writeModule("helper.cjs", "module.exports = {};\n");
+    const specifier = await writeModule(
+      "uses-commonjs.mjs",
+      'import "./helper.cjs"; export default () => {};'
+    );
+
+    await session.importer(specifier);
+
+    expect(session.commonJsPaths()).toContain(join(root, "helper.cjs"));
+  });
+
   it("rejects imports after disposal", async () => {
     const specifier = await writeModule("late.mjs", "export default () => {};");
     await session.dispose();

--- a/apps/coding-agent/src/extensions/manager/reload-staging.ts
+++ b/apps/coding-agent/src/extensions/manager/reload-staging.ts
@@ -19,6 +19,8 @@ import type { ImportExtensionModule } from "./types";
  * execution for keeping the live module graph untouched on failure.
  */
 export interface ExtensionStagingSession {
+  /** CommonJS modules loaded while evaluating candidate graphs. */
+  commonJsPaths(): readonly string[];
   /** Terminates the staging worker. Safe to call multiple times. */
   dispose(): Promise<void>;
   /** Imports a specifier in the staging worker and returns a stub. */
@@ -26,6 +28,7 @@ export interface ExtensionStagingSession {
 }
 
 interface StagingResponse {
+  readonly commonJsPaths?: readonly string[];
   readonly id?: string;
   readonly message?: string;
   readonly ok: boolean;
@@ -35,14 +38,18 @@ interface StagingResponse {
 
 const STAGING_WORKER_SOURCE = `
 const { parentPort } = require("node:worker_threads");
+const baselineCommonJs = new Set(Object.keys(require.cache));
 parentPort.on("message", ({ requestId, specifier }) => {
   import(specifier).then((namespace) => {
+    const commonJsPaths = Object.keys(require.cache).filter(
+      (path) => !baselineCommonJs.has(path)
+    );
     const candidate =
       namespace !== null && typeof namespace === "object" && "default" in namespace
         ? namespace.default
         : namespace;
     if (typeof candidate === "function") {
-      parentPort.postMessage({ ok: true, requestId, shape: "factory" });
+      parentPort.postMessage({ commonJsPaths, ok: true, requestId, shape: "factory" });
       return;
     }
     if (
@@ -53,13 +60,14 @@ parentPort.on("message", ({ requestId, specifier }) => {
     ) {
       parentPort.postMessage({
         id: candidate.id,
+        commonJsPaths,
         ok: true,
         requestId,
         shape: "extension",
       });
       return;
     }
-    parentPort.postMessage({ ok: true, requestId, shape: "invalid" });
+    parentPort.postMessage({ commonJsPaths, ok: true, requestId, shape: "invalid" });
   }, (error) => {
     parentPort.postMessage({
       message:
@@ -86,6 +94,7 @@ export function beginExtensionStagingSession(): ExtensionStagingSession {
   >();
   let nextRequestId = 0;
   let terminated = false;
+  const commonJsPaths = new Set<string>();
 
   const syncRef = (): void => {
     if (terminated) {
@@ -145,10 +154,14 @@ export function beginExtensionStagingSession(): ExtensionStagingSession {
         `Staged extension import failed for ${specifier}: ${response.message ?? "unknown error"}`
       );
     }
+    for (const path of response.commonJsPaths ?? []) {
+      commonJsPaths.add(path);
+    }
     return stubNamespace(response);
   };
 
   return {
+    commonJsPaths: () => [...commonJsPaths],
     dispose: async () => {
       terminated = true;
       failAllPending(new Error("Extension staging session is disposed"));

--- a/apps/coding-agent/src/extensions/manager/settings.ts
+++ b/apps/coding-agent/src/extensions/manager/settings.ts
@@ -1,19 +1,13 @@
 import { randomUUID } from "node:crypto";
-import {
-  mkdir,
-  open,
-  readFile,
-  rename,
-  stat,
-  unlink,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import { withProcessFileLock } from "@minpeter/pss-runtime/platform/file";
 import { z } from "zod";
 import type { ExtensionSettingsEntry } from "./types";
 
 /** In-process serialization per settings path (complements cross-process lockfile). */
 const settingsQueues = new Map<string, Promise<unknown>>();
+const operationQueues = new Map<string, Promise<unknown>>();
 
 const targetSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("module"), path: z.string().min(1) }),
@@ -110,7 +104,12 @@ export async function withExtensionSettingsLock<Result>(
   settingsQueues.set(path, queued);
   await previous.catch(() => undefined);
   try {
-    return await withExclusiveLockfile(`${path}.lock`, run);
+    return await withProcessFileLock(
+      `${path}.lock`,
+      "extension settings",
+      run,
+      { timeoutMs: SETTINGS_LOCK_WAIT_MS }
+    );
   } finally {
     release();
     if (settingsQueues.get(path) === queued) {
@@ -119,47 +118,34 @@ export async function withExtensionSettingsLock<Result>(
   }
 }
 
-const LOCK_STALE_MS = 30_000;
-const LOCK_WAIT_MS = 10_000;
-
-async function withExclusiveLockfile<Result>(
-  lockPath: string,
+/** Serialize the entire package/settings transaction for one install root. */
+export async function withExtensionOperationLock<Result>(
+  installRoot: string,
   run: () => Promise<Result>
 ): Promise<Result> {
-  await mkdir(dirname(lockPath), { mode: 0o700, recursive: true });
-  const started = Date.now();
-  let handle: Awaited<ReturnType<typeof open>> | undefined;
-  while (handle === undefined) {
-    try {
-      handle = await open(lockPath, "wx");
-    } catch (error) {
-      if (!hasErrorCode(error, "EEXIST")) {
-        throw error;
-      }
-      try {
-        const info = await stat(lockPath);
-        if (Date.now() - info.mtimeMs > LOCK_STALE_MS) {
-          await unlink(lockPath).catch(() => undefined);
-          continue;
-        }
-      } catch {
-        // lock disappeared; retry create
-      }
-      if (Date.now() - started > LOCK_WAIT_MS) {
-        throw new Error(
-          `Timed out acquiring extension settings lock: ${lockPath}`
-        );
-      }
-      await new Promise((resolve) => setTimeout(resolve, 15));
+  const lockPath = `${installRoot}.operation.lock`;
+  const previous = operationQueues.get(lockPath) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.catch(() => undefined).then(() => gate);
+  operationQueues.set(lockPath, queued);
+  await previous.catch(() => undefined);
+  try {
+    return await withProcessFileLock(lockPath, "extension operation", run, {
+      timeoutMs: OPERATION_LOCK_WAIT_MS,
+    });
+  } finally {
+    release();
+    if (operationQueues.get(lockPath) === queued) {
+      operationQueues.delete(lockPath);
     }
   }
-  try {
-    return await run();
-  } finally {
-    await handle.close().catch(() => undefined);
-    await unlink(lockPath).catch(() => undefined);
-  }
 }
+
+const SETTINGS_LOCK_WAIT_MS = 10_000;
+const OPERATION_LOCK_WAIT_MS = 15 * 60_000;
 
 export async function readTrustedProjects(
   path: string
@@ -184,6 +170,18 @@ export async function writeTrustedProjects(
   await writeJsonAtomically(path, {
     projects: [...projects],
     schemaVersion: 1,
+  });
+}
+
+export async function addTrustedProject(
+  path: string,
+  project: string
+): Promise<void> {
+  await withExtensionSettingsLock(path, async () => {
+    const projects = await readTrustedProjects(path);
+    if (!projects.includes(project)) {
+      await writeTrustedProjects(path, [...projects, project]);
+    }
   });
 }
 

--- a/apps/worker-agent/src/session/session-events.test.ts
+++ b/apps/worker-agent/src/session/session-events.test.ts
@@ -62,6 +62,7 @@ describe("session SSE event stream", () => {
           })
         );
       },
+      reconnect: { delay: () => Promise.resolve(), random: () => 1 },
       token: "secret",
     });
     const iterator = stream[Symbol.asyncIterator]();
@@ -82,6 +83,112 @@ describe("session SSE event stream", () => {
     ).toBeNull();
     expect(new URL(requests[1]?.url ?? "").searchParams.get("after")).toBe("0");
     await iterator.return?.();
+  });
+
+  it("paces repeated empty reconnects with capped exponential backoff", async () => {
+    const delays: number[] = [];
+    let requests = 0;
+    const iterator = streamRemoteSessionEvents({
+      channel: { id: "local", kind: "tui" },
+      endpoint: "https://worker.example/session/events",
+      fetch: () => {
+        requests += 1;
+        return Promise.resolve(
+          new Response(requests === 4 ? formatSseEvent(firstEvent) : "")
+        );
+      },
+      reconnect: {
+        delay: (ms) => {
+          delays.push(ms);
+          return Promise.resolve();
+        },
+        initialDelayMs: 100,
+        maxDelayMs: 400,
+        random: () => 1,
+      },
+    })[Symbol.asyncIterator]();
+
+    await expect(withTimeout(iterator.next())).resolves.toEqual({
+      done: false,
+      value: firstEvent,
+    });
+    expect(delays).toEqual([100, 200, 400]);
+    await iterator.return?.();
+  });
+
+  it("preserves the cursor across empty reconnects", async () => {
+    const after: (string | null)[] = [];
+    const bodies = [
+      formatSseEvent(firstEvent),
+      "",
+      formatSseEvent(secondEvent),
+    ];
+    const iterator = streamRemoteSessionEvents({
+      channel: { id: "local", kind: "tui" },
+      endpoint: "https://worker.example/session/events",
+      fetch: (request) => {
+        after.push(new URL(request.url).searchParams.get("after"));
+        return Promise.resolve(new Response(bodies.shift()));
+      },
+      reconnect: { delay: () => Promise.resolve(), random: () => 1 },
+    })[Symbol.asyncIterator]();
+
+    await iterator.next();
+    await iterator.next();
+    expect(after).toEqual([null, "0", "0"]);
+    await iterator.return?.();
+  });
+
+  it("resets backoff after yielding an event", async () => {
+    const delays: number[] = [];
+    const bodies = [
+      "",
+      formatSseEvent(firstEvent),
+      "",
+      formatSseEvent(secondEvent),
+    ];
+    const iterator = streamRemoteSessionEvents({
+      channel: { id: "local", kind: "tui" },
+      endpoint: "https://worker.example/session/events",
+      fetch: () => Promise.resolve(new Response(bodies.shift())),
+      reconnect: {
+        delay: (ms) => {
+          delays.push(ms);
+          return Promise.resolve();
+        },
+        initialDelayMs: 100,
+        random: () => 1,
+      },
+    })[Symbol.asyncIterator]();
+
+    await iterator.next();
+    await iterator.next();
+    expect(delays).toEqual([100, 100, 200]);
+    await iterator.return?.();
+  });
+
+  it("stops without reconnecting when aborted during backoff", async () => {
+    const abort = new AbortController();
+    let requests = 0;
+    const iterator = streamRemoteSessionEvents({
+      channel: { id: "local", kind: "tui" },
+      endpoint: "https://worker.example/session/events",
+      fetch: () => {
+        requests += 1;
+        return Promise.resolve(new Response(""));
+      },
+      reconnect: { initialDelayMs: 60_000, random: () => 1 },
+      signal: abort.signal,
+    })[Symbol.asyncIterator]();
+
+    const next = iterator.next();
+    await Promise.resolve();
+    abort.abort();
+    await expect(withTimeout(next)).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(requests).toBe(1);
   });
 });
 

--- a/apps/worker-agent/src/session/session-remote.ts
+++ b/apps/worker-agent/src/session/session-remote.ts
@@ -12,43 +12,117 @@ interface RemoteSessionEventStreamConfig {
   readonly channel: SubmitTurnRequest["channel"];
   readonly endpoint: string;
   readonly fetch?: (request: Request) => Promise<Response>;
+  /** Overrides used to make reconnect pacing deterministic in tests. */
+  readonly reconnect?: {
+    readonly initialDelayMs?: number;
+    readonly maxDelayMs?: number;
+    readonly random?: () => number;
+    readonly delay?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  };
   readonly sessionScopeKey?: string;
   readonly signal?: AbortSignal;
   readonly token?: string;
 }
+
+const DEFAULT_RECONNECT_INITIAL_DELAY_MS = 250;
+const DEFAULT_RECONNECT_MAX_DELAY_MS = 10_000;
 
 export async function* streamRemoteSessionEvents(
   config: RemoteSessionEventStreamConfig
 ): AsyncIterable<StoredThreadEvent> {
   const fetchSessionEvents = config.fetch ?? ((request) => fetch(request));
   let cursor = config.after;
+  let reconnectAttempt = 0;
 
   while (!config.signal?.aborted) {
-    const url = new URL(config.endpoint);
-    url.searchParams.set("channel", serializeSessionChannel(config.channel));
-    if (cursor) {
-      url.searchParams.set("after", serializeThreadEventCursor(cursor));
-    }
-    if (config.sessionScopeKey) {
-      url.searchParams.set("sessionScopeKey", config.sessionScopeKey);
-    }
-    const request = new Request(url, {
-      headers: {
-        accept: "text/event-stream",
-        ...(config.token ? { authorization: `Bearer ${config.token}` } : {}),
-      },
-      ...(config.signal ? { signal: config.signal } : {}),
-    });
+    const request = createSessionEventRequest(config, cursor);
     const response = await fetchSessionEvents(request);
     if (!response.ok) {
       throw new RemoteSessionEventStreamError(response.status);
     }
 
+    let madeProgress = false;
     for await (const event of decodeSessionEventStream(response)) {
+      madeProgress = true;
       cursor = event.cursor;
       yield event;
     }
+
+    // A successful response alone is not evidence that the connection was
+    // healthy: an intermediary can repeatedly return an immediately closed
+    // 200 response. Only an event resets the reconnect pacing.
+    if (madeProgress) {
+      reconnectAttempt = 0;
+    }
+    if (!(await waitForReconnect(config, reconnectAttempt))) {
+      return;
+    }
+    reconnectAttempt += 1;
   }
+}
+
+function createSessionEventRequest(
+  config: RemoteSessionEventStreamConfig,
+  cursor: ThreadEventCursor | undefined
+): Request {
+  const url = new URL(config.endpoint);
+  url.searchParams.set("channel", serializeSessionChannel(config.channel));
+  if (cursor) {
+    url.searchParams.set("after", serializeThreadEventCursor(cursor));
+  }
+  if (config.sessionScopeKey) {
+    url.searchParams.set("sessionScopeKey", config.sessionScopeKey);
+  }
+  return new Request(url, {
+    headers: {
+      accept: "text/event-stream",
+      ...(config.token ? { authorization: `Bearer ${config.token}` } : {}),
+    },
+    ...(config.signal ? { signal: config.signal } : {}),
+  });
+}
+
+async function waitForReconnect(
+  config: RemoteSessionEventStreamConfig,
+  attempt: number
+): Promise<boolean> {
+  const initialDelayMs =
+    config.reconnect?.initialDelayMs ?? DEFAULT_RECONNECT_INITIAL_DELAY_MS;
+  const maxDelayMs =
+    config.reconnect?.maxDelayMs ?? DEFAULT_RECONNECT_MAX_DELAY_MS;
+  const exponentialDelay = Math.min(maxDelayMs, initialDelayMs * 2 ** attempt);
+  const random = config.reconnect?.random ?? Math.random;
+  const delayMs = Math.floor(exponentialDelay * (0.5 + random() * 0.5));
+  try {
+    await (config.reconnect?.delay ?? abortableDelay)(delayMs, config.signal);
+    return true;
+  } catch (error) {
+    if (config.signal?.aborted) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(
+      signal.reason ?? new DOMException("Aborted", "AbortError")
+    );
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(finish, ms);
+    signal?.addEventListener("abort", abort, { once: true });
+
+    function finish() {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }
+    function abort() {
+      clearTimeout(timeout);
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    }
+  });
 }
 
 async function* decodeSessionEventStream(

--- a/packages/runtime/src/platform/file/index.ts
+++ b/packages/runtime/src/platform/file/index.ts
@@ -30,6 +30,7 @@ export type {
 } from "./host/scheduled-work-types";
 export { FileAttachmentStore } from "./storage/file-attachment-store";
 export { FileExecutionStore } from "./storage/file-execution-store";
+export { withProcessFileLock } from "./storage/file-lock";
 export {
   type FileThreadInspection,
   type FileThreadInspectionCompaction,

--- a/packages/runtime/src/platform/file/storage/file-execution-store.test.ts
+++ b/packages/runtime/src/platform/file/storage/file-execution-store.test.ts
@@ -213,7 +213,7 @@ describe("FileExecutionStore", () => {
     });
   });
 
-  it("keeps long transaction locks fresh while direct thread writes wait", async () => {
+  it("does not reclaim a live transaction lock regardless of its mtime", async () => {
     const directory = await tempDir();
     const store = new FileExecutionStore(directory);
     const transactionStarted = createDeferred();

--- a/packages/runtime/src/platform/file/storage/file-execution-store.ts
+++ b/packages/runtime/src/platform/file/storage/file-execution-store.ts
@@ -24,6 +24,11 @@ import {
 } from "./file-execution-store/lock";
 import { createFileExecutionStorePorts } from "./file-execution-store/ports";
 
+/**
+ * A file-backed store for processes on one host using a local filesystem.
+ * Its locking relies on host PIDs and local atomic filesystem operations; do
+ * not share the directory between hosts or over a network filesystem.
+ */
 export class FileExecutionStore implements HostStore {
   readonly checkpoints: CheckpointStore;
   readonly events: EventStore;

--- a/packages/runtime/src/platform/file/storage/file-execution-store/lock.ts
+++ b/packages/runtime/src/platform/file/storage/file-execution-store/lock.ts
@@ -1,14 +1,5 @@
-import { mkdir, rm, stat, utimes } from "node:fs/promises";
-import { dirname } from "node:path";
-import { clearInterval, setInterval } from "node:timers";
-import { setTimeout } from "node:timers/promises";
-import { isNodeError } from "../../../../internal/guards";
+import { withProcessFileLock } from "../file-lock";
 import type { FileExecutionLock } from "./types";
-
-const LOCK_HEARTBEAT_INTERVAL_MS = 100;
-const LOCK_POLL_INTERVAL_MS = 10;
-const LOCK_STALE_AFTER_MS = 30_000;
-const LOCK_TIMEOUT_MS = 5000;
 
 type LockMode = "auto" | "held";
 
@@ -27,66 +18,5 @@ export async function withFileLock<T>(
   owner: string,
   fn: () => Promise<T>
 ): Promise<T> {
-  await acquireFileLock(lockDirectory, owner);
-  const heartbeat = setInterval(() => {
-    refreshFileLock(lockDirectory).catch(() => undefined);
-  }, LOCK_HEARTBEAT_INTERVAL_MS);
-  try {
-    return await fn();
-  } finally {
-    clearInterval(heartbeat);
-    await rm(lockDirectory, { force: true, recursive: true });
-  }
-}
-
-async function acquireFileLock(
-  lockDirectory: string,
-  owner: string
-): Promise<void> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < LOCK_TIMEOUT_MS) {
-    try {
-      await mkdir(dirname(lockDirectory), { recursive: true });
-      await mkdir(lockDirectory);
-      return;
-    } catch (error) {
-      if (!(isNodeError(error) && error.code === "EEXIST")) {
-        throw error;
-      }
-      await removeStaleLock(lockDirectory);
-    }
-
-    await setTimeout(LOCK_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(
-    `Timed out waiting for ${owner} lock ${JSON.stringify(lockDirectory)}`
-  );
-}
-
-async function removeStaleLock(lockDirectory: string): Promise<void> {
-  try {
-    const stats = await stat(lockDirectory);
-    if (Date.now() - stats.mtimeMs < LOCK_STALE_AFTER_MS) {
-      return;
-    }
-    await rm(lockDirectory, { force: true, recursive: true });
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return;
-    }
-    throw error;
-  }
-}
-
-async function refreshFileLock(lockDirectory: string): Promise<void> {
-  const now = new Date();
-  try {
-    await utimes(lockDirectory, now, now);
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return;
-    }
-    throw error;
-  }
+  return await withProcessFileLock(lockDirectory, owner, fn);
 }

--- a/packages/runtime/src/platform/file/storage/file-lock.test.ts
+++ b/packages/runtime/src/platform/file/storage/file-lock.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { withProcessFileLock } from "./file-lock";
+
+describe("process file lock", () => {
+  it("reclaims a definitely dead owner", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pss-lock-"));
+    const lock = join(directory, "lock");
+    await writeFile(
+      lock,
+      JSON.stringify({ pid: 2_147_483_647, token: "dead" })
+    );
+
+    await expect(
+      withProcessFileLock(lock, "test", async () => "acquired")
+    ).resolves.toBe("acquired");
+  });
+
+  it("does not release a successor whose acquisition token differs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pss-lock-"));
+    const lock = join(directory, "lock");
+    const successor = { pid: process.pid, token: "successor" };
+
+    await withProcessFileLock(lock, "test", async () => {
+      await rm(lock);
+      await writeFile(lock, JSON.stringify(successor));
+    });
+
+    await expect(readFile(lock, "utf8")).resolves.toBe(
+      JSON.stringify(successor)
+    );
+  });
+
+  it("recovers a reaping marker whose owner is dead", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pss-lock-"));
+    const lock = join(directory, "lock");
+    await writeFile(
+      `${lock}.reaping`,
+      JSON.stringify({ pid: 2_147_483_647, token: "dead-reaper" })
+    );
+
+    await expect(
+      withProcessFileLock(lock, "test", async () => "acquired")
+    ).resolves.toBe("acquired");
+  });
+});

--- a/packages/runtime/src/platform/file/storage/file-lock.ts
+++ b/packages/runtime/src/platform/file/storage/file-lock.ts
@@ -1,0 +1,165 @@
+import { randomUUID } from "node:crypto";
+import { link, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { setTimeout } from "node:timers/promises";
+import { isNodeError } from "../../../internal/guards";
+
+const POLL_INTERVAL_MS = 10;
+const LOCK_TIMEOUT_MS = 5000;
+
+interface LockOwner {
+  readonly pid: number;
+  readonly token: string;
+}
+
+/**
+ * A process-owned lock for a single host and local filesystem. This is not a
+ * distributed lock: PID liveness and local atomic link/unlink semantics are
+ * required. Locks never expire; a live (including stopped) process retains
+ * ownership, and only an owner whose PID is definitely absent is reclaimed.
+ */
+export async function withProcessFileLock<T>(
+  lockFile: string,
+  label: string,
+  fn: () => Promise<T>,
+  options: { readonly timeoutMs?: number } = {}
+): Promise<T> {
+  const owner = await acquireProcessFileLock(
+    lockFile,
+    label,
+    options.timeoutMs ?? LOCK_TIMEOUT_MS
+  );
+  try {
+    return await fn();
+  } finally {
+    await releaseProcessFileLock(lockFile, owner);
+  }
+}
+
+async function acquireProcessFileLock(
+  lockFile: string,
+  label: string,
+  timeoutMs: number
+): Promise<LockOwner> {
+  const owner = { pid: process.pid, token: randomUUID() };
+  const startedAt = Date.now();
+  await mkdir(dirname(lockFile), { recursive: true });
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const reapingFile = `${lockFile}.reaping`;
+    if (await lockIsOwned(reapingFile)) {
+      await setTimeout(POLL_INTERVAL_MS);
+      continue;
+    }
+    try {
+      await publishOwner(lockFile, owner);
+      // A reaper which was already in flight excludes this acquisition. The
+      // token check makes dropping this attempt owner-safe.
+      if (await lockIsOwned(reapingFile)) {
+        await releaseProcessFileLock(lockFile, owner);
+      } else {
+        return owner;
+      }
+    } catch (error) {
+      if (!(isNodeError(error) && error.code === "EEXIST")) {
+        throw error;
+      }
+      await reclaimDeadOwner(lockFile);
+    }
+    await setTimeout(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out waiting for ${label} lock ${JSON.stringify(lockFile)}`
+  );
+}
+
+async function reclaimDeadOwner(lockFile: string): Promise<void> {
+  const observed = await readOwner(lockFile);
+  if (!observed || isProcessPossiblyAlive(observed.pid)) {
+    return;
+  }
+
+  const reapingFile = `${lockFile}.reaping`;
+  const reaper = { pid: process.pid, token: randomUUID() };
+  try {
+    await publishOwner(reapingFile, reaper);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "EEXIST") {
+      return;
+    }
+    throw error;
+  }
+
+  try {
+    const current = await readOwner(lockFile);
+    if (
+      current?.token === observed.token &&
+      current.pid === observed.pid &&
+      !isProcessPossiblyAlive(current.pid)
+    ) {
+      await rm(lockFile, { force: true });
+    }
+  } finally {
+    await releaseProcessFileLock(reapingFile, reaper);
+  }
+}
+
+async function publishOwner(lockFile: string, owner: LockOwner): Promise<void> {
+  const tempFile = `${lockFile}.${owner.pid}.${owner.token}.tmp`;
+  try {
+    await writeFile(tempFile, JSON.stringify(owner), { flag: "wx" });
+    await link(tempFile, lockFile);
+  } finally {
+    await rm(tempFile, { force: true }).catch(() => undefined);
+  }
+}
+
+async function lockIsOwned(lockFile: string): Promise<boolean> {
+  const owner = await readOwner(lockFile);
+  if (!owner) {
+    return false;
+  }
+  if (isProcessPossiblyAlive(owner.pid)) {
+    return true;
+  }
+  await releaseProcessFileLock(lockFile, owner);
+  return false;
+}
+
+async function releaseProcessFileLock(
+  lockFile: string,
+  owner: LockOwner
+): Promise<void> {
+  const current = await readOwner(lockFile);
+  if (current?.pid === owner.pid && current.token === owner.token) {
+    await rm(lockFile, { force: true });
+  }
+}
+
+async function readOwner(lockFile: string): Promise<LockOwner | null> {
+  try {
+    const value = JSON.parse(
+      await readFile(lockFile, "utf8")
+    ) as Partial<LockOwner>;
+    return typeof value.pid === "number" && typeof value.token === "string"
+      ? { pid: value.pid, token: value.token }
+      : null;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return null;
+    }
+    if (error instanceof SyntaxError) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function isProcessPossiblyAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !(isNodeError(error) && error.code === "ESRCH");
+  }
+}

--- a/packages/runtime/src/platform/file/storage/file-thread-store.test.ts
+++ b/packages/runtime/src/platform/file/storage/file-thread-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -116,13 +116,14 @@ describe("FileThreadStore", () => {
     ]);
   });
 
-  it("clears stale lock directories before committing", async () => {
+  it("reclaims a lock only when its owning PID is dead", async () => {
     const dir = await tempDir();
     const key = "stale";
     const lockDirectory = join(dir, `${threadFileName(key)}.lock`);
-    await mkdir(lockDirectory);
-    const staleTime = new Date(Date.now() - 60_000);
-    await utimes(lockDirectory, staleTime, staleTime);
+    await writeFile(
+      lockDirectory,
+      JSON.stringify({ pid: 2_147_483_647, token: "dead-owner" })
+    );
 
     await expect(
       new FileThreadStore(dir).commit(

--- a/packages/runtime/src/platform/file/storage/file-thread-store.ts
+++ b/packages/runtime/src/platform/file/storage/file-thread-store.ts
@@ -1,18 +1,19 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { setTimeout } from "node:timers/promises";
 import type {
   CommitResult,
   StoredThread,
   ThreadStore,
   ThreadStoreCommit,
 } from "../../../thread/store/types";
+import { withProcessFileLock } from "./file-lock";
 
-const LOCK_POLL_INTERVAL_MS = 10;
-const LOCK_STALE_AFTER_MS = 30_000;
-const LOCK_TIMEOUT_MS = 5000;
-
+/**
+ * A file-backed store for processes on one host using a local filesystem.
+ * Its locking relies on host PIDs and local atomic filesystem operations; do
+ * not share the directory between hosts or over a network filesystem.
+ */
 export class FileThreadStore implements ThreadStore {
   readonly #directory: string;
 
@@ -49,50 +50,48 @@ export class FileThreadStore implements ThreadStore {
     const file = this.#fileForKey(key);
     const lockDirectory = `${file}.lock`;
     await mkdir(dirname(file), { recursive: true });
-    await acquireFileLock(lockDirectory);
-    try {
-      const current = await this.load(key);
-      const currentVersion = current?.version ?? null;
+    return await withProcessFileLock(
+      lockDirectory,
+      "FileThreadStore",
+      async () => {
+        const current = await this.load(key);
+        const currentVersion = current?.version ?? null;
 
-      if (options.expectedVersion !== currentVersion) {
-        return { ok: false, reason: "conflict" };
+        if (options.expectedVersion !== currentVersion) {
+          return { ok: false, reason: "conflict" };
+        }
+
+        const version = String((Number(current?.version ?? "0") || 0) + 1);
+        const payload: StoredThread = structuredClone({
+          state: next.state,
+          version,
+        });
+        const tempFile = `${file}.${process.pid}.${randomUUID()}.tmp`;
+
+        try {
+          await writeFile(
+            tempFile,
+            `${JSON.stringify(payload, null, 2)}\n`,
+            "utf8"
+          );
+          await rename(tempFile, file);
+        } catch (error) {
+          await rm(tempFile, { force: true }).catch(() => undefined);
+          throw error;
+        }
+
+        return { ok: true, version };
       }
-
-      const version = String((Number(current?.version ?? "0") || 0) + 1);
-      const payload: StoredThread = structuredClone({
-        state: next.state,
-        version,
-      });
-      const tempFile = `${file}.${process.pid}.${randomUUID()}.tmp`;
-
-      try {
-        await writeFile(
-          tempFile,
-          `${JSON.stringify(payload, null, 2)}\n`,
-          "utf8"
-        );
-        await rename(tempFile, file);
-      } catch (error) {
-        await rm(tempFile, { force: true }).catch(() => undefined);
-        throw error;
-      }
-
-      return { ok: true, version };
-    } finally {
-      await rm(lockDirectory, { force: true, recursive: true });
-    }
+    );
   }
 
   async delete(key: string): Promise<void> {
     const file = this.#fileForKey(key);
     const lockDirectory = `${file}.lock`;
     await mkdir(dirname(file), { recursive: true });
-    await acquireFileLock(lockDirectory);
-    try {
+    await withProcessFileLock(lockDirectory, "FileThreadStore", async () => {
       await rm(file, { force: true });
-    } finally {
-      await rm(lockDirectory, { force: true, recursive: true });
-    }
+    });
   }
 
   #fileForKey(key: string): string {
@@ -128,41 +127,3 @@ import {
   isNodeError,
   isPlainRecord as isRecord,
 } from "../../../internal/guards";
-
-async function acquireFileLock(lockDirectory: string): Promise<void> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < LOCK_TIMEOUT_MS) {
-    try {
-      await mkdir(lockDirectory);
-      return;
-    } catch (error) {
-      if (!(isNodeError(error) && error.code === "EEXIST")) {
-        throw error;
-      }
-      await removeStaleLock(lockDirectory);
-    }
-
-    await setTimeout(LOCK_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(
-    `Timed out waiting for FileThreadStore lock ${JSON.stringify(
-      lockDirectory
-    )}`
-  );
-}
-
-async function removeStaleLock(lockDirectory: string): Promise<void> {
-  try {
-    const stats = await stat(lockDirectory);
-    if (Date.now() - stats.mtimeMs < LOCK_STALE_AFTER_MS) {
-      return;
-    }
-    await rm(lockDirectory, { force: true, recursive: true });
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return;
-    }
-    throw error;
-  }
-}


### PR DESCRIPTION
## Summary
- replace expiring file leases with PID/token-owned local locks
- serialize and compensate extension package/settings mutations
- supervise npm subprocesses and isolate CommonJS reload staging
- add paced, abort-aware SSE reconnects

## Validation
- full repository test suite ()

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens file-based ownership and makes extension install/update/remove transactional to prevent races and partial failures. Adds safer reload behavior and paced, abort-aware SSE reconnects.

- **New Features**
  - Introduced process-owned file locks (`withProcessFileLock` from `@minpeter/pss-runtime/platform/file`) and applied them to `FileThreadStore`, `FileExecutionStore`, and extension settings/operations.
  - Serialized package/settings mutations per install root to dedupe concurrent installs and avoid races.
  - Added snapshot/restore around managed package updates/removals and settings trust/enable to roll back cleanly on failure.
  - Supervised npm subprocesses: capped output (2MB), deadline with `PSS_EXTENSION_NPM_TIMEOUT_MS`, and group termination with SIGTERM→SIGKILL.
  - Refused live reload when extension-owned CommonJS is loaded; ESM graphs still hot-reload. Staging now detects CommonJS and the CLI enforces restart when needed.
  - Implemented capped exponential backoff with jitter for SSE reconnects; preserves cursor and respects aborts.

- **Migration**
  - Extensions that load CommonJS now require a process restart to apply changes; ESM-only extensions still reload live.
  - Runtime stores and extension locks assume a single host with a local filesystem; do not place these directories on network/shared filesystems.

<sup>Written for commit 0634392db2233483dedd2172e14694ddebc1421b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

