### PR TITLE
chore: configure Amp orb lifecycle

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This repository has no backing services or tunnels to repair after an orb wakes.
+echo "Orb resume complete; no services require repair."

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+export PATH="$HOME/.local/bin:$PATH"
+mkdir -p "$HOME/.local/bin" "$HOME/.local/share"
+
+profile_marker="# pss-runtime orb tools"
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+  cat >> "$HOME/.bash_profile" <<'EOF'
+
+# pss-runtime orb tools
+export PATH="$HOME/.local/bin:$PATH"
+EOF
+fi
+
+node_version="$(tr -d '[:space:]' < .node-version)"
+node_major="${node_version%%.*}"
+local_node="$HOME/.local/bin/node"
+
+if [[ ! -x "$local_node" ]] || [[ "$($local_node --version 2>/dev/null || true)" != v"$node_major".* ]]; then
+  case "$(uname -m)" in
+    x86_64) node_arch="x64" ;;
+    aarch64 | arm64) node_arch="arm64" ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+  esac
+
+  echo "Installing the latest Node.js $node_major release..."
+  node_release="$(curl --fail --location --silent --show-error \
+    "https://nodejs.org/dist/latest-v${node_major}.x/SHASUMS256.txt" \
+    | sed -n "s/.*  node-\(v[^-]*\)-linux-${node_arch}\.tar\.xz/\1/p")"
+  if [[ -z "$node_release" ]]; then
+    echo "Could not resolve a Node.js $node_major release for $node_arch" >&2
+    exit 1
+  fi
+
+  archive="node-${node_release}-linux-${node_arch}.tar.xz"
+  temporary_directory="$(mktemp -d)"
+  trap 'rm -rf "$temporary_directory"' EXIT
+  curl --fail --location --silent --show-error \
+    "https://nodejs.org/dist/${node_release}/${archive}" \
+    --output "$temporary_directory/$archive"
+  curl --fail --location --silent --show-error \
+    "https://nodejs.org/dist/${node_release}/SHASUMS256.txt" \
+    --output "$temporary_directory/SHASUMS256.txt"
+  (
+    cd "$temporary_directory"
+    grep "  ${archive}$" SHASUMS256.txt | sha256sum --check --status
+  )
+
+  node_directory="$HOME/.local/share/node-v${node_major}"
+  rm -rf "$node_directory"
+  mkdir -p "$node_directory"
+  tar --extract --xz --file "$temporary_directory/$archive" \
+    --directory "$node_directory" --strip-components=1
+  for binary in node npm npx corepack; do
+    if [[ -e "$node_directory/bin/$binary" ]]; then
+      ln -sfn "$node_directory/bin/$binary" "$HOME/.local/bin/$binary"
+    fi
+  done
+  rm -rf "$temporary_directory"
+  trap - EXIT
+fi
+
+hash -r
+pnpm_spec="$(node -p "require('./package.json').packageManager")"
+pnpm_version="${pnpm_spec#pnpm@}"
+pnpm_version="${pnpm_version%%+*}"
+if [[ "$(pnpm --version 2>/dev/null || true)" != "$pnpm_version" ]]; then
+  echo "Installing pnpm $pnpm_version..."
+  npm install --global --prefix "$HOME/.local" "pnpm@$pnpm_version"
+fi
+
+if [[ ! -f .env ]]; then
+  cp -- .env.example .env
+fi
+
+echo "Installing workspace dependencies..."
+CI=1 pnpm install --frozen-lockfile
+
+echo "Orb setup complete (Node $(node --version), pnpm $(pnpm --version))."

--- a/.agents/setup
+++ b/.agents/setup
@@ -7,6 +7,14 @@ cd "$repo_root"
 export PATH="$HOME/.local/bin:$PATH"
 mkdir -p "$HOME/.local/bin" "$HOME/.local/share"
 
+if [[ ! -x /usr/bin/google-chrome ]] &&
+  [[ ! -x /usr/bin/chromium ]] &&
+  [[ ! -x /usr/bin/chromium-browser ]]; then
+  echo "Installing Chromium for LaTeX rendering tests..."
+  sudo apt-get update
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y chromium
+fi
+
 profile_marker="# pss-runtime orb tools"
 if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
   cat >> "$HOME/.bash_profile" <<'EOF'

--- a/.tegami/2026-08-03-amp-orb-setup.md
+++ b/.tegami/2026-08-03-amp-orb-setup.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Prepare fresh Amp orbs for development
+
+Install the pinned Node and pnpm toolchain, workspace dependencies, and Chromium in fresh Amp orbs, with a fast wake-up lifecycle.


### PR DESCRIPTION
## Summary
- install Node 24 and pinned pnpm dependencies in fresh Amp orbs
- install Chromium for the LaTeX rendering test suite
- add a fast, idempotent resume lifecycle and patch Tegami entry

## Validation
- `pnpm test` (two full green runs; latest post-rebase run hit one unrelated transient process-timeout test)
- `pnpm --filter @minpeter/pss-coding-agent exec vitest run src/extensions/manager/package-installer.test.ts` (focused rerun passed)
- setup run twice; clean-login toolchain and resume timing verified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure Amp orb lifecycle for reproducible setup and fast wake-ups.

- **New Features**
  - Add `.agents/setup` to install Node 24 (from `.node-version`), pin `pnpm` from `packageManager`, install Chromium for LaTeX tests, set PATH, create `.env` from example if missing, and run `pnpm install --frozen-lockfile`.
  - Add `.agents/resume` for a fast, idempotent wake-up.
  - Add Tegami release note for `@minpeter/pss-runtime`.

<sup>Written for commit 266387502ff26430ac4726e99bdb472a7a77633a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

