### PR TITLE
chore: add missing tegami for PR #303

### DIFF
--- a/.tegami/2026-08-04-line-id-schema-descriptions.md
+++ b/.tegami/2026-08-04-line-id-schema-descriptions.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Describe LINE#ID anchors in the edit tool schemas
+
+Add Zod field descriptions so `read_file` and `edit_file` expose the LINE#ID anchor format in their JSON Schema.
+Export `./instructions` and `./workspace-tools` subpaths for the edit-format benchmark.


### PR DESCRIPTION
#303 머지 시 누락된 Tegami 엔트리를 추가합니다. patch 레벨, `@minpeter/pss-coding-agent` 대상.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing Tegami entry for PR #303 to ship a patch for `@minpeter/pss-coding-agent` that documents LINE#ID anchors in the edit tool schemas. Adds Zod field descriptions for `read_file` and `edit_file`, and exports `./instructions` and `./workspace-tools` subpaths for the edit-format benchmark.

<sup>Written for commit d4840fc55fd313def178a766eb7d78539b7ef98a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

