### PR TITLE
feat(runtime): align SDK and thread storage lifecycle

### DIFF
--- a/.tegami/2026-08-04-thread-storage-upgrade.md
+++ b/.tegami/2026-08-04-thread-storage-upgrade.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Harden thread storage lifecycle
+
+Make Durable Object thread schema migration idempotent and add aggregate thread deletion that removes runtime-owned snapshots, events, runs, notifications, scheduled work, and payload chunks.

--- a/.tegami/2026-08-04-update-runtime-ai-sdk.md
+++ b/.tegami/2026-08-04-update-runtime-ai-sdk.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Update the runtime AI SDK
+
+Update the runtime to AI SDK 7.0.51 for downstream version alignment.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -102,7 +102,7 @@
     "@jsquash/avif": "^2.1.1",
     "@jsquash/webp": "^1.5.0",
     "@opentelemetry/api": "^1.9.1",
-    "ai": "7.0.45",
+    "ai": "7.0.51",
     "fast-png": "^8.0.0",
     "heic-decode": "^2.1.0",
     "jpeg-js": "^0.4.4",

--- a/packages/runtime/scripts/storage-inspect-output.ts
+++ b/packages/runtime/scripts/storage-inspect-output.ts
@@ -102,6 +102,7 @@ export function printApiMap(): void {
   printSection("API -> SQL table map");
   const lines = [
     "threads.commit/load -> pss_thread_meta + pss_thread_message + pss_thread_message_chunk",
+    "store.deleteThread -> all runtime-owned thread, run, event, checkpoint, notification, input, scheduled-work, and payload-chunk rows",
     "turns.create/get/update -> pss_run",
     "events.append/read -> pss_event + pss_event_meta",
     "checkpoints.append/latest -> pss_checkpoint + pss_run.checkpoint_version",

--- a/packages/runtime/src/contracts/execution-store/contract.ts
+++ b/packages/runtime/src/contracts/execution-store/contract.ts
@@ -3,6 +3,7 @@ import type { HostStore } from "../../execution";
 import {
   appendCheckpoint,
   collectEvents,
+  collectThreadEvents,
   createDeferred,
   createQueuedRun,
 } from "./fixtures";
@@ -101,6 +102,105 @@ export function describeExecutionStoreContract({
       ).rejects.toThrow("transaction failed");
 
       await expect(store.threads.load("thread-1")).resolves.toBeNull();
+    });
+
+    it("deletes aggregate thread execution data when supported", async () => {
+      const store = createStore();
+      if (!store.deleteThread) {
+        return;
+      }
+      await store.threads.commit(
+        "thread-1",
+        { state: { messages: ["delete me"] } },
+        { expectedVersion: null }
+      );
+      await store.turns.create(createQueuedRun());
+      await store.events.append("run-1", { type: "turn-start" });
+      await appendCheckpoint(store, 0);
+      await store.notifications.enqueue({
+        idempotencyKey: "delete-notification",
+        input: { text: "delete", type: "user-input" },
+        notificationId: "delete-notification",
+        runId: "run-1",
+        threadKey: "thread-1",
+        status: "pending",
+      });
+      await store.threadEvents?.append("thread-1", { type: "turn-start" });
+      await store.inputs.admit({
+        input: { text: "delete", type: "user-input" },
+        kind: "send",
+        messageId: "delete-input",
+        threadKey: "thread-1",
+      });
+
+      await store.threads.commit(
+        "thread-2",
+        { state: { messages: ["keep me"] } },
+        { expectedVersion: null }
+      );
+      await store.turns.create({
+        ...createQueuedRun("run-2"),
+        threadKey: "thread-2",
+      });
+      await store.events.append("run-2", { type: "turn-start" });
+      await store.checkpoints.append(
+        {
+          checkpointId: "checkpoint-keep",
+          phase: "before-model",
+          runId: "run-2",
+          runtimeState: {},
+          threadSnapshot: {},
+          version: 1,
+        },
+        { expectedVersion: 0 }
+      );
+      await store.notifications.enqueue({
+        idempotencyKey: "keep-notification",
+        input: { text: "keep", type: "user-input" },
+        notificationId: "keep-notification",
+        runId: "run-2",
+        threadKey: "thread-2",
+        status: "pending",
+      });
+      await store.threadEvents?.append("thread-2", { type: "turn-start" });
+      await store.inputs.admit({
+        input: { text: "keep", type: "user-input" },
+        kind: "send",
+        messageId: "keep-input",
+        threadKey: "thread-2",
+      });
+
+      await store.deleteThread("thread-1");
+      await store.deleteThread("thread-1");
+
+      await expect(store.threads.load("thread-1")).resolves.toBeNull();
+      await expect(store.turns.get("run-1")).resolves.toBeNull();
+      await expect(store.checkpoints.latest("run-1")).resolves.toBeNull();
+      expect(await collectEvents(store.events.read("run-1"))).toEqual([]);
+      await expect(
+        store.notifications.getByIdempotencyKey("delete-notification")
+      ).resolves.toBeNull();
+      await expect(store.threads.load("thread-2")).resolves.toMatchObject({
+        state: { messages: ["keep me"] },
+      });
+      await expect(store.turns.get("run-2")).resolves.toMatchObject({
+        threadKey: "thread-2",
+      });
+      await expect(store.checkpoints.latest("run-2")).resolves.toMatchObject({
+        checkpointId: "checkpoint-keep",
+      });
+      expect(await collectEvents(store.events.read("run-2"))).toHaveLength(1);
+      await expect(
+        store.notifications.getByIdempotencyKey("keep-notification")
+      ).resolves.toMatchObject({ threadKey: "thread-2" });
+      await expect(
+        store.inputs.claimNext("thread-2", "turn-idle")
+      ).resolves.toMatchObject({ messageId: "keep-input" });
+      if (store.threadEvents) {
+        expect(
+          await collectThreadEvents(store.threadEvents.read("thread-2"))
+        ).toHaveLength(1);
+      }
     });
 
     describeThreadInputInboxContract({ createStore });

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -38,6 +38,8 @@ import type {
 import {
   AgentHookError,
   createAgent,
+  decodeStoredThreadState,
+  encodeThreadSnapshot,
   isStreamAgentEvent,
   ModelToolSelectionError,
   threadStoreKey as runtimeThreadStoreKey,
@@ -71,6 +73,19 @@ const forbiddenChannelRootExports = [
 ] as const;
 
 describe("runtime public exports", () => {
+  it("exports the canonical stored thread codecs", async () => {
+    const runtime = await import("../index");
+
+    expect(runtime).toHaveProperty(
+      "decodeStoredThreadState",
+      decodeStoredThreadState
+    );
+    expect(runtime).toHaveProperty(
+      "encodeThreadSnapshot",
+      encodeThreadSnapshot
+    );
+  });
+
   it("does not expose internal agent loop runner from package root", async () => {
     const runtime = await import("../index");
 

--- a/packages/runtime/src/execution/host/types.ts
+++ b/packages/runtime/src/execution/host/types.ts
@@ -277,8 +277,12 @@ export interface HostStorePorts {
   readonly turns: TurnStore;
 }
 
-export interface HostStoreTransaction extends HostStorePorts {}
+export interface HostStoreTransaction extends HostStorePorts {
+  deleteThread?(threadKey: string): Promise<void>;
+}
 
 export interface HostStore extends HostStorePorts {
+  /** Atomically removes all runtime-owned data for a thread, when supported. */
+  deleteThread?(threadKey: string): Promise<void>;
   transaction<T>(fn: (tx: HostStoreTransaction) => Promise<T>): Promise<T>;
 }

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/notification-write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/notification-write.ts
@@ -14,6 +14,14 @@ export function writeNotificationStatement(
     upsertNotification(state, bindings);
     return true;
   }
+  if (query.startsWith("delete from pss_notification")) {
+    const prefix = stringBinding(bindings[0]);
+    const threadKey = stringBinding(bindings[1]);
+    state.notifications = state.notifications.filter(
+      (row) => !(row.prefix === prefix && row.thread_key === threadKey)
+    );
+    return true;
+  }
   return false;
 }
 

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/run-write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/run-write.ts
@@ -15,7 +15,7 @@ export function writeRunStatement(
     return true;
   }
   if (query.startsWith("delete from pss_run")) {
-    deleteRun(state, bindings);
+    deleteRun(state, query, bindings);
     return true;
   }
   return false;
@@ -35,12 +35,19 @@ function upsertRun(
 
 function deleteRun(
   state: InMemoryDurableObjectSqlState,
+  query: string,
   bindings: readonly unknown[]
 ): void {
   const prefix = stringBinding(bindings[0]);
-  const runId = stringBinding(bindings[1]);
+  const value = stringBinding(bindings[1]);
   state.turns = state.turns.filter(
-    (row) => !(row.prefix === prefix && row.run_id === runId)
+    (row) =>
+      !(
+        row.prefix === prefix &&
+        (query.includes("thread_key = ?")
+          ? row.thread_key === value
+          : row.run_id === value)
+      )
   );
 }
 

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
@@ -83,6 +83,12 @@ function selectRunRows(
   bindings: readonly unknown[]
 ): unknown[] {
   const prefix = stringBinding(bindings[0]);
+  if (query.includes("thread_key = ?")) {
+    const threadKey = stringBinding(bindings[1]);
+    return state.turns
+      .filter((row) => row.prefix === prefix && row.thread_key === threadKey)
+      .map((row) => ({ run_id: row.run_id }));
+  }
   if (query.includes("run_id = ?")) {
     const runId = stringBinding(bindings[1]);
     return state.turns
@@ -114,6 +120,12 @@ function selectNotificationRows(
   bindings: readonly unknown[]
 ): unknown[] {
   const prefix = stringBinding(bindings[0]);
+  if (query.includes("thread_key = ?")) {
+    const threadKey = stringBinding(bindings[1]);
+    return state.notifications
+      .filter((row) => row.prefix === prefix && row.thread_key === threadKey)
+      .map((row) => ({ idempotency_key: row.idempotency_key }));
+  }
   if (query.includes("idempotency_key = ?")) {
     const idempotencyKey = stringBinding(bindings[1]);
     return state.notifications

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
@@ -1,4 +1,5 @@
 export interface ThreadMetaRow {
+  readonly applied_migrations: string | null;
   readonly message_count: number;
   readonly next_seq: number;
   readonly state_blob: string | null;
@@ -130,6 +131,7 @@ export interface InMemoryDurableObjectSqlState {
   threadMessageChunks: ThreadMessageChunkRow[];
   threadMessages: ThreadMessageRow[];
   threadMeta: Map<string, ThreadMetaRow>;
+  threadMetaColumns: Set<string>;
   turns: RunRow[];
 }
 
@@ -149,6 +151,13 @@ export function createInMemoryDurableObjectSqlState(): InMemoryDurableObjectSqlS
     threadMessageChunks: [],
     threadMessages: [],
     threadMeta: new Map(),
+    threadMetaColumns: new Set([
+      "thread_key",
+      "version",
+      "message_count",
+      "next_seq",
+      "state_blob",
+    ]),
   };
 }
 
@@ -179,5 +188,6 @@ export function cloneInMemoryDurableObjectSqlState(
     threadMeta: new Map(
       [...state.threadMeta].map(([key, value]) => [key, structuredClone(value)])
     ),
+    threadMetaColumns: new Set(state.threadMetaColumns),
   };
 }

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/storage.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/storage.ts
@@ -20,6 +20,22 @@ export class InMemoryDurableObjectSqlStorage implements SqlStorage {
     ...bindings: unknown[]
   ): SqlStorageCursorLike<T> {
     const normalized = normalizeSql(query);
+    if (normalized === "pragma table_info(pss_thread_meta)") {
+      return toCursor<T>(
+        [...this.#state.threadMetaColumns].map((name) => ({ name }))
+      );
+    }
+    if (normalized.startsWith("pragma table_info(pss_")) {
+      return toCursor<T>([{ name: "test-double-column" }]);
+    }
+    if (normalized.startsWith("alter table pss_thread_meta add column ")) {
+      const name = normalized.split(" ")[5];
+      if (!name || this.#state.threadMetaColumns.has(name)) {
+        throw new Error(`duplicate column name: ${name}`);
+      }
+      this.#state.threadMetaColumns.add(name);
+      return toCursor<T>([]);
+    }
     if (isSchemaStatement(normalized) || isTransactionStatement(normalized)) {
       return toCursor<T>([]);
     }

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/thread-select.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/thread-select.ts
@@ -151,6 +151,7 @@ function projectThreadInput(row: ThreadInputRow, query: string): unknown {
 function projectThreadMeta(row: ThreadMetaRow, query: string): unknown {
   if (query.startsWith("select version, message_count, next_seq, state_blob")) {
     return {
+      applied_migrations: row.applied_migrations,
       message_count: row.message_count,
       next_seq: row.next_seq,
       state_blob: row.state_blob,

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/thread-write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/thread-write.ts
@@ -16,6 +16,10 @@ export function writeThreadStatement(
   query: string,
   bindings: readonly unknown[]
 ): void {
+  if (query.startsWith("delete from pss_thread_input")) {
+    deleteThreadInputs(state, bindings);
+    return;
+  }
   if (query.startsWith("insert into pss_thread_input")) {
     upsertThreadInput(state, bindings);
     return;
@@ -61,6 +65,17 @@ export function writeThreadStatement(
     return;
   }
   throw new Error(`Unsupported in-memory thread SQL statement: ${query}`);
+}
+
+function deleteThreadInputs(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const prefix = stringBinding(bindings[0]);
+  const threadKey = stringBinding(bindings[1]);
+  state.threadInputs = state.threadInputs.filter(
+    (row) => !(row.prefix === prefix && row.thread_key === threadKey)
+  );
 }
 
 function upsertThreadInput(
@@ -230,6 +245,7 @@ function createThreadMetaRow(
 ): ThreadMetaRow {
   if (bindings.length >= 5) {
     return {
+      applied_migrations: nullableStringBinding(bindings[5]),
       message_count: numberBinding(bindings[2]),
       next_seq: numberBinding(bindings[3]),
       state_blob: nullableStringBinding(bindings[4]),
@@ -238,6 +254,7 @@ function createThreadMetaRow(
     };
   }
   return {
+    applied_migrations: null,
     message_count: 1,
     next_seq: 1,
     state_blob: null,

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/write.ts
@@ -21,6 +21,17 @@ export function writeSqlStatement(
     writeThreadEvent(state, bindings);
     return;
   }
+  if (query.startsWith("delete from pss_thread_event_meta")) {
+    state.threadEventMeta.delete(stringBinding(bindings[0]));
+    return;
+  }
+  if (query.startsWith("delete from pss_thread_event")) {
+    const key = stringBinding(bindings[0]);
+    state.threadEvents = state.threadEvents.filter(
+      (row) => row.thread_key !== key
+    );
+    return;
+  }
   if (query.includes("pss_thread_")) {
     writeThreadStatement(state, query, bindings);
     return;
@@ -37,6 +48,20 @@ export function writeSqlStatement(
   }
   if (query.startsWith("delete from pss_payload_chunk")) {
     deletePayloadChunks(state, bindings);
+    return;
+  }
+  if (query.startsWith("delete from pss_event_meta")) {
+    state.eventMeta.delete(stringBinding(bindings[0]));
+    return;
+  }
+  if (query.startsWith("delete from pss_event")) {
+    const key = stringBinding(bindings[0]);
+    state.events = state.events.filter((row) => row.run_key !== key);
+    return;
+  }
+  if (query.startsWith("delete from pss_checkpoint")) {
+    const key = stringBinding(bindings[0]);
+    state.checkpoints = state.checkpoints.filter((row) => row.run_key !== key);
     return;
   }
   if (query.startsWith("insert into pss_event_meta")) {
@@ -93,13 +118,14 @@ function deletePayloadChunks(
 ): void {
   const scope = stringBinding(bindings[0]);
   const ownerKey = stringBinding(bindings[1]);
-  const payloadKey = stringBinding(bindings[2]);
+  const payloadKey =
+    bindings.length > 2 ? stringBinding(bindings[2]) : undefined;
   state.payloadChunks = state.payloadChunks.filter(
     (row) =>
       !(
         row.scope === scope &&
         row.owner_key === ownerKey &&
-        row.payload_key === payloadKey
+        (payloadKey === undefined || row.payload_key === payloadKey)
       )
   );
 }

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store-contract.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store-contract.test.ts
@@ -152,12 +152,24 @@ describe("DurableObjectExecutionStore payload guards", () => {
     await expect(
       store.threads.commit(
         "thread-1",
-        { state: { history: [message], schemaVersion: 1 } },
+        {
+          state: {
+            appliedMigrations: { "workspace/sanitize": 2 },
+            compactions: [],
+            history: [message],
+            schemaVersion: 3,
+          },
+        },
         { expectedVersion: null }
       )
     ).resolves.toEqual({ ok: true, version: "1" });
     await expect(store.threads.load("thread-1")).resolves.toEqual({
-      state: { history: [message], schemaVersion: 1 },
+      state: {
+        appliedMigrations: { "workspace/sanitize": 2 },
+        compactions: [],
+        history: [message],
+        schemaVersion: 3,
+      },
       version: "1",
     });
   });
@@ -189,8 +201,231 @@ describe("DurableObjectExecutionStore payload guards", () => {
       messageId: "input-default-storage",
       status: "claiming",
     });
+    await host.store.deleteThread?.("thread-1");
+    await expect(
+      host.store.inputs.claimNext("thread-1", "turn-idle")
+    ).resolves.toBeNull();
+  });
+
+  it("deletes every SQLite row and payload chunk owned by a thread", async () => {
+    const prefix = "aggregate-delete-test";
+    const threadKey = "thread-1";
+    const runId = "run-delete";
+    const sql = new TransactionalInMemorySqlStorage();
+    const storage = new InMemoryCloudflareDurableObjectStorage({ sql });
+    const store = await seedThreadAggregate(
+      storage,
+      sql,
+      prefix,
+      threadKey,
+      runId,
+      "delete"
+    );
+    const deletedCounts = rowCounts(sql);
+    expect(payloadScopeCounts(sql)).toEqual({
+      checkpoint: expect.any(Number),
+      event: expect.any(Number),
+      notification: expect.any(Number),
+      "thread-event": expect.any(Number),
+      "thread-input": expect.any(Number),
+    });
+    expect(
+      Object.values(payloadScopeCounts(sql)).every((count) => count > 0)
+    ).toBe(true);
+    await seedThreadAggregate(
+      storage,
+      sql,
+      prefix,
+      "thread-2",
+      "run-keep-thread",
+      "keep-thread"
+    );
+    const otherPrefixStore = await seedThreadAggregate(
+      storage,
+      sql,
+      "aggregate-delete-other-prefix",
+      threadKey,
+      "run-keep-prefix",
+      "keep-prefix"
+    );
+    const beforeDelete = rowCounts(sql);
+
+    await store.deleteThread(threadKey);
+    await store.deleteThread(threadKey);
+
+    for (const table of aggregateTables) {
+      expect(rowCount(sql, table), table).toBe(
+        beforeDelete[table] - deletedCounts[table]
+      );
+    }
+    await expect(store.threads.load("thread-2")).resolves.not.toBeNull();
+    await expect(store.turns.get("run-keep-thread")).resolves.not.toBeNull();
+    await expect(
+      otherPrefixStore.threads.load(threadKey)
+    ).resolves.not.toBeNull();
+    await expect(
+      otherPrefixStore.turns.get("run-keep-prefix")
+    ).resolves.not.toBeNull();
+  });
+
+  it("rolls back aggregate deletion when SQL fails mid-transaction", async () => {
+    const prefix = "aggregate-delete-rollback";
+    const threadKey = "thread-rollback";
+    const runId = "run-rollback";
+    const sql = new TransactionalInMemorySqlStorage();
+    const storage = new InMemoryCloudflareDurableObjectStorage({ sql });
+    const store = await seedThreadAggregate(
+      storage,
+      sql,
+      prefix,
+      threadKey,
+      runId,
+      "rollback"
+    );
+    const beforeDelete = rowCounts(sql);
+    sql.failNext("delete from pss_checkpoint");
+
+    await expect(store.deleteThread(threadKey)).rejects.toThrow(
+      "injected SQL failure"
+    );
+
+    expect(rowCounts(sql)).toEqual(beforeDelete);
+    await expect(store.threads.load(threadKey)).resolves.not.toBeNull();
+    await expect(store.turns.get(runId)).resolves.not.toBeNull();
+    await expect(store.checkpoints.latest(runId)).resolves.not.toBeNull();
+    await expect(
+      store.notifications.getByIdempotencyKey("notification-rollback")
+    ).resolves.not.toBeNull();
   });
 });
+
+const aggregateTables = [
+  "pss_thread_input",
+  "pss_thread_event",
+  "pss_thread_event_meta",
+  "pss_payload_chunk",
+  "pss_event",
+  "pss_event_meta",
+  "pss_checkpoint",
+  "pss_run",
+  "pss_notification",
+  "pss_scheduled_work",
+  "pss_thread_message",
+  "pss_thread_message_chunk",
+  "pss_thread_compaction",
+  "pss_thread_meta",
+] as const;
+
+type AggregateTable = (typeof aggregateTables)[number];
+
+async function seedThreadAggregate(
+  storage: InMemoryCloudflareDurableObjectStorage,
+  sql: SqlStorage,
+  prefix: string,
+  threadKey: string,
+  runId: string,
+  suffix: string
+): Promise<DurableObjectExecutionStore> {
+  const store = new DurableObjectExecutionStore({
+    maxPayloadBytes: 180,
+    prefix,
+    storage,
+  });
+  const largeText = `${suffix}:${"x".repeat(400)}`;
+  await store.threads.commit(
+    threadKey,
+    {
+      state: {
+        appliedMigrations: { "workspace/sanitize": 2 },
+        compactions: [
+          {
+            endSeqExclusive: 1,
+            schemaVersion: 1,
+            startSeq: 0,
+            summary: { content: `${suffix} summary`, role: "system" },
+          },
+        ],
+        history: [{ content: largeText, role: "user" }],
+        schemaVersion: 3,
+      },
+    },
+    { expectedVersion: null }
+  );
+  await store.inputs.admit({
+    input: { text: largeText, type: "user-input" },
+    kind: "send",
+    messageId: `input-${suffix}`,
+    threadKey,
+  });
+  await store.threadEvents.append(threadKey, {
+    text: largeText,
+    type: "assistant-output",
+  });
+  await store.turns.create(runRecord(runId, { threadKey }));
+  await store.events.append(runId, {
+    text: largeText,
+    type: "assistant-output",
+  });
+  await store.checkpoints.append(
+    {
+      checkpointId: `checkpoint-${suffix}`,
+      phase: "after-model",
+      runId,
+      runtimeState: { text: largeText },
+      threadSnapshot: { threadKey },
+      version: 1,
+    },
+    { expectedVersion: 0 }
+  );
+  await store.notifications.enqueue(
+    notificationRecord(`notification-${suffix}`, {
+      input: { text: largeText, type: "user-input" },
+      runId,
+      threadKey,
+    })
+  );
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS pss_scheduled_work (prefix TEXT NOT NULL, kind TEXT NOT NULL, work_id TEXT NOT NULL, payload TEXT NOT NULL, thread_key TEXT, run_id TEXT, created_at INTEGER NOT NULL, PRIMARY KEY (prefix, kind, work_id))"
+  );
+  sql.exec(
+    "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    prefix,
+    "thread-prompt",
+    `work-${suffix}`,
+    "{}",
+    threadKey,
+    runId,
+    1
+  );
+  return store;
+}
+
+function rowCounts(sql: SqlStorage): Record<AggregateTable, number> {
+  return Object.fromEntries(
+    aggregateTables.map((table) => [table, rowCount(sql, table)])
+  ) as Record<AggregateTable, number>;
+}
+
+function payloadScopeCounts(sql: SqlStorage): Record<string, number> {
+  return Object.fromEntries(
+    sql
+      .exec<{ readonly count: number; readonly scope: string }>(
+        "SELECT scope, COUNT(*) AS count FROM pss_payload_chunk GROUP BY scope"
+      )
+      .toArray()
+      .map((row) => [row.scope, row.count])
+  );
+}
+
+function rowCount(sql: SqlStorage, table: string): number {
+  return (
+    sql
+      .exec<{ readonly count: number }>(
+        `SELECT COUNT(*) AS count FROM ${table}`
+      )
+      .toArray()[0]?.count ?? 0
+  );
+}
 
 function createBudgetedStore(
   maxPayloadBytes: number
@@ -203,12 +438,24 @@ function createBudgetedStore(
 }
 
 class TransactionalInMemorySqlStorage implements SqlStorage {
+  #failureFragment: string | undefined;
   readonly #storage = new InMemorySqlStorage();
+
+  failNext(queryFragment: string): void {
+    this.#failureFragment = queryFragment.toLowerCase();
+  }
 
   exec<T = Record<string, unknown>>(
     query: string,
     ...bindings: unknown[]
   ): SqlStorageCursorLike<T> {
+    if (
+      this.#failureFragment &&
+      query.toLowerCase().includes(this.#failureFragment)
+    ) {
+      this.#failureFragment = undefined;
+      throw new Error("injected SQL failure");
+    }
     return this.#storage.exec<T>(query, ...bindings);
   }
 

--- a/packages/runtime/src/platform/cloudflare/storage/execution/store.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/store.ts
@@ -25,6 +25,7 @@ import { DurableObjectSqliteThreadEventLog } from "../sqlite/thread-event-log";
 import { DurableObjectSqliteThreadStore } from "../sqlite/thread-store";
 import { DurableObjectThreadInputInbox } from "./input-store";
 import { DurableObjectNotificationInbox } from "./notification-store";
+import { storeKey } from "./records";
 import { DurableObjectRunStore } from "./run-store";
 
 export class DurableObjectExecutionStore implements HostStore {
@@ -89,6 +90,18 @@ export class DurableObjectExecutionStore implements HostStore {
     return this.threads;
   }
 
+  async deleteThread(threadKey: string): Promise<void> {
+    await this.transaction((tx) => {
+      const store = tx as DurableObjectExecutionStore;
+      deleteThreadRows(
+        store.#storage.sql as SqlStorage,
+        store.#prefix,
+        threadKey
+      );
+      return Promise.resolve();
+    });
+  }
+
   async transaction<T>(
     fn: (tx: HostStoreTransaction) => Promise<T>
   ): Promise<T> {
@@ -144,4 +157,178 @@ function transactionalSqlStorage(
       ? { transactionSync: (fn) => value.transactionSync?.(fn) ?? fn() }
       : {}),
   };
+}
+
+function deleteThreadRows(
+  sql: SqlStorage,
+  prefix: string,
+  threadKey: string
+): void {
+  const threadRowKey = storeKey(prefix, "thread", threadKey);
+  const threadEventKey = storeKey(prefix, "thread-events", threadKey);
+  const runIds = selectThreadRunIds(sql, prefix, threadKey);
+  const notificationKeys = selectThreadNotificationKeys(sql, prefix, threadKey);
+
+  deleteThreadPayloadChunks(
+    sql,
+    prefix,
+    threadKey,
+    threadEventKey,
+    runIds,
+    notificationKeys
+  );
+  deleteRowsByKey(sql, threadRowKey, [
+    ["pss_thread_message_chunk", "thread_key"],
+    ["pss_thread_message", "thread_key"],
+    ["pss_thread_compaction", "thread_key"],
+    ["pss_thread_meta", "thread_key"],
+  ]);
+  deleteRowsByKey(sql, threadEventKey, [
+    ["pss_thread_event", "thread_key"],
+    ["pss_thread_event_meta", "thread_key"],
+  ]);
+  deleteRunRows(sql, prefix, runIds);
+  deleteDirectThreadRows(sql, prefix, threadKey, runIds);
+}
+
+function selectThreadRunIds(
+  sql: SqlStorage,
+  prefix: string,
+  threadKey: string
+): string[] {
+  if (!hasTable(sql, "pss_run")) {
+    return [];
+  }
+  return sql
+    .exec<{ readonly run_id: string }>(
+      "SELECT run_id FROM pss_run WHERE prefix = ? AND thread_key = ?",
+      prefix,
+      threadKey
+    )
+    .toArray()
+    .map((row) => row.run_id);
+}
+
+function selectThreadNotificationKeys(
+  sql: SqlStorage,
+  prefix: string,
+  threadKey: string
+): string[] {
+  if (!hasTable(sql, "pss_notification")) {
+    return [];
+  }
+  return sql
+    .exec<{ readonly idempotency_key: string }>(
+      "SELECT idempotency_key FROM pss_notification WHERE prefix = ? AND thread_key = ?",
+      prefix,
+      threadKey
+    )
+    .toArray()
+    .map((row) => row.idempotency_key);
+}
+
+function deleteThreadPayloadChunks(
+  sql: SqlStorage,
+  prefix: string,
+  threadKey: string,
+  threadEventKey: string,
+  runIds: readonly string[],
+  notificationKeys: readonly string[]
+): void {
+  if (!hasTable(sql, "pss_payload_chunk")) {
+    return;
+  }
+  deletePayloadChunks(sql, "thread-input", `${prefix}:${threadKey}`);
+  deletePayloadChunks(sql, "thread-event", threadEventKey);
+  for (const runId of runIds) {
+    deletePayloadChunks(sql, "event", storeKey(prefix, "events", runId));
+    deletePayloadChunks(
+      sql,
+      "checkpoint",
+      storeKey(prefix, "checkpoints", runId)
+    );
+  }
+  for (const key of notificationKeys) {
+    sql.exec(
+      "DELETE FROM pss_payload_chunk WHERE scope = ? AND owner_key = ? AND payload_key = ?",
+      "notification",
+      prefix,
+      key
+    );
+  }
+}
+
+function deletePayloadChunks(
+  sql: SqlStorage,
+  scope: string,
+  ownerKey: string
+): void {
+  sql.exec(
+    "DELETE FROM pss_payload_chunk WHERE scope = ? AND owner_key = ?",
+    scope,
+    ownerKey
+  );
+}
+
+function deleteRowsByKey(
+  sql: SqlStorage,
+  key: string,
+  tables: readonly (readonly [string, string])[]
+): void {
+  for (const [table, column] of tables) {
+    if (hasTable(sql, table)) {
+      sql.exec(`DELETE FROM ${table} WHERE ${column} = ?`, key);
+    }
+  }
+}
+
+function deleteRunRows(
+  sql: SqlStorage,
+  prefix: string,
+  runIds: readonly string[]
+): void {
+  for (const runId of runIds) {
+    deleteRowsByKey(sql, storeKey(prefix, "events", runId), [
+      ["pss_event", "run_key"],
+      ["pss_event_meta", "run_key"],
+    ]);
+    deleteRowsByKey(sql, storeKey(prefix, "checkpoints", runId), [
+      ["pss_checkpoint", "run_key"],
+    ]);
+  }
+}
+
+function deleteDirectThreadRows(
+  sql: SqlStorage,
+  prefix: string,
+  threadKey: string,
+  runIds: readonly string[]
+): void {
+  if (hasTable(sql, "pss_scheduled_work")) {
+    sql.exec(
+      "DELETE FROM pss_scheduled_work WHERE prefix = ? AND thread_key = ?",
+      prefix,
+      threadKey
+    );
+    for (const runId of runIds) {
+      sql.exec(
+        "DELETE FROM pss_scheduled_work WHERE prefix = ? AND run_id = ?",
+        prefix,
+        runId
+      );
+    }
+  }
+  for (const table of ["pss_notification", "pss_thread_input", "pss_run"]) {
+    if (hasTable(sql, table)) {
+      sql.exec(
+        `DELETE FROM ${table} WHERE prefix = ? AND thread_key = ?`,
+        prefix,
+        threadKey
+      );
+    }
+  }
+}
+
+function hasTable(sql: SqlStorage, table: string): boolean {
+  return sql.exec(`PRAGMA table_info(${table})`).toArray().length > 0;
 }

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql/schema/bootstrap.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql/schema/bootstrap.ts
@@ -10,10 +10,11 @@ export function ensureThreadSchema(sql: SqlStorage): void {
   sql.exec(
     "CREATE TABLE IF NOT EXISTS pss_thread_meta (thread_key TEXT PRIMARY KEY, version TEXT NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT, applied_migrations TEXT)"
   );
-  try {
+  const metaColumns = sql
+    .exec<{ readonly name: string }>("PRAGMA table_info(pss_thread_meta)")
+    .toArray();
+  if (!metaColumns.some((column) => column.name === "applied_migrations")) {
     sql.exec("ALTER TABLE pss_thread_meta ADD COLUMN applied_migrations TEXT");
-  } catch {
-    // Column already exists on stores created before schemaVersion 3 support.
   }
   sql.exec(
     "CREATE TABLE IF NOT EXISTS pss_thread_message_chunk (thread_key TEXT NOT NULL, seq INTEGER NOT NULL, chunk_index INTEGER NOT NULL, chunk TEXT NOT NULL, PRIMARY KEY (thread_key, seq, chunk_index))"

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.test.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { decodeStoredThreadSnapshot } from "../../../../thread/state/snapshot";
-import type { InMemorySqlStorage } from "../../sql/node-test/node-sqlite-storage";
+import { InMemorySqlStorage } from "../../sql/node-test/node-sqlite-storage";
 import type { CloudflareDurableObjectStorage } from "../durable-object/durable-object-storage";
 import { storeKey } from "../execution/records";
 import { DurableObjectSqliteThreadStore } from "./thread-store";
@@ -16,6 +16,23 @@ import {
 import { ensureThreadSchema } from "./thread-store-sql";
 
 describe("DurableObjectSqliteThreadStore", () => {
+  it("migrates old thread meta schemas once and keeps repeated ensure idempotent", () => {
+    const storage = new InMemorySqlStorage();
+    storage.exec(
+      "CREATE TABLE pss_thread_meta (thread_key TEXT PRIMARY KEY, version TEXT NOT NULL, message_count INTEGER NOT NULL, next_seq INTEGER NOT NULL, state_blob TEXT)"
+    );
+
+    ensureThreadSchema(storage);
+    ensureThreadSchema(storage);
+
+    expect(
+      storage
+        .exec<{ readonly name: string }>("PRAGMA table_info(pss_thread_meta)")
+        .toArray()
+        .filter((column) => column.name === "applied_migrations")
+    ).toHaveLength(1);
+  });
+
   it("throws when the Durable Object is not SQLite-backed", () => {
     expect(
       () =>

--- a/packages/runtime/src/platform/memory/execution/store.ts
+++ b/packages/runtime/src/platform/memory/execution/store.ts
@@ -54,6 +54,12 @@ export class InMemoryExecutionStore implements HostStore {
     return this.threads;
   }
 
+  async deleteThread(threadKey: string): Promise<void> {
+    await this.transaction(async (tx) => {
+      await tx.deleteThread?.(threadKey);
+    });
+  }
+
   async transaction<T>(
     fn: (tx: HostStoreTransaction) => Promise<T>
   ): Promise<T> {
@@ -98,6 +104,35 @@ class InMemoryTransactionStore implements HostStoreTransaction {
 
   get sessions(): ThreadStore {
     return this.threads;
+  }
+
+  deleteThread(threadKey: string): Promise<void> {
+    deleteThreadFromState(this.#state, threadKey);
+    return Promise.resolve();
+  }
+}
+
+function deleteThreadFromState(state: ExecutionState, threadKey: string): void {
+  const runIds = [...state.turns.values()]
+    .filter((turn) => turn.threadKey === threadKey)
+    .map((turn) => turn.runId);
+  const runIdSet = new Set(runIds);
+  state.inputsByThread.delete(threadKey);
+  state.threadEvents.delete(threadKey);
+  state.threads.delete(threadKey);
+  state.threadVersions.delete(threadKey);
+  for (const runId of runIds) {
+    state.turns.delete(runId);
+    state.events.delete(runId);
+    state.checkpoints.delete(runId);
+  }
+  for (const [key, notification] of state.notificationsByKey) {
+    if (
+      notification.threadKey === threadKey ||
+      runIdSet.has(notification.runId)
+    ) {
+      state.notificationsByKey.delete(key);
+    }
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,10 +125,10 @@ importers:
         version: 3.0.16(zod@4.4.3)
       '@chat-adapter/state-memory':
         specifier: 4.35.0
-        version: 4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)
+        version: 4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)
       '@chat-adapter/telegram':
         specifier: 4.35.0
-        version: 4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)
+        version: 4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)
       '@minpeter/pss-runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
@@ -143,13 +143,13 @@ importers:
         version: 11.18.0(typescript@7.0.2)
       agents:
         specifier: 0.20.0
-        version: 0.20.0(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260731.1)(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0-beta.5)(ai@7.0.45(zod@4.4.3))(chat@4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(zod@4.4.3)
+        version: 0.20.0(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260731.1)(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0-beta.5)(ai@7.0.51(zod@4.4.3))(chat@4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(zod@4.4.3)
       chat:
         specifier: 4.35.0
-        version: 4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)
+        version: 4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)
       evlog:
         specifier: ^2.22.4
-        version: 2.22.4(ai@7.0.45(zod@4.4.3))(express@5.2.1)(hono@4.12.33)(react@19.2.7)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 2.22.4(ai@7.0.51(zod@4.4.3))(express@5.2.1)(hono@4.12.33)(react@19.2.7)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -522,8 +522,8 @@ importers:
         specifier: ^1.9.1
         version: 1.9.1
       ai:
-        specifier: 7.0.45
-        version: 7.0.45(zod@4.4.3)
+        specifier: 7.0.51
+        version: 7.0.51(zod@4.4.3)
       fast-png:
         specifier: ^8.0.0
         version: 8.0.0
@@ -539,7 +539,7 @@ importers:
     devDependencies:
       agents:
         specifier: 0.20.0
-        version: 0.20.0(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260731.1)(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0-beta.5)(ai@7.0.45(zod@4.4.3))(chat@4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(zod@4.4.3)
+        version: 0.20.0(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260731.1)(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0-beta.5)(ai@7.0.51(zod@4.4.3))(chat@4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(zod@4.4.3)
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
@@ -566,6 +566,12 @@ packages:
 
   '@ai-sdk/gateway@4.0.34':
     resolution: {integrity: sha512-r9h1pwSjAFI75c6PFNGVnhrZIQ3zfWnjwnrc+qGgbnqkWdiuq3ZpTCrAlsphy3h/b3T10OwjfsLd+3yKpyoa/g==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@4.0.40':
+    resolution: {integrity: sha512-poNySlk+zSe04M4v0wgJKt+mzY6Vk6abcQid58YZnFUBJYo6VwfsFUaW7oINoR1vYYB7Ne6eqY1doSxYKt0KDg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -600,6 +606,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.20':
+    resolution: {integrity: sha512-9W8c2mXiGgbo9sBBT4ybEWF8znxla2CO8VTim8t5oCCLP4aDH4o6RvkHfwL/iLC6mEbO4a6LpS2FBbQHccU+ig==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
@@ -610,6 +622,10 @@ packages:
 
   '@ai-sdk/provider@4.0.4':
     resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.5':
+    resolution: {integrity: sha512-9WAerTaPU2jcVi8dh8x27tySEuLur1Kfg7Go74GuCmsC/2MDSvrTkrK8ZrXWjryEevKfcPPmO1enveE7eqlzoA==}
     engines: {node: '>=22'}
 
   '@asamuzakjp/css-color@5.1.11':
@@ -2243,6 +2259,12 @@ packages:
 
   ai@7.0.45:
     resolution: {integrity: sha512-BLMm4DGw1o2KgDhwWixiRNFQu2zeiNi6XfQlT++japjTbLpIFKST6TRKfsn90Ski6eZ06M34lQlb4viOcFl48Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.51:
+    resolution: {integrity: sha512-yyxSDZmlpTZs2oepyjzHMXrPk0mJ2ITpw8TfXYiF53yo0WkQJ1qm6MbpUiYclh640D35nNJ8bq57RffSrX+Qzg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4754,6 +4776,13 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/gateway@4.0.40(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.5
+      '@ai-sdk/provider-utils': 5.0.20(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
   '@ai-sdk/openai-compatible@3.0.16(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.4
@@ -4791,6 +4820,15 @@ snapshots:
       undici: 7.29.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.20(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.5
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
@@ -4800,6 +4838,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.4':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.5':
     dependencies:
       json-schema: 0.4.0
 
@@ -5005,28 +5047,28 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1': {}
 
-  '@chat-adapter/shared@4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)':
+  '@chat-adapter/shared@4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      chat: 4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)
+      chat: 4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - workflow
       - zod
 
-  '@chat-adapter/state-memory@4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)':
+  '@chat-adapter/state-memory@4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      chat: 4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)
+      chat: 4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - workflow
       - zod
 
-  '@chat-adapter/telegram@4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)':
+  '@chat-adapter/telegram@4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)
-      chat: 4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)
+      '@chat-adapter/shared': 4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)
+      chat: 4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -6058,7 +6100,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agents@0.20.0(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260731.1)(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0-beta.5)(ai@7.0.45(zod@4.4.3))(chat@4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(zod@4.4.3):
+  agents@0.20.0(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260731.1)(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0-beta.5)(ai@7.0.51(zod@4.4.3))(chat@4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3))(react@19.2.7)(rolldown@1.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(zod@4.4.3):
     dependencies:
       '@babel/plugin-proposal-decorators': 8.0.2(@babel/core@8.0.1)
       '@cfworker/json-schema': 4.1.1
@@ -6077,8 +6119,8 @@ snapshots:
       yargs: 18.1.0
       zod: 4.4.3
     optionalDependencies:
-      ai: 7.0.45(zod@4.4.3)
-      chat: 4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3)
+      ai: 7.0.51(zod@4.4.3)
+      chat: 4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3)
       vite: 8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -6100,6 +6142,13 @@ snapshots:
       '@ai-sdk/gateway': 4.0.34(zod@4.4.3)
       '@ai-sdk/provider': 4.0.4
       '@ai-sdk/provider-utils': 5.0.17(zod@4.4.3)
+      zod: 4.4.3
+
+  ai@7.0.51(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.40(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.5
+      '@ai-sdk/provider-utils': 5.0.20(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@3.0.1:
@@ -6306,7 +6355,7 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chat@4.35.0(ai@7.0.45(zod@4.4.3))(zod@4.4.3):
+  chat@4.35.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -6316,7 +6365,7 @@ snapshots:
       remend: 1.3.0
       unified: 11.0.5
     optionalDependencies:
-      ai: 7.0.45(zod@4.4.3)
+      ai: 7.0.51(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -6806,9 +6855,9 @@ snapshots:
     dependencies:
       eventsource-parser: 3.1.0
 
-  evlog@2.22.4(ai@7.0.45(zod@4.4.3))(express@5.2.1)(hono@4.12.33)(react@19.2.7)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  evlog@2.22.4(ai@7.0.51(zod@4.4.3))(express@5.2.1)(hono@4.12.33)(react@19.2.7)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     optionalDependencies:
-      ai: 7.0.45(zod@4.4.3)
+      ai: 7.0.51(zod@4.4.3)
       express: 5.2.1
       hono: 4.12.33
       react: 19.2.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,8 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - rolldown-plugin-dts
-  - '@ai-sdk/gateway@4.0.22'
+  - '@ai-sdk/gateway@4.0.22 || 4.0.40'
   - '@ai-sdk/openai-compatible@3.0.11'
-  - ai@7.0.30
+  - ai@7.0.30 || 7.0.51
+  - '@ai-sdk/provider-utils@5.0.20'
+  - '@ai-sdk/provider@4.0.5'


### PR DESCRIPTION
## Summary
- align the runtime with AI SDK 7.0.51
- add public snapshot codec contracts and lazy thread metadata migration
- add atomic aggregate thread deletion for memory and Cloudflare stores

## Verification
- pnpm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the runtime with `ai` 7.0.51 and hardens the thread storage lifecycle. Adds public snapshot codecs and atomic, idempotent thread deletion across supported stores.

- **New Features**
  - Add `deleteThread(threadKey)` to `HostStore`, implemented for Cloudflare SQLite Durable Objects and in-memory stores. Atomically removes all runtime-owned rows and payload chunks for a thread; safe to call multiple times.
  - Export canonical codecs from the package root: `decodeStoredThreadState` and `encodeThreadSnapshot`.
  - Make Durable Object thread meta schema upgrades idempotent by lazily adding the `applied_migrations` column once.

- **Dependencies**
  - Bump `ai` to 7.0.51 and align workspace pins.

<sup>Written for commit 62d52bf7e795cc59aed96cde81669739ab58e78f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

