### PR TITLE
fix(release): block private dependent bumps

### DIFF
--- a/.tegami/2026-08-04-prevent-private-dependent-bumps.md
+++ b/.tegami/2026-08-04-prevent-private-dependent-bumps.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Prevent private dependent version bumps
+
+Disable Tegami dependency propagation into excluded workspaces so coding-agent releases cannot mutate private benchmark versions or delay publication.

--- a/scripts/tegami-config.test.mjs
+++ b/scripts/tegami-config.test.mjs
@@ -89,6 +89,16 @@ describe("Tegami release configuration", () => {
     }
   });
 
+  it("does not propagate dependency bumps into excluded workspaces", () => {
+    const script = readFileSync("scripts/tegami.mts", "utf8");
+
+    expect(script).toContain("releaseIgnore.includes(dependent.name)");
+    expect(script).toContain('case "dependencies":');
+    expect(script).toContain('case "optionalDependencies":');
+    expect(script).toContain('case "devDependencies":');
+    expect(script).toContain('case "peerDependencies":');
+  });
+
   it("removes Changesets release state", () => {
     expect(existsSync(".changeset/config.json")).toBe(false);
   });

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -26,6 +26,22 @@ const paper = tegami({
   ignore: releaseIgnore,
   npm: {
     client: "pnpm",
+    bumpDep: ({ dependent, kind }) => {
+      if (releaseIgnore.includes(dependent.name)) {
+        return false;
+      }
+      switch (kind) {
+        case "dependencies":
+        case "optionalDependencies":
+          return "patch";
+        case "devDependencies":
+          return false;
+        case "peerDependencies":
+          return "major";
+        default:
+          return false;
+      }
+    },
     trustedPublish: {
       provider: "github",
       workflow: "release.yml",


### PR DESCRIPTION
## Summary

- disable Tegami dependency propagation into excluded private and experimental workspaces
- preserve Tegami's default bump behavior for public dependencies, optional dependencies, dev dependencies, and peer dependencies
- add regression coverage and a coding-agent patch release note

## Why

Tegami maintains an npm dependency graph separate from its core ignored graph. The default npm `bumpDep` policy could therefore still mutate a private benchmark manifest even after the workspace was excluded from release planning.

## Behavioral verification

A clean detached worktree ran:

`CI=true node scripts/tegami.mts version --no-checks`

Result:

- release plan: only `@minpeter/pss-coding-agent 0.0.14-next.9 → 0.0.14-next.10`
- changed manifests: only `apps/coding-agent/package.json`
- `experimental/pss-edit-format-bench` remained `0.0.4`

Additional checks:

- `pnpm exec vitest run scripts/tegami-config.test.mjs scripts/release-workflow.test.mjs`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec ultracite check scripts/tegami.mts scripts/tegami-config.test.mjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Tegami from bumping versions in excluded private or experimental workspaces during release.

- **Bug Fixes**
  - Add a custom `npm.bumpDep` that skips excluded dependents and preserves public bump rules: patch for `dependencies` and `optionalDependencies`, none for `devDependencies`, major for `peerDependencies`.
  - Add regression tests and a patch note for `@minpeter/pss-coding-agent`.

<sup>Written for commit eb6474740f7c35d02eecfc60282eaca648f26061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

