### PR TITLE
fix(release): verify local package dependency graph

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
           pack_dir="$RUNNER_TEMP/coding-agent-pack"
           install_dir="$RUNNER_TEMP/coding-agent-install"
           mkdir -p "$pack_dir" "$install_dir"
+          pnpm --filter @minpeter/pss-runtime pack --pack-destination "$pack_dir"
+          pnpm --filter @minpeter/pss-extension-web pack --pack-destination "$pack_dir"
           pnpm --filter @minpeter/pss-coding-agent pack --pack-destination "$pack_dir"
           npm install --package-lock-only --ignore-scripts --prefix "$install_dir" "$pack_dir"/*.tgz
 

--- a/extensions/web/package.json
+++ b/extensions/web/package.json
@@ -42,6 +42,7 @@
     "@minpeter/pss-coding-agent": "workspace:^"
   },
   "devDependencies": {
+    "@minpeter/pss-coding-agent": "workspace:*",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
         specifier: 7.0.51
         version: 7.0.51(zod@4.4.3)
     devDependencies:
+      '@minpeter/pss-coding-agent':
+        specifier: workspace:*
+        version: link:../../apps/coding-agent
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -26,6 +26,8 @@ describe("release workflow", () => {
     expect(ciWorkflow).toContain('node: ["24", "26"]');
     expect(ciWorkflow).toContain("cancel-in-progress: true");
     expect(workflow).toContain("pnpm tegami ci");
+    expect(workflow).toContain("pnpm --filter @minpeter/pss-runtime pack");
+    expect(workflow).toContain("pnpm --filter @minpeter/pss-extension-web pack");
     expect(workflow).toContain("pnpm --filter @minpeter/pss-coding-agent pack");
     expect(workflow).toContain(
       "npm install --package-lock-only --ignore-scripts"


### PR DESCRIPTION
## Summary
- install the coding-agent peer in the web extension development graph
- pack runtime and web extension alongside coding-agent during release verification
- verify simultaneous prerelease dependencies without requiring them to exist in npm first

## Verification
- pnpm install --frozen-lockfile
- pnpm exec vitest run scripts/release-workflow.test.mjs
- local packed runtime + web extension + coding-agent npm resolution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify local package dependency graph in the release workflow by packing `@minpeter/pss-runtime` and `@minpeter/pss-extension-web` alongside `@minpeter/pss-coding-agent`. This enables prerelease testing without publishing to npm.

- **Bug Fixes**
  - CI now packs `@minpeter/pss-runtime` and `@minpeter/pss-extension-web` and installs all tarballs for verification.
  - Added `@minpeter/pss-coding-agent` as a devDependency in `extensions/web` to satisfy the peer during local builds.
  - Updated tests to assert new pack steps; lockfile updated.

<sup>Written for commit af5367a739db1a53b968afb51fe7961d2e9f5b48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

