### PR TITLE
Increase default LaTeX display size

### DIFF
--- a/.tegami/2026-08-03-latex-display-size.md
+++ b/.tegami/2026-08-03-latex-display-size.md
@@ -1,0 +1,8 @@
+---
+packages:
+  npm:@minpeter/pss-extension-latex: patch
+---
+
+## Increase the default LaTeX display size
+
+Render display formulas at a more readable terminal size while preserving high-resolution source images and user scale overrides.

--- a/extensions/latex/src/latex-markdown.test.ts
+++ b/extensions/latex/src/latex-markdown.test.ts
@@ -23,6 +23,7 @@ const originalCells = getCellDimensions();
 const originalPath = process.env.PATH;
 const originalCache = process.env.PSS_LATEX_CACHE_DIR;
 const originalLatexSetting = process.env.PSS_LATEX;
+const originalLatexScale = process.env.PSS_LATEX_SCALE;
 const temporaryDirectories: string[] = [];
 const theme: MarkdownTheme = Object.fromEntries(
   [
@@ -61,6 +62,11 @@ afterEach(async () => {
   } else {
     process.env.PSS_LATEX = originalLatexSetting;
   }
+  if (originalLatexScale === undefined) {
+    delete process.env.PSS_LATEX_SCALE;
+  } else {
+    process.env.PSS_LATEX_SCALE = originalLatexScale;
+  }
   await Promise.all(
     temporaryDirectories
       .splice(0)
@@ -74,6 +80,7 @@ const renderFormula = async (
 ): Promise<string[]> => {
   process.env.PSS_LATEX_CACHE_DIR = cache;
   process.env.PSS_LATEX = "1";
+  process.env.PSS_LATEX_SCALE = "1";
   setCapabilities({ hyperlinks: true, images: "kitty", trueColor: true });
   setCellDimensions({ heightPx: 18, widthPx: 9 });
   let resolve!: () => void;
@@ -123,6 +130,7 @@ describe("LatexMarkdown WASM rendering", () => {
     const entries = await readdir(cache);
     expect(entries).toHaveLength(1);
     expect(first.join("\n")).toContain("\x1b_Ga=T,f=100,q=2,C=1");
+    expect(first.join("\n")).toContain("r=2");
     const second = await renderFormula("x^2+y^2=z^2", cache);
     expect(await readdir(cache)).toEqual(entries);
     expect(second.join("\n")).toContain("\x1b_Ga=T");

--- a/extensions/latex/src/latex-markdown.ts
+++ b/extensions/latex/src/latex-markdown.ts
@@ -16,7 +16,8 @@ import { formulaCjkLocale, renderMathJaxPng } from "./mathjax-renderer";
 
 const CACHE_VERSION = "mathjax-resvg-wasm-v1";
 const DEFAULT_COLOR = "#767676";
-const MATHJAX_DISPLAY_SCALE = 0.25;
+// The worker rasterizes at 48 px; display at a readable 20 px logical size.
+const MATHJAX_DISPLAY_SCALE = 5 / 12;
 const MAX_FORMULA_LENGTH = 8192;
 const MAX_PNG_BYTES = 8 * 1024 * 1024;
 const MAX_PNG_DIMENSION = 8192;


### PR DESCRIPTION
## Summary

- increase the default logical LaTeX display size from 12 px to 20 px
- preserve high-resolution source images and existing `PSS_LATEX_SCALE` overrides
- add regression coverage for the expected two-row terminal rendering
- add a patch-level Tegami entry

## Verification

- `pnpm --filter @minpeter/pss-extension-latex test`
- `pnpm --filter @minpeter/pss-extension-latex typecheck`
- `pnpm exec ultracite check extensions/latex/src/latex-markdown.ts extensions/latex/src/latex-markdown.test.ts`
- `pnpm exec vitest run scripts/tegami-config.test.mjs`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the default LaTeX display size from 12 px to 20 px for clearer terminal rendering in `@minpeter/pss-extension-latex`.
Preserves high‑resolution source images and respects existing `PSS_LATEX_SCALE` overrides; adds a regression test for two-row output and a patch-level Tegami entry.

<sup>Written for commit da9f2e26765713bfca493d07a45de91ab8a3be5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

