### PR TITLE
fix(release): exclude private workspaces from Tegami

### DIFF
--- a/.tegami/2026-08-04-exclude-private-release-workspaces.md
+++ b/.tegami/2026-08-04-exclude-private-release-workspaces.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Keep private workspaces out of release planning
+
+Exclude every private and experimental workspace from Tegami's dependency graph so benchmark dependency bumps cannot indefinitely block coding-agent publication.

--- a/scripts/tegami-config.test.mjs
+++ b/scripts/tegami-config.test.mjs
@@ -1,5 +1,41 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+
+const releaseIgnoreBlockPattern = /const releaseIgnore = \[([\s\S]*?)\];/;
+const quotedListItemPattern = /^\s+"([^"]+)",$/gm;
+const workspaceRoots = [
+  "apps",
+  "packages",
+  "examples",
+  "experimental",
+  "extensions",
+];
+
+function readWorkspaceManifests() {
+  const paths = [
+    "package.json",
+    ...workspaceRoots.flatMap((root) =>
+      readdirSync(root, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => `${root}/${entry.name}/package.json`)
+        .filter(existsSync)
+    ),
+  ];
+
+  return paths.map((path) => ({
+    manifest: JSON.parse(readFileSync(path, "utf8")),
+    path,
+  }));
+}
+
+function readReleaseIgnore(script) {
+  const block = script.match(releaseIgnoreBlockPattern)?.[1];
+  expect(block).toBeDefined();
+
+  return new Set(
+    [...block.matchAll(quotedListItemPattern)].map((match) => match[1])
+  );
+}
 
 describe("Tegami release configuration", () => {
   it("targets the repository's next prerelease lane", () => {
@@ -20,13 +56,37 @@ describe("Tegami release configuration", () => {
     expect(script).toContain('"@minpeter/pss-extension-web"');
   });
 
-  it("excludes every private workspace from release planning", () => {
+  it("excludes every private and experimental workspace from the graph", () => {
     const script = readFileSync("scripts/tegami.mts", "utf8");
+    const ignored = readReleaseIgnore(script);
+    const expected = readWorkspaceManifests()
+      .filter(
+        ({ manifest, path }) =>
+          manifest.private === true || path.startsWith("experimental/")
+      )
+      .map(({ manifest }) => manifest.name);
 
-    expect(script).toContain('"pss-next"');
-    expect(script).toContain('"@minpeter/pss-worker-agent"');
-    expect(script).toContain('"@minpeter/pss-runtime-edge-image-qa"');
-    expect(script).toContain("/^@minpeter\\/pss-example-/");
+    expect(ignored).toEqual(new Set(expected));
+  });
+
+  it("keeps every public app and package in release planning", () => {
+    const script = readFileSync("scripts/tegami.mts", "utf8");
+    const ignored = readReleaseIgnore(script);
+    const publicAppsAndPackages = readWorkspaceManifests().filter(
+      ({ manifest, path }) =>
+        (path.startsWith("apps/") || path.startsWith("packages/")) &&
+        manifest.private !== true
+    );
+
+    expect(publicAppsAndPackages.map(({ manifest }) => manifest.name)).toEqual(
+      expect.arrayContaining([
+        "@minpeter/pss-coding-agent",
+        "@minpeter/pss-runtime",
+      ])
+    );
+    for (const { manifest } of publicAppsAndPackages) {
+      expect(ignored.has(manifest.name)).toBe(false);
+    }
   });
 
   it("removes Changesets release state", () => {

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -2,13 +2,28 @@ import { tegami } from "tegami";
 import { runCli } from "tegami/cli";
 import { github } from "tegami/plugins/github";
 
+// Tegami propagates dependency bumps through private packages unless they are
+// removed from its graph. Keep every non-release workspace explicit here; the
+// config test derives the expected list from package manifests and fails when a
+// new private or experimental workspace is not added.
+const releaseIgnore = [
+  "pss-next",
+  "@minpeter/pss-worker-agent",
+  "@minpeter/pss-bench-shared",
+  "@minpeter/pss-benchmark-compaction-score",
+  "@minpeter/pss-benchmark-nextjs",
+  "@minpeter/pss-edit-format-bench",
+  "@minpeter/pss-runtime-edge-image-qa",
+  "@minpeter/pss-example-background-subagent",
+  "@minpeter/pss-example-basic",
+  "@minpeter/pss-example-evals",
+  "@minpeter/pss-example-hooks",
+  "@minpeter/pss-example-local-file-agent",
+  "@minpeter/pss-example-sync-subagent",
+];
+
 const paper = tegami({
-  ignore: [
-    "pss-next",
-    "@minpeter/pss-worker-agent",
-    "@minpeter/pss-runtime-edge-image-qa",
-    /^@minpeter\/pss-example-/,
-  ],
+  ignore: releaseIgnore,
   npm: {
     client: "pnpm",
     trustedPublish: {


### PR DESCRIPTION
## Summary

- remove every private and experimental workspace from Tegami's dependency graph
- keep public apps, packages, and extensions eligible for release
- derive release-boundary assertions from all workspace manifests so future omissions fail CI
- add a coding-agent patch Tegami entry to recover publication on the next prerelease

## Why

Private benchmark dependency propagation repeatedly generated Version Packages PRs and prevented `@minpeter/pss-coding-agent` from reaching npm publish.

## Verification

- `pnpm exec vitest run scripts/*.test.mjs` (58 tests)
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec ultracite check scripts/tegami.mts scripts/tegami-config.test.mjs`
- `pnpm tegami check-publish` (pending lock detected)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude all private and experimental workspaces from Tegami’s release graph to stop dependency bump propagation and unblock publishing for `@minpeter/pss-coding-agent`. Public apps and packages remain eligible, and CI now enforces this boundary.

- **Bug Fixes**
  - Centralized `releaseIgnore` in `scripts/tegami.mts` and pass it to Tegami `ignore`.
  - Tests derive the ignore set from workspace `package.json` files and fail if a new private/experimental workspace isn’t listed.
  - Assert public apps and packages are included in release planning.
  - Added a Tegami patch entry to publish `@minpeter/pss-coding-agent` on the next prerelease.

<sup>Written for commit aedd0c4f597aed2c4b3f930843ecfb68ef98f696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

