### PR TITLE
Add patch release note for ownership hardening

### DIFF
--- a/.tegami/2026-08-03-harden-runtime-ownership.md
+++ b/.tegami/2026-08-03-harden-runtime-ownership.md
@@ -1,0 +1,28 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Harden file ownership and extension mutation transactions
+
+Replace time-expiring local file leases with atomic PID/token-owned locks.
+Live processes retain ownership even while suspended, dead owners are reaped
+under a separately owned lock, and stale holders cannot release a successor's
+lock. The lock explicitly targets one host and a local filesystem rather than
+claiming distributed-filesystem safety.
+
+Serialize each extension scope's install, update, remove, enable, and trust
+mutations through one operation owner. Package updates validate before
+mutation and restore a single install-root snapshot if any package or final
+settings commit fails; failed removals likewise restore package bytes before
+restoring settings, and failed project trust restores the prior enabled state.
+Package-manager subprocesses now have bounded output, a configurable deadline,
+and process-group SIGTERM/SIGKILL escalation.
+
+Reload staging now rejects candidate graphs that introduce CommonJS modules
+before importing them into the live process. Existing extension-owned
+CommonJS cache entries return a restart-required result instead of attempting
+unsafe process-wide cache eviction, while ESM reload remains supported.


### PR DESCRIPTION
## Summary
- add a Tegami patch entry for @minpeter/pss-runtime
- add a Tegami patch entry for @minpeter/pss-coding-agent
- document file-lock, extension transaction, subprocess, and reload changes

## Validation
- full repository test suite ()
- 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Tegami patch release notes for `@minpeter/pss-runtime` and `@minpeter/pss-coding-agent`. The notes document hardened local PID/token file locks, serialized extension mutations with rollback, bounded package-manager subprocesses with escalation, and safer reload staging (CJS requires restart; ESM reload supported).

<sup>Written for commit 963a0dad1438b170ceb1e148632c97e2b0427d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

