### PR TITLE
Document the PR Tegami policy

### DIFF
--- a/.tegami/2026-08-03-document-pr-tegami-policy.md
+++ b/.tegami/2026-08-03-document-pr-tegami-policy.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Document the pull request Tegami policy
+
+Require pull requests to include a concise Tegami entry before merge and use
+patch-level releases by default unless another release level is requested.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Pull Requests
+
+- Before merging a pull request, add a Tegami entry with a concise 1–3 line summary of the change.
+- Use a patch-level release unless the pull request or user explicitly specifies a different release level.


### PR DESCRIPTION
## Summary
- require a concise 1–3 line Tegami entry before merging pull requests
- default Tegami releases to patch level unless otherwise requested

## Testing
- `pnpm test` (Node 24)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the PR Tegami policy: every PR must include a concise 1–3 line Tegami entry before merge, and releases default to patch unless a different level is requested.
Added `AGENTS.md` with the policy and a Tegami entry marking a patch release for `npm:@minpeter/pss-runtime`.

<sup>Written for commit 4e5c0c5717eaa948c6864575233e2f3b0bcf9a9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

