### PR TITLE
fix(release): format workflow verification test

### DIFF
--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -27,8 +27,12 @@ describe("release workflow", () => {
     expect(ciWorkflow).toContain("cancel-in-progress: true");
     expect(workflow).toContain("pnpm tegami ci");
     expect(workflow).toContain("pnpm --filter @minpeter/pss-runtime pack");
-    expect(workflow).toContain("extensions/web/node_modules/@minpeter/pss-coding-agent");
-    expect(workflow).toContain("pnpm --filter @minpeter/pss-extension-web pack");
+    expect(workflow).toContain(
+      "extensions/web/node_modules/@minpeter/pss-coding-agent"
+    );
+    expect(workflow).toContain(
+      "pnpm --filter @minpeter/pss-extension-web pack"
+    );
     expect(workflow).toContain("pnpm --filter @minpeter/pss-coding-agent pack");
     expect(workflow).toContain(
       "npm install --package-lock-only --ignore-scripts"


### PR DESCRIPTION
Fixes the formatter failure blocking the next.7 release workflow.\n\nValidated with the focused Ultracite check and release workflow test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a formatting error in the release workflow verification test to unblock the next.7 release. Reformats long assertions without changing test behavior; validated with the focused Ultracite check and the release workflow test.

- **Bug Fixes**
  - Reformatted long expect() strings in `scripts/release-workflow.test.mjs` to satisfy the formatter; no logic changes.

<sup>Written for commit 0e7c10dab4f17b19576ba5ed1acb646db09ae4b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

