### PR TITLE
fix(coding-agent): avoid recounting prompt tokens

### DIFF
--- a/.tegami/2026-08-03-token-usage-footer-accounting.md
+++ b/.tegami/2026-08-03-token-usage-footer-accounting.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+---
+
+## Fix token usage footer accounting
+
+Avoid recounting cached and reasoning prompt tokens when aggregating token usage in the coding-agent footer.

--- a/apps/coding-agent/src/tui/usage-footer.test.ts
+++ b/apps/coding-agent/src/tui/usage-footer.test.ts
@@ -30,14 +30,14 @@ describe("TokenUsageTracker", () => {
     expect(tracker.footerText()).toBeUndefined();
   });
 
-  it("accumulates authoritative usage across steps", () => {
+  it("shows the latest authoritative usage without recounting prior context", () => {
     const tracker = new TokenUsageTracker();
     tracker.addUsage(usage({ inputTokens: 100, outputTokens: 20 }));
     tracker.addUsage(
       usage({ inputTokens: 900, outputTokens: 180, totalTokens: 1080 })
     );
 
-    expect(tracker.footerText()).toBe("1.2k tokens (1.0k in / 200 out)");
+    expect(tracker.footerText()).toBe("1.1k tokens (900 in / 180 out)");
   });
 
   it("shows a live estimate while the first step streams", () => {

--- a/apps/coding-agent/src/tui/usage-footer.ts
+++ b/apps/coding-agent/src/tui/usage-footer.ts
@@ -14,7 +14,7 @@ export const formatTokens = (n: number): string => {
 };
 
 /**
- * Tracks session token usage for the TUI footer.
+ * Tracks the latest model request's token usage for the TUI footer.
  *
  * Authoritative numbers come from `model-usage` events at each step end.
  * Between those, streamed output fragments feed a live estimate (prefixed
@@ -28,13 +28,13 @@ export class TokenUsageTracker {
   #outputTokens = 0;
   #totalTokens = 0;
 
-  /** Fold an authoritative per-step usage event into the session totals. */
+  /** Replace the previous step with the latest authoritative usage. */
   addUsage(usage: ModelUsage): void {
     // The finished step's live estimate is superseded by the real numbers.
     this.#estimatedChars = 0;
-    this.#inputTokens += usage.inputTokens ?? 0;
-    this.#outputTokens += usage.outputTokens ?? 0;
-    this.#totalTokens +=
+    this.#inputTokens = usage.inputTokens ?? 0;
+    this.#outputTokens = usage.outputTokens ?? 0;
+    this.#totalTokens =
       usage.totalTokens ?? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
   }
 


### PR DESCRIPTION
## Summary
- aggregate prompt tokens without recounting cached or reasoning token details
- add focused usage-footer coverage and a patch-level Tegami entry

## Tests
- `pnpm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TUI footer token accounting by using the latest step’s authoritative usage instead of accumulating across steps. This avoids double-counting cached and reasoning tokens and shows accurate in/out/total values.

- **Bug Fixes**
  - `TokenUsageTracker.addUsage` now replaces prior values instead of folding them in.
  - Updated test to assert correct footer: "1.1k tokens (900 in / 180 out)".
  - Added a Tegami patch note for `npm:@minpeter/pss-coding-agent`.

<sup>Written for commit da554c325d1f13cd2e45f6a8de2a9c31e59cedfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

