### PR TITLE
Add automatic session titles

### DIFF
--- a/.tegami/2026-08-03-auto-session-titles.md
+++ b/.tegami/2026-08-03-auto-session-titles.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+---
+
+## Generate titles for new coding sessions
+
+Use the active conversation model and cache-friendly first-turn context to name unnamed sessions, with a prompt-text fallback and protection for manually assigned names.

--- a/apps/coding-agent/src/sessions/session-auto-title.test.ts
+++ b/apps/coding-agent/src/sessions/session-auto-title.test.ts
@@ -1,0 +1,128 @@
+import type { LanguageModel, ModelMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import {
+  generateSessionTitle,
+  sanitizeGeneratedTitle,
+} from "./session-auto-title";
+
+const history: readonly ModelMessage[] = [
+  { content: "세션 이름을 자동으로 만들자", role: "user" },
+  { content: "첫 응답 후 제목을 생성하겠습니다.", role: "assistant" },
+];
+
+const modelWithText = (text: string, inspect?: (options: unknown) => void) =>
+  ({
+    doGenerate: (options: unknown) => {
+      inspect?.(options);
+      return Promise.resolve({
+        content: [{ text, type: "text" }],
+        finishReason: { raw: undefined, unified: "stop" },
+        usage: { inputTokens: { total: 1 }, outputTokens: { total: 1 } },
+        warnings: [],
+      });
+    },
+    doStream: () => Promise.reject(new Error("Unexpected stream")),
+    modelId: "title-test",
+    provider: "test",
+    specificationVersion: "v4",
+    supportedUrls: {},
+  }) as unknown as LanguageModel;
+
+const failingModel = {
+  doGenerate: () => Promise.reject(new Error("offline")),
+  doStream: () => Promise.reject(new Error("Unexpected stream")),
+  modelId: "title-test",
+  provider: "test",
+  specificationVersion: "v4",
+  supportedUrls: {},
+} as unknown as LanguageModel;
+
+describe("generateSessionTitle", () => {
+  it("keeps the conversation as the prompt prefix", async () => {
+    const inspect = vi.fn();
+    const title = await generateSessionTitle({
+      history,
+      instructions: "coding instructions",
+      model: modelWithText("세션 자동 제목", inspect),
+    });
+
+    expect(title).toBe("세션 자동 제목");
+    expect(inspect).toHaveBeenCalledOnce();
+    expect(inspect.mock.calls[0]?.[0]).toMatchObject({
+      maxOutputTokens: 24,
+      temperature: 0,
+    });
+    const prompt = (
+      inspect.mock.calls[0]?.[0] as { prompt: ModelMessage[] } | undefined
+    )?.prompt;
+    expect(prompt).toBeDefined();
+    if (prompt === undefined) {
+      throw new Error("Expected a generated model prompt");
+    }
+    expect(prompt[0]).toEqual({
+      content: "coding instructions",
+      role: "system",
+    });
+    expect(prompt.slice(1, history.length + 1)).toMatchObject([
+      { content: [{ text: history[0]?.content }], role: "user" },
+      { content: [{ text: history[1]?.content }], role: "assistant" },
+    ]);
+  });
+
+  it("falls back to a truncated first user message when generation fails", async () => {
+    const title = await generateSessionTitle({
+      history: [
+        {
+          content:
+            "아주 긴 사용자 요청을 바탕으로 자동 제목을 생성하지만 모델 호출에 실패한 경우에도 읽을 수 있어야 합니다",
+          role: "user",
+        },
+        { content: "응답", role: "assistant" },
+      ],
+      instructions: "coding instructions",
+      model: failingModel,
+    });
+
+    expect(title).toBe(
+      "아주 긴 사용자 요청을 바탕으로 자동 제목을 생성하지만 모델 호출에 실패한 경우에도 읽을…"
+    );
+  });
+
+  it("does not title sessions that already contain multiple user turns", async () => {
+    const inspect = vi.fn();
+    const title = await generateSessionTitle({
+      history: [
+        ...history,
+        { content: "두 번째 요청", role: "user" },
+        { content: "두 번째 응답", role: "assistant" },
+      ],
+      instructions: "coding instructions",
+      model: modelWithText("제목", inspect),
+    });
+
+    expect(title).toBeUndefined();
+    expect(inspect).not.toHaveBeenCalled();
+  });
+
+  it("uses the first message fallback when a turn has no assistant text", async () => {
+    const inspect = vi.fn();
+    const title = await generateSessionTitle({
+      history: [{ content: "도구 호출 세션", role: "user" }],
+      instructions: "coding instructions",
+      model: modelWithText("unused", inspect),
+    });
+
+    expect(title).toBe("도구 호출 세션");
+    expect(inspect).not.toHaveBeenCalled();
+  });
+});
+
+describe("sanitizeGeneratedTitle", () => {
+  it("removes common wrappers and bounds generated titles", () => {
+    expect(sanitizeGeneratedTitle('제목: **"세션 자동 제목"**\n설명')).toBe(
+      "세션 자동 제목"
+    );
+    expect(sanitizeGeneratedTitle("x".repeat(50))).toBe(`${"x".repeat(39)}…`);
+    expect(sanitizeGeneratedTitle(" \n ")).toBeUndefined();
+  });
+});

--- a/apps/coding-agent/src/sessions/session-auto-title.ts
+++ b/apps/coding-agent/src/sessions/session-auto-title.ts
@@ -1,0 +1,104 @@
+import { generateText, type LanguageModel, type ModelMessage } from "ai";
+
+const GENERATED_TITLE_MAX_LENGTH = 40;
+const FALLBACK_TITLE_MAX_LENGTH = 50;
+const FIRST_LINE_BREAK = /\r?\n/;
+const TITLE_PREFIX = /^\s*(?:title|제목)\s*:\s*/i;
+const TITLE_WRAPPER = /^(?:["'`]|\*\*)+|(?:["'`]|\*\*)+$/g;
+const WHITESPACE_RUN = /\s+/g;
+
+const TITLE_REQUEST: ModelMessage = {
+  content: [
+    "Create a concise title for the coding session above.",
+    "Use the user's language and preserve important technical names.",
+    "Use 3-7 words and at most 40 characters.",
+    "Return only the title, without quotes, markdown, or explanation.",
+  ].join("\n"),
+  role: "user",
+};
+
+export interface GenerateSessionTitleOptions {
+  readonly history: readonly ModelMessage[];
+  readonly instructions: string;
+  readonly model: LanguageModel;
+}
+
+/**
+ * Generate a title only for an initial completed turn. Keeping the original
+ * instructions and history as the request prefix lets providers reuse prompt
+ * caches when they support prefix caching.
+ */
+export async function generateSessionTitle({
+  history,
+  instructions,
+  model,
+}: GenerateSessionTitleOptions): Promise<string | undefined> {
+  const userMessages = history.filter((message) => message.role === "user");
+  if (userMessages.length !== 1) {
+    return;
+  }
+
+  const fallback = titleFromUserMessage(userMessages[0]);
+  if (!hasAssistantText(history)) {
+    return fallback;
+  }
+  try {
+    const result = await generateText({
+      instructions,
+      maxOutputTokens: 24,
+      messages: [...history, TITLE_REQUEST],
+      model,
+      temperature: 0,
+    });
+    return sanitizeGeneratedTitle(result.text) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function sanitizeGeneratedTitle(value: string): string | undefined {
+  const firstLine = value
+    .trim()
+    .split(FIRST_LINE_BREAK, 1)[0]
+    ?.replace(TITLE_PREFIX, "")
+    .replace(TITLE_WRAPPER, "")
+    .replace(WHITESPACE_RUN, " ")
+    .trim();
+  if (!firstLine) {
+    return;
+  }
+  return truncateTitle(firstLine, GENERATED_TITLE_MAX_LENGTH);
+}
+
+function hasAssistantText(history: readonly ModelMessage[]): boolean {
+  return history.some(
+    (message) =>
+      message.role === "assistant" && messageText(message).trim().length > 0
+  );
+}
+
+function titleFromUserMessage(message: ModelMessage): string | undefined {
+  const text = messageText(message).replace(WHITESPACE_RUN, " ").trim();
+  return text.length === 0
+    ? undefined
+    : truncateTitle(text, FALLBACK_TITLE_MAX_LENGTH);
+}
+
+function messageText(message: ModelMessage): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  return message.content
+    .map((part) =>
+      typeof part === "object" && part !== null && "text" in part
+        ? String(part.text)
+        : ""
+    )
+    .join(" ");
+}
+
+function truncateTitle(value: string, maxLength: number): string {
+  return value.length <= maxLength
+    ? value
+    : `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}

--- a/apps/coding-agent/src/sessions/session-manager.test.ts
+++ b/apps/coding-agent/src/sessions/session-manager.test.ts
@@ -277,6 +277,25 @@ describe("createSessionManager", () => {
     );
   });
 
+  it("sets an automatic name only while a session is unnamed", async () => {
+    const { manager: sessions } = manager();
+    const entry = await sessions.resolveStartupSession();
+    const generated = await sessions.renameSessionIfUnnamed(
+      entry.key,
+      "generated"
+    );
+    expect(generated?.name).toBe("generated");
+
+    await sessions.renameSession(entry.key, "manual");
+    expect(
+      await sessions.renameSessionIfUnnamed(entry.key, "late generation")
+    ).toBeUndefined();
+    expect((await sessions.getSession(entry.key))?.name).toBe("manual");
+    expect(
+      await sessions.renameSessionIfUnnamed("ghost", "generated")
+    ).toBeUndefined();
+  });
+
   it("removes sessions along with their durable thread state", async () => {
     const { manager: sessions, threads } = manager();
     const entry = await sessions.resolveStartupSession();

--- a/apps/coding-agent/src/sessions/session-manager.ts
+++ b/apps/coding-agent/src/sessions/session-manager.ts
@@ -80,6 +80,11 @@ export interface SessionManager {
   /** Delete a session's metadata and its durable thread state. */
   removeSession(key: string): Promise<void>;
   renameSession(key: string, name: string): Promise<SessionIndexEntry>;
+  /** Set an automatic name without overwriting a concurrent manual rename. */
+  renameSessionIfUnnamed(
+    key: string,
+    name: string
+  ): Promise<SessionIndexEntry | undefined>;
   /**
    * Resolve which thread key this startup should use. An explicit override
    * reuses that key; otherwise every process gets a new per-cwd session.
@@ -291,6 +296,23 @@ export function createSessionManager(
           return Promise.reject(
             new Error(`Unknown session ${JSON.stringify(key)}`)
           );
+        }
+        const at = timestamp();
+        const next = renameSession(document, key, name, at);
+        return Promise.resolve({
+          document: next,
+          result: { ...existing, name, updatedAt: at },
+        });
+      });
+    },
+    renameSessionIfUnnamed: (key, name) => {
+      invalidateResumableSessions();
+      return enqueue((document) => {
+        const existing = document.sessions.find(
+          (session) => session.key === key
+        );
+        if (existing === undefined || existing.name !== undefined) {
+          return Promise.resolve({ document, result: undefined });
         }
         const at = timestamp();
         const next = renameSession(document, key, name, at);

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -1151,9 +1151,13 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           sawModelUsage ? { ...turnUsage } : undefined,
           finishReason
         )
-      ).catch((error) => {
-        console.error("onTurnComplete callback failed in TUI:", error);
-      });
+      )
+        .then(() => {
+          updateHeader();
+        })
+        .catch((error) => {
+          console.error("onTurnComplete callback failed in TUI:", error);
+        });
 
       if (finishReason !== undefined) {
         addAbnormalFinishReasonMessage(finishReason);

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -33,6 +33,7 @@ import {
   createProviderObservationFetch,
   type ProviderObservationEmitter,
 } from "../provider-observation";
+import { generateSessionTitle } from "../sessions/session-auto-title";
 import {
   approveSessionChange,
   type SessionChangeEvent,
@@ -327,6 +328,7 @@ export async function startTui(
 
     const footer: { text?: string } = {};
     const usageTracker = new TokenUsageTracker();
+    const titleGenerationInFlight = new Set<string>();
 
     const renderUsageFooter = (): void => {
       footer.text = usageTracker.footerText();
@@ -344,6 +346,44 @@ export async function startTui(
         : `${base}\nsession: ${currentSession.name}`;
     };
     const header = { title: "pss", subtitle: buildSubtitle() };
+
+    const currentInstructions = (): string =>
+      [
+        composeCodingAgentInstructions(contextResources.instructionFragments),
+        ...extensionHost.instructionFragments,
+      ].join("\n\n");
+
+    const generateTitleForSession = async (
+      session: SessionIndexEntry
+    ): Promise<void> => {
+      if (
+        session.name !== undefined ||
+        titleGenerationInFlight.has(session.key)
+      ) {
+        return;
+      }
+      titleGenerationInFlight.add(session.key);
+      try {
+        const title = await generateSessionTitle({
+          history: await sessionManager.loadSessionHistory(session.key),
+          instructions: currentInstructions(),
+          model,
+        });
+        if (title === undefined) {
+          return;
+        }
+        const renamed = await sessionManager.renameSessionIfUnnamed(
+          session.key,
+          title
+        );
+        if (renamed !== undefined && currentSession.key === renamed.key) {
+          currentSession = renamed;
+          header.subtitle = buildSubtitle();
+        }
+      } finally {
+        titleGenerationInFlight.delete(session.key);
+      }
+    };
 
     const emitSessionEvent = (
       type: string,
@@ -450,9 +490,15 @@ export async function startTui(
         renderUsageFooter();
       },
       onTurnComplete: () => {
+        const completedSession = currentSession;
         // Keep /resume recency meaningful: every completed turn bumps the
         // session's updatedAt (best-effort; never surfaces to the user).
-        sessionManager.touchSession(currentSession.key).catch(() => undefined);
+        return Promise.all([
+          sessionManager
+            .touchSession(completedSession.key)
+            .catch(() => undefined),
+          generateTitleForSession(completedSession).catch(() => undefined),
+        ]).then(() => undefined);
       },
       onExtensionUiReady: async (createUi) => {
         createExtensionUiForHost = createUi;


### PR DESCRIPTION
## Summary
- generate cache-friendly titles with the active conversation model after the first turn
- fall back to the first user message and preserve manual session names
- refresh TUI session metadata and document the patch in Tegami

## Testing
- pnpm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically generate concise titles for new coding sessions after the first turn, using the active conversation model with safe fallbacks. Improves session list clarity without overwriting manual names.

- **New Features**
  - Auto-name sessions after the first completed turn using the active model; preserves user language and key technical terms.
  - Reuses the original instructions and first turn as a prompt prefix for cache-friendly requests.
  - Falls back to the first user message if generation isn’t possible; never replaces a manual name.
  - Adds `renameSessionIfUnnamed` to `SessionManager` for atomic/safe renames; TUI triggers generation on turn complete and refreshes the header.
  - Sanitizes and bounds titles (strip wrappers/prefixes, 40-char limit; fallback 50). Tests added and documented in Tegami.

<sup>Written for commit 2cdbf45d33406dd43dd2be1f85565aa3e7ecfdb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

