### PR TITLE
test(coding-agent): stabilize package timeout process startup

### DIFF
--- a/.tegami/2026-08-03-stabilize-package-timeout-test.md
+++ b/.tegami/2026-08-03-stabilize-package-timeout-test.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Stabilize package timeout testing
+
+Give spawned test processes enough startup time on loaded CI runners while preserving coverage of forced descendant termination.

--- a/apps/coding-agent/src/extensions/manager/package-installer.test.ts
+++ b/apps/coding-agent/src/extensions/manager/package-installer.test.ts
@@ -162,7 +162,7 @@ describe("managed extension package installation", () => {
         'const { writeFileSync } = require("node:fs")',
         `writeFileSync(${JSON.stringify(descendantStarted)}, "started")`,
         'process.on("SIGTERM", () => undefined)',
-        `setTimeout(() => writeFileSync(${JSON.stringify(delayedWrite)}, "late"), 1800)`,
+        `setTimeout(() => writeFileSync(${JSON.stringify(delayedWrite)}, "late"), 2500)`,
         "setInterval(() => undefined, 1000)",
       ].join(";");
       const parentScript = [
@@ -171,13 +171,14 @@ describe("managed extension package installation", () => {
         "setInterval(() => undefined, 1000)",
       ].join(";");
       const previousTimeout = process.env.PSS_EXTENSION_NPM_TIMEOUT_MS;
-      process.env.PSS_EXTENSION_NPM_TIMEOUT_MS = "250";
+      // Leave enough time for both Node processes to start on loaded CI runners.
+      process.env.PSS_EXTENSION_NPM_TIMEOUT_MS = "1000";
       try {
         const result = await defaultRunExtensionCommand(process.execPath, [
           "-e",
           parentScript,
         ]);
-        await new Promise((resolve) => setTimeout(resolve, 700));
+        await new Promise((resolve) => setTimeout(resolve, 1600));
 
         expect(result.code).toBe(1);
         await expect(readFile(descendantStarted, "utf8")).resolves.toBe(


### PR DESCRIPTION
## Summary

- give the parent and descendant Node processes enough startup time on loaded CI runners
- keep the delayed-write assertion beyond the SIGKILL grace period so descendant termination remains covered
- add a patch Tegami entry for the coding agent

## Root cause

The test used a 250ms command deadline. On the Node 26 runner, the parent process timed out before its descendant wrote the startup marker, so the assertion failed with `ENOENT` without exercising the intended process-group termination behavior.

## Verification

- Node 26: full `package-installer.test.ts` — 5/5 passed
- Node 26: affected test repeated 5 times — all passed
- Node 24: affected test repeated 3 times — all passed
- `ultracite check` on the changed test — passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the package installer timeout test to avoid startup races on slower CI while still verifying forced descendant termination. Adds a Tegami patch note for `npm:@minpeter/pss-coding-agent`.

- **Bug Fixes**
  - Raise `PSS_EXTENSION_NPM_TIMEOUT_MS` to 1000ms so parent and child Node processes can start.
  - Delay the late write to 2500ms and wait 1600ms before assertions to keep SIGKILL coverage and reduce flakiness.

- **Dependencies**
  - Add Tegami patch entry for `npm:@minpeter/pss-coding-agent`.

<sup>Written for commit 84a2423cb9c417faa42d8891fac9a5e2b16d40f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

