### PR TITLE
Add adaptive context token accounting

### DIFF
--- a/.tegami/2026-08-04-adaptive-context-token-accounting.md
+++ b/.tegami/2026-08-04-adaptive-context-token-accounting.md
@@ -1,0 +1,14 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+  npm:@minpeter/pss-coding-agent:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+---
+
+## Add adaptive context token accounting
+
+Measure provider-visible prompts in the runtime and calibrate estimates from
+reported usage so context gating, compaction, and TUI usage stay aligned.

--- a/apps/coding-agent/src/extensions/registry.ts
+++ b/apps/coding-agent/src/extensions/registry.ts
@@ -31,6 +31,7 @@ const EXTENSION_EVENT_TYPES = Object.freeze({
   "assistant-output-delta": true,
   "assistant-reasoning": true,
   "assistant-reasoning-delta": true,
+  "context-usage": true,
   "model-usage": true,
   "runtime-input": true,
   "step-end": true,

--- a/apps/coding-agent/src/tui/agent-event-stream.test.ts
+++ b/apps/coding-agent/src/tui/agent-event-stream.test.ts
@@ -1,14 +1,14 @@
-import type { AgentEvent, ModelUsage } from "@minpeter/pss-runtime";
+import type { AgentEvent } from "@minpeter/pss-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { agentEventStreamParts } from "./agent-event-stream";
+import {
+  type AgentEventStreamOptions,
+  agentEventStreamParts,
+} from "./agent-event-stream";
 import type { TuiStreamPart } from "./stream-handlers";
 
 const collect = async (
   events: AgentEvent[],
-  options?: {
-    onModelUsage?: (usage: ModelUsage) => void;
-    onOutputDelta?: (text: string) => void;
-  }
+  options?: AgentEventStreamOptions
 ): Promise<TuiStreamPart[]> => {
   const parts: TuiStreamPart[] = [];
   const source = (async function* () {
@@ -21,33 +21,19 @@ const collect = async (
 };
 
 describe("agentEventStreamParts", () => {
-  it("forwards streamed output fragments to onOutputDelta", async () => {
-    const onOutputDelta = vi.fn();
-    await collect(
-      [
-        { type: "step-start" },
-        { type: "assistant-reasoning-delta", text: "thinking" },
-        { type: "assistant-output-delta", text: "Hello" },
-        {
-          type: "tool-call-input-start",
-          toolCallId: "call-1",
-          toolName: "bash",
-        },
-        {
-          type: "tool-call-input-delta",
-          inputTextDelta: '{"command":"ls"}',
-          toolCallId: "call-1",
-        },
-        { type: "step-end" },
-      ],
-      { onOutputDelta }
-    );
-
-    expect(onOutputDelta.mock.calls.map(([text]) => text)).toEqual([
-      "thinking",
-      "Hello",
-      '{"command":"ls"}',
-    ]);
+  it("forwards runtime context snapshots", async () => {
+    const onContextUsage = vi.fn();
+    const snapshot = {
+      calibration: { observations: 0, revision: 0 },
+      currentRequest: {
+        input: { basis: "heuristic", marginTokens: 1, tokens: 10 },
+        output: { basis: "heuristic", marginTokens: 1, tokens: 2 },
+        total: { basis: "heuristic", marginTokens: 2, tokens: 12 },
+      },
+      type: "context-usage",
+    } as const;
+    await collect([snapshot], { onContextUsage });
+    expect(onContextUsage).toHaveBeenCalledWith(snapshot);
   });
 
   it("streams assistant text deltas without replaying the committed text", async () => {

--- a/apps/coding-agent/src/tui/agent-event-stream.ts
+++ b/apps/coding-agent/src/tui/agent-event-stream.ts
@@ -1,4 +1,8 @@
-import type { AgentEvent, ModelUsage } from "@minpeter/pss-runtime";
+import type {
+  AgentEvent,
+  ContextUsageSnapshot,
+  ModelUsage,
+} from "@minpeter/pss-runtime";
 import { createTuiErrorPresentation } from "./error-presentation";
 import type { TuiStreamPart } from "./stream-handlers";
 
@@ -6,14 +10,8 @@ import type { TuiStreamPart } from "./stream-handlers";
  * Options accepted by the agent-event to stream-part adapter.
  */
 export interface AgentEventStreamOptions {
-  /** Receives every normalized model-usage event for footer/telemetry. */
+  onContextUsage?: (snapshot: ContextUsageSnapshot) => void;
   onModelUsage?: (usage: ModelUsage) => void;
-  /**
-   * Receives every streamed output text fragment (assistant text,
-   * reasoning, and tool-call input deltas) so callers can estimate live
-   * token usage between authoritative `model-usage` events.
-   */
-  onOutputDelta?: (text: string) => void;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -92,6 +90,9 @@ export async function* agentEventStreamParts(
 
   for await (const event of events) {
     switch (event.type) {
+      case "context-usage":
+        options.onContextUsage?.(event);
+        break;
       case "turn-start":
         yield { type: "start" };
         break;
@@ -101,7 +102,6 @@ export async function* agentEventStreamParts(
         yield { type: "start-step" };
         break;
       case "assistant-reasoning-delta":
-        options.onOutputDelta?.(event.text);
         yield* assistantDeltaParts("reasoning", event.text, sawReasoningDelta);
         sawReasoningDelta = true;
         break;
@@ -113,7 +113,6 @@ export async function* agentEventStreamParts(
         );
         break;
       case "assistant-output-delta":
-        options.onOutputDelta?.(event.text);
         yield* assistantDeltaParts("text", event.text, sawTextDelta);
         sawTextDelta = true;
         break;
@@ -128,7 +127,6 @@ export async function* agentEventStreamParts(
         };
         break;
       case "tool-call-input-delta":
-        options.onOutputDelta?.(event.inputTextDelta);
         yield {
           type: "tool-input-delta",
           inputTextDelta: event.inputTextDelta,

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -635,18 +635,13 @@ export interface AgentTUIConfig {
     switchModel(modelId: string): void | Promise<void>;
   };
   onCommandAction?: (action: TuiCommandAction) => void | Promise<void>;
+  onContextUsage?: (
+    snapshot: import("@minpeter/pss-runtime").ContextUsageSnapshot
+  ) => void;
   onExtensionUiReady?: (
     createUi: (hostSignal?: AbortSignal) => CodingAgentExtensionUi
   ) => void | Promise<void>;
-  onModelUsage?: (usage: ModelUsage) => void;
-  /**
-   * Receives streamed output text fragments (assistant text, reasoning,
-   * tool-call input) so the host can estimate token usage live between
-   * authoritative `onModelUsage` calls.
-   */
-  onOutputDelta?: (text: string) => void;
   onSetup?: () => void | Promise<void>;
-  onStreamStart?: () => void | Promise<void>;
   onTurnComplete?: (
     usage: TurnUsage | undefined,
     finishReason?: string
@@ -1101,30 +1096,19 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
     try {
       showLoader("Working...");
-      try {
-        await config.onStreamStart?.();
-      } catch (hookError) {
-        console.error("[tui] onStreamStart threw; continuing turn:", hookError);
-      }
-
       const clearStreamingLoader = createStreamingLoaderClearer();
 
       const { finishReason } = await renderAgentStream(
         agentEventStreamParts(run.events(), {
+          onContextUsage: (snapshot) => {
+            config.onContextUsage?.(snapshot);
+            updateHeader();
+          },
           onModelUsage: (usage) => {
             sawModelUsage = true;
             accumulateUsage(turnUsage, usage);
-            config.onModelUsage?.(usage);
             updateHeader();
           },
-          ...(config.onOutputDelta === undefined
-            ? {}
-            : {
-                onOutputDelta: (text: string) => {
-                  config.onOutputDelta?.(text);
-                  updateHeader();
-                },
-              }),
         }),
         {
           showReasoning: true,

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   type AgentOptions,
+  type ContextUsageSnapshot,
   commitThreadStateMigrations,
   threadStoreKey,
 } from "@minpeter/pss-runtime";
@@ -64,7 +65,7 @@ import { createToolRenderers } from "./renderers/tool-renderers";
 import { createSessionCommands } from "./session-commands";
 import { shouldReplayOnStartup } from "./session-startup-replay";
 import { formatSessionResumeHint } from "./terminal-exit";
-import { TokenUsageTracker } from "./usage-footer";
+import { contextUsageFooter } from "./usage-footer";
 
 export interface StartTuiOptions {
   readonly extensions?: readonly CodingAgentExtensionInput[];
@@ -327,15 +328,15 @@ export async function startTui(
     }
 
     const footer: { text?: string } = {};
-    const usageTracker = new TokenUsageTracker();
+    let latestContextUsage: ContextUsageSnapshot | undefined;
     const titleGenerationInFlight = new Set<string>();
 
     const renderUsageFooter = (): void => {
-      footer.text = usageTracker.footerText();
+      footer.text = contextUsageFooter(latestContextUsage);
     };
 
     const resetUsageTotals = (): void => {
-      usageTracker.reset();
+      latestContextUsage = undefined;
       renderUsageFooter();
     };
 
@@ -462,8 +463,8 @@ export async function startTui(
               },
             },
           }),
-      onModelUsage: (usage) => {
-        usageTracker.addUsage(usage);
+      onContextUsage: (snapshot) => {
+        latestContextUsage = snapshot;
         renderUsageFooter();
       },
       sessionSelector: {
@@ -480,14 +481,6 @@ export async function startTui(
           const entry = await sessionManager.switchToSession(sessionKey);
           await switchThread(entry, "resume");
         },
-      },
-      onOutputDelta: (text) => {
-        usageTracker.addOutputDelta(text);
-        renderUsageFooter();
-      },
-      onStreamStart: () => {
-        usageTracker.beginTurn();
-        renderUsageFooter();
       },
       onTurnComplete: () => {
         const completedSession = currentSession;

--- a/apps/coding-agent/src/tui/usage-footer.test.ts
+++ b/apps/coding-agent/src/tui/usage-footer.test.ts
@@ -1,95 +1,48 @@
-import type { ModelUsage } from "@minpeter/pss-runtime";
+import type {
+  ContextUsageSnapshot,
+  TokenEstimate,
+} from "@minpeter/pss-runtime";
 import { describe, expect, it } from "vitest";
-import { formatTokens, TokenUsageTracker } from "./usage-footer";
+import { contextUsageFooter, formatTokens } from "./usage-footer";
 
-const usage = (partial: Partial<ModelUsage>): ModelUsage => ({
-  attemptId: "attempt",
-  type: "model-usage",
-  ...partial,
+const estimate = (
+  tokens: number,
+  basis: TokenEstimate["basis"]
+): TokenEstimate => ({
+  basis,
+  marginTokens: 0,
+  tokens,
+});
+
+describe("contextUsageFooter", () => {
+  it("formats runtime snapshots and marks only estimates", () => {
+    const snapshot: ContextUsageSnapshot = {
+      calibration: { observations: 1, revision: 1 },
+      currentRequest: {
+        input: estimate(1000, "reported"),
+        output: estimate(20, "calibrated"),
+        total: estimate(1020, "calibrated"),
+      },
+    };
+    expect(contextUsageFooter(snapshot)).toBe(
+      "≈1.0k tokens (1.0k in / ≈20 out)"
+    );
+  });
+
+  it("hides an empty snapshot", () => {
+    expect(
+      contextUsageFooter({
+        calibration: { observations: 0, revision: 0 },
+        currentRequest: {
+          input: estimate(0, "heuristic"),
+          output: estimate(0, "heuristic"),
+          total: estimate(0, "heuristic"),
+        },
+      })
+    ).toBeUndefined();
+  });
 });
 
 describe("formatTokens", () => {
-  it("prints small counts verbatim and large counts in k", () => {
-    expect(formatTokens(0)).toBe("0");
-    expect(formatTokens(999)).toBe("999");
-    expect(formatTokens(1000)).toBe("1.0k");
-    expect(formatTokens(12_345)).toBe("12.3k");
-  });
-});
-
-describe("TokenUsageTracker", () => {
-  it("shows nothing before any usage or streaming", () => {
-    const tracker = new TokenUsageTracker();
-    expect(tracker.footerText()).toBeUndefined();
-  });
-
-  it("never renders a false 0 tokens claim when usage events carry no numbers", () => {
-    const tracker = new TokenUsageTracker();
-    // Providers without stream usage report events with all fields missing.
-    tracker.addUsage(usage({}));
-    expect(tracker.footerText()).toBeUndefined();
-  });
-
-  it("shows the latest authoritative usage without recounting prior context", () => {
-    const tracker = new TokenUsageTracker();
-    tracker.addUsage(usage({ inputTokens: 100, outputTokens: 20 }));
-    tracker.addUsage(
-      usage({ inputTokens: 900, outputTokens: 180, totalTokens: 1080 })
-    );
-
-    expect(tracker.footerText()).toBe("1.1k tokens (900 in / 180 out)");
-  });
-
-  it("shows a live estimate while the first step streams", () => {
-    const tracker = new TokenUsageTracker();
-    tracker.addOutputDelta("x".repeat(400));
-
-    expect(tracker.footerText()).toBe("≈100 tokens");
-  });
-
-  it("adds the live estimate on top of committed totals", () => {
-    const tracker = new TokenUsageTracker();
-    tracker.addUsage(
-      usage({ inputTokens: 100, outputTokens: 50, totalTokens: 150 })
-    );
-    tracker.addOutputDelta("x".repeat(200));
-
-    expect(tracker.footerText()).toBe("≈200 tokens (100 in / 100 out)");
-  });
-
-  it("replaces the estimate with real numbers when usage arrives", () => {
-    const tracker = new TokenUsageTracker();
-    tracker.addOutputDelta("x".repeat(4000));
-    tracker.addUsage(
-      usage({ inputTokens: 10, outputTokens: 5, totalTokens: 15 })
-    );
-
-    expect(tracker.footerText()).toBe("15 tokens (10 in / 5 out)");
-  });
-
-  it("drops a stale estimate when a new turn begins", () => {
-    const tracker = new TokenUsageTracker();
-    tracker.addOutputDelta("x".repeat(400));
-    tracker.beginTurn();
-
-    expect(tracker.footerText()).toBeUndefined();
-  });
-
-  it("reset clears totals and estimate", () => {
-    const tracker = new TokenUsageTracker();
-    tracker.addUsage(
-      usage({ inputTokens: 10, outputTokens: 5, totalTokens: 15 })
-    );
-    tracker.addOutputDelta("estimate");
-    tracker.reset();
-
-    expect(tracker.footerText()).toBeUndefined();
-  });
-
-  it("derives total when the provider omits totalTokens", () => {
-    const tracker = new TokenUsageTracker();
-    tracker.addUsage(usage({ inputTokens: 30, outputTokens: 12 }));
-
-    expect(tracker.footerText()).toBe("42 tokens (30 in / 12 out)");
-  });
+  it("abbreviates thousands", () => expect(formatTokens(12_345)).toBe("12.3k"));
 });

--- a/apps/coding-agent/src/tui/usage-footer.ts
+++ b/apps/coding-agent/src/tui/usage-footer.ts
@@ -1,81 +1,21 @@
-import type { ModelUsage } from "@minpeter/pss-runtime";
+import type {
+  ContextUsageSnapshot,
+  TokenEstimate,
+} from "@minpeter/pss-runtime";
 
-/**
- * Rough chars-per-token divisor for the live estimate shown while a step is
- * still streaming (before the authoritative `model-usage` event arrives).
- */
-const ESTIMATED_CHARS_PER_TOKEN = 4;
+export const formatTokens = (tokens: number): string =>
+  tokens >= 1000 ? `${(tokens / 1000).toFixed(1)}k` : String(tokens);
 
-export const formatTokens = (n: number): string => {
-  if (n >= 1000) {
-    return `${(n / 1000).toFixed(1)}k`;
+const displayed = (estimate: TokenEstimate): string =>
+  `${estimate.basis === "reported" ? "" : "≈"}${formatTokens(estimate.tokens)}`;
+
+/** Pure product formatting for the runtime-owned current-request snapshot. */
+export function contextUsageFooter(
+  snapshot: ContextUsageSnapshot | undefined
+): string | undefined {
+  if (!snapshot || snapshot.currentRequest.total.tokens === 0) {
+    return;
   }
-  return String(n);
-};
-
-/**
- * Tracks the latest model request's token usage for the TUI footer.
- *
- * Authoritative numbers come from `model-usage` events at each step end.
- * Between those, streamed output fragments feed a live estimate (prefixed
- * with `≈`) so the counter moves while the model is generating. When no
- * usage was ever reported and nothing is streaming, the footer is hidden
- * instead of claiming a false "0 tokens".
- */
-export class TokenUsageTracker {
-  #estimatedChars = 0;
-  #inputTokens = 0;
-  #outputTokens = 0;
-  #totalTokens = 0;
-
-  /** Replace the previous step with the latest authoritative usage. */
-  addUsage(usage: ModelUsage): void {
-    // The finished step's live estimate is superseded by the real numbers.
-    this.#estimatedChars = 0;
-    this.#inputTokens = usage.inputTokens ?? 0;
-    this.#outputTokens = usage.outputTokens ?? 0;
-    this.#totalTokens =
-      usage.totalTokens ?? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
-  }
-
-  /** Accumulate streamed output text for the live estimate. */
-  addOutputDelta(text: string): void {
-    this.#estimatedChars += text.length;
-  }
-
-  /** Drop a stale estimate left by an aborted or errored step. */
-  beginTurn(): void {
-    this.#estimatedChars = 0;
-  }
-
-  /** Clear everything (e.g. when a new session starts). */
-  reset(): void {
-    this.#estimatedChars = 0;
-    this.#inputTokens = 0;
-    this.#outputTokens = 0;
-    this.#totalTokens = 0;
-  }
-
-  /**
-   * Footer text for the current state, or `undefined` when there is nothing
-   * truthful to show yet.
-   */
-  footerText(): string | undefined {
-    const estimated = Math.round(
-      this.#estimatedChars / ESTIMATED_CHARS_PER_TOKEN
-    );
-    const hasReportedUsage =
-      this.#totalTokens > 0 || this.#inputTokens > 0 || this.#outputTokens > 0;
-
-    if (!hasReportedUsage) {
-      // Never claim "0 tokens (0 in / 0 out)" — either show the live
-      // estimate or nothing.
-      return estimated > 0 ? `≈${formatTokens(estimated)} tokens` : undefined;
-    }
-
-    const approx = estimated > 0 ? "≈" : "";
-    const total = this.#totalTokens + estimated;
-    const output = this.#outputTokens + estimated;
-    return `${approx}${formatTokens(total)} tokens (${formatTokens(this.#inputTokens)} in / ${formatTokens(output)} out)`;
-  }
+  const { input, output, total } = snapshot.currentRequest;
+  return `${displayed(total)} tokens (${displayed(input)} in / ${displayed(output)} out)`;
 }

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -1,4 +1,8 @@
 import type { AgentHost, NotificationRecord } from "../../execution/host/types";
+import {
+  ContextTokenCalibrationRegistry,
+  ContextTokenMeter,
+} from "../../llm/context-tokens";
 import { createInMemoryHost } from "../../platform/memory";
 import { AgentThread } from "../../thread/handle/agent-thread";
 import type { AgentInput } from "../../thread/input/input";
@@ -58,6 +62,8 @@ export type AgentConstructorOptions = AgentOptions;
 export class Agent {
   readonly #modelOptions: AgentModelOptions;
   readonly #threads = new Map<string, AgentThreadEntry>();
+  readonly #contextTokenRegistry = new ContextTokenCalibrationRegistry();
+  readonly #contextTokens?: AgentOptions["contextTokens"];
   readonly #ownerNamespace: string;
   readonly #store: ThreadStore;
   readonly #host: AgentHost;
@@ -88,6 +94,7 @@ export class Agent {
     this.#hookRuntime = new AgentHookRuntime(options.hooks);
     this.#notificationOverlays = options.notificationOverlays;
     this.#compaction = options.compaction;
+    this.#contextTokens = options.contextTokens;
     this.#modelOptions = {
       alwaysActiveTools: options.alwaysActiveTools,
       attachmentStore:
@@ -171,7 +178,14 @@ export class Agent {
 
     let thread: AgentThread | undefined;
     thread = new AgentThread(
-      this.#modelOptions,
+      {
+        ...this.#modelOptions,
+        contextTokenMeter: new ContextTokenMeter(
+          this.#contextTokenRegistry,
+          this.#contextTokens
+        ),
+        contextTokens: this.#contextTokens,
+      },
       { key, migrations: this.#threadMigrations, store: this.#store },
       {
         compaction: this.#compaction,

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -2,6 +2,7 @@ import type { LanguageModel, ToolSet } from "ai";
 import type { RuntimeDiagnosticsSink } from "../../diagnostics";
 import type { AgentHost } from "../../execution/host/types";
 import type { ModelContextGateOptions } from "../../llm/context-gate";
+import type { ContextTokenOptions } from "../../llm/context-tokens";
 import type { PrepareModelStep } from "../../llm/model-step-preparation";
 import type { AgentToolChoice } from "../../llm/model-step-types";
 import { assertNoUnsupportedToolApproval } from "../../llm/tool-approval";
@@ -26,6 +27,7 @@ export interface AgentOptions {
   readonly alwaysActiveTools?: readonly string[];
   readonly attachmentStore?: HostAttachmentStore;
   readonly compaction?: AgentCompaction;
+  readonly contextTokens?: ContextTokenOptions;
   readonly hooks?: AgentHooks;
   readonly host?: AgentHost;
   readonly instructions?: string;
@@ -47,6 +49,7 @@ export type AgentModelOptions = Pick<
   | "alwaysActiveTools"
   | "attachmentStore"
   | "instructions"
+  | "contextTokens"
   | "model"
   | "prepareModelStep"
   | "toolChoice"
@@ -54,6 +57,7 @@ export type AgentModelOptions = Pick<
   | "tools"
 > & {
   readonly contextGate?: false | AgentContextGateOptions;
+  readonly contextTokenMeter?: import("../../llm/context-tokens").ContextTokenMeter;
   readonly diagnostics?: RuntimeDiagnosticsSink;
 };
 

--- a/packages/runtime/src/agent/loop/step-output.ts
+++ b/packages/runtime/src/agent/loop/step-output.ts
@@ -72,6 +72,9 @@ export async function appendCapturedStepOutput({
 }): Promise<StepOutputResult> {
   try {
     await emit(output.usage);
+    if (output.contextUsage) {
+      await emit({ ...output.contextUsage, type: "context-usage" });
+    }
     const transformedOutput = transformModelStep
       ? await transformModelStep(output.messages, signal)
       : output.messages;

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -93,6 +93,7 @@ describe("runtime public exports", () => {
     expectTypeOf<StreamAgentEvent["type"]>().toEqualTypeOf<
       | "assistant-output-delta"
       | "assistant-reasoning-delta"
+      | "context-usage"
       | "tool-call-input-delta"
       | "tool-call-input-end"
       | "tool-call-input-start"

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -50,10 +50,24 @@ export type {
   ThreadEventCursor,
   ThreadEventReadOptions,
 } from "./execution/host/types";
+export type {
+  ModelContextTokenEstimateInput,
+  ModelPromptMeasurement,
+  ModelPromptMeasurementProfile,
+  ModelPromptTool,
+} from "./llm/context-gate";
 export {
   ContextBudgetExceededError,
+  defaultModelPromptMeasurementProfile,
   estimateModelMessagesTokens,
 } from "./llm/context-gate";
+export type {
+  ContextTokenOptions,
+  ContextTokenProfile,
+  ContextUsageSnapshot,
+  TokenEstimate,
+  TokenEstimateBasis,
+} from "./llm/context-tokens";
 export { ModelToolSelectionError } from "./llm/model-step-error";
 export type {
   PrepareModelStep,

--- a/packages/runtime/src/llm/context-gate.test.ts
+++ b/packages/runtime/src/llm/context-gate.test.ts
@@ -1,0 +1,144 @@
+import { asSchema, jsonSchema, type ModelMessage, type ToolSet } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import {
+  defaultModelPromptMeasurementProfile,
+  enforceContextGate,
+  materializeModelPromptTools,
+  modelPromptTools,
+} from "./context-gate";
+
+describe("model prompt measurement", () => {
+  it("counts instructions and provider-visible tools once, with aligned marginal messages", async () => {
+    const execute = vi.fn();
+    const messages: readonly ModelMessage[] = [
+      { content: "one", role: "user" },
+      { content: "two", role: "assistant" },
+    ];
+    const tools = await modelPromptTools({
+      search: {
+        description: "Search",
+        execute,
+        inputSchema: jsonSchema({ type: "object" }),
+      },
+    } as unknown as ToolSet);
+    const measurement = defaultModelPromptMeasurementProfile.measurePrompt({
+      instructions: "Be useful",
+      messages,
+      toolChoice: { toolName: "search", type: "tool" },
+      tools,
+    });
+
+    expect(measurement.messageUnits).toEqual(
+      defaultModelPromptMeasurementProfile.measureMessages(messages)
+    );
+    expect(measurement.messageUnits).toHaveLength(messages.length);
+    expect(measurement.totalUnits).toBe(
+      measurement.fixedUnits +
+        measurement.messageUnits.reduce((sum, units) => sum + units, 0)
+    );
+    expect(JSON.stringify(tools)).not.toContain("execute");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("projects the complete function-tool surface sent by the AI SDK", async () => {
+    const description = vi.fn(() => "Dynamic search");
+    const tools = await modelPromptTools({
+      search: {
+        description,
+        inputExamples: [{ input: { query: "example" } }],
+        inputSchema: jsonSchema({ type: "object" }),
+        providerOptions: { provider: { cache: true } },
+        strict: true,
+      },
+    } as unknown as ToolSet);
+
+    expect(tools).toEqual([
+      {
+        description: "Dynamic search",
+        inputExamples: [{ input: { query: "example" } }],
+        inputSchema: { type: "object" },
+        name: "search",
+        providerOptions: { provider: { cache: true } },
+        strict: true,
+        type: "function",
+      },
+    ]);
+    expect(description).toHaveBeenCalledWith({
+      context: undefined,
+      experimental_sandbox: undefined,
+    });
+  });
+
+  it("materializes dynamic tool metadata once for measurement and dispatch", async () => {
+    const description = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("first")
+      .mockReturnValueOnce("second");
+    const materialized = await materializeModelPromptTools({
+      search: {
+        description,
+        inputSchema: jsonSchema({ type: "object" }),
+      },
+    } as unknown as ToolSet);
+    const dispatched = materialized.tools?.search;
+
+    expect(materialized.promptTools?.[0]?.description).toBe("first");
+    expect(dispatched?.description).toBe("first");
+    if (dispatched?.type !== "provider") {
+      await asSchema(dispatched?.inputSchema).jsonSchema;
+    }
+    expect(description).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits asynchronous schemas and preserves their validator", async () => {
+    const validate = vi.fn(() => ({
+      success: true as const,
+      value: { normalized: true },
+    }));
+    const materialized = await materializeModelPromptTools({
+      search: {
+        inputSchema: jsonSchema(
+          Promise.resolve({
+            properties: { query: { type: "string" } },
+            type: "object",
+          }),
+          { validate }
+        ),
+      },
+    });
+    const dispatched = materialized.tools?.search;
+
+    expect(materialized.promptTools?.[0]?.inputSchema).toEqual({
+      properties: { query: { type: "string" } },
+      type: "object",
+    });
+    if (dispatched?.type !== "provider") {
+      const schema = asSchema(dispatched?.inputSchema);
+      expect(await schema.validate?.({ query: "value" })).toEqual({
+        success: true,
+        value: { normalized: true },
+      });
+    }
+    expect(validate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the context-gate custom estimator contract", () => {
+    const estimateTokens = vi.fn(() => 1);
+    const messages: readonly ModelMessage[] = [
+      { content: "hello", role: "user" },
+    ];
+
+    enforceContextGate({
+      contextGate: { estimateTokens, maxInputTokens: 2 },
+      instructions: "instruction",
+      messages,
+    });
+
+    expect(estimateTokens).toHaveBeenCalledWith({
+      instructions: "instruction",
+      messages,
+      toolChoice: undefined,
+      tools: undefined,
+    });
+  });
+});

--- a/packages/runtime/src/llm/context-gate.ts
+++ b/packages/runtime/src/llm/context-gate.ts
@@ -1,8 +1,43 @@
-import type { ModelMessage } from "ai";
+import { asSchema, jsonSchema, type ModelMessage, type ToolSet } from "ai";
+import type { PreparedModelToolChoice } from "./model-step-preparation";
 
 export interface ModelContextTokenEstimateInput {
   readonly instructions?: string;
   readonly messages: readonly ModelMessage[];
+  readonly toolChoice?: PreparedModelToolChoice;
+  readonly tools?: readonly ModelPromptTool[];
+}
+
+export interface ModelPromptTool {
+  readonly args?: Readonly<Record<string, unknown>>;
+  readonly description?: string;
+  readonly id?: string;
+  readonly inputExamples?: readonly unknown[];
+  readonly inputSchema?: unknown;
+  readonly name: string;
+  readonly providerOptions?: Readonly<Record<string, unknown>>;
+  readonly strict?: boolean;
+  readonly type?: string;
+}
+
+/** Product-neutral units measured for one provider-visible model request. */
+export interface ModelPromptMeasurement {
+  /** Stable identity for fixed prompt content; used for safe marginal calibration. */
+  readonly fixedFingerprint: string;
+  /** Instructions, tool definitions, tool choice, and request framing. */
+  readonly fixedUnits: number;
+  /** Marginal cost aligned by index with the input messages. */
+  readonly messageUnits: readonly number[];
+  readonly totalUnits: number;
+}
+
+export interface ModelPromptMeasurementProfile {
+  readonly measureMessages: (
+    messages: readonly ModelMessage[]
+  ) => readonly number[];
+  readonly measurePrompt: (
+    input: ModelContextTokenEstimateInput
+  ) => ModelPromptMeasurement;
 }
 
 export interface ModelContextGateOptions {
@@ -44,10 +79,14 @@ export function enforceContextGate({
   contextGate,
   instructions,
   messages,
+  promptTools,
+  toolChoice,
 }: {
   readonly contextGate?: false | ModelContextGateOptions;
   readonly instructions?: string;
   readonly messages: readonly ModelMessage[];
+  readonly promptTools?: readonly ModelPromptTool[];
+  readonly toolChoice?: PreparedModelToolChoice;
 }): void {
   if (!contextGate) {
     return;
@@ -55,7 +94,12 @@ export function enforceContextGate({
 
   const bufferTokens = contextGate.bufferTokens ?? 0;
   const estimatedTokens = estimatePromptTokens(
-    { instructions, messages },
+    {
+      instructions,
+      messages,
+      toolChoice,
+      tools: promptTools,
+    },
     contextGate.estimateTokens
   );
   if (estimatedTokens + bufferTokens <= contextGate.maxInputTokens) {
@@ -78,15 +122,37 @@ function estimatePromptTokens(
     return estimator(input);
   }
 
-  const serialized = JSON.stringify(
-    {
-      instructions: input.instructions,
-      messages: input.messages,
-    },
-    promptTokenEstimateReplacer
-  );
-  return Math.ceil(serialized.length / 4);
+  return defaultModelPromptMeasurementProfile.measurePrompt(input).totalUnits;
 }
+
+export const defaultModelPromptMeasurementProfile = Object.freeze({
+  measureMessages(messages: readonly ModelMessage[]) {
+    return messages.map((message) => countJsonUnits(message));
+  },
+  measurePrompt(input: ModelContextTokenEstimateInput) {
+    const messageUnits = measureDefaultMessageUnits(input.messages);
+    const toolChoice = providerPromptToolChoice(input.toolChoice);
+    const fixedUnits = countJsonUnits({
+      instructions: input.instructions,
+      toolChoice,
+      tools: input.tools,
+    });
+    return {
+      fixedFingerprint: JSON.stringify(
+        {
+          instructions: input.instructions,
+          toolChoice,
+          tools: input.tools,
+        },
+        promptTokenEstimateReplacer
+      ),
+      fixedUnits,
+      messageUnits,
+      totalUnits:
+        fixedUnits + messageUnits.reduce((sum, units) => sum + units, 0),
+    };
+  },
+}) satisfies ModelPromptMeasurementProfile;
 
 export function estimateModelMessagesTokens(
   messages: readonly ModelMessage[]
@@ -94,6 +160,91 @@ export function estimateModelMessagesTokens(
   return Math.ceil(
     JSON.stringify(messages, promptTokenEstimateReplacer).length / 4
   );
+}
+
+function countJsonUnits(value: unknown): number {
+  return JSON.stringify(value, promptTokenEstimateReplacer).length / 4;
+}
+
+function measureDefaultMessageUnits(
+  messages: readonly ModelMessage[]
+): readonly number[] {
+  return messages.map((message) => countJsonUnits(message));
+}
+
+export async function modelPromptTools(
+  tools: ToolSet | undefined
+): Promise<readonly ModelPromptTool[] | undefined> {
+  return (await materializeModelPromptTools(tools)).promptTools;
+}
+
+export async function materializeModelPromptTools(
+  tools: ToolSet | undefined
+): Promise<{
+  readonly promptTools?: readonly ModelPromptTool[];
+  readonly tools?: ToolSet;
+}> {
+  if (!tools) {
+    return {};
+  }
+  const entries = await Promise.all(
+    Object.entries(tools).map(async ([name, tool]) => {
+      if (tool.type === "provider") {
+        return [
+          name,
+          tool,
+          { args: tool.args, id: tool.id, name, type: tool.type },
+        ] as const;
+      }
+      const description =
+        typeof tool.description === "function"
+          ? tool.description({
+              context: undefined,
+              experimental_sandbox: undefined,
+            })
+          : tool.description;
+      const schema = asSchema(tool.inputSchema);
+      const resolvedInputSchema = await schema.jsonSchema;
+      const promptTool = {
+        ...(description === undefined ? {} : { description }),
+        ...(tool.inputExamples === undefined
+          ? {}
+          : { inputExamples: tool.inputExamples }),
+        inputSchema: resolvedInputSchema,
+        name,
+        ...(tool.providerOptions === undefined
+          ? {}
+          : { providerOptions: tool.providerOptions }),
+        ...(tool.strict === undefined ? {} : { strict: tool.strict }),
+        type: "function",
+      };
+      return [
+        name,
+        {
+          ...tool,
+          ...(description === undefined ? {} : { description }),
+          inputSchema: jsonSchema(
+            resolvedInputSchema,
+            schema.validate ? { validate: schema.validate } : undefined
+          ),
+        },
+        promptTool,
+      ] as const;
+    })
+  );
+  return {
+    promptTools: entries.map((entry) => entry[2]),
+    tools: Object.fromEntries(entries.map(([name, tool]) => [name, tool])),
+  };
+}
+
+function providerPromptToolChoice(
+  toolChoice: PreparedModelToolChoice | undefined
+): unknown {
+  if (toolChoice === undefined) {
+    return { type: "auto" };
+  }
+  return typeof toolChoice === "string" ? { type: toolChoice } : toolChoice;
 }
 
 function promptTokenEstimateReplacer(_key: string, value: unknown): unknown {

--- a/packages/runtime/src/llm/context-tokens.test.ts
+++ b/packages/runtime/src/llm/context-tokens.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+import {
+  ContextTokenCalibrationRegistry,
+  ContextTokenMeter,
+} from "./context-tokens";
+
+const measurement = (messageUnits: number, fixedFingerprint = "fixed") => ({
+  fixedFingerprint,
+  fixedUnits: 50,
+  messageUnits: [messageUnits],
+  totalUnits: 50 + messageUnits,
+});
+
+describe("ContextTokenMeter", () => {
+  it("deduplicates attempts and isolates provider/model calibration", () => {
+    const registry = new ContextTokenCalibrationRegistry();
+    const meter = new ContextTokenMeter(registry);
+    meter.begin({
+      attemptId: "a",
+      fixedFingerprint: "fixed",
+      measurement: measurement(100),
+      scope: "p\0a",
+    });
+    meter.report("a", {
+      attemptId: "a",
+      inputTokens: 300,
+      outputTokens: 20,
+      type: "model-usage",
+    });
+    const revision = meter.snapshot().calibration.revision;
+    meter.report("a", {
+      attemptId: "a",
+      inputTokens: 900,
+      type: "model-usage",
+    });
+    expect(meter.snapshot().calibration.revision).toBe(revision);
+    meter.begin({
+      attemptId: "b",
+      fixedFingerprint: "fixed",
+      measurement: measurement(200),
+      scope: "p\0b",
+    });
+    expect(meter.snapshot().calibration.observations).toBe(0);
+  });
+
+  it("learns marginal input only from consecutive equal fixed fingerprints", () => {
+    const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
+    meter.begin({
+      attemptId: "a",
+      fixedFingerprint: "fixed",
+      measurement: measurement(100),
+      scope: "p\0m",
+    });
+    meter.report("a", {
+      attemptId: "a",
+      inputTokens: 200,
+      type: "model-usage",
+    });
+    meter.begin({
+      attemptId: "b",
+      fixedFingerprint: "fixed",
+      measurement: measurement(200),
+      scope: "p\0m",
+    });
+    meter.report("b", {
+      attemptId: "b",
+      inputTokens: 400,
+      type: "model-usage",
+    });
+    expect(meter.snapshot().calibration.observations).toBe(2);
+    meter.begin({
+      attemptId: "c",
+      fixedFingerprint: "changed",
+      measurement: measurement(10, "changed"),
+      scope: "p\0m",
+    });
+    expect(meter.snapshot().currentRequest.input.tokens).toBeLessThan(200);
+  });
+
+  it("rejects stale deltas and replaces estimates with reported usage", () => {
+    const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
+    meter.begin({
+      attemptId: "new",
+      fixedFingerprint: "fixed",
+      measurement: measurement(10),
+    });
+    expect(meter.outputDelta("old", "ignored")).toBeUndefined();
+    meter.outputDelta("new", "x".repeat(40));
+    expect(meter.snapshot().currentRequest.output.basis).toBe("heuristic");
+    meter.report("new", {
+      attemptId: "new",
+      inputTokens: 12,
+      outputTokens: 3,
+      totalTokens: 15,
+      type: "model-usage",
+    });
+    expect(meter.snapshot().currentRequest.total).toEqual({
+      basis: "reported",
+      marginTokens: 0,
+      tokens: 15,
+    });
+  });
+
+  it("derives a missing reported side from total usage", () => {
+    const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
+    meter.begin({
+      attemptId: "partial",
+      fixedFingerprint: "fixed",
+      measurement: measurement(10),
+      scope: "p\0partial",
+    });
+    meter.outputDelta("partial", "x".repeat(40));
+    meter.report("partial", {
+      attemptId: "partial",
+      outputTokens: 25,
+      totalTokens: 100,
+      type: "model-usage",
+    });
+
+    expect(meter.snapshot().currentRequest).toEqual({
+      input: { basis: "reported", marginTokens: 0, tokens: 75 },
+      output: { basis: "reported", marginTokens: 0, tokens: 25 },
+      total: { basis: "reported", marginTokens: 0, tokens: 100 },
+    });
+    expect(meter.snapshot().calibration.observations).toBe(1);
+  });
+
+  it("is invariant to stream delta fragmentation", () => {
+    const registry = new ContextTokenCalibrationRegistry();
+    const chunked = new ContextTokenMeter(registry);
+    const whole = new ContextTokenMeter(registry);
+    chunked.begin({
+      attemptId: "chunked",
+      fixedFingerprint: "fixed",
+      measurement: measurement(10),
+    });
+    whole.begin({
+      attemptId: "whole",
+      fixedFingerprint: "fixed",
+      measurement: measurement(10),
+    });
+    for (const character of "abcdefghij") {
+      chunked.outputDelta("chunked", character);
+    }
+    whole.outputDelta("whole", "abcdefghij");
+
+    expect(chunked.snapshot().currentRequest.output).toEqual(
+      whole.snapshot().currentRequest.output
+    );
+  });
+
+  it("learns both request-route and resolved-model scopes", () => {
+    const registry = new ContextTokenCalibrationRegistry();
+    const meter = new ContextTokenMeter(registry);
+    meter.begin({
+      attemptId: "routed",
+      fixedFingerprint: "fixed",
+      measurement: measurement(100),
+      scope: "gateway\0route",
+    });
+    meter.report(
+      "routed",
+      {
+        attemptId: "routed",
+        inputTokens: 1500,
+        modelId: "resolved",
+        provider: "provider",
+        type: "model-usage",
+      },
+      "provider\0resolved"
+    );
+    meter.begin({
+      attemptId: "next",
+      fixedFingerprint: "fixed",
+      measurement: measurement(100),
+      scope: "gateway\0route",
+    });
+
+    expect(meter.inputUpperBound()).toBeGreaterThanOrEqual(1500);
+  });
+
+  it("makes a large first same-fixed observation conservative", () => {
+    const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
+    meter.begin({
+      attemptId: "large",
+      fixedFingerprint: "fixed",
+      measurement: measurement(100),
+      scope: "p\0large",
+    });
+    meter.report("large", {
+      attemptId: "large",
+      inputTokens: 1500,
+      type: "model-usage",
+    });
+    meter.begin({
+      attemptId: "next",
+      fixedFingerprint: "fixed",
+      measurement: measurement(100),
+      scope: "p\0large",
+    });
+    expect(meter.inputUpperBound()).toBeGreaterThanOrEqual(1500);
+  });
+
+  it("never lowers the learned marginal safety slope", () => {
+    const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
+    for (const [attemptId, fingerprint, units, inputTokens] of [
+      ["a1", "dense", 100, 1050],
+      ["a2", "dense", 200, 2050],
+      ["b1", "sparse", 100, 150],
+      ["b2", "sparse", 200, 250],
+    ] as const) {
+      meter.begin({
+        attemptId,
+        fixedFingerprint: fingerprint,
+        measurement: measurement(units, fingerprint),
+        scope: "p\0mixed",
+      });
+      meter.report(attemptId, {
+        attemptId,
+        inputTokens,
+        type: "model-usage",
+      });
+    }
+    meter.begin({
+      attemptId: "next",
+      fixedFingerprint: "dense",
+      measurement: measurement(100, "dense"),
+      scope: "p\0mixed",
+    });
+
+    expect(meter.inputUpperBound()).toBeGreaterThanOrEqual(1050);
+  });
+
+  it("pins calibration values in an immutable view", () => {
+    const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
+    meter.begin({
+      attemptId: "a1",
+      fixedFingerprint: "fixed",
+      measurement: measurement(100),
+      scope: "p\0pin",
+    });
+    meter.report("a1", {
+      attemptId: "a1",
+      inputTokens: 150,
+      type: "model-usage",
+    });
+    const view = meter.view();
+    const pinned = view.estimateMessageUnits([100]);
+    meter.begin({
+      attemptId: "a2",
+      fixedFingerprint: "fixed",
+      measurement: measurement(200),
+      scope: "p\0pin",
+    });
+    meter.report("a2", {
+      attemptId: "a2",
+      inputTokens: 1050,
+      type: "model-usage",
+    });
+
+    expect(view.estimateMessageUnits([100])).toEqual(pinned);
+    expect(meter.estimateMessageUnits([100])[0]).toBeGreaterThan(
+      pinned[0] ?? 0
+    );
+  });
+
+  it("labels each estimated side only from side-specific evidence", () => {
+    const inputOnly = new ContextTokenMeter(
+      new ContextTokenCalibrationRegistry()
+    );
+    inputOnly.begin({
+      attemptId: "input",
+      fixedFingerprint: "fixed",
+      measurement: measurement(10),
+      scope: "p\0input",
+    });
+    inputOnly.outputDelta("input", "output");
+    inputOnly.report("input", {
+      attemptId: "input",
+      inputTokens: 60,
+      type: "model-usage",
+    });
+    expect(inputOnly.snapshot().currentRequest.output.basis).toBe("heuristic");
+    expect(inputOnly.snapshot().currentRequest.total.basis).toBe("heuristic");
+
+    const outputOnly = new ContextTokenMeter(
+      new ContextTokenCalibrationRegistry()
+    );
+    outputOnly.begin({
+      attemptId: "output",
+      fixedFingerprint: "fixed",
+      measurement: measurement(10),
+      scope: "p\0output",
+    });
+    outputOnly.outputDelta("output", "output");
+    outputOnly.report("output", {
+      attemptId: "output",
+      outputTokens: 6,
+      type: "model-usage",
+    });
+    expect(outputOnly.snapshot().currentRequest.input.basis).toBe("heuristic");
+    expect(outputOnly.snapshot().currentRequest.total.basis).toBe("heuristic");
+  });
+});

--- a/packages/runtime/src/llm/context-tokens.ts
+++ b/packages/runtime/src/llm/context-tokens.ts
@@ -1,0 +1,463 @@
+import type { ModelUsage } from "../thread/protocol/events";
+import type {
+  ModelPromptMeasurement,
+  ModelPromptMeasurementProfile,
+} from "./context-gate";
+
+export type TokenEstimateBasis = "heuristic" | "calibrated" | "reported";
+
+export interface TokenEstimate {
+  readonly basis: TokenEstimateBasis;
+  readonly marginTokens: number;
+  readonly tokens: number;
+}
+
+export interface ContextUsageSnapshot {
+  readonly calibration: {
+    readonly observations: number;
+    readonly revision: number;
+    readonly scope?: string;
+  };
+  readonly contextWindow?: { readonly maxInputTokens: number };
+  readonly currentRequest: {
+    readonly input: TokenEstimate;
+    readonly output: TokenEstimate;
+    readonly total: TokenEstimate;
+  };
+}
+
+/** Immutable, revision-pinned decomposition used by gates and compaction. */
+export interface ContextTokenProfile {
+  readonly fixedPrompt: number;
+  readonly fullInput: number;
+  readonly historyMarginal: readonly number[];
+  readonly revision: number;
+  readonly wrapper: number;
+}
+
+interface CalibrationBucket {
+  fixed: Map<string, { errorBound: number; observations: number }>;
+  inputObservations: number;
+  marginalInputScale: number;
+  outputObservations: number;
+  outputTokens: number;
+  outputUnits: number;
+  previousByFixed: Map<
+    string,
+    {
+      fixedFingerprint: string;
+      inputTokens: number;
+      messageUnits: number;
+    }
+  >;
+  revision: number;
+}
+
+/** Process-local adaptive calibration shared by all threads of one Agent. */
+export class ContextTokenCalibrationRegistry {
+  readonly #buckets = new Map<string, CalibrationBucket>();
+  readonly #attempts = new Set<string>();
+
+  bucket(scope: string | undefined): CalibrationBucket | undefined {
+    if (!scope) {
+      return;
+    }
+    let bucket = this.#buckets.get(scope);
+    if (!bucket) {
+      bucket = {
+        inputObservations: 0,
+        marginalInputScale: 1,
+        fixed: new Map(),
+        outputTokens: 0,
+        outputUnits: 0,
+        outputObservations: 0,
+        previousByFixed: new Map(),
+        revision: 0,
+      };
+      this.#buckets.set(scope, bucket);
+    }
+    return bucket;
+  }
+
+  observe(
+    attemptId: string,
+    scope: string | undefined,
+    fixedFingerprint: string,
+    measurement: ModelPromptMeasurement,
+    outputUnits: number,
+    usage: ModelUsage
+  ): boolean {
+    if (!scope) {
+      return false;
+    }
+    const observationId = `${scope}\0${attemptId}`;
+    if (this.#attempts.has(observationId)) {
+      return false;
+    }
+    this.#attempts.add(observationId);
+    const bucket = this.bucket(scope);
+    if (!bucket) {
+      return false;
+    }
+    const reported = reportedUsageTokens(usage);
+    const input = reported.input;
+    if (input !== undefined) {
+      const previous = bucket.previousByFixed.get(fixedFingerprint);
+      // Only a same-fixed-prompt pair can safely identify marginal slope.
+      if (previous?.fixedFingerprint === fixedFingerprint) {
+        const deltaUnits =
+          measurement.messageUnits.reduce((a, b) => a + b, 0) -
+          previous.messageUnits;
+        const deltaTokens = input - previous.inputTokens;
+        if (deltaUnits > 0 && deltaTokens >= 0) {
+          bucket.marginalInputScale = Math.max(
+            bucket.marginalInputScale,
+            deltaTokens / deltaUnits
+          );
+        }
+      }
+      const residual =
+        input -
+        measurement.messageUnits.reduce((a, b) => a + b, 0) *
+          bucket.marginalInputScale -
+        measurement.fixedUnits;
+      const fixed = bucket.fixed.get(fixedFingerprint) ?? {
+        errorBound: 0,
+        observations: 0,
+      };
+      fixed.errorBound = Math.max(fixed.errorBound, residual, 0);
+      fixed.observations += 1;
+      bucket.fixed.set(fixedFingerprint, fixed);
+      bucket.previousByFixed.set(fixedFingerprint, {
+        fixedFingerprint,
+        inputTokens: input,
+        messageUnits: measurement.messageUnits.reduce((a, b) => a + b, 0),
+      });
+      bucket.inputObservations += 1;
+    }
+    if (reported.output !== undefined && outputUnits > 0) {
+      bucket.outputUnits += outputUnits;
+      bucket.outputTokens += reported.output;
+      bucket.outputObservations += 1;
+    }
+    bucket.revision += 1;
+    return true;
+  }
+}
+
+export interface ContextTokenOptions {
+  readonly calibration?: boolean;
+  readonly measurementProfile?: ModelPromptMeasurementProfile;
+}
+
+interface Attempt {
+  readonly attemptId: string;
+  readonly fixedFingerprint: string;
+  readonly measurement: ModelPromptMeasurement;
+  outputUnits: number;
+  usage?: ModelUsage;
+}
+
+export interface ContextTokenMeterCheckpoint {
+  readonly attempt?: Attempt;
+  readonly maxInputTokens?: number;
+  readonly scope?: string;
+}
+
+export interface ContextTokenProfileInput {
+  readonly contextMessageUnits?: readonly number[];
+  readonly historyMessageUnits?: readonly number[];
+  readonly wrapperUnits?: number;
+}
+
+export interface ContextTokenView {
+  readonly estimateMessageUnits: (
+    units: readonly number[]
+  ) => readonly number[];
+  readonly profile: (input?: ContextTokenProfileInput) => ContextTokenProfile;
+}
+
+export class ContextTokenMeter {
+  readonly #registry: ContextTokenCalibrationRegistry;
+  readonly #calibration: boolean;
+  #attempt?: Attempt;
+  #scope?: string;
+  #maxInputTokens?: number;
+
+  constructor(
+    registry: ContextTokenCalibrationRegistry,
+    options: ContextTokenOptions = {}
+  ) {
+    this.#registry = registry;
+    this.#calibration = options.calibration !== false;
+  }
+
+  checkpoint(): ContextTokenMeterCheckpoint {
+    return {
+      ...(this.#attempt
+        ? {
+            attempt: {
+              ...this.#attempt,
+              outputUnits: this.#attempt.outputUnits,
+            },
+          }
+        : {}),
+      ...(this.#maxInputTokens === undefined
+        ? {}
+        : { maxInputTokens: this.#maxInputTokens }),
+      ...(this.#scope === undefined ? {} : { scope: this.#scope }),
+    };
+  }
+
+  restore(checkpoint: ContextTokenMeterCheckpoint): ContextUsageSnapshot {
+    this.#attempt = checkpoint.attempt
+      ? { ...checkpoint.attempt, outputUnits: checkpoint.attempt.outputUnits }
+      : undefined;
+    this.#maxInputTokens = checkpoint.maxInputTokens;
+    this.#scope = checkpoint.scope;
+    return this.snapshot();
+  }
+
+  begin(input: {
+    attemptId: string;
+    fixedFingerprint: string;
+    maxInputTokens?: number;
+    measurement: ModelPromptMeasurement;
+    scope?: string;
+  }): ContextUsageSnapshot {
+    this.#attempt = { ...input, outputUnits: 0 };
+    this.#scope = input.scope;
+    this.#maxInputTokens = input.maxInputTokens;
+    return this.snapshot();
+  }
+
+  outputDelta(
+    attemptId: string,
+    text: string
+  ): ContextUsageSnapshot | undefined {
+    if (this.#attempt?.attemptId !== attemptId) {
+      return;
+    }
+    this.#attempt.outputUnits += text.length / 4;
+    return this.snapshot();
+  }
+
+  report(
+    attemptId: string,
+    usage: ModelUsage,
+    resolvedScope?: string
+  ): ContextUsageSnapshot | undefined {
+    const attempt = this.#attempt;
+    if (attempt?.attemptId !== attemptId) {
+      return;
+    }
+    attempt.usage = usage;
+    if (this.#calibration) {
+      this.#registry.observe(
+        attemptId,
+        this.#scope,
+        attempt.fixedFingerprint,
+        attempt.measurement,
+        attempt.outputUnits,
+        usage
+      );
+      if (resolvedScope && resolvedScope !== this.#scope) {
+        this.#registry.observe(
+          attemptId,
+          resolvedScope,
+          attempt.fixedFingerprint,
+          attempt.measurement,
+          attempt.outputUnits,
+          usage
+        );
+      }
+    }
+    if (resolvedScope) {
+      this.#scope = resolvedScope;
+    }
+    return this.snapshot();
+  }
+
+  abort(attemptId: string): ContextUsageSnapshot | undefined {
+    if (this.#attempt?.attemptId !== attemptId) {
+      return;
+    }
+    this.#attempt.outputUnits = 0;
+    return this.snapshot();
+  }
+
+  snapshot(): ContextUsageSnapshot {
+    const attempt = this.#attempt;
+    const bucket = this.#calibration
+      ? this.#registry.bucket(this.#scope)
+      : undefined;
+    const inputScale = bucket?.marginalInputScale ?? 1;
+    const outputScale =
+      bucket && bucket.outputUnits > 0
+        ? bucket.outputTokens / bucket.outputUnits
+        : 1;
+    const messageUnits =
+      attempt?.measurement.messageUnits.reduce((a, b) => a + b, 0) ?? 0;
+    const fixed = attempt && bucket?.fixed.get(attempt.fixedFingerprint);
+    const estimatedInput = Math.ceil(
+      (attempt?.measurement.fixedUnits ?? 0) +
+        messageUnits * inputScale +
+        (fixed?.errorBound ?? 0)
+    );
+    const estimatedOutput = Math.ceil(
+      (attempt?.outputUnits ?? 0) * outputScale
+    );
+    const reported = attempt?.usage
+      ? reportedUsageTokens(attempt.usage)
+      : undefined;
+    const inputReported = reported?.input;
+    const outputReported = reported?.output;
+    const input = estimate(
+      inputReported,
+      estimatedInput,
+      (bucket?.inputObservations ?? 0) > 0
+    );
+    const output = estimate(
+      outputReported,
+      estimatedOutput,
+      (bucket?.outputObservations ?? 0) > 0
+    );
+    const totalReported = attempt?.usage?.totalTokens;
+    const total: TokenEstimate =
+      totalReported === undefined
+        ? {
+            basis: combinedBasis(input, output),
+            marginTokens: input.marginTokens + output.marginTokens,
+            tokens: input.tokens + output.tokens,
+          }
+        : ({
+            basis: "reported",
+            marginTokens: 0,
+            tokens: totalReported,
+          } as const);
+    return {
+      calibration: {
+        observations: bucket?.inputObservations ?? 0,
+        revision: bucket?.revision ?? 0,
+        ...(this.#scope ? { scope: this.#scope } : {}),
+      },
+      ...(this.#maxInputTokens === undefined
+        ? {}
+        : { contextWindow: { maxInputTokens: this.#maxInputTokens } }),
+      currentRequest: { input, output, total },
+    };
+  }
+
+  inputUpperBound(): number {
+    const estimate = this.snapshot().currentRequest.input;
+    return estimate.tokens + estimate.marginTokens;
+  }
+
+  profile(input: ContextTokenProfileInput = {}): ContextTokenProfile {
+    return this.view().profile(input);
+  }
+
+  view(): ContextTokenView {
+    const attempt = this.#attempt;
+    const bucket = this.#calibration
+      ? this.#registry.bucket(this.#scope)
+      : undefined;
+    const scale = bucket?.marginalInputScale ?? 1;
+    const fixedError =
+      (attempt && bucket?.fixed.get(attempt.fixedFingerprint)?.errorBound) ?? 0;
+    const fixedUnits = attempt?.measurement.fixedUnits ?? 0;
+    const messageUnits = attempt?.measurement.messageUnits ?? [];
+    const revision = bucket?.revision ?? 0;
+    return Object.freeze({
+      estimateMessageUnits: (units: readonly number[]) =>
+        roundedUnitCosts(units, scale),
+      profile: (input: ContextTokenProfileInput = {}) => {
+        const fixedPrompt = Math.ceil(fixedUnits + fixedError);
+        const contextMarginal = roundedUnitCosts(
+          input.contextMessageUnits ?? messageUnits,
+          scale
+        );
+        const historyMarginal = roundedUnitCosts(
+          input.historyMessageUnits ?? messageUnits,
+          scale
+        );
+        return Object.freeze({
+          fixedPrompt,
+          fullInput:
+            fixedPrompt +
+            contextMarginal.reduce((sum, tokens) => sum + tokens, 0),
+          historyMarginal: Object.freeze(historyMarginal),
+          revision,
+          wrapper: Math.ceil((input.wrapperUnits ?? 0) * scale),
+        });
+      },
+    });
+  }
+
+  estimateMessageUnits(units: readonly number[]): readonly number[] {
+    return this.view().estimateMessageUnits(units);
+  }
+}
+
+function reportedUsageTokens(usage: ModelUsage): {
+  readonly input?: number;
+  readonly output?: number;
+} {
+  let input = usage.inputTokens;
+  let output = usage.outputTokens;
+  if (
+    input === undefined &&
+    output !== undefined &&
+    usage.totalTokens !== undefined &&
+    usage.totalTokens >= output
+  ) {
+    input = usage.totalTokens - output;
+  } else if (
+    output === undefined &&
+    input !== undefined &&
+    usage.totalTokens !== undefined &&
+    usage.totalTokens >= input
+  ) {
+    output = usage.totalTokens - input;
+  }
+  return { input, output };
+}
+
+function roundedUnitCosts(units: readonly number[], scale: number): number[] {
+  let rounded = 0;
+  let cumulative = 0;
+  return units.map((value) => {
+    cumulative += value * scale;
+    const next = Math.ceil(cumulative);
+    const cost = next - rounded;
+    rounded = next;
+    return cost;
+  });
+}
+
+function combinedBasis(
+  input: TokenEstimate,
+  output: TokenEstimate
+): TokenEstimateBasis {
+  if (input.basis === "reported" && output.basis === "reported") {
+    return "reported";
+  }
+  return input.basis === "heuristic" || output.basis === "heuristic"
+    ? "heuristic"
+    : "calibrated";
+}
+
+function estimate(
+  reported: number | undefined,
+  tokens: number,
+  hasEvidence: boolean
+): TokenEstimate {
+  if (reported !== undefined) {
+    return { basis: "reported", marginTokens: 0, tokens: reported };
+  }
+  return {
+    basis: hasEvidence ? "calibrated" : "heuristic",
+    marginTokens: Math.ceil(tokens * 0.2),
+    tokens,
+  };
+}

--- a/packages/runtime/src/llm/model-step-types.ts
+++ b/packages/runtime/src/llm/model-step-types.ts
@@ -4,6 +4,7 @@ import type { HostAttachmentStore } from "../thread/input/attachments";
 import type { ModelUsage, StreamAgentEvent } from "../thread/protocol/events";
 import type { ThreadContextMessage } from "../thread/state/context";
 import type { ModelContextGateOptions } from "./context-gate";
+import type { ContextTokenMeter, ContextTokenOptions } from "./context-tokens";
 import type {
   PreparedModelToolChoice,
   PrepareModelStep,
@@ -17,6 +18,7 @@ export type ModelStepOutput = Awaited<
 export type ModelStepOutputPart = ModelStepOutput[number];
 
 export interface ModelStepResult {
+  readonly contextUsage?: import("./context-tokens").ContextUsageSnapshot;
   readonly messages: ModelStepOutput;
   readonly usage: ModelUsage;
 }
@@ -25,6 +27,8 @@ export interface ModelGenerationOptions {
   alwaysActiveTools?: readonly string[];
   attachmentStore?: HostAttachmentStore;
   contextGate?: false | ModelContextGateOptions;
+  contextTokenMeter?: ContextTokenMeter;
+  contextTokens?: ContextTokenOptions;
   diagnostics?: RuntimeDiagnosticsSink;
   instructions?: string;
   maxOutputTokens?: number;

--- a/packages/runtime/src/llm/model-step.ts
+++ b/packages/runtime/src/llm/model-step.ts
@@ -4,7 +4,11 @@ import {
   compactionContextForModel,
   type ThreadContextMessage,
 } from "../thread/state/context";
-import { enforceContextGate } from "./context-gate";
+import {
+  defaultModelPromptMeasurementProfile,
+  enforceContextGate,
+  materializeModelPromptTools,
+} from "./context-gate";
 import { ModelToolSelectionError } from "./model-step-error";
 import { resolveModelStepOptions } from "./model-step-preparation";
 import {
@@ -33,10 +37,13 @@ export async function generateModelStep(
   return (await generateModelStepResult(options)).messages;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: provider request lifecycle is intentionally kept in one exception-safe scope.
 export async function generateModelStepResult({
   alwaysActiveTools,
   attachmentStore,
   contextGate,
+  contextTokenMeter,
+  contextTokens,
   diagnostics,
   history,
   model,
@@ -81,10 +88,50 @@ export async function generateModelStepResult({
     prompt.messages,
     attachmentStore
   );
+  const materializedTools =
+    contextTokenMeter || contextGate
+      ? await materializeModelPromptTools(prepared.tools)
+      : {};
+  const visibleTools = materializedTools.promptTools;
+  const promptMeasurement =
+    contextTokenMeter || contextGate
+      ? (
+          contextTokens?.measurementProfile ??
+          defaultModelPromptMeasurementProfile
+        ).measurePrompt({
+          instructions: prompt.instructions,
+          messages,
+          toolChoice: prepared.toolChoice,
+          tools: visibleTools,
+        })
+      : undefined;
+  const provider = configuredProvider(prepared.model);
+  const modelId = configuredModelId(prepared.model);
+  const scope = provider && modelId ? `${provider}\0${modelId}` : undefined;
+  const initialUsage =
+    promptMeasurement &&
+    contextTokenMeter?.begin({
+      attemptId,
+      fixedFingerprint: promptMeasurement.fixedFingerprint,
+      maxInputTokens: contextGate ? contextGate.maxInputTokens : undefined,
+      measurement: promptMeasurement,
+      scope,
+    });
+  if (initialUsage) {
+    onStreamEvent?.({ ...initialUsage, type: "context-usage" });
+  }
   enforceContextGate({
-    contextGate,
+    contextGate:
+      contextGate && contextTokenMeter && !contextGate.estimateTokens
+        ? {
+            ...contextGate,
+            estimateTokens: () => contextTokenMeter.inputUpperBound(),
+          }
+        : contextGate,
     instructions: prompt.instructions,
     messages,
+    promptTools: visibleTools,
+    toolChoice: prepared.toolChoice,
   });
   assertNoUnsupportedToolApproval(prepared.tools);
   const handle = createModelStepStream({
@@ -98,7 +145,11 @@ export async function generateModelStepResult({
     temperature,
     toolChoice: prepared.toolChoice,
     toolOrder: prepared.toolOrder,
-    tools: normalizeToolCallIds(prepared.tools, toolCallIds, toolExecution),
+    tools: normalizeToolCallIds(
+      materializedTools.tools ?? prepared.tools,
+      toolCallIds,
+      toolExecution
+    ),
   });
   prepared.startToolCacheFingerprintReport?.();
   let aborted = false;
@@ -111,6 +162,14 @@ export async function generateModelStepResult({
       const event = mapStreamPartToAgentEvent(part);
       if (event) {
         onStreamEvent?.(event);
+        const delta = streamedTokenText(event);
+        const usageSnapshot =
+          delta === undefined
+            ? undefined
+            : contextTokenMeter?.outputDelta(attemptId, delta);
+        if (usageSnapshot) {
+          onStreamEvent?.({ ...usageSnapshot, type: "context-usage" });
+        }
       }
     }
     if (aborted || signal?.aborted) {
@@ -119,35 +178,63 @@ export async function generateModelStepResult({
     const { finalStep, finishReason, response, responseMessages, usage } =
       await handle.finalize();
 
+    const normalizedUsage = modelUsageEvent({
+      attemptId,
+      durationMs: finalStep?.performance.responseTimeMs,
+      finishReason,
+      modelId: firstSafeTelemetryIdentifier(
+        response?.modelId ?? finalStep?.model.modelId ?? modelId,
+        finalStep?.model.modelId,
+        modelId
+      ),
+      provider: firstSafeTelemetryIdentifier(
+        finalStep?.model.provider,
+        provider
+      ),
+      usage,
+    });
+    const resolvedScope =
+      normalizedUsage.provider && normalizedUsage.modelId
+        ? `${normalizedUsage.provider}\0${normalizedUsage.modelId}`
+        : undefined;
+    const usageSnapshot = contextTokenMeter?.report(
+      attemptId,
+      normalizedUsage,
+      resolvedScope
+    );
     return {
+      ...(usageSnapshot ? { contextUsage: usageSnapshot } : {}),
       messages: responseMessages.map((message) =>
         rewriteMessageToolCallIds(message, toolCallIds)
       ),
-      usage: modelUsageEvent({
-        attemptId,
-        durationMs: finalStep?.performance.responseTimeMs,
-        finishReason,
-        modelId: firstSafeTelemetryIdentifier(
-          response?.modelId ??
-            finalStep?.model.modelId ??
-            configuredModelId(prepared.model),
-          finalStep?.model.modelId,
-          configuredModelId(prepared.model)
-        ),
-        provider: firstSafeTelemetryIdentifier(
-          finalStep?.model.provider,
-          configuredProvider(prepared.model)
-        ),
-        usage,
-      }),
+      usage: normalizedUsage,
     };
   } catch (error) {
+    const usageSnapshot = contextTokenMeter?.abort(attemptId);
+    if (usageSnapshot) {
+      onStreamEvent?.({ ...usageSnapshot, type: "context-usage" });
+    }
     await handle.finalize().then(
       () => undefined,
       () => undefined
     );
     throw error;
   }
+}
+
+function streamedTokenText(
+  event: NonNullable<ReturnType<typeof mapStreamPartToAgentEvent>>
+): string | undefined {
+  if (event.type === "tool-call-input-delta") {
+    return event.inputTextDelta;
+  }
+  if (
+    event.type === "assistant-output-delta" ||
+    event.type === "assistant-reasoning-delta"
+  ) {
+    return event.text;
+  }
+  return;
 }
 
 function mapStreamPartToAgentEvent(part: ModelStepStreamPart) {

--- a/packages/runtime/src/otel/attributes.ts
+++ b/packages/runtime/src/otel/attributes.ts
@@ -36,6 +36,7 @@ export function defaultAgentEventAttributes(event: AgentEvent): Attributes {
       return base;
     case "assistant-output-delta":
     case "assistant-reasoning-delta":
+    case "context-usage":
     case "tool-call-input-delta":
     case "tool-call-input-end":
     case "tool-call-input-start":

--- a/packages/runtime/src/otel/trace-state.ts
+++ b/packages/runtime/src/otel/trace-state.ts
@@ -78,6 +78,7 @@ export function recordRuntimeTraceEvent(
     case "assistant-output-delta":
     case "assistant-reasoning":
     case "assistant-reasoning-delta":
+    case "context-usage":
     case "model-usage":
     case "runtime-input":
     case "tool-call-input-delta":

--- a/packages/runtime/src/thread/handle/lifecycle.test.ts
+++ b/packages/runtime/src/thread/handle/lifecycle.test.ts
@@ -116,7 +116,9 @@ describe("Agent thread lifecycle", () => {
       ),
     });
 
-    const events = await collect(await agent.send("fail"));
+    const events = (await collect(await agent.send("fail"))).filter(
+      (event) => event.type !== "context-usage"
+    );
 
     expect(events).toEqual([
       sentUserText("fail"),
@@ -128,6 +130,23 @@ describe("Agent thread lifecycle", () => {
         type: "turn-error",
       },
     ]);
+  });
+
+  it("restores context usage before exposing a failed turn", async () => {
+    const agent = new Agent({
+      model: createCallbackModel(() =>
+        Promise.reject(new Error("model unavailable"))
+      ),
+    });
+
+    const events = await collect(await agent.send("fail"));
+    const errorIndex = events.findIndex((event) => event.type === "turn-error");
+    const restored = events[errorIndex - 1];
+
+    expect(restored?.type).toBe("context-usage");
+    if (restored?.type === "context-usage") {
+      expect(restored.currentRequest.total.tokens).toBe(0);
+    }
   });
 
   it("emits whitelisted structured metadata for API call failures", async () => {
@@ -163,7 +182,9 @@ describe("Agent thread lifecycle", () => {
     });
 
     const events = await collect(await agent.send("fail safely"));
-    const turnError = events.at(-1);
+    const turnError = events
+      .filter((event) => event.type !== "context-usage")
+      .at(-1);
 
     expect(turnError).toEqual({
       error: {

--- a/packages/runtime/src/thread/handle/stream-events.test.ts
+++ b/packages/runtime/src/thread/handle/stream-events.test.ts
@@ -123,7 +123,11 @@ describe("thread stream events", () => {
 
     const live = await collect(await thread.send("go"));
 
-    expect(live.map((event) => event.type)).toEqual(expectedLiveTypes);
+    expect(
+      live
+        .filter((event) => event.type !== "context-usage")
+        .map((event) => event.type)
+    ).toEqual(expectedLiveTypes);
   });
 
   it("preserves committed event parity with doGenerate-only models", async () => {
@@ -156,13 +160,22 @@ describe("thread stream events", () => {
     );
   });
 
-  it("rejects stream events at the durable recording boundary", () => {
-    expect(() =>
-      recordDurableThreadEvent([], {
-        text: "must stay ephemeral",
-        type: "assistant-output-delta",
-      })
-    ).toThrow(TypeError);
+  it.each([
+    {
+      text: "must stay ephemeral",
+      type: "assistant-output-delta" as const,
+    },
+    {
+      calibration: { observations: 0, revision: 0 },
+      currentRequest: {
+        input: { basis: "heuristic" as const, marginTokens: 0, tokens: 0 },
+        output: { basis: "heuristic" as const, marginTokens: 0, tokens: 0 },
+        total: { basis: "heuristic" as const, marginTokens: 0, tokens: 0 },
+      },
+      type: "context-usage" as const,
+    },
+  ])("rejects $type at the durable recording boundary", (event) => {
+    expect(() => recordDurableThreadEvent([], event)).toThrow(TypeError);
   });
 
   it("bypasses observer capture for stream events", async () => {

--- a/packages/runtime/src/thread/handle/thread-events.test.ts
+++ b/packages/runtime/src/thread/handle/thread-events.test.ts
@@ -111,7 +111,11 @@ describe("AgentThread durable event replay", () => {
       ({ event }) => event.type === "model-usage"
     )?.event;
 
-    expect(live.map((event) => event.type)).toEqual([
+    expect(
+      live
+        .filter((event) => event.type !== "context-usage")
+        .map((event) => event.type)
+    ).toEqual([
       "user-input",
       "turn-start",
       "step-start",
@@ -163,7 +167,11 @@ describe("AgentThread durable event replay", () => {
 
     expect(failedUsageAppend).toBe(true);
     expect(modelStepHookCalls).toBe(0);
-    expect(live.map((event) => event.type)).toEqual([
+    expect(
+      live
+        .filter((event) => event.type !== "context-usage")
+        .map((event) => event.type)
+    ).toEqual([
       "user-input",
       "turn-start",
       "step-start",
@@ -196,7 +204,9 @@ describe("AgentThread durable event replay", () => {
     const live = await collect(
       await agent.thread("safe-rollback-failure").send("hello")
     );
-    const turnError = live.at(-1);
+    const turnError = live
+      .filter((event) => event.type !== "context-usage")
+      .at(-1);
     const serialized = JSON.stringify(turnError);
 
     expect(turnError).toEqual({

--- a/packages/runtime/src/thread/protocol/events.ts
+++ b/packages/runtime/src/thread/protocol/events.ts
@@ -1,3 +1,4 @@
+import type { ContextUsageSnapshot } from "../../llm/context-tokens";
 import type { UserInput, UserMessage, UserText } from "../input/input";
 import type { InputEventMeta } from "../input/input-meta-types";
 
@@ -101,6 +102,10 @@ export interface ToolCallInputEnd {
   type: "tool-call-input-end";
 }
 
+export interface ContextUsageEvent extends ContextUsageSnapshot {
+  type: "context-usage";
+}
+
 export type TurnErrorCategory =
   | "authentication"
   | "bad-request"
@@ -188,7 +193,8 @@ export type AgentEvent =
    * Ephemeral signal that tool-call input streaming finished; never persisted.
    * The committed tool-call event remains the durable record.
    */
-  | ToolCallInputEnd;
+  | ToolCallInputEnd
+  | ContextUsageEvent;
 
 export type AgentEventListener = (event: AgentEvent) => void;
 
@@ -218,6 +224,7 @@ const telemetryAgentEventTypes = {
 } satisfies Partial<Record<AgentEvent["type"], true>>;
 
 export const streamAgentEventTypes = Object.freeze({
+  "context-usage": true,
   "assistant-output-delta": true,
   "assistant-reasoning-delta": true,
   "tool-call-input-delta": true,

--- a/packages/runtime/src/thread/runtime/auto-compaction-range.test.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-range.test.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage } from "ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ThreadCompactionRecord } from "../state/snapshot";
 import type { CompactionRangePolicy } from "./auto-compaction-range";
 import { selectAutoCompactionRange } from "./auto-compaction-range";
@@ -61,6 +61,28 @@ const policy = (
 });
 
 describe("selectAutoCompactionRange", () => {
+  it("uses aligned marginal costs without re-estimating each message", () => {
+    const history = [
+      userMessage("u0"),
+      assistantMessage("a1"),
+      userMessage("u2"),
+      assistantMessage("a3"),
+    ];
+    const estimateTokens = vi.fn(tenTokensPerMessage);
+
+    expect(
+      selectAutoCompactionRange({
+        compactions: [],
+        history,
+        instructionsTokens: 20,
+        messageTokenCosts: [10, 10, 10, 10],
+        policy: policy({ estimateTokens, retainTokens: 20 }),
+      })
+    ).toEqual({ endSeqExclusive: 2, startSeq: 0 });
+    // Only the compaction wrapper floor still needs estimation.
+    expect(estimateTokens).toHaveBeenCalledTimes(1);
+  });
+
   it("returns undefined while estimated tokens are below the trigger", () => {
     const history = [userMessage("a"), assistantMessage("b"), userMessage("c")];
 

--- a/packages/runtime/src/thread/runtime/auto-compaction-range.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-range.ts
@@ -28,21 +28,29 @@ export function selectAutoCompactionRange({
   compactions,
   history,
   instructionsTokens = 0,
+  messageTokenCosts,
   policy,
 }: {
   readonly compactions: readonly ThreadCompactionRecord[];
   readonly history: readonly ModelMessage[];
   readonly instructionsTokens?: number;
+  /** Precomputed marginal costs aligned by index with history. */
+  readonly messageTokenCosts?: readonly number[];
   readonly policy: CompactionRangePolicy;
 }): AutoCompactionRange | undefined {
   const estimate = policy.estimateTokens ?? estimateModelMessagesTokens;
+  if (messageTokenCosts && messageTokenCosts.length !== history.length) {
+    throw new TypeError("messageTokenCosts must align with history.");
+  }
   const covered = latestPrefixCompaction(compactions);
   const coveredEnd = covered?.endSeqExclusive ?? 0;
   const summaryTokens = covered
     ? estimate([compactionContextForModel(compactionContextMessage(covered))])
     : 0;
   const suffix = history.slice(coveredEnd);
-  const suffixTokens = suffix.map((message) => estimate([message]));
+  const suffixTokens = messageTokenCosts
+    ? messageTokenCosts.slice(coveredEnd)
+    : suffix.map((message) => estimate([message]));
   const totalTokens =
     instructionsTokens +
     summaryTokens +

--- a/packages/runtime/src/thread/runtime/auto-compaction-runner.test.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-runner.test.ts
@@ -1,6 +1,10 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import {
+  ContextTokenCalibrationRegistry,
+  ContextTokenMeter,
+} from "../../llm/context-tokens";
+import {
   MemoryAttachmentStore,
   MemoryThreadStore,
 } from "../../platform/memory";
@@ -196,6 +200,64 @@ describe("compaction runner concurrency", () => {
       compactThreadBlocking({
         compaction,
         model,
+        state,
+        threadKey: "thread",
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("shares calibrated fixed and marginal costs with compaction", async () => {
+    const state = await stateWithHistory();
+    const registry = new ContextTokenCalibrationRegistry();
+    const contextTokenMeter = new ContextTokenMeter(registry);
+    const measurementProfile = {
+      measureMessages: (messages: readonly ModelMessage[]) =>
+        messages.map(() => 10),
+      measurePrompt: () => ({
+        fixedFingerprint: "fixed",
+        fixedUnits: 10,
+        messageUnits: [10],
+        totalUnits: 20,
+      }),
+    };
+    contextTokenMeter.begin({
+      attemptId: "attempt",
+      fixedFingerprint: "fixed",
+      measurement: measurementProfile.measurePrompt(),
+      scope: "provider\0model",
+    });
+    contextTokenMeter.report("attempt", {
+      attemptId: "attempt",
+      inputTokens: 100,
+      modelId: "model",
+      provider: "provider",
+      type: "model-usage",
+    });
+    const compaction: AgentCompaction = (context) => {
+      expect(context.instructionsTokens).toBe(100);
+      expect(context.estimatedHistoryMessageTokens).toEqual([10, 10, 10]);
+      expect(context.estimatedContextTokens).toBe(130);
+      expect(
+        context.estimateTokens?.([{ content: "wrapper", role: "user" }])
+      ).toBe(10);
+      return;
+    };
+
+    await expect(
+      compactThreadBlocking({
+        compaction,
+        model: {
+          ...model,
+          contextTokenMeter,
+          contextTokens: { measurementProfile },
+        },
+        latestContextTransform: () => ({
+          input: [{ content: "before", role: "user" }],
+          output: [
+            { content: "before", role: "user" },
+            { content: "added", role: "user" },
+          ],
+        }),
         state,
         threadKey: "thread",
       })

--- a/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
@@ -1,5 +1,9 @@
 import type { ModelMessage } from "ai";
-import { estimateModelMessagesTokens } from "../../llm/context-gate";
+import {
+  defaultModelPromptMeasurementProfile,
+  estimateModelMessagesTokens,
+} from "../../llm/context-gate";
+import type { ContextTokenView } from "../../llm/context-tokens";
 import type { ModelGenerationOptions } from "../../llm/model-step-types";
 import { hydrateRuntimeAttachments } from "../input/attachments";
 import { compactionContextForModel } from "../state/context";
@@ -96,6 +100,16 @@ function runSingleFlight(options: RunOptions): Promise<boolean> {
 
 async function compactThreadOnce(options: RunOptions): Promise<boolean> {
   const { state } = options;
+  const legacyEstimate = options.compaction
+    ? estimatorForCompaction(options.compaction)
+    : undefined;
+  const meterView = legacyEstimate
+    ? undefined
+    : options.model.contextTokenMeter?.view();
+  const observationSnapshot = options.latestContextTransform?.();
+  const observation = observationSnapshot
+    ? deepFreeze(structuredClone(observationSnapshot))
+    : undefined;
   const history = deepFreeze(structuredClone(state.modelSnapshot()));
   const compactions = deepFreeze(structuredClone(state.compactionSnapshot()));
   const rawModelContext = state
@@ -114,14 +128,6 @@ async function compactThreadOnce(options: RunOptions): Promise<boolean> {
       options.model.attachmentStore
     )
   );
-  const estimate = options.compaction
-    ? (estimatorForCompaction(options.compaction) ??
-      estimateModelMessagesTokens)
-    : estimateModelMessagesTokens;
-  const instructionsTokens = options.model.instructions
-    ? estimate([{ content: options.model.instructions, role: "system" }])
-    : 0;
-  const observation = options.latestContextTransform?.();
   const observedInput = observation
     ? await hydrateRuntimeAttachments(
         modelMessagesForEstimate(observation.input),
@@ -134,11 +140,20 @@ async function compactThreadOnce(options: RunOptions): Promise<boolean> {
         options.model.attachmentStore
       )
     : [];
-  const transformOverhead = Math.max(
-    0,
-    estimate(observedOutput) - estimate(observedInput)
-  );
-  const fixedTokens = instructionsTokens + transformOverhead;
+  const {
+    estimate,
+    estimatedContextTokens,
+    estimatedHistoryMessageTokens,
+    fixedTokens,
+  } = compactionTokenAccounting({
+    estimatedHistory,
+    hydratedModelContext,
+    legacyEstimate,
+    meterView,
+    model: options.model,
+    observedInput,
+    observedOutput,
+  });
   const signal = options.signal ?? new AbortController().signal;
   const summarize = async (range: AutoCompactionRange): Promise<string> => {
     assertRange(range, history.length);
@@ -158,8 +173,12 @@ async function compactThreadOnce(options: RunOptions): Promise<boolean> {
   const input = await options.compaction?.(
     Object.freeze({
       compactions,
-      estimatedContextTokens: estimate(hydratedModelContext) + fixedTokens,
+      estimatedContextTokens,
       estimatedHistory,
+      ...(estimatedHistoryMessageTokens
+        ? { estimatedHistoryMessageTokens }
+        : {}),
+      estimateTokens: estimate,
       history,
       instructionsTokens: fixedTokens,
       modelContext: hydratedModelContext,
@@ -205,6 +224,74 @@ async function compactThreadOnce(options: RunOptions): Promise<boolean> {
   }
   await state.compact(input);
   return true;
+}
+
+function compactionTokenAccounting({
+  estimatedHistory,
+  hydratedModelContext,
+  legacyEstimate,
+  meterView,
+  model,
+  observedInput,
+  observedOutput,
+}: {
+  readonly estimatedHistory: readonly ModelMessage[];
+  readonly hydratedModelContext: readonly ModelMessage[];
+  readonly legacyEstimate?: (messages: readonly ModelMessage[]) => number;
+  readonly meterView?: ContextTokenView;
+  readonly model: ModelGenerationOptions;
+  readonly observedInput: readonly ModelMessage[];
+  readonly observedOutput: readonly ModelMessage[];
+}): {
+  readonly estimate: (messages: readonly ModelMessage[]) => number;
+  readonly estimatedContextTokens: number;
+  readonly estimatedHistoryMessageTokens?: readonly number[];
+  readonly fixedTokens: number;
+} {
+  const measurementProfile =
+    model.contextTokens?.measurementProfile ??
+    defaultModelPromptMeasurementProfile;
+  let estimate = legacyEstimate ?? estimateModelMessagesTokens;
+  if (meterView) {
+    estimate = (messages) =>
+      meterView
+        .estimateMessageUnits(measurementProfile.measureMessages(messages))
+        .reduce((sum, tokens) => sum + tokens, 0);
+  }
+
+  const instructionsTokens =
+    meterView || !model.instructions
+      ? 0
+      : estimate([{ content: model.instructions, role: "system" }]);
+  const transformOverhead = Math.max(
+    0,
+    estimate(observedOutput) - estimate(observedInput)
+  );
+  const legacyFixedTokens = instructionsTokens + transformOverhead;
+  const meterProfile = meterView?.profile({
+    contextMessageUnits:
+      measurementProfile.measureMessages(hydratedModelContext),
+    historyMessageUnits: measurementProfile.measureMessages(estimatedHistory),
+  });
+  let estimatedHistoryMessageTokens: readonly number[] | undefined;
+  if (meterProfile) {
+    estimatedHistoryMessageTokens = meterProfile.historyMarginal;
+  } else if (legacyEstimate) {
+    estimatedHistoryMessageTokens = estimatedHistory.map((message) =>
+      estimate([message])
+    );
+  }
+  const fixedTokens = meterProfile
+    ? meterProfile.fixedPrompt + transformOverhead
+    : legacyFixedTokens;
+  return {
+    estimate,
+    estimatedContextTokens: meterProfile
+      ? meterProfile.fullInput + transformOverhead
+      : estimate(hydratedModelContext) + fixedTokens,
+    ...(estimatedHistoryMessageTokens ? { estimatedHistoryMessageTokens } : {}),
+    fixedTokens,
+  };
 }
 
 function assertRange(range: AutoCompactionRange, length: number): void {

--- a/packages/runtime/src/thread/runtime/auto-compaction-types.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-types.ts
@@ -13,6 +13,10 @@ export interface AgentCompactionContext {
   readonly compactions: readonly ThreadCompactionRecord[];
   readonly estimatedContextTokens: number;
   readonly estimatedHistory: readonly ModelMessage[];
+  /** Marginal costs aligned by index with estimatedHistory. */
+  readonly estimatedHistoryMessageTokens?: readonly number[];
+  /** Runtime-pinned estimator aligned with estimatedContextTokens. */
+  readonly estimateTokens?: ThreadTokenEstimator;
   readonly history: readonly ModelMessage[];
   readonly instructionsTokens: number;
   readonly modelContext: readonly ModelMessage[];

--- a/packages/runtime/src/thread/runtime/queued-input-processor.ts
+++ b/packages/runtime/src/thread/runtime/queued-input-processor.ts
@@ -58,6 +58,7 @@ export async function processQueuedInput({
     turnId,
   });
   const historySnapshot = state.modelSnapshot();
+  const meterCheckpoint = model.contextTokenMeter?.checkpoint();
   let executionRun: ThreadExecutionRun | undefined;
   let pendingDurableInputClaim = durableInputClaim;
   const durableEvents: DurableThreadEventBuffer = [];
@@ -225,6 +226,7 @@ export async function processQueuedInput({
       });
       pendingDurableInputClaim = undefined;
     }
+    restoreContextTokenMeter(model.contextTokenMeter, meterCheckpoint, run);
     await recoverTurnProcessingError({
       durableEvents,
       error,
@@ -248,4 +250,15 @@ export async function processQueuedInput({
     release();
     run.close();
   }
+}
+
+function restoreContextTokenMeter(
+  meter: ProcessQueuedInputOptions["model"]["contextTokenMeter"],
+  checkpoint: ReturnType<NonNullable<typeof meter>["checkpoint"]> | undefined,
+  run: ProcessQueuedInputOptions["item"]["run"]
+): void {
+  if (!(meter && checkpoint)) {
+    return;
+  }
+  run.emit({ ...meter.restore(checkpoint), type: "context-usage" });
 }

--- a/packages/runtime/src/thread/runtime/speculative-compaction.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction.test.ts
@@ -1,7 +1,11 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentCompactionContext } from "./auto-compaction-types";
-import { speculativeCompaction } from "./speculative-compaction";
+import {
+  contextGateForCompaction,
+  estimatorForCompaction,
+  speculativeCompaction,
+} from "./speculative-compaction";
 
 const message = (
   content: string,
@@ -38,6 +42,33 @@ describe("speculativeCompaction", () => {
     { prepareRatio: 0.9, promoteRatio: 0.8 },
   ])("rejects invalid factory options: %o", (options) => {
     expect(() => speculativeCompaction(options)).toThrow(TypeError);
+  });
+
+  it("leaves default token accounting to the runtime context meter", () => {
+    const compaction = speculativeCompaction({ maxInputTokens: 100 });
+
+    expect(estimatorForCompaction(compaction)).toBeUndefined();
+    expect(contextGateForCompaction(compaction)).toEqual({
+      maxInputTokens: 100,
+      onOverflow: "compact",
+    });
+  });
+
+  it("preserves an explicit token estimator as a complete override", () => {
+    const estimateTokens = vi.fn(() => 17);
+    const compaction = speculativeCompaction({ estimateTokens });
+
+    expect(estimatorForCompaction(compaction)).toBe(estimateTokens);
+    expect(
+      contextGateForCompaction(compaction)?.estimateTokens?.({
+        instructions: "system",
+        messages: [message("user")],
+      })
+    ).toBe(17);
+    expect(estimateTokens).toHaveBeenCalledWith([
+      { content: "system", role: "system" },
+      message("user"),
+    ]);
   });
 
   it("promotes a prepared candidate after tail append without summarizing twice", async () => {

--- a/packages/runtime/src/thread/runtime/speculative-compaction.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction.ts
@@ -76,7 +76,8 @@ export function speculativeCompaction(
       "speculativeCompaction: prepareRatio must be smaller than promoteRatio."
     );
   }
-  const estimate = options.estimateTokens ?? estimateModelMessagesTokens;
+  const customEstimate = options.estimateTokens;
+  const estimate = customEstimate ?? estimateModelMessagesTokens;
   const candidates = new WeakMap<object, Candidate>();
   const compaction: AgentCompaction = async (context) => {
     const tokens = context.estimatedContextTokens;
@@ -98,16 +99,22 @@ export function speculativeCompaction(
     return;
   };
   contextGateMetadata.set(compaction, {
-    estimateTokens: ({ instructions, messages }) =>
-      estimate(
-        instructions
-          ? [{ content: instructions, role: "system" }, ...messages]
-          : messages
-      ),
+    ...(customEstimate
+      ? {
+          estimateTokens: ({ instructions, messages }) =>
+            customEstimate(
+              instructions
+                ? [{ content: instructions, role: "system" }, ...messages]
+                : messages
+            ),
+        }
+      : {}),
     maxInputTokens: max,
     onOverflow: "compact",
   });
-  estimatorMetadata.set(compaction, estimate);
+  if (customEstimate) {
+    estimatorMetadata.set(compaction, customEstimate);
+  }
   return compaction;
 }
 
@@ -201,8 +208,9 @@ function selectRange(
     compactions: context.compactions,
     history: context.estimatedHistory,
     instructionsTokens: context.instructionsTokens,
+    messageTokenCosts: context.estimatedHistoryMessageTokens,
     policy: {
-      estimateTokens: estimate,
+      estimateTokens: context.estimateTokens ?? estimate,
       retainTokens: Math.floor(max * retain),
       triggerTokens: 1,
     },

--- a/packages/runtime/src/thread/runtime/windows.test.ts
+++ b/packages/runtime/src/thread/runtime/windows.test.ts
@@ -144,7 +144,7 @@ describe("Agent thread runtime input windows", () => {
       steerRuntimeInput("step-end runtime", "step-end")
     );
     expect(seenHistory).toEqual([firstStepHistory, secondStepHistory]);
-    expect(trace).toEqual([
+    expect(trace.filter((entry) => entry !== "event:context-usage")).toEqual([
       "hook:user-input",
       "event:user-input",
       "hook:turn-start",


### PR DESCRIPTION
## Summary
- move context-token measurement and calibration into the runtime
- share calibrated accounting with context gating and speculative compaction
- make the coding-agent TUI format runtime-owned usage snapshots

## Validation
- pnpm test
- pnpm exec vitest run scripts/tegami-config.test.mjs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds adaptive context token accounting to the runtime. We now measure provider-visible prompts, calibrate against reported usage, and stream `context-usage` snapshots that power context gating, compaction, and the TUI footer.

- **New Features**
  - `@minpeter/pss-runtime`: Adds `ContextTokenMeter` with a shared calibration registry and emits ephemeral `context-usage` snapshots during begin/delta/report/abort.
  - Context gate uses the meter’s upper bound when no custom `estimateTokens` is provided; prompt measurement covers instructions, tools, and messages.
  - Speculative and auto-compaction consume calibrated fixed and marginal costs, with aligned per-message token costs to avoid re-estimation.
  - Public API exports: `ContextUsageSnapshot`, `ContextTokenOptions`, `TokenEstimate`, `defaultModelPromptMeasurementProfile`.
  - `@minpeter/pss-coding-agent` TUI: footer now renders from runtime snapshots and no longer counts streamed output heuristically.

- **Migration**
  - TUI integrations: use `onContextUsage(snapshot)` and `contextUsageFooter(snapshot)`. Remove `onOutputDelta` and `onStreamStart`.
  - Runtime consumers: optionally pass `contextTokens` in `AgentOptions`. Keep a custom `estimateTokens` only if you need a full override; otherwise the meter supplies estimates.
  - Stream handlers should accept the new ephemeral `context-usage` event.

<sup>Written for commit 2885d459326407344ff523f92c2e9f32df2d12e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

