### PR TITLE
fix(coding-agent): speed up resume autocomplete

### DIFF
--- a/.tegami/2026-08-03-resume-autocomplete.md
+++ b/.tegami/2026-08-03-resume-autocomplete.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+---
+
+## Improve resume autocomplete responsiveness
+
+Match displayed session labels during `/resume` completion, show progress while sessions load, and cache resumable session discovery so subsequent keystrokes respond immediately.

--- a/apps/coding-agent/src/sessions/session-manager.test.ts
+++ b/apps/coding-agent/src/sessions/session-manager.test.ts
@@ -20,8 +20,10 @@ afterEach(async () => {
 });
 
 function memoryThreadStore(): ThreadStore & {
+  readonly loadCalls: string[];
   readonly stored: Map<string, unknown>;
 } {
+  const loadCalls: string[] = [];
   const stored = new Map<string, unknown>();
   return {
     commit: (key, next, options) => {
@@ -39,10 +41,13 @@ function memoryThreadStore(): ThreadStore & {
       stored.delete(key);
       return Promise.resolve();
     },
-    load: (key) =>
-      Promise.resolve(
+    load: (key) => {
+      loadCalls.push(key);
+      return Promise.resolve(
         stored.has(key) ? { state: stored.get(key), version: "1" } : null
-      ),
+      );
+    },
+    loadCalls,
     stored,
   };
 }
@@ -212,6 +217,24 @@ describe("createSessionManager", () => {
     });
 
     expect(await sessions.listResumableSessions()).toEqual([populated]);
+  });
+
+  it("caches resumable sessions until session state changes", async () => {
+    const { manager: sessions, threads } = manager();
+    const entry = await sessions.resolveStartupSession();
+    threads.stored.set(entry.key, {
+      history: [{ content: "hello", role: "user" }],
+      schemaVersion: 1,
+    });
+
+    expect(await sessions.listResumableSessions()).toEqual([entry]);
+    expect(await sessions.listResumableSessions()).toEqual([entry]);
+    expect(threads.loadCalls).toEqual([entry.key]);
+
+    threads.stored.set(entry.key, { history: [], schemaVersion: 1 });
+    await sessions.touchSession(entry.key);
+    expect(await sessions.listResumableSessions()).toEqual([]);
+    expect(threads.loadCalls).toEqual([entry.key, entry.key]);
   });
 
   it("loads the decoded message history for a recorded session", async () => {

--- a/apps/coding-agent/src/sessions/session-manager.ts
+++ b/apps/coding-agent/src/sessions/session-manager.ts
@@ -104,6 +104,10 @@ export function createSessionManager(
   // Serialize read-modify-write cycles so concurrent commands cannot drop
   // one another's index updates.
   let queue: Promise<unknown> = Promise.resolve();
+  let resumableSessionsCache: Promise<readonly SessionIndexEntry[]> | undefined;
+  const invalidateResumableSessions = (): void => {
+    resumableSessionsCache = undefined;
+  };
   const enqueue = <Result>(
     task: (document: SessionIndexDocument) => Promise<{
       readonly document: SessionIndexDocument;
@@ -131,8 +135,9 @@ export function createSessionManager(
     setActiveSession(upsertSession(document, entry), cwd, entry.key);
 
   return {
-    createSession: (name) =>
-      enqueue((document) => {
+    createSession: (name) => {
+      invalidateResumableSessions();
+      return enqueue((document) => {
         const at = timestamp();
         const entry: SessionIndexEntry = {
           createdAt: at,
@@ -145,7 +150,8 @@ export function createSessionManager(
           document: registerActive(document, entry),
           result: entry,
         });
-      }),
+      });
+    },
     cwd,
     findSession: (query) =>
       enqueue((document) =>
@@ -155,6 +161,7 @@ export function createSessionManager(
         })
       ),
     forkSession: async (fromKey, forkOptions = {}) => {
+      invalidateResumableSessions();
       if (threads === undefined) {
         throw new Error("Forking requires thread storage.");
       }
@@ -225,8 +232,11 @@ export function createSessionManager(
       }
       return points;
     },
-    listResumableSessions: () =>
-      enqueue(async (document) => {
+    listResumableSessions: () => {
+      if (resumableSessionsCache !== undefined) {
+        return resumableSessionsCache;
+      }
+      const request = enqueue(async (document) => {
         if (threads === undefined) {
           return { document, result: [] };
         }
@@ -245,7 +255,15 @@ export function createSessionManager(
             .filter(({ hasMessages }) => hasMessages)
             .map(({ session }) => session),
         };
-      }),
+      });
+      resumableSessionsCache = request;
+      request.catch(() => {
+        if (resumableSessionsCache === request) {
+          resumableSessionsCache = undefined;
+        }
+      });
+      return request;
+    },
     listSessions: () =>
       enqueue((document) =>
         Promise.resolve({
@@ -254,6 +272,7 @@ export function createSessionManager(
         })
       ),
     removeSession: async (key) => {
+      invalidateResumableSessions();
       await enqueue((document) =>
         Promise.resolve({
           document: removeSession(document, key),
@@ -262,8 +281,9 @@ export function createSessionManager(
       );
       await threads?.delete(key);
     },
-    renameSession: (key, name) =>
-      enqueue((document) => {
+    renameSession: (key, name) => {
+      invalidateResumableSessions();
+      return enqueue((document) => {
         const existing = document.sessions.find(
           (session) => session.key === key
         );
@@ -278,9 +298,11 @@ export function createSessionManager(
           document: next,
           result: { ...existing, name, updatedAt: at },
         });
-      }),
-    resolveStartupSession: ({ name, overrideKey } = {}) =>
-      enqueue((document) => {
+      });
+    },
+    resolveStartupSession: ({ name, overrideKey } = {}) => {
+      invalidateResumableSessions();
+      return enqueue((document) => {
         const key = overrideKey ?? newSessionKey(cwd);
         const existing = document.sessions.find(
           (session) => session.key === key
@@ -304,9 +326,11 @@ export function createSessionManager(
             ? registerActive(document, entry)
             : upsertSession(document, entry);
         return Promise.resolve({ document: next, result: entry });
-      }),
-    touchSession: (key) =>
-      enqueue((document) => {
+      });
+    },
+    touchSession: (key) => {
+      invalidateResumableSessions();
+      return enqueue((document) => {
         const exists = document.sessions.some((session) => session.key === key);
         return Promise.resolve({
           document: exists
@@ -314,9 +338,11 @@ export function createSessionManager(
             : document,
           result: undefined,
         });
-      }),
-    switchToSession: (key) =>
-      enqueue((document) => {
+      });
+    },
+    switchToSession: (key) => {
+      invalidateResumableSessions();
+      return enqueue((document) => {
         const existing = document.sessions.find(
           (session) => session.key === key
         );
@@ -335,7 +361,8 @@ export function createSessionManager(
           document: next,
           result: { ...existing, updatedAt: at },
         });
-      }),
+      });
+    },
   };
 }
 

--- a/apps/coding-agent/src/tui/autocomplete.test.ts
+++ b/apps/coding-agent/src/tui/autocomplete.test.ts
@@ -55,7 +55,7 @@ describe("createAliasAwareAutocompleteProvider", () => {
     });
   });
 
-  it("restores argument completions after erasing a query", async () => {
+  it("keeps argument completions closed after erasing a query", async () => {
     const sessions = [
       { label: "untitled  #aaaaaaaa", value: "#aaaaaaaa" },
       { label: "test-ek   #bbbbbbbb", value: "test-ek" },
@@ -66,9 +66,11 @@ describe("createAliasAwareAutocompleteProvider", () => {
           description: "Resume a session",
           execute: () => ({ success: true }),
           getArgumentCompletions: async (query) =>
-            sessions.filter(({ label }) =>
-              label.toLowerCase().includes(query.toLowerCase())
-            ),
+            query.length === 0
+              ? null
+              : sessions.filter(({ label }) =>
+                  label.toLowerCase().includes(query.toLowerCase())
+                ),
           name: "resume",
         },
       ],
@@ -83,10 +85,7 @@ describe("createAliasAwareAutocompleteProvider", () => {
     });
     await expect(
       provider.getSuggestions(["/resume "], 0, 8, options)
-    ).resolves.toMatchObject({
-      items: sessions,
-      prefix: "",
-    });
+    ).resolves.toBeNull();
   });
 
   it("does not treat canonical command names as aliases", () => {

--- a/apps/coding-agent/src/tui/session-commands.test.ts
+++ b/apps/coding-agent/src/tui/session-commands.test.ts
@@ -28,6 +28,8 @@ interface FakeUiScript {
 function fakeUi(script: FakeUiScript): {
   selectLabels: string[];
   selectOptions: { label: string; value: string }[][];
+  statusClears: () => number;
+  statusMessages: string[];
   ui: CodingAgentExtensionUi;
 } {
   const selects = [...(script.selects ?? [])];
@@ -35,6 +37,8 @@ function fakeUi(script: FakeUiScript): {
   const confirms = [...(script.confirms ?? [])];
   const selectLabels: string[] = [];
   const selectOptions: { label: string; value: string }[][] = [];
+  const statusMessages: string[] = [];
+  let statusClears = 0;
   const ui: CodingAgentExtensionUi = {
     confirm: () => Promise.resolve(confirms.shift() ?? false),
     input: () => Promise.resolve(inputs.shift()),
@@ -49,9 +53,20 @@ function fakeUi(script: FakeUiScript): {
       );
       return Promise.resolve(selects.shift());
     },
-    status: () => () => undefined,
+    status: (message) => {
+      statusMessages.push(message);
+      return () => {
+        statusClears += 1;
+      };
+    },
   };
-  return { selectLabels, selectOptions, ui };
+  return {
+    selectLabels,
+    selectOptions,
+    statusClears: () => statusClears,
+    statusMessages,
+    ui,
+  };
 }
 
 function createContext(overrides?: Partial<SessionCommandContext>): {
@@ -224,6 +239,60 @@ describe("/resume", () => {
     expect(visibleWidth(label.slice(0, label.indexOf("#")))).toBe(21);
   });
 
+  it("matches unnamed sessions by their displayed untitled label", async () => {
+    const { context, manager } = createContext();
+    (
+      manager.listResumableSessions as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([entry("cwd:/work"), entry("cwd:/work#deadbeef")]);
+
+    const completions = await command(
+      context,
+      "resume"
+    ).getArgumentCompletions?.("t");
+
+    expect(completions).toEqual([
+      expect.objectContaining({
+        label: expect.stringContaining("untitled"),
+        value: "cwd:/work#deadbeef",
+      }),
+    ]);
+  });
+
+  it("does not load sessions until a search query is entered", async () => {
+    const { statusMessages, ui } = fakeUi({});
+    const { context, manager } = createContext({ ui: () => ui });
+
+    await expect(
+      command(context, "resume").getArgumentCompletions?.(" ")
+    ).resolves.toBeNull();
+    expect(manager.listResumableSessions).not.toHaveBeenCalled();
+    expect(statusMessages).toEqual([]);
+  });
+
+  it("shows loading status while session completions are pending", async () => {
+    const { statusClears, statusMessages, ui } = fakeUi({});
+    const { context, manager } = createContext({ ui: () => ui });
+    let resolveSessions: ((sessions: SessionIndexEntry[]) => void) | undefined;
+    (
+      manager.listResumableSessions as ReturnType<typeof vi.fn>
+    ).mockImplementation(
+      () =>
+        new Promise<SessionIndexEntry[]>((resolve) => {
+          resolveSessions = resolve;
+        })
+    );
+
+    const completions = command(context, "resume").getArgumentCompletions?.(
+      "t"
+    );
+
+    expect(statusMessages).toEqual(["Loading sessions..."]);
+    expect(statusClears()).toBe(0);
+    resolveSessions?.([entry("cwd:/work#deadbeef")]);
+    await completions;
+    expect(statusClears()).toBe(1);
+  });
+
   it("keeps the short id visible in long autocomplete labels", async () => {
     const { context, manager } = createContext();
     (
@@ -255,7 +324,7 @@ describe("/resume", () => {
     const completions = await command(
       context,
       "resume"
-    ).getArgumentCompletions?.("");
+    ).getArgumentCompletions?.("#");
     const hashColumns = completions?.map(({ label }) =>
       visibleWidth(label.slice(0, label.indexOf("#")))
     );

--- a/apps/coding-agent/src/tui/session-commands.ts
+++ b/apps/coding-agent/src/tui/session-commands.ts
@@ -1,5 +1,9 @@
 import type { CodingAgentExtensionUi } from "../extensions/types";
-import { sessionUpdatedLabel } from "../sessions/session-display";
+import {
+  sessionDisplayKey,
+  sessionDisplayTitle,
+  sessionUpdatedLabel,
+} from "../sessions/session-display";
 import type { SessionChangeEvent } from "../sessions/session-guards";
 import type { SessionIndexEntry } from "../sessions/session-index";
 import {
@@ -102,15 +106,28 @@ function createResumeCommand(context: SessionCommandContext): TuiCommand {
         return await resumeSession(context, entry);
       }),
     getArgumentCompletions: async (argumentPrefix) => {
-      const sessions = await context.manager.listResumableSessions();
-      const prefix = argumentPrefix.toLowerCase();
+      const prefix = argumentPrefix.trim().toLowerCase();
+      if (prefix.length === 0) {
+        return null;
+      }
+      const clearLoading = context.ui?.()?.status("Loading sessions...");
+      let sessions: readonly SessionIndexEntry[];
+      try {
+        sessions = await context.manager.listResumableSessions();
+      } finally {
+        clearLoading?.();
+      }
       const completions: TuiCommandArgumentCompletion[] = [];
       for (const session of sessions) {
         if (session.key === context.currentSession().key) {
           continue;
         }
         const value = session.name ?? session.key;
-        if (prefix.length > 0 && !value.toLowerCase().startsWith(prefix)) {
+        const matchesDisplayedValue = [
+          sessionDisplayTitle(session),
+          sessionDisplayKey(session),
+        ].some((candidate) => candidate.toLowerCase().includes(prefix));
+        if (!matchesDisplayedValue) {
           continue;
         }
         completions.push({


### PR DESCRIPTION
## Summary
- match resume completions against displayed session labels and short IDs
- avoid empty-query loading and show progress for real searches
- cache resumable-session discovery across autocomplete keystrokes

## Testing
- pnpm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the `/resume` autocomplete by caching session discovery, matching against displayed labels/short IDs, and avoiding unnecessary loads. The UI now shows a brief "Loading sessions..." message when fetching.

- **Bug Fixes**
  - Cache `listResumableSessions()` between keystrokes and invalidate on session changes.
  - Match queries against displayed titles (including "untitled") and short IDs, not only raw names.
  - Skip loading on empty queries and keep completions closed; show a loading status while fetching.
  - Added tests for cache invalidation, UI status behavior, and label/ID matching.

<sup>Written for commit e46ead915f9c1496ebb0d3c8aca3a3f8074825c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

