### PR TITLE
Complete extension transaction compensation

### DIFF
--- a/.tegami/2026-08-03-harden-runtime-ownership.md
+++ b/.tegami/2026-08-03-harden-runtime-ownership.md
@@ -11,8 +11,9 @@ packages:
 Replace time-expiring local file leases with atomic PID/token-owned locks.
 Live processes retain ownership even while suspended, dead owners are reaped
 under a separately owned lock, and stale holders cannot release a successor's
-lock. The lock explicitly targets one host and a local filesystem rather than
-claiming distributed-filesystem safety.
+lock. The lock explicitly targets one shared PID namespace and a local
+filesystem rather than claiming cross-container or distributed-filesystem
+safety.
 
 Serialize each extension scope's install, update, remove, enable, and trust
 mutations through one operation owner. Package updates validate before
@@ -20,9 +21,9 @@ mutation and restore a single install-root snapshot if any package or final
 settings commit fails; failed removals likewise restore package bytes before
 restoring settings, and failed project trust restores the prior enabled state.
 Package-manager subprocesses now have bounded output, a configurable deadline,
-and process-group SIGTERM/SIGKILL escalation.
+and process-group SIGTERM/SIGKILL escalation where supported.
 
-Reload staging now rejects candidate graphs that introduce CommonJS modules
-before importing them into the live process. Existing extension-owned
+Reload staging now rejects candidate graphs that introduce extension-owned
+CommonJS modules before importing them into the live process. Existing
 CommonJS cache entries return a restart-required result instead of attempting
 unsafe process-wide cache eviction, while ESM reload remains supported.

--- a/apps/coding-agent/src/extension-cli.integration.test.ts
+++ b/apps/coding-agent/src/extension-cli.integration.test.ts
@@ -191,13 +191,9 @@ describe("extension management CLI", () => {
       // Then
       expect(result.code).toBe(1);
       expect(result.output).toContain("default export must be a function");
-      const managed = JSON.parse(
-        await readFile(
-          join(fixture.home, ".pss", "extensions", "package.json"),
-          "utf8"
-        )
-      );
-      expect(managed.dependencies ?? {}).not.toHaveProperty("invalid-package");
+      await expect(
+        access(join(fixture.home, ".pss", "extensions"))
+      ).rejects.toThrow();
     } finally {
       await rm(fixture.root, { force: true, recursive: true });
     }

--- a/apps/coding-agent/src/extensions/manager/install-trust.test.ts
+++ b/apps/coding-agent/src/extensions/manager/install-trust.test.ts
@@ -160,4 +160,96 @@ describe("extension installation transaction", () => {
       extensions: [{ id: "demo" }],
     });
   });
+
+  it("restores package bytes when npm fails after a partial mutation", async () => {
+    const root = await mkdtemp(
+      join(tmpdir(), "pss-extension-install-partial-")
+    );
+    cleanupRoots.push(root);
+    const cwd = join(root, "project");
+    const home = join(root, "home");
+    await mkdir(cwd, { recursive: true });
+    const context = { cwd, home, scope: "global" as const };
+    const paths = await extensionScopePaths(context);
+    const originalPackageJson = `${JSON.stringify({
+      dependencies: { existing: "1.0.0" },
+      private: true,
+    })}\n`;
+    await mkdir(join(paths.installRoot, "node_modules", "existing"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(paths.installRoot, "package.json"),
+      originalPackageJson,
+      "utf8"
+    );
+    await writeFile(
+      join(paths.installRoot, "node_modules", "existing", "index.js"),
+      "original\n",
+      "utf8"
+    );
+    const runCommand: RunExtensionCommand = async () => {
+      await writeFile(
+        join(paths.installRoot, "package.json"),
+        JSON.stringify({ dependencies: { demo: "1.0.0" } }),
+        "utf8"
+      );
+      await mkdir(join(paths.installRoot, "node_modules", "demo"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(paths.installRoot, "node_modules", "demo", "partial.js"),
+        "partial\n",
+        "utf8"
+      );
+      return { code: 1, stderr: "partial install failure", stdout: "" };
+    };
+
+    await expect(
+      installExtension({
+        ...context,
+        enabled: true,
+        runCommand,
+        source: "demo@1.0.0",
+      })
+    ).rejects.toThrow("partial install failure");
+
+    await expect(
+      readFile(join(paths.installRoot, "package.json"), "utf8")
+    ).resolves.toBe(originalPackageJson);
+    await expect(
+      readFile(
+        join(paths.installRoot, "node_modules", "existing", "index.js"),
+        "utf8"
+      )
+    ).resolves.toBe("original\n");
+    await expect(
+      access(join(paths.installRoot, "node_modules", "demo"))
+    ).rejects.toThrow();
+  });
+
+  it("removes a newly created package root when its first install fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-install-new-"));
+    cleanupRoots.push(root);
+    const cwd = join(root, "project");
+    const home = join(root, "home");
+    await mkdir(cwd, { recursive: true });
+    const context = { cwd, home, scope: "global" as const };
+    const paths = await extensionScopePaths(context);
+
+    await expect(
+      installExtension({
+        ...context,
+        enabled: true,
+        runCommand: async () => ({
+          code: 1,
+          stderr: "first install failure",
+          stdout: "",
+        }),
+        source: "demo@1.0.0",
+      })
+    ).rejects.toThrow("first install failure");
+
+    await expect(access(paths.installRoot)).rejects.toThrow();
+  });
 });

--- a/apps/coding-agent/src/extensions/manager/install.ts
+++ b/apps/coding-agent/src/extensions/manager/install.ts
@@ -1,9 +1,11 @@
 import { trustProject } from "./activation";
 import { loadExtensionTarget } from "./module-loader";
 import {
+  discardInstallRootSnapshot,
   type InstalledExtensionPackage,
   installExtensionPackage,
-  rollbackExtensionPackage,
+  restoreInstallRoot,
+  snapshotInstallRoot,
 } from "./package-installer";
 import { extensionScopePaths } from "./paths";
 import {
@@ -52,12 +54,16 @@ async function installExtensionOwned(
   if (knownId !== undefined) {
     validateAvailableExtensionId(knownId, document.extensions);
   }
-  const installation = await installManagedExtensionPackage(
-    context,
-    parsedSource,
-    paths.installRoot
-  );
+  const backup =
+    parsedSource.kind === "package"
+      ? await snapshotInstallRoot(paths.installRoot)
+      : undefined;
   try {
+    const installation = await installManagedExtensionPackage(
+      context,
+      parsedSource,
+      paths.installRoot
+    );
     return await recordExtensionInstallation({
       context,
       document,
@@ -67,12 +73,22 @@ async function installExtensionOwned(
       settingsPath: paths.settingsPath,
     });
   } catch (error) {
-    return await rollbackFailedInstallation(
-      context,
-      paths.installRoot,
-      installation,
-      error
-    );
+    if (backup === undefined) {
+      throw error;
+    }
+    try {
+      await restoreInstallRoot(paths.installRoot, backup);
+    } catch (restoreError) {
+      throw new AggregateError(
+        [error, restoreError],
+        "Extension installation and package root restore both failed"
+      );
+    }
+    throw error;
+  } finally {
+    if (backup !== undefined) {
+      await discardInstallRootSnapshot(backup);
+    }
   }
 }
 
@@ -179,32 +195,6 @@ async function recordExtensionInstallation({
     }
   }
   return entry;
-}
-
-async function rollbackFailedInstallation(
-  context: ExtensionManagerContext,
-  installRoot: string,
-  installation: InstalledExtensionPackage | undefined,
-  error: unknown
-): Promise<never> {
-  if (installation === undefined) {
-    throw error;
-  }
-  try {
-    await rollbackExtensionPackage({
-      installRoot,
-      installed: installation,
-      ...(context.runCommand === undefined
-        ? {}
-        : { runCommand: context.runCommand }),
-    });
-  } catch (rollbackError) {
-    throw new AggregateError(
-      [error, rollbackError],
-      "Extension installation and rollback both failed"
-    );
-  }
-  throw error;
 }
 
 function validateAvailableExtensionId(

--- a/apps/coding-agent/src/extensions/manager/manager-remove.test.ts
+++ b/apps/coding-agent/src/extensions/manager/manager-remove.test.ts
@@ -129,4 +129,52 @@ describe("managed extension removal", () => {
       expect.objectContaining({ id: "demo" }),
     ]);
   });
+
+  it("does not change settings when package snapshot preparation fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pss-extension-remove-prepare-"));
+    cleanupRoots.push(root);
+    const cwd = join(root, "project");
+    const home = join(root, "home");
+    await mkdir(cwd, { recursive: true });
+    const paths = await extensionScopePaths({ cwd, home, scope: "global" });
+    await mkdir(paths.installRoot, { recursive: true });
+    await writeFile(join(paths.installRoot, "unreadable"), "content\n");
+    await writeExtensionSettings(paths.settingsPath, {
+      extensions: [
+        {
+          enabled: true,
+          id: "demo",
+          installedAt: "2026-08-03T00:00:00.000Z",
+          source: "demo@1.0.0",
+          sourceKind: "npm",
+          target: { kind: "package", packageName: "demo" },
+        },
+      ],
+      values: {},
+    });
+    const invocations: string[][] = [];
+    await chmod(paths.installRoot, 0o000);
+    try {
+      await expect(
+        removeExtension({
+          cwd,
+          home,
+          id: "demo",
+          runCommand: (_command, args) => {
+            invocations.push([...args]);
+            return Promise.resolve({ code: 0, stderr: "", stdout: "" });
+          },
+          scope: "global",
+        })
+      ).rejects.toThrow();
+    } finally {
+      await chmod(paths.installRoot, 0o700);
+    }
+
+    expect(invocations).toEqual([]);
+    const persisted = JSON.parse(await readFile(paths.settingsPath, "utf8"));
+    expect(persisted.extensions).toEqual([
+      expect.objectContaining({ id: "demo" }),
+    ]);
+  });
 });

--- a/apps/coding-agent/src/extensions/manager/manager.ts
+++ b/apps/coding-agent/src/extensions/manager/manager.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from "node:crypto";
-import { cp, mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadExtensionTarget } from "./module-loader";
 import {
+  discardInstallRootSnapshot,
   installExtensionPackage,
   removeExtensionPackage,
+  restoreInstallRoot,
+  snapshotInstallRoot,
 } from "./package-installer";
 import { extensionScopePaths } from "./paths";
 import {
@@ -36,62 +39,71 @@ async function removeExtensionOwned(
   context: ExtensionManagerContext & { readonly id: string },
   paths: Awaited<ReturnType<typeof extensionScopePaths>>
 ): Promise<ExtensionSettingsEntry> {
-  let removed: ExtensionSettingsEntry | undefined;
-  let remainingPackages: readonly ExtensionSettingsEntry[] = [];
-  await updateExtensionSettings(paths.settingsPath, (document) => {
-    const entry = document.extensions.find((item) => item.id === context.id);
-    if (entry === undefined) {
-      throw new Error(`Extension "${context.id}" is not installed`);
-    }
-    removed = entry;
-    remainingPackages = document.extensions.filter(
-      (item) => item.id !== entry.id
+  const document = await readExtensionSettings(paths.settingsPath);
+  const entry = document.extensions.find((item) => item.id === context.id);
+  if (entry === undefined) {
+    throw new Error(`Extension "${context.id}" is not installed`);
+  }
+  const remainingPackages = document.extensions.filter(
+    (item) => item.id !== entry.id
+  );
+  const packageName =
+    entry.target.kind === "package" ? entry.target.packageName : undefined;
+  const removePackage =
+    packageName !== undefined &&
+    !remainingPackages.some(
+      (item) =>
+        item.target.kind === "package" &&
+        item.target.packageName === packageName
     );
-    return {
-      ...document,
-      extensions: remainingPackages,
-    };
-  });
-  const entry = removed as ExtensionSettingsEntry;
-  if (entry.target.kind === "package") {
-    const packageName = entry.target.packageName;
-    if (
-      !remainingPackages.some(
-        (item) =>
-          item.target.kind === "package" &&
-          item.target.packageName === packageName
-      )
-    ) {
-      const backup = await snapshotInstallRoot(paths.installRoot);
-      try {
-        await removeExtensionPackage({
-          installRoot: paths.installRoot,
-          packageName,
-          ...(context.runCommand === undefined
-            ? {}
-            : { runCommand: context.runCommand }),
-        });
-      } catch (error) {
-        try {
-          await restoreInstallRoot(paths.installRoot, backup.root);
-          await updateExtensionSettings(paths.settingsPath, (latest) => ({
-            ...latest,
-            extensions: latest.extensions.some(
-              (candidate) => candidate.id === entry.id
-            )
-              ? latest.extensions
-              : [...latest.extensions, entry],
-          }));
-        } catch (restoreError) {
-          throw new AggregateError(
-            [error, restoreError],
-            `Extension "${entry.id}" removal and settings restore both failed`
-          );
-        }
-        throw error;
-      } finally {
-        await rm(backup.parent, { force: true, recursive: true });
+  const backup = removePackage
+    ? await snapshotInstallRoot(paths.installRoot)
+    : undefined;
+  let settingsRemoved = false;
+  try {
+    await updateExtensionSettings(paths.settingsPath, (latest) => {
+      if (!latest.extensions.some((item) => item.id === entry.id)) {
+        throw new Error(`Extension "${entry.id}" is not installed`);
       }
+      return {
+        ...latest,
+        extensions: latest.extensions.filter((item) => item.id !== entry.id),
+      };
+    });
+    settingsRemoved = true;
+    if (removePackage && packageName !== undefined) {
+      await removeExtensionPackage({
+        installRoot: paths.installRoot,
+        packageName,
+        ...(context.runCommand === undefined
+          ? {}
+          : { runCommand: context.runCommand }),
+      });
+    }
+  } catch (error) {
+    if (!(settingsRemoved && backup)) {
+      throw error;
+    }
+    try {
+      await restoreInstallRoot(paths.installRoot, backup);
+      await updateExtensionSettings(paths.settingsPath, (latest) => ({
+        ...latest,
+        extensions: latest.extensions.some(
+          (candidate) => candidate.id === entry.id
+        )
+          ? latest.extensions
+          : [...latest.extensions, entry],
+      }));
+    } catch (restoreError) {
+      throw new AggregateError(
+        [error, restoreError],
+        `Extension "${entry.id}" removal and settings restore both failed`
+      );
+    }
+    throw error;
+  } finally {
+    if (backup) {
+      await discardInstallRootSnapshot(backup);
     }
   }
   return entry;
@@ -154,7 +166,7 @@ async function updateExtensionsOwned(
     await commitSettings();
   } catch (error) {
     try {
-      await restoreInstallRoot(paths.installRoot, backup.root);
+      await restoreInstallRoot(paths.installRoot, backup);
     } catch (restoreError) {
       throw new AggregateError(
         [error, restoreError],
@@ -163,7 +175,7 @@ async function updateExtensionsOwned(
     }
     throw error;
   } finally {
-    await rm(backup.parent, { force: true, recursive: true });
+    await discardInstallRootSnapshot(backup);
   }
   return updated;
 }
@@ -251,23 +263,6 @@ async function applyManagedPackageUpdate(
     installRoot,
     target,
   });
-}
-
-async function snapshotInstallRoot(
-  installRoot: string
-): Promise<{ readonly parent: string; readonly root: string }> {
-  const parent = await mkdtemp(join(tmpdir(), "pss-extension-backup-"));
-  const root = join(parent, "managed");
-  await cp(installRoot, root, { recursive: true });
-  return { parent, root };
-}
-
-async function restoreInstallRoot(
-  installRoot: string,
-  backupRoot: string
-): Promise<void> {
-  await rm(installRoot, { force: true, recursive: true });
-  await cp(backupRoot, installRoot, { recursive: true });
 }
 
 async function validatePackageUpdate(

--- a/apps/coding-agent/src/extensions/manager/package-installer.test.ts
+++ b/apps/coding-agent/src/extensions/manager/package-installer.test.ts
@@ -150,4 +150,47 @@ describe("managed extension package installation", () => {
       }
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "waits for SIGTERM-resistant descendants before settling a timeout",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "pss-extension-timeout-"));
+      cleanupRoots.push(root);
+      const descendantStarted = join(root, "descendant-started");
+      const delayedWrite = join(root, "descendant-wrote");
+      const descendantScript = [
+        'const { writeFileSync } = require("node:fs")',
+        `writeFileSync(${JSON.stringify(descendantStarted)}, "started")`,
+        'process.on("SIGTERM", () => undefined)',
+        `setTimeout(() => writeFileSync(${JSON.stringify(delayedWrite)}, "late"), 1800)`,
+        "setInterval(() => undefined, 1000)",
+      ].join(";");
+      const parentScript = [
+        'const { spawn } = require("node:child_process")',
+        `spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], { stdio: "ignore" })`,
+        "setInterval(() => undefined, 1000)",
+      ].join(";");
+      const previousTimeout = process.env.PSS_EXTENSION_NPM_TIMEOUT_MS;
+      process.env.PSS_EXTENSION_NPM_TIMEOUT_MS = "250";
+      try {
+        const result = await defaultRunExtensionCommand(process.execPath, [
+          "-e",
+          parentScript,
+        ]);
+        await new Promise((resolve) => setTimeout(resolve, 700));
+
+        expect(result.code).toBe(1);
+        await expect(readFile(descendantStarted, "utf8")).resolves.toBe(
+          "started"
+        );
+        await expect(readFile(delayedWrite, "utf8")).rejects.toThrow();
+      } finally {
+        if (previousTimeout === undefined) {
+          delete process.env.PSS_EXTENSION_NPM_TIMEOUT_MS;
+        } else {
+          process.env.PSS_EXTENSION_NPM_TIMEOUT_MS = previousTimeout;
+        }
+      }
+    }
+  );
 });

--- a/apps/coding-agent/src/extensions/manager/package-installer.ts
+++ b/apps/coding-agent/src/extensions/manager/package-installer.ts
@@ -1,5 +1,14 @@
 import { spawn } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  cp,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { CommandResult, RunExtensionCommand } from "./types";
 
@@ -11,6 +20,7 @@ export interface InstalledExtensionPackage {
 const DEFAULT_NPM_TIMEOUT_MS = 120_000;
 const MAX_COMMAND_OUTPUT = 2_000_000;
 const TERMINATION_GRACE_MS = 1000;
+const TERMINATION_POLL_MS = 10;
 
 export const defaultRunExtensionCommand: RunExtensionCommand = (
   command,
@@ -34,33 +44,62 @@ export const defaultRunExtensionCommand: RunExtensionCommand = (
     let stderr = "";
     let settled = false;
     let timedOut = false;
+    let childClosed = false;
     let forceTimer: ReturnType<typeof setTimeout> | undefined;
+    let terminationPoll: ReturnType<typeof setInterval> | undefined;
     const append = (current: string, chunk: string): string =>
       (current + chunk).slice(-MAX_COMMAND_OUTPUT);
-    const kill = (signal: NodeJS.Signals) => {
+    const timedOutResult = (): CommandResult => ({
+      code: 1,
+      stderr: stderr || `npm command timed out after ${timeoutMs}ms`,
+      stdout,
+    });
+    const processGroupIsAlive = (): boolean => {
+      if (process.platform === "win32" || child.pid === undefined) {
+        return !childClosed;
+      }
+      try {
+        process.kill(-child.pid, 0);
+        return true;
+      } catch (error) {
+        return !hasErrorCode(error, "ESRCH");
+      }
+    };
+    const kill = (signal: NodeJS.Signals): void => {
       if (child.pid === undefined) {
+        return;
+      }
+      if (process.platform === "win32") {
+        child.kill(signal);
         return;
       }
       try {
         process.kill(-child.pid, signal);
-      } catch {
+      } catch (error) {
+        if (hasErrorCode(error, "ESRCH")) {
+          return;
+        }
         child.kill(signal);
       }
     };
-    const terminate = () => {
-      kill("SIGTERM");
-      forceTimer = setTimeout(() => {
-        kill("SIGKILL");
-        settle({
-          code: 1,
-          stderr: stderr || `npm command timed out after ${timeoutMs}ms`,
-          stdout,
-        });
-      }, TERMINATION_GRACE_MS);
-    };
     const timer = setTimeout(() => {
       timedOut = true;
-      terminate();
+      kill("SIGTERM");
+      forceTimer = setTimeout(() => {
+        if (processGroupIsAlive()) {
+          kill("SIGKILL");
+        }
+        if (terminationPoll === undefined) {
+          terminationPoll = setInterval(() => {
+            if (childClosed && !processGroupIsAlive()) {
+              settle(timedOutResult());
+            }
+          }, TERMINATION_POLL_MS);
+        }
+        if (childClosed && !processGroupIsAlive()) {
+          settle(timedOutResult());
+        }
+      }, TERMINATION_GRACE_MS);
     }, timeoutMs);
     const settle = (result: CommandResult) => {
       if (settled) {
@@ -70,6 +109,9 @@ export const defaultRunExtensionCommand: RunExtensionCommand = (
       clearTimeout(timer);
       if (forceTimer !== undefined) {
         clearTimeout(forceTimer);
+      }
+      if (terminationPoll !== undefined) {
+        clearInterval(terminationPoll);
       }
       resolvePromise(result);
     };
@@ -85,7 +127,11 @@ export const defaultRunExtensionCommand: RunExtensionCommand = (
       settle({ code: 1, stderr: error.message, stdout });
     });
     child.on("close", (code) => {
+      childClosed = true;
       if (timedOut) {
+        if (!processGroupIsAlive()) {
+          settle(timedOutResult());
+        }
         return;
       }
       settle({
@@ -95,6 +141,52 @@ export const defaultRunExtensionCommand: RunExtensionCommand = (
       });
     });
   });
+
+export interface InstallRootSnapshot {
+  readonly existed: boolean;
+  readonly parent: string;
+  readonly root: string;
+}
+
+export async function snapshotInstallRoot(
+  installRoot: string
+): Promise<InstallRootSnapshot> {
+  const parent = await mkdtemp(join(tmpdir(), "pss-extension-backup-"));
+  const root = join(parent, "managed");
+  try {
+    try {
+      await lstat(installRoot);
+    } catch (error) {
+      if (!hasErrorCode(error, "ENOENT")) {
+        throw error;
+      }
+      return { existed: false, parent, root };
+    }
+    await cp(installRoot, root, { recursive: true });
+    return { existed: true, parent, root };
+  } catch (error) {
+    await rm(parent, { force: true, recursive: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function restoreInstallRoot(
+  installRoot: string,
+  snapshot: InstallRootSnapshot
+): Promise<void> {
+  await rm(installRoot, { force: true, recursive: true });
+  if (snapshot.existed) {
+    await cp(snapshot.root, installRoot, { recursive: true });
+  }
+}
+
+export async function discardInstallRootSnapshot(
+  snapshot: InstallRootSnapshot
+): Promise<void> {
+  await rm(snapshot.parent, { force: true, recursive: true }).catch(
+    () => undefined
+  );
+}
 
 export async function installExtensionPackage({
   installRoot,

--- a/packages/runtime/src/platform/file/storage/file-lock.ts
+++ b/packages/runtime/src/platform/file/storage/file-lock.ts
@@ -13,10 +13,11 @@ interface LockOwner {
 }
 
 /**
- * A process-owned lock for a single host and local filesystem. This is not a
- * distributed lock: PID liveness and local atomic link/unlink semantics are
- * required. Locks never expire; a live (including stopped) process retains
- * ownership, and only an owner whose PID is definitely absent is reclaimed.
+ * A process-owned lock for one shared PID namespace and local filesystem. This
+ * is not a distributed or cross-container lock: shared PID visibility and
+ * local atomic link/unlink semantics are required. Locks never expire; a live
+ * (including stopped) process retains ownership, and only an owner whose PID
+ * is definitely absent is reclaimed.
  */
 export async function withProcessFileLock<T>(
   lockFile: string,


### PR DESCRIPTION
## Summary
- wait for POSIX package-manager process groups to quiesce after timeout
- snapshot and restore the complete install root for every failed install
- prepare removal snapshots before committing settings mutations
- narrow file-lock and release-note platform guarantees

## Validation
- Oracle follow-up review: approved
- full repository test suite ()
- coding-agent typecheck
- Ultracite and 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make extension installs, updates, and removals fully transactional to prevent partial state. We snapshot the install root, restore on failure, and harden command timeouts with POSIX process-group handling where supported.

- **Bug Fixes**
  - Snapshot and restore the entire install root on failed installs/updates/removals; first-time failed installs remove the newly created root.
  - Do not change settings if snapshot preparation fails; if package removal fails after settings change, restore both package bytes and settings.
  - Command runner enforces bounded output and a configurable timeout with SIGTERM→SIGKILL escalation and process-group waits (POSIX only).

- **Refactors**
  - Centralized `snapshotInstallRoot`, `restoreInstallRoot`, and `discardInstallRootSnapshot` in `package-installer`; replaced per-install rollback with root snapshots.
  - Tightened `file-lock` guarantees to a shared PID namespace and local filesystems only.

<sup>Written for commit 343116bd06f42b82032eaeffab24a0795dcccfc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

