### PR TITLE
fix(ci): verify coding-agent installability before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,14 @@ jobs:
       - name: Verify release artifacts
         run: pnpm verify:release
 
+      - name: Verify coding-agent dependency resolution
+        run: |
+          pack_dir="$RUNNER_TEMP/coding-agent-pack"
+          install_dir="$RUNNER_TEMP/coding-agent-install"
+          mkdir -p "$pack_dir" "$install_dir"
+          pnpm --filter @minpeter/pss-coding-agent pack --pack-destination "$pack_dir"
+          npm install --package-lock-only --ignore-scripts --prefix "$install_dir" "$pack_dir"/*.tgz
+
       - name: Version or publish packages
         run: pnpm tegami ci
         env:

--- a/.tegami/2026-08-04-verify-coding-agent-installability.md
+++ b/.tegami/2026-08-04-verify-coding-agent-installability.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Verify coding-agent dependencies before publishing
+
+Pack the coding agent and resolve its registry dependencies before Tegami can publish, preventing releases that depend on missing npm packages.

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -26,8 +26,9 @@ describe("release workflow", () => {
     expect(ciWorkflow).toContain('node: ["24", "26"]');
     expect(ciWorkflow).toContain("cancel-in-progress: true");
     expect(workflow).toContain("pnpm tegami ci");
-    expect(workflow).not.toContain(
-      "Verify npm trusted publishing prerequisites"
+    expect(workflow).toContain("pnpm --filter @minpeter/pss-coding-agent pack");
+    expect(workflow).toContain(
+      "npm install --package-lock-only --ignore-scripts"
     );
     expect(workflow).not.toContain("NPM_CONFIG_PROVENANCE");
     expect(workflow).not.toContain("changesets/action");


### PR DESCRIPTION
## Summary
- pack the coding agent before Tegami runs
- resolve the packed manifest against npm without downloading package contents
- block publication when any required registry dependency is missing

## Verification
- `pnpm exec vitest run scripts/release-workflow.test.mjs scripts/tegami-config.test.mjs`
- `pnpm exec ultracite check scripts/release-workflow.test.mjs`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a preflight check that packs `@minpeter/pss-coding-agent` and verifies its registry dependencies resolve before publishing. This blocks releases when required npm packages are missing.

**Bug Fixes**
- Pack `@minpeter/pss-coding-agent` and run a lockfile-only install to confirm all registry deps resolve.
- Fail the workflow to prevent publish on resolution errors; updated tests to cover the new step.

<sup>Written for commit 9bd2d8a492206deaab2dab78140fbbd417979a99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

