### PR TITLE
fix(release): avoid package graph cycle during verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           install_dir="$RUNNER_TEMP/coding-agent-install"
           mkdir -p "$pack_dir" "$install_dir"
           pnpm --filter @minpeter/pss-runtime pack --pack-destination "$pack_dir"
+          ln -s "$GITHUB_WORKSPACE/apps/coding-agent" extensions/web/node_modules/@minpeter/pss-coding-agent
           pnpm --filter @minpeter/pss-extension-web pack --pack-destination "$pack_dir"
           pnpm --filter @minpeter/pss-coding-agent pack --pack-destination "$pack_dir"
           npm install --package-lock-only --ignore-scripts --prefix "$install_dir" "$pack_dir"/*.tgz

--- a/extensions/web/package.json
+++ b/extensions/web/package.json
@@ -42,7 +42,6 @@
     "@minpeter/pss-coding-agent": "workspace:^"
   },
   "devDependencies": {
-    "@minpeter/pss-coding-agent": "workspace:*",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,9 +500,6 @@ importers:
         specifier: 7.0.51
         version: 7.0.51(zod@4.4.3)
     devDependencies:
-      '@minpeter/pss-coding-agent':
-        specifier: workspace:*
-        version: link:../../apps/coding-agent
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -27,6 +27,7 @@ describe("release workflow", () => {
     expect(ciWorkflow).toContain("cancel-in-progress: true");
     expect(workflow).toContain("pnpm tegami ci");
     expect(workflow).toContain("pnpm --filter @minpeter/pss-runtime pack");
+    expect(workflow).toContain("extensions/web/node_modules/@minpeter/pss-coding-agent");
     expect(workflow).toContain("pnpm --filter @minpeter/pss-extension-web pack");
     expect(workflow).toContain("pnpm --filter @minpeter/pss-coding-agent pack");
     expect(workflow).toContain(


### PR DESCRIPTION
## Summary
- keep the production package graph acyclic
- stage the web extension peer only while packing release artifacts
- retain local tarball verification for simultaneous prerelease dependencies

## Verification
- pnpm boundaries
- pnpm exec vitest run scripts/release-workflow.test.mjs
- local packed runtime + web extension + coding-agent npm resolution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a release-time package cycle by removing the web extension’s dev link to the coding agent and staging the agent only during packing via a temporary symlink. Local tarball install verification for prereleases remains unchanged.

- **Bug Fixes**
  - Removed `@minpeter/pss-coding-agent` from `extensions/web` devDependencies and lockfile to keep the production graph acyclic.
  - In `release.yml`, symlink `apps/coding-agent` into `extensions/web/node_modules/@minpeter/pss-coding-agent` before packing `@minpeter/pss-extension-web`, so the peer is present only at pack time.
  - Updated the release workflow test to assert the new symlink step.

<sup>Written for commit 04e95295bdf45efa8af94aa6c05b3a112a7b0870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

