### PR TITLE
Add composable assistant renderers and Mermaid ASCII diagrams

### DIFF
--- a/.tegami/2026-08-04-mermaid-ascii-renderer.md
+++ b/.tegami/2026-08-04-mermaid-ascii-renderer.md
@@ -1,0 +1,16 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+  npm:@minpeter/pss-extension-latex:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-extension-latex)
+  npm:@minpeter/pss-extension-mermaid:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-extension-mermaid)
+---
+
+## Add Mermaid ASCII diagram renderer with composable assistant renderers
+
+Compose fallback assistant renderers into an ordered chain, and render mermaid fences as CJK-safe Unicode box art below their preserved source via the new mermaid extension.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -385,11 +385,13 @@ speculative guidance.
 
 LaTeX support is implemented by the official
 `@minpeter/pss-extension-latex` package. The coding-agent includes it by
-default but only owns the generic, exclusive assistant-renderer capability and
-the ordinary Markdown fallback; the extension package owns formula parsing,
-rendering, caching, Kitty placement, instructions, and dependency notices.
-This uses the same extension registration, conflict attribution, and `/reload`
-lifecycle as third-party extensions.
+default and owns the generic assistant-renderer capability plus the ordinary
+Markdown fallback; each extension package owns its own parsing, rendering,
+caching, instructions, and dependency notices. Bundled fallback renderers
+compose into an ordered chain: each renderer handles the fragments it owns
+and delegates everything else inward, and the plain Markdown view sits at the
+bottom. This uses the same extension registration, conflict attribution, and
+`/reload` lifecycle as third-party extensions.
 
 The extension is independently importable:
 
@@ -397,12 +399,14 @@ The extension is independently importable:
 import createLatexExtension from "@minpeter/pss-extension-latex";
 ```
 
-Bundled LaTeX registers as the fallback assistant renderer. A third-party
-renderer can replace it only by explicitly registering with
-`{ override: true }`; a bare second renderer remains a source-attributed
-configuration error. Renderer contexts receive an `AbortSignal`,
-session-scoped `notifyOnce`, and a redraw callback, and optional view disposal
-runs when the transcript is cleared or the TUI stops.
+Bundled LaTeX and Mermaid register as fallback assistant renderers; later
+registrations delegate unhandled Markdown to earlier ones. A third-party
+renderer can join the chain with `{ fallback: true }` or replace it entirely
+by explicitly registering with `{ override: true }`; a bare second exclusive
+renderer remains a source-attributed configuration error. Renderer contexts
+receive an `AbortSignal`, session-scoped `notifyOnce`, a redraw callback, and
+a `delegate` that renders unhandled text through the next inner renderer.
+Optional view disposal runs when the transcript is cleared or the TUI stops.
 
 On Kitty-graphics terminals (Kitty, Ghostty, WezTerm, and Warp), complete
 Markdown display-math blocks are rendered as typeset images:
@@ -456,6 +460,29 @@ has conservative Node heap and stack limits; a 10-second timeout, cancellation,
 or worker failure terminates it, falls back to source Markdown, and lets the
 next formula start a fresh worker. These are Node worker heap/time limits, not
 hard CPU or OS address-space limits.
+
+### Mermaid diagrams in the TUI
+
+Mermaid support is implemented by the official
+`@minpeter/pss-extension-mermaid` package, included by default and registered
+as the outermost fallback assistant renderer after LaTeX. The extension is
+independently importable:
+
+```ts
+import createMermaidExtension from "@minpeter/pss-extension-mermaid";
+```
+
+Complete ```` ```mermaid ```` fenced blocks keep their original source visible
+and get a Unicode box-art rendering appended directly below, following the pi
+ecosystem's `pi-mermaid` convention. Rendering is synchronous and pure
+TypeScript via `beautiful-mermaid`: no browser, DOM shim, worker, image
+protocol, disk cache, or network access, so it works in every terminal.
+Flowchart, sequence, state, class, ER, and XY-chart diagrams are supported,
+and wide East Asian label characters keep box borders aligned through a
+placeholder expansion shim. Unclosed fences while streaming, malformed or
+unsupported sources, expansions beyond a complexity budget, and oversized
+outputs all fall back to showing only the source fence. Set `PSS_MERMAID=0`
+to disable rendering.
 
 ## CLI
 

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -474,9 +474,10 @@ import createMermaidExtension from "@minpeter/pss-extension-mermaid";
 
 Complete ```` ```mermaid ```` fenced blocks keep their original source visible
 and get a Unicode box-art rendering appended directly below, following the pi
-ecosystem's `pi-mermaid` convention. Rendering is synchronous and pure
-TypeScript via `beautiful-mermaid`: no browser, DOM shim, worker, image
-protocol, disk cache, or network access, so it works in every terminal.
+ecosystem's `pi-mermaid` convention. Rendering runs in a bounded Node
+worker (5-second timeout, 256 MB heap cap) via `beautiful-mermaid`: no
+browser, DOM shim, image protocol, disk cache, or network access, so it
+works in every terminal.
 Flowchart, sequence, state, class, ER, and XY-chart diagrams are supported,
 and wide East Asian label characters keep box borders aligned through a
 placeholder expansion shim. Unclosed fences while streaming, malformed or

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -86,12 +86,14 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "lint": "ultracite check .",
-    "preview:edit": "tsx --conditions=@minpeter/pss-source scripts/preview-edit-render.ts"
+    "preview:edit": "tsx --conditions=@minpeter/pss-source scripts/preview-edit-render.ts",
+    "preview:assistant": "tsx --conditions=@minpeter/pss-source scripts/preview-assistant-render.ts"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "3.0.16",
     "@earendil-works/pi-tui": "^0.82.1",
     "@minpeter/pss-extension-latex": "workspace:^",
+    "@minpeter/pss-extension-mermaid": "workspace:^",
     "@minpeter/pss-extension-web": "workspace:^",
     "@minpeter/pss-runtime": "workspace:^",
     "@t3-oss/env-core": "^0.13.11",

--- a/apps/coding-agent/scripts/preview-assistant-render.ts
+++ b/apps/coding-agent/scripts/preview-assistant-render.ts
@@ -1,0 +1,105 @@
+// Visual preview of the composed assistant renderer (LaTeX + Mermaid):
+// `pnpm preview:assistant`. Prints one frame after both images resolve.
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import { createCodingAgentExtensionHostWithDefaults } from "../src/extensions/defaults";
+
+const plainTheme: MarkdownTheme = {
+  heading: (t) => t,
+  link: (t) => t,
+  linkUrl: (t) => t,
+  code: (t) => t,
+  codeBlock: (t) => t,
+  codeBlockBorder: (t) => t,
+  quote: (t) => t,
+  quoteBorder: (t) => t,
+  hr: (t) => t,
+  listBullet: (t) => t,
+  bold: (t) => t,
+  italic: (t) => t,
+  strikethrough: (t) => t,
+  underline: (t) => t,
+};
+
+const KITTY_SEQUENCE = "\u001b_G";
+const RENDER_TIMEOUT_MS = 30_000;
+
+const text = [
+  "Here are the quadratic formula and the request flow:",
+  "",
+  "$$",
+  String.raw`x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}`,
+  "$$",
+  "",
+  "```mermaid",
+  "graph TD;",
+  "  subgraph client[클라이언트]",
+  "    A[사용자 입력] --> B[pss TUI];",
+  "  end;",
+  "  B --> C[createCodingAgent];",
+  "  C --> D[createAgent 런타임];",
+  "  C --> E[도구 병합];",
+  "  E --> F[workspace-tools];",
+  "  E --> G[web_search/web_fetch];",
+  "```",
+  "",
+  "Both blocks render inline above.",
+].join("\n");
+
+const main = async (): Promise<void> => {
+  const host = await createCodingAgentExtensionHostWithDefaults([], {
+    web: false,
+  });
+  try {
+    const width = Math.min(process.stdout.columns || 100, 120);
+    let notifyReady: (() => void) | undefined;
+    const ready = new Promise<void>((resolve) => {
+      notifyReady = resolve;
+    });
+    const view = host.assistantRenderer?.({
+      markdownTheme: plainTheme,
+      notify: (message) => process.stderr.write(`${message}\n`),
+      notifyOnce: (_key, message) => process.stderr.write(`${message}\n`),
+      requestRender: () => {
+        const output = view?.render(width).join("\n") ?? "";
+        const imagesReady =
+          output.includes(KITTY_SEQUENCE) &&
+          output.includes("┌") &&
+          !output.includes("x =");
+        if (imagesReady) {
+          notifyReady?.();
+        }
+      },
+      signal: host.signal,
+    });
+    if (view === undefined) {
+      throw new Error("assistant renderer is unavailable");
+    }
+    view.setText(text);
+    view.render(width);
+    const winner = await Promise.race([
+      ready.then(() => "ready" as const),
+      new Promise((resolve) => {
+        setTimeout(() => resolve("timeout" as const), RENDER_TIMEOUT_MS);
+      }),
+    ]);
+    const lines = view.render(width);
+    process.stdout.write(
+      `\nassistant renderer preview — width ${width}\n\n${lines.join("\n")}\n`
+    );
+    const imageLines = lines.filter((line) => line.includes(KITTY_SEQUENCE));
+    const metadata = {
+      formulas: 1,
+      images: imageLines.map((line) => ({ margin: line.startsWith(" ") })),
+    };
+    process.stdout.write(`__PSS_QA_META__${JSON.stringify(metadata)}\n`);
+    view.dispose?.();
+    if (winner === "timeout") {
+      process.stderr.write("timed out waiting for both renders\n");
+      process.exitCode = 1;
+    }
+  } finally {
+    await host.dispose();
+  }
+};
+
+await main();

--- a/apps/coding-agent/scripts/preview-assistant-render.ts
+++ b/apps/coding-agent/scripts/preview-assistant-render.ts
@@ -56,6 +56,7 @@ const main = async (): Promise<void> => {
       notifyReady = resolve;
     });
     const view = host.assistantRenderer?.({
+      foregroundColor: process.env.PSS_TUI_FOREGROUND,
       markdownTheme: plainTheme,
       notify: (message) => process.stderr.write(`${message}\n`),
       notifyOnce: (_key, message) => process.stderr.write(`${message}\n`),
@@ -76,12 +77,13 @@ const main = async (): Promise<void> => {
     }
     view.setText(text);
     view.render(width);
-    const winner = await Promise.race([
-      ready.then(() => "ready" as const),
-      new Promise((resolve) => {
-        setTimeout(() => resolve("timeout" as const), RENDER_TIMEOUT_MS);
-      }),
-    ]);
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      notifyReady?.();
+    }, RENDER_TIMEOUT_MS);
+    await ready;
+    clearTimeout(timeout);
     const lines = view.render(width);
     process.stdout.write(
       `\nassistant renderer preview — width ${width}\n\n${lines.join("\n")}\n`
@@ -93,7 +95,7 @@ const main = async (): Promise<void> => {
     };
     process.stdout.write(`__PSS_QA_META__${JSON.stringify(metadata)}\n`);
     view.dispose?.();
-    if (winner === "timeout") {
+    if (timedOut) {
       process.stderr.write("timed out waiting for both renders\n");
       process.exitCode = 1;
     }

--- a/apps/coding-agent/src/extensions/capability-host.test.ts
+++ b/apps/coding-agent/src/extensions/capability-host.test.ts
@@ -202,6 +202,159 @@ describe("coding-agent extension capabilities", () => {
     });
   });
 
+  it("composes fallback assistant renderers in registration order", async () => {
+    const wrapRenderer =
+      (name: string) =>
+      ({
+        delegate,
+      }: {
+        delegate?: (text: string) => { render(width: number): string[] };
+      }) => {
+        let text = "";
+        return {
+          invalidate() {
+            return;
+          },
+          render(width: number) {
+            const inner = delegate?.(`${name}(${text})`);
+            return inner === undefined
+              ? [`${name}(${text})`]
+              : inner.render(width);
+          },
+          setText(value: string) {
+            text = value;
+          },
+        };
+      };
+    const host = await createCodingAgentExtensionHost([
+      {
+        default(pss) {
+          pss.provide(
+            assistantRenderer(wrapRenderer("first"), { fallback: true })
+          );
+        },
+        id: "first-fallback",
+      },
+      {
+        default(pss) {
+          pss.provide(
+            assistantRenderer(wrapRenderer("second"), { fallback: true })
+          );
+        },
+        id: "second-fallback",
+      },
+    ]);
+
+    expect(host.getAssistantRendererChainOwners()).toEqual([
+      "first-fallback",
+      "second-fallback",
+    ]);
+    expect(host.getAssistantRendererOwner()).toBe("second-fallback");
+
+    const markdownTheme = new Proxy(
+      {},
+      { get: () => (text: string) => text }
+    ) as never;
+    const view = host.assistantRenderer?.({
+      markdownTheme,
+      notify: () => undefined,
+      notifyOnce: () => undefined,
+      requestRender: () => undefined,
+      signal: new AbortController().signal,
+    });
+    view?.setText("hello");
+    // The last registered fallback ("second") is outermost: it processes the
+    // raw text first, then "first" wraps the result.
+    expect(view?.render(80).join("\n")).toContain("first(second(hello))");
+    await host.dispose();
+  });
+
+  it("rejects a fallback once an override owns the renderer slot", async () => {
+    const renderer = () => ({
+      invalidate() {
+        return;
+      },
+      render() {
+        return [];
+      },
+      setText() {
+        return;
+      },
+    });
+
+    await expect(
+      createCodingAgentExtensionHost([
+        {
+          default(pss) {
+            pss.provide(assistantRenderer(renderer, { override: true }));
+          },
+          id: "override-owner",
+        },
+        {
+          default(pss) {
+            pss.provide(assistantRenderer(renderer, { fallback: true }));
+          },
+          id: "late-fallback",
+        },
+      ])
+    ).rejects.toMatchObject({
+      cause: {
+        message:
+          'Assistant renderer from extension "late-fallback" conflicts with extension "override-owner"',
+      },
+    });
+  });
+
+  it("lets an override replace a composed fallback chain", async () => {
+    const fallback = () => ({
+      invalidate() {
+        return;
+      },
+      render() {
+        return ["fallback"];
+      },
+      setText() {
+        return;
+      },
+    });
+    const preferred = () => ({
+      invalidate() {
+        return;
+      },
+      render() {
+        return ["preferred"];
+      },
+      setText() {
+        return;
+      },
+    });
+    const host = await createCodingAgentExtensionHost([
+      {
+        default(pss) {
+          pss.provide(assistantRenderer(fallback, { fallback: true }));
+        },
+        id: "first-fallback",
+      },
+      {
+        default(pss) {
+          pss.provide(assistantRenderer(fallback, { fallback: true }));
+        },
+        id: "second-fallback",
+      },
+      {
+        default(pss) {
+          pss.provide(assistantRenderer(preferred, { override: true }));
+        },
+        id: "preferred-renderer",
+      },
+    ]);
+
+    expect(host.assistantRenderer).toBe(preferred);
+    expect(host.getAssistantRendererOwner()).toBe("preferred-renderer");
+    expect(host.getAssistantRendererChainOwners()).toEqual([]);
+    await host.dispose();
+  });
+
   it("exposes only the three factory composition methods", async () => {
     let keys: string[] = [];
     const host = await createCodingAgentExtensionHost([

--- a/apps/coding-agent/src/extensions/default-renderer-composition.test.ts
+++ b/apps/coding-agent/src/extensions/default-renderer-composition.test.ts
@@ -1,0 +1,77 @@
+import {
+  getCapabilities,
+  type MarkdownTheme,
+  setCapabilities,
+} from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { createCodingAgentExtensionHostWithDefaults } from "./defaults";
+
+const KITTY_SEQUENCE = "_G";
+const BOX_ART = "┌";
+
+const markdownTheme: MarkdownTheme = {
+  bold: (text) => text,
+  code: (text) => text,
+  codeBlock: (text) => text,
+  codeBlockBorder: (text) => text,
+  heading: (text) => text,
+  hr: (text) => text,
+  italic: (text) => text,
+  link: (text) => text,
+  linkUrl: (text) => text,
+  listBullet: (text) => text,
+  quote: (text) => text,
+  quoteBorder: (text) => text,
+  strikethrough: (text) => text,
+  underline: (text) => text,
+};
+
+describe("default assistant renderer composition", () => {
+  it("renders display math and mermaid diagrams through one fallback chain", async () => {
+    const originalCapabilities = getCapabilities();
+    setCapabilities({ hyperlinks: true, images: "kitty", trueColor: true });
+    try {
+      const host = await createCodingAgentExtensionHostWithDefaults([], {
+        web: false,
+      });
+      expect(host.getAssistantRendererChainOwners()).toEqual([
+        "@minpeter/pss-extension-latex",
+        "@minpeter/pss-extension-mermaid",
+      ]);
+
+      let resolveReady: (() => void) | undefined;
+      const ready = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+      });
+      const view = host.assistantRenderer?.({
+        markdownTheme,
+        notify: () => undefined,
+        notifyOnce: () => undefined,
+        requestRender: () => {
+          const output = view?.render(80).join("\n") ?? "";
+          if (output.includes(KITTY_SEQUENCE) && !output.includes("x = 1")) {
+            resolveReady?.();
+          }
+        },
+        signal: host.signal,
+      });
+      view?.setText(
+        "Before\n\n$$\nx = 1\n$$\n\n```mermaid\ngraph TD;\n  A-->B;\n```\n"
+      );
+      view?.render(80);
+      await ready;
+
+      const output = view?.render(80).join("\n") ?? "";
+      expect(output).toContain("Before");
+      expect(output).toContain(KITTY_SEQUENCE);
+      expect(output).toContain("```mermaid");
+      expect(output).toContain("graph TD");
+      expect(output).toContain(BOX_ART);
+      expect(output).not.toContain("x = 1");
+      view?.dispose?.();
+      await host.dispose();
+    } finally {
+      setCapabilities(originalCapabilities);
+    }
+  }, 60_000);
+});

--- a/apps/coding-agent/src/extensions/default-renderer-composition.test.ts
+++ b/apps/coding-agent/src/extensions/default-renderer-composition.test.ts
@@ -49,7 +49,11 @@ describe("default assistant renderer composition", () => {
         notifyOnce: () => undefined,
         requestRender: () => {
           const output = view?.render(80).join("\n") ?? "";
-          if (output.includes(KITTY_SEQUENCE) && !output.includes("x = 1")) {
+          const imagesReady =
+            output.includes(KITTY_SEQUENCE) &&
+            output.includes(BOX_ART) &&
+            !output.includes("x = 1");
+          if (imagesReady) {
             resolveReady?.();
           }
         },

--- a/apps/coding-agent/src/extensions/defaults.test.ts
+++ b/apps/coding-agent/src/extensions/defaults.test.ts
@@ -84,12 +84,17 @@ describe("default coding-agent extensions", () => {
     const recoveredHost = await createCodingAgentExtensionHostWithDefaults([]);
 
     expect(initialHost.getAssistantRendererOwner()).toBe(
-      "@minpeter/pss-extension-latex"
+      "@minpeter/pss-extension-mermaid"
     );
+    expect(initialHost.getAssistantRendererChainOwners()).toEqual([
+      "@minpeter/pss-extension-latex",
+      "@minpeter/pss-extension-mermaid",
+    ]);
     expect(replacementHost.assistantRenderer).toBe(overrideRenderer);
     expect(replacementHost.getAssistantRendererOwner()).toBe("reload-override");
+    expect(replacementHost.getAssistantRendererChainOwners()).toEqual([]);
     expect(recoveredHost.getAssistantRendererOwner()).toBe(
-      "@minpeter/pss-extension-latex"
+      "@minpeter/pss-extension-mermaid"
     );
 
     await Promise.all([

--- a/apps/coding-agent/src/extensions/defaults.ts
+++ b/apps/coding-agent/src/extensions/defaults.ts
@@ -1,4 +1,5 @@
 import latexExtension from "@minpeter/pss-extension-latex";
+import mermaidExtension from "@minpeter/pss-extension-mermaid";
 import {
   type CreateCodingAgentToolsOptions,
   createWebExtension,
@@ -12,6 +13,11 @@ import type {
 const latexModule: CodingAgentExtensionModule = {
   default: latexExtension,
   id: "@minpeter/pss-extension-latex",
+};
+
+const mermaidModule: CodingAgentExtensionModule = {
+  default: mermaidExtension,
+  id: "@minpeter/pss-extension-mermaid",
 };
 
 export interface DefaultCodingAgentExtensionsOptions {
@@ -31,6 +37,7 @@ export const withDefaultCodingAgentExtensions = (
         };
   return [
     latexModule,
+    mermaidModule,
     ...(webModule === undefined ? [] : [webModule]),
     ...extensions,
   ];

--- a/apps/coding-agent/src/extensions/host.ts
+++ b/apps/coding-agent/src/extensions/host.ts
@@ -6,7 +6,10 @@ import type {
 } from "@minpeter/pss-runtime";
 import type { ToolSet } from "ai";
 import type { RegisteredSessionGuard } from "../sessions/session-guards";
-import type { AssistantRenderer } from "../tui/assistant-renderer";
+import {
+  type AssistantRenderer,
+  composeAssistantRenderers,
+} from "../tui/assistant-renderer";
 import type { TuiCommand } from "../tui/command";
 import type { ToolRendererMap } from "../tui/tool-call-view";
 import { composeAgentHooks, type RegisteredAgentHooks } from "./compose-hooks";
@@ -30,6 +33,8 @@ import type {
 export class CodingAgentExtensionHost {
   readonly #collections: ExtensionRegistryCollections;
   readonly #lifecycle: ExtensionHostLifecycle;
+  #composedFallbackRenderer: AssistantRenderer | undefined;
+  #fallbackRendererComposed = false;
 
   private constructor(
     extensions: readonly CodingAgentExtension[],
@@ -94,7 +99,17 @@ export class CodingAgentExtensionHost {
   }
 
   get assistantRenderer(): AssistantRenderer | undefined {
-    return this.#collections.assistantRenderer?.renderer;
+    const exclusive = this.#collections.assistantRenderer;
+    if (exclusive !== undefined) {
+      return exclusive.renderer;
+    }
+    if (!this.#fallbackRendererComposed) {
+      this.#composedFallbackRenderer = composeAssistantRenderers(
+        this.#collections.assistantRendererChain.map((entry) => entry.renderer)
+      );
+      this.#fallbackRendererComposed = true;
+    }
+    return this.#composedFallbackRenderer;
   }
 
   get hookRegistrations(): readonly RegisteredAgentHooks[] {
@@ -198,7 +213,15 @@ export class CodingAgentExtensionHost {
   }
 
   getAssistantRendererOwner(): string | undefined {
-    return this.#collections.owners.assistantRenderer;
+    return (
+      this.#collections.owners.assistantRenderer ??
+      this.#collections.owners.assistantRendererChain.at(-1)
+    );
+  }
+
+  /** Owners of the fallback chain in registration order (innermost first). */
+  getAssistantRendererChainOwners(): readonly string[] {
+    return [...this.#collections.owners.assistantRendererChain];
   }
 
   getToolRendererOwner(name: string): string | undefined {

--- a/apps/coding-agent/src/extensions/registry-collections.ts
+++ b/apps/coding-agent/src/extensions/registry-collections.ts
@@ -20,7 +20,10 @@ export interface RegisteredAssistantRenderer {
 }
 
 export interface ExtensionRegistryCollections {
+  /** Exclusive or override renderer; mutually exclusive with the chain. */
   assistantRenderer?: RegisteredAssistantRenderer;
+  /** Fallback renderers in registration order; the last entry is outermost. */
+  readonly assistantRendererChain: RegisteredAssistantRenderer[];
   readonly commands: TuiCommand[];
   readonly events: RegisteredCodingAgentExtensionEvent[];
   readonly hooks: RegisteredAgentHooks[];
@@ -36,6 +39,8 @@ export interface ExtensionRegistryCollections {
 
 interface ExtensionContributionOwners {
   assistantRenderer?: string;
+  /** Owner per fallback chain entry, parallel to `assistantRendererChain`. */
+  readonly assistantRendererChain: string[];
   readonly commands: Map<string, string>;
   readonly migrations: Map<string, string>;
   readonly modelProviders: Map<string, string>;
@@ -45,6 +50,7 @@ interface ExtensionContributionOwners {
 
 export function createExtensionRegistryCollections(): ExtensionRegistryCollections {
   return {
+    assistantRendererChain: [],
     commands: [],
     events: [],
     hooks: [],
@@ -52,6 +58,7 @@ export function createExtensionRegistryCollections(): ExtensionRegistryCollectio
     migrations: [],
     modelProviders: new Map(),
     owners: {
+      assistantRendererChain: [],
       commands: new Map(),
       migrations: new Map(),
       modelProviders: new Map(),
@@ -65,27 +72,48 @@ export function createExtensionRegistryCollections(): ExtensionRegistryCollectio
   };
 }
 
+const OVERRIDE_HINT =
+  "; register with { override: true } to replace the fallback";
+
+/**
+ * Validate assistant-renderer contributions across extensions. Fallback
+ * renderers compose into a chain; an override replaces the chain; an
+ * exclusive renderer requires an empty slot. Mutations happen in the main
+ * commit path after every conflict check has passed.
+ */
+function commitAssistantRenderer(
+  target: ExtensionRegistryCollections,
+  staged: ExtensionRegistryCollections,
+  extensionId: string
+): void {
+  const conflict = (owner: string | undefined, hint = ""): never => {
+    throw new Error(
+      `Assistant renderer from extension "${extensionId}" conflicts with extension "${owner ?? extensionId}"${hint}`
+    );
+  };
+  const incoming = staged.assistantRenderer;
+  if (incoming !== undefined) {
+    if (target.assistantRenderer !== undefined) {
+      conflict(target.owners.assistantRenderer);
+    }
+    if (!incoming.override && target.assistantRendererChain.length > 0) {
+      conflict(target.owners.assistantRendererChain.at(-1), OVERRIDE_HINT);
+    }
+  }
+  if (
+    staged.assistantRendererChain.length > 0 &&
+    target.assistantRenderer !== undefined
+  ) {
+    conflict(target.owners.assistantRenderer);
+  }
+}
+
 export function commitExtensionRegistryCollections(
   target: ExtensionRegistryCollections,
   staged: ExtensionRegistryCollections,
   extensionId: string
 ): void {
-  const existingAssistantRenderer = target.assistantRenderer;
-  const incomingAssistantRenderer = staged.assistantRenderer;
-  if (
-    existingAssistantRenderer !== undefined &&
-    incomingAssistantRenderer !== undefined &&
-    !(existingAssistantRenderer.fallback && incomingAssistantRenderer.override)
-  ) {
-    const existingOwner = target.owners.assistantRenderer ?? extensionId;
-    const overrideHint =
-      existingAssistantRenderer.fallback && !incomingAssistantRenderer.override
-        ? "; register with { override: true } to replace the fallback"
-        : "";
-    throw new Error(
-      `Assistant renderer from extension "${extensionId}" conflicts with extension "${existingOwner}"${overrideHint}`
-    );
-  }
+  commitAssistantRenderer(target, staged, extensionId);
   assertNoCommandConflicts(
     target.commands,
     staged.commands,
@@ -131,10 +159,19 @@ export function commitExtensionRegistryCollections(
   target.resourceRoots.prompts.push(...staged.resourceRoots.prompts);
   target.resourceRoots.skills.push(...staged.resourceRoots.skills);
   target.sessionGuards.push(...staged.sessionGuards);
-  if (incomingAssistantRenderer !== undefined) {
-    target.assistantRenderer = incomingAssistantRenderer;
+  if (staged.assistantRenderer !== undefined) {
+    if (staged.assistantRenderer.override) {
+      // An explicit override replaces the whole fallback chain.
+      target.assistantRendererChain.length = 0;
+      target.owners.assistantRendererChain.length = 0;
+    }
+    target.assistantRenderer = staged.assistantRenderer;
     target.owners.assistantRenderer = extensionId;
   }
+  target.assistantRendererChain.push(...staged.assistantRendererChain);
+  target.owners.assistantRendererChain.push(
+    ...staged.assistantRendererChain.map(() => extensionId)
+  );
   for (const [id, provider] of staged.modelProviders) {
     target.modelProviders.set(id, provider);
     target.owners.modelProviders.set(id, extensionId);

--- a/apps/coding-agent/src/extensions/registry.ts
+++ b/apps/coding-agent/src/extensions/registry.ts
@@ -79,18 +79,30 @@ export function createCodingAgentExtensionRegistry({
     if (typeof renderer !== "function") {
       throw new TypeError("Assistant renderer must be a function");
     }
-    if (collections.assistantRenderer !== undefined) {
-      const existingOwner = collections.owners.assistantRenderer ?? extensionId;
-      throw new Error(
-        `Assistant renderer from extension "${extensionId}" conflicts with extension "${existingOwner}"`
-      );
-    }
     const fallback = options.fallback === true;
     const override = options.override === true;
     if (fallback && override) {
       throw new TypeError(
         "Assistant renderer cannot be both a fallback and an override"
       );
+    }
+    if (
+      collections.assistantRenderer !== undefined ||
+      collections.assistantRendererChain.length > 0
+    ) {
+      const existingOwner = collections.owners.assistantRenderer ?? extensionId;
+      throw new Error(
+        `Assistant renderer from extension "${extensionId}" conflicts with extension "${existingOwner}"`
+      );
+    }
+    if (fallback) {
+      collections.assistantRendererChain.push({
+        fallback,
+        override,
+        renderer: renderer as AssistantRenderer,
+      });
+      collections.owners.assistantRendererChain.push(extensionId);
+      return;
     }
     collections.assistantRenderer = {
       fallback,

--- a/apps/coding-agent/src/tui/app-renderers.test.ts
+++ b/apps/coding-agent/src/tui/app-renderers.test.ts
@@ -293,7 +293,7 @@ describe("TUI extension renderer merging", () => {
       throw new Error("Expected a recovered extension host");
     }
     expect(recovered.getAssistantRendererOwner()).toBe(
-      "@minpeter/pss-extension-latex"
+      "@minpeter/pss-extension-mermaid"
     );
     expect(runtime.assistantRenderer).toBe(recovered.assistantRenderer);
     expect(runtime.assistantRendererSignal).toBe(recovered.signal);

--- a/apps/coding-agent/src/tui/assistant-renderer.test.ts
+++ b/apps/coding-agent/src/tui/assistant-renderer.test.ts
@@ -1,5 +1,10 @@
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
-import { createAssistantRendererNotifications } from "./assistant-renderer";
+import {
+  type AssistantRenderer,
+  composeAssistantRenderers,
+  createAssistantRendererNotifications,
+} from "./assistant-renderer";
 
 describe("assistant renderer notifications", () => {
   it("deduplicates keys for the whole TUI session", () => {
@@ -13,5 +18,131 @@ describe("assistant renderer notifications", () => {
     notifications.notifyOnce("other", "second");
 
     expect(messages).toEqual(["first", "second"]);
+  });
+});
+
+const markdownTheme: MarkdownTheme = {
+  bold: (text) => text,
+  code: (text) => text,
+  codeBlock: (text) => text,
+  codeBlockBorder: (text) => text,
+  heading: (text) => text,
+  hr: (text) => text,
+  italic: (text) => text,
+  link: (text) => text,
+  linkUrl: (text) => text,
+  listBullet: (text) => text,
+  quote: (text) => text,
+  quoteBorder: (text) => text,
+  strikethrough: (text) => text,
+  underline: (text) => text,
+};
+
+const wrapRenderer =
+  (name: string): AssistantRenderer =>
+  (context) => {
+    let text = "";
+    return {
+      invalidate() {
+        return;
+      },
+      render(width: number) {
+        const inner = context.delegate?.(`${name}(${text})`);
+        return inner === undefined ? [`${name}(${text})`] : inner.render(width);
+      },
+      setText(value: string) {
+        text = value;
+      },
+    };
+  };
+
+describe("composeAssistantRenderers", () => {
+  it("returns undefined for an empty chain", () => {
+    expect(composeAssistantRenderers([])).toBeUndefined();
+  });
+
+  it("delegates from the last registered renderer down to plain Markdown", () => {
+    const composed = composeAssistantRenderers([
+      wrapRenderer("inner"),
+      wrapRenderer("outer"),
+    ]);
+    const view = composed?.({
+      markdownTheme,
+      notify: () => undefined,
+      notifyOnce: () => undefined,
+      requestRender: () => undefined,
+      signal: new AbortController().signal,
+    });
+    view?.setText("hello");
+    // "outer" runs first on the raw text, then the inner renderer wraps it.
+    expect(view?.render(80).join("\n")).toContain("inner(outer(hello))");
+  });
+
+  it("gives every fallback renderer a delegate", () => {
+    const composed = composeAssistantRenderers([wrapRenderer("only")]);
+    const view = composed?.({
+      markdownTheme,
+      notify: () => undefined,
+      notifyOnce: () => undefined,
+      requestRender: () => undefined,
+      signal: new AbortController().signal,
+    });
+    view?.setText("hello");
+    expect(view?.render(80).join("\n")).toContain("only(hello)");
+  });
+
+  it("invalidates outer views when an inner renderer requests a redraw", () => {
+    let innerRequestRender: (() => void) | undefined;
+    let innerVersion = 0;
+    const inner: AssistantRenderer = (context) => {
+      innerRequestRender = context.requestRender;
+      return {
+        invalidate() {
+          return;
+        },
+        render() {
+          return [`v${innerVersion}`];
+        },
+        setText() {
+          return;
+        },
+      };
+    };
+    let outerInvalidations = 0;
+    const outer: AssistantRenderer = (context) => {
+      let text = "";
+      return {
+        invalidate() {
+          outerInvalidations += 1;
+        },
+        render(width: number) {
+          const delegated = context.delegate?.(text);
+          return delegated === undefined ? [] : delegated.render(width);
+        },
+        setText(value: string) {
+          text = value;
+        },
+      };
+    };
+    let tuiRedraws = 0;
+    const composed = composeAssistantRenderers([inner, outer]);
+    const view = composed?.({
+      markdownTheme,
+      notify: () => undefined,
+      notifyOnce: () => undefined,
+      requestRender: () => {
+        tuiRedraws += 1;
+      },
+      signal: new AbortController().signal,
+    });
+    view?.setText("x");
+    expect(view?.render(80)).toEqual(["v0"]);
+
+    innerVersion = 1;
+    innerRequestRender?.();
+
+    expect(outerInvalidations).toBe(1);
+    expect(tuiRedraws).toBe(1);
+    expect(view?.render(80)).toEqual(["v1"]);
   });
 });

--- a/apps/coding-agent/src/tui/assistant-renderer.ts
+++ b/apps/coding-agent/src/tui/assistant-renderer.ts
@@ -1,11 +1,23 @@
-import type { Component, MarkdownTheme } from "@earendil-works/pi-tui";
+import {
+  type Component,
+  Markdown,
+  type MarkdownTheme,
+} from "@earendil-works/pi-tui";
 
 export interface AssistantTextView extends Component {
   dispose?(): void;
   setText(text: string): void;
 }
 
+/**
+ * Render a text fragment through the next inner renderer in a composed
+ * fallback chain. The host wires this; renderers fall back to plain Markdown
+ * when it is absent (for example in unit tests).
+ */
+export type AssistantRendererDelegate = (text: string) => AssistantTextView;
+
 export interface AssistantRendererContext {
+  readonly delegate?: AssistantRendererDelegate;
   readonly foregroundColor?: string;
   readonly markdownTheme: MarkdownTheme;
   readonly notify: (message: string) => void;
@@ -17,6 +29,53 @@ export interface AssistantRendererContext {
 export type AssistantRenderer = (
   context: AssistantRendererContext
 ) => AssistantTextView;
+
+/**
+ * Compose fallback assistant renderers into one renderer. Renderers are given
+ * in registration order; the last registered renderer is outermost and each
+ * renderer's `delegate` context property renders through the next inner one,
+ * bottoming out at the plain Markdown view the TUI uses without extensions.
+ */
+export const composeAssistantRenderers = (
+  renderers: readonly AssistantRenderer[]
+): AssistantRenderer | undefined => {
+  if (renderers.length === 0) {
+    return;
+  }
+  return (context) => {
+    const createView = (
+      index: number,
+      notifyOutward: () => void
+    ): AssistantTextView => {
+      if (index < 0) {
+        return new Markdown("", 1, 0, context.markdownTheme);
+      }
+      const renderer = renderers[index];
+      if (renderer === undefined) {
+        return createView(index - 1, notifyOutward);
+      }
+      let self: AssistantTextView | undefined;
+      // An async inner render (image ready) must drop every outer cached
+      // frame before the TUI repaints, or the update never becomes visible.
+      const requestRender = (): void => {
+        self?.invalidate();
+        notifyOutward();
+      };
+      const view = renderer({
+        ...context,
+        delegate: (text) => {
+          const inner = createView(index - 1, requestRender);
+          inner.setText(text);
+          return inner;
+        },
+        requestRender,
+      });
+      self = view;
+      return view;
+    };
+    return createView(renderers.length - 1, context.requestRender);
+  };
+};
 
 export type AssistantRendererRegistrationOptions =
   | { readonly fallback?: never; readonly override?: never }

--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -53,6 +53,7 @@
     "@minpeter/pss-coding-agent": "workspace:^"
   },
   "devDependencies": {
+    "playwright-core": "1.62.0",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/extensions/latex/src/index.ts
+++ b/extensions/latex/src/index.ts
@@ -17,8 +17,9 @@ export const createLatexExtension: CodingAgentExtensionFactory = (pss) => {
   pss.provide(instructions(LATEX_OUTPUT_INSTRUCTIONS));
   pss.provide(
     assistantRenderer(
-      ({ foregroundColor, markdownTheme, requestRender, signal }) =>
+      ({ delegate, foregroundColor, markdownTheme, requestRender, signal }) =>
         new LatexMarkdown("", 1, 0, markdownTheme, {
+          delegate,
           foregroundColor,
           requestRender,
           signal,

--- a/extensions/latex/src/latex-markdown.ts
+++ b/extensions/latex/src/latex-markdown.ts
@@ -66,6 +66,10 @@ interface MarkdownTextStyle {
 
 interface LatexMarkdownOptions {
   defaultTextStyle?: MarkdownTextStyle;
+  delegate?: (text: string) => {
+    dispose?(): void;
+    render(width: number): string[];
+  };
   foregroundColor?: string;
   requestRender?: () => void;
   signal?: AbortSignal;
@@ -694,6 +698,10 @@ export class LatexMarkdown implements Component {
   private readonly paddingX: number;
   private readonly paddingY: number;
   private readonly renderStates = new Map<string, MathRenderState>();
+  private readonly delegateViews = new Map<
+    string,
+    { dispose?(): void; render(width: number): string[] }
+  >();
   private text: string;
   private readonly theme: MarkdownTheme;
   private readonly signal: AbortSignal;
@@ -723,6 +731,7 @@ export class LatexMarkdown implements Component {
       return;
     }
     this.disposed = true;
+    this.disposeDelegateViews();
     this.controller.abort();
   }
 
@@ -731,6 +740,7 @@ export class LatexMarkdown implements Component {
       return;
     }
     this.text = text;
+    this.disposeDelegateViews();
     this.invalidate();
     this.startRenderJobs();
   }
@@ -791,13 +801,47 @@ export class LatexMarkdown implements Component {
     paddingY: number,
     width: number
   ): string[] {
-    return new Markdown(
-      highlightInlineMath(text),
-      this.paddingX,
-      paddingY,
-      this.theme,
-      this.options.defaultTextStyle
-    ).render(width);
+    const highlighted = highlightInlineMath(text);
+    const delegate = this.options.delegate;
+    if (delegate === undefined) {
+      return new Markdown(
+        highlighted,
+        this.paddingX,
+        paddingY,
+        this.theme,
+        this.options.defaultTextStyle
+      ).render(width);
+    }
+    const lines = this.delegateMarkdown(delegate, highlighted).render(width);
+    if (paddingY <= 0) {
+      return lines;
+    }
+    const emptyLine = " ".repeat(width);
+    const margin = Array.from({ length: paddingY }, () => emptyLine);
+    return [...margin, ...lines, ...margin];
+  }
+
+  private delegateMarkdown(
+    delegate: (text: string) => {
+      dispose?(): void;
+      render(width: number): string[];
+    },
+    text: string
+  ): { dispose?(): void; render(width: number): string[] } {
+    const existing = this.delegateViews.get(text);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const view = delegate(text);
+    this.delegateViews.set(text, view);
+    return view;
+  }
+
+  private disposeDelegateViews(): void {
+    for (const view of this.delegateViews.values()) {
+      view.dispose?.();
+    }
+    this.delegateViews.clear();
   }
 
   private cache(width: number, lines: string[]): string[] {

--- a/extensions/mermaid/README.md
+++ b/extensions/mermaid/README.md
@@ -10,11 +10,10 @@ diagrams as Unicode box art with
 original fence source stays visible and the rendered diagram appears directly
 below it, as an annotation.
 
-Rendering is synchronous, pure TypeScript, and works in every terminal: no
-browser, DOM shim, worker thread, image protocol, disk cache, or network
-access. Flowchart, sequence, state, class, ER, and XY-chart diagrams are
-supported; other diagram types and malformed sources simply show the original
-fence. Unclosed fences while streaming show the source until they complete,
+Rendering runs in a bounded Node worker (5-second timeout, 256 MB heap
+cap) and works in every terminal: no browser, DOM shim, image protocol,
+disk cache, or network access. Pathological or malformed diagrams fall back
+to the original fence. Unclosed fences while streaming show the source until they complete,
 and oversized outputs fall back to the source.
 
 ```ts

--- a/extensions/mermaid/README.md
+++ b/extensions/mermaid/README.md
@@ -1,0 +1,30 @@
+# `@minpeter/pss-extension-mermaid`
+
+Official Mermaid diagram renderer for the PSS coding-agent TUI.
+
+The package contributes assistant output instructions and a fallback renderer
+for ```` ```mermaid ```` fenced code blocks. Following the pi ecosystem's
+approach ([`pi-mermaid`](https://github.com/Gurpartap/pi-mermaid)), it renders
+diagrams as Unicode box art with
+[`beautiful-mermaid`](https://www.npmjs.com/package/beautiful-mermaid): the
+original fence source stays visible and the rendered diagram appears directly
+below it, as an annotation.
+
+Rendering is synchronous, pure TypeScript, and works in every terminal: no
+browser, DOM shim, worker thread, image protocol, disk cache, or network
+access. Flowchart, sequence, state, class, ER, and XY-chart diagrams are
+supported; other diagram types and malformed sources simply show the original
+fence. Unclosed fences while streaming show the source until they complete,
+and oversized outputs fall back to the source.
+
+```ts
+import mermaidExtension from "@minpeter/pss-extension-mermaid";
+```
+
+The coding-agent includes this package by default. It composes with the LaTeX
+extension through the assistant-renderer fallback chain: the Mermaid renderer
+handles diagram fences and delegates all other Markdown inward. Third-party
+assistant renderers can replace the chain only through an explicit
+`{ override: true }` registration.
+
+`PSS_MERMAID=0` disables diagram rendering (fences show as plain code blocks).

--- a/extensions/mermaid/package.json
+++ b/extensions/mermaid/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@minpeter/pss-extension-mermaid",
+  "version": "0.0.1-next.0",
+  "description": "Self-contained Mermaid diagram rendering for the PSS coding-agent TUI.",
+  "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "@minpeter/pss-source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/minpeter/pss-runtime.git",
+    "directory": "extensions/mermaid"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "lint": "ultracite check ."
+  },
+  "dependencies": {
+    "beautiful-mermaid": "1.1.3"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-tui": "^0.82.1",
+    "@minpeter/pss-coding-agent": "workspace:^"
+  },
+  "devDependencies": {
+    "tsdown": "^0.22.14",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/extensions/mermaid/src/index.test.ts
+++ b/extensions/mermaid/src/index.test.ts
@@ -86,13 +86,4 @@ describe("Mermaid extension factory", () => {
       view.dispose?.();
     }
   );
-
-  it("documents complete mermaid fence output", () => {
-    expect(MERMAID_OUTPUT_INSTRUCTIONS).toContain("```mermaid");
-    expect(MERMAID_OUTPUT_INSTRUCTIONS).toContain(
-      "close the fence before continuing"
-    );
-    expect(MERMAID_OUTPUT_INSTRUCTIONS).toContain("one diagram per fence");
-    expect(MERMAID_OUTPUT_INSTRUCTIONS).toContain("valid Mermaid source");
-  });
 });

--- a/extensions/mermaid/src/index.test.ts
+++ b/extensions/mermaid/src/index.test.ts
@@ -1,0 +1,98 @@
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import type {
+  CodingAgentExtensionFactory,
+  ExtensionAPI,
+  ExtensionCapability,
+} from "@minpeter/pss-coding-agent/extension";
+import { describe, expect, it } from "vitest";
+import mermaidExtension, {
+  createMermaidExtension,
+  MERMAID_OUTPUT_INSTRUCTIONS,
+} from "./index";
+
+const markdownTheme: MarkdownTheme = {
+  bold: (text) => text,
+  code: (text) => text,
+  codeBlock: (text) => text,
+  codeBlockBorder: (text) => text,
+  heading: (text) => text,
+  hr: (text) => text,
+  italic: (text) => text,
+  link: (text) => text,
+  linkUrl: (text) => text,
+  listBullet: (text) => text,
+  quote: (text) => text,
+  quoteBorder: (text) => text,
+  strikethrough: (text) => text,
+  underline: (text) => text,
+};
+
+const recordCapabilities = async (
+  factory: CodingAgentExtensionFactory
+): Promise<readonly ExtensionCapability[]> => {
+  const capabilities: ExtensionCapability[] = [];
+  const api: ExtensionAPI = {
+    on() {
+      return;
+    },
+    provide(capability) {
+      capabilities.push(capability);
+    },
+    use() {
+      return;
+    },
+  };
+  await factory(api);
+  return capabilities;
+};
+
+describe("Mermaid extension factory", () => {
+  it.each([
+    ["default", mermaidExtension],
+    ["named", createMermaidExtension],
+  ])(
+    "contributes instructions and a fallback renderer through %s",
+    async (_, factory) => {
+      const capabilities = await recordCapabilities(factory);
+      const instructionCapability = capabilities.find(
+        (capability) => capability.kind === "instructions"
+      );
+      const rendererCapability = capabilities.find(
+        (capability) => capability.kind === "assistant-renderer"
+      );
+
+      expect(instructionCapability).toMatchObject({
+        fragments: [MERMAID_OUTPUT_INSTRUCTIONS],
+        kind: "instructions",
+      });
+      expect(rendererCapability).toMatchObject({
+        fallback: true,
+        kind: "assistant-renderer",
+        override: false,
+      });
+      if (rendererCapability?.kind !== "assistant-renderer") {
+        throw new Error("Expected the assistant renderer capability");
+      }
+      const view = rendererCapability.renderer({
+        markdownTheme,
+        notify: () => undefined,
+        notifyOnce: () => undefined,
+        requestRender: () => undefined,
+        signal: new AbortController().signal,
+      });
+      view.setText("plain assistant text");
+
+      expect(view.render(80).join("\n")).toContain("plain assistant text");
+      view.dispose?.();
+    }
+  );
+
+  it("documents complete mermaid fence output", () => {
+    expect(MERMAID_OUTPUT_INSTRUCTIONS).toContain("```mermaid");
+    expect(MERMAID_OUTPUT_INSTRUCTIONS).toContain(
+      "close the fence before continuing"
+    );
+    expect(MERMAID_OUTPUT_INSTRUCTIONS).toContain("one diagram per fence");
+    expect(MERMAID_OUTPUT_INSTRUCTIONS).toContain("valid Mermaid source");
+  });
+});

--- a/extensions/mermaid/src/index.ts
+++ b/extensions/mermaid/src/index.ts
@@ -15,8 +15,12 @@ export const createMermaidExtension: CodingAgentExtensionFactory = (pss) => {
   pss.provide(instructions(MERMAID_OUTPUT_INSTRUCTIONS));
   pss.provide(
     assistantRenderer(
-      ({ delegate, markdownTheme }) =>
-        new MermaidMarkdown("", 1, 0, markdownTheme, { delegate }),
+      ({ delegate, markdownTheme, requestRender, signal }) =>
+        new MermaidMarkdown("", 1, 0, markdownTheme, {
+          delegate,
+          requestRender,
+          signal,
+        }),
       { fallback: true }
     )
   );

--- a/extensions/mermaid/src/index.ts
+++ b/extensions/mermaid/src/index.ts
@@ -1,0 +1,28 @@
+import {
+  assistantRenderer,
+  type CodingAgentExtensionFactory,
+  instructions,
+} from "@minpeter/pss-coding-agent/extension";
+import { MermaidMarkdown } from "./mermaid-markdown";
+
+export const MERMAID_OUTPUT_INSTRUCTIONS = `Format diagrams consistently in user-facing responses:
+- Put every Mermaid diagram in a complete fenced code block tagged \`\`\`mermaid on its own line, and close the fence before continuing with prose.
+- Keep one diagram per fence and all explanatory prose outside the fence.
+- Write only valid Mermaid source inside the fence; do not nest code fences, Markdown, or non-Mermaid comments inside it.
+- Prefer flowcharts (graph TD or graph LR) or sequence diagrams unless another diagram type is clearly a better fit.`;
+
+export const createMermaidExtension: CodingAgentExtensionFactory = (pss) => {
+  pss.provide(instructions(MERMAID_OUTPUT_INSTRUCTIONS));
+  pss.provide(
+    assistantRenderer(
+      ({ delegate, markdownTheme }) =>
+        new MermaidMarkdown("", 1, 0, markdownTheme, { delegate }),
+      { fallback: true }
+    )
+  );
+};
+
+const createDefaultMermaidExtension: CodingAgentExtensionFactory = (pss) =>
+  createMermaidExtension(pss);
+
+export default createDefaultMermaidExtension;

--- a/extensions/mermaid/src/mermaid-art-worker.ts
+++ b/extensions/mermaid/src/mermaid-art-worker.ts
@@ -7,7 +7,7 @@ const MAX_ART_LINES = 80;
 const MAX_EXPANDED_EDGES = 200;
 const MAX_NODES = 200;
 const MAX_PLACEHOLDER_INDICES = 16_384;
-const RESERVED_PUA_PATTERN = /[\uE000-\uE07F]/;
+const RESERVED_PUA_PATTERN = /[\uE000-\uE1FF]/;
 const HEADER_SEMICOLON_PATTERN =
   /^(\s*(?:graph|flowchart)\s+[A-Za-z]{2})\s*;+\s*/;
 const TRAILING_SEMICOLON_PATTERN = /;[ \t]*$/gm;
@@ -34,7 +34,10 @@ const NODE_DECLARATION_PATTERN = /[[({][^\](){}]*[\])}]/g;
 const ARROW_TOKEN_PATTERN = /-{1,2}>+|-{1,2}\+{1,2}>/;
 const PLACEHOLDER_BASE = 0xe0_00;
 const PLACEHOLDER_DIGIT = 0x7f;
+const PLACEHOLDER_SINGLE_BASE = 0xe1_00;
+const MAX_SINGLE_PLACEHOLDERS = 128;
 const PLACEHOLDER_PATTERN = /[\uE000-\uE07F]{2}/g;
+const PLACEHOLDER_SINGLE_PATTERN = /[\uE100-\uE17F]/g;
 
 interface AsciiPreset {
   readonly boxBorderPadding: number;
@@ -215,11 +218,22 @@ const expandWideChars = (
   let expanded = "";
   // NFC folds combining sequences into single codepoints so both sides of
   // the shim count the same widths; zero-width characters are dropped since
-  // the library would count them but terminals never draw them.
+  // the library would count them but terminals never draw them. Graphemes
+  // that occupy one cell across several codepoints (e.g. q + a combining
+  // accent with no precomposed form) get a single placeholder from a second
+  // alphabet so their column count matches too.
   for (const grapheme of graphemes(source.normalize("NFC"))) {
     const width = visibleWidth(grapheme);
     if (width === 0 && grapheme !== "\n") {
       continue;
+    }
+    if (width === 1 && grapheme.length > 1) {
+      const index = wideChars.length;
+      if (index < MAX_SINGLE_PLACEHOLDERS) {
+        wideChars.push(grapheme);
+        expanded += String.fromCodePoint(PLACEHOLDER_SINGLE_BASE + index);
+        continue;
+      }
     }
     if (width === 2) {
       const index = wideChars.length;
@@ -241,14 +255,19 @@ const expandWideChars = (
 const collapsePlaceholders = (
   art: string,
   wideChars: readonly string[]
-): string =>
-  art.replace(PLACEHOLDER_PATTERN, (pair) => {
+): string => {
+  const paired = art.replace(PLACEHOLDER_PATTERN, (pair) => {
     const index =
       ((pair.codePointAt(0) ?? 0) - PLACEHOLDER_BASE) *
         (PLACEHOLDER_DIGIT + 1) +
       ((pair.codePointAt(1) ?? 0) - PLACEHOLDER_BASE);
     return wideChars[index] ?? "";
   });
+  return paired.replace(PLACEHOLDER_SINGLE_PATTERN, (char) => {
+    const index = (char.codePointAt(0) ?? 0) - PLACEHOLDER_SINGLE_BASE;
+    return wideChars[index] ?? "";
+  });
+};
 
 const squareBracketsBalanced = (source: string): boolean => {
   let square = 0;

--- a/extensions/mermaid/src/mermaid-art-worker.ts
+++ b/extensions/mermaid/src/mermaid-art-worker.ts
@@ -11,7 +11,7 @@ const RESERVED_PUA_PATTERN = /[\uE000-\uE07F]/;
 const HEADER_SEMICOLON_PATTERN =
   /^(\s*(?:graph|flowchart)\s+[A-Za-z]{2})\s*;+\s*/;
 const TRAILING_SEMICOLON_PATTERN = /;[ \t]*$/gm;
-const FLOWCHART_HEADER_PATTERN = /^\s*(?:graph|flowchart)\b/m;
+const FLOWCHART_HEADER_PATTERN = /^\s*(?:graph|flowchart)\b/;
 const ARROW_TOKEN = "(-->>|->>|-->|->|==>|-.->)";
 const ARROW_PREFIX = "([\\w\\]\\)}\"'가-힯])";
 const ARROW_BEFORE_NODE_PATTERN = new RegExp(
@@ -213,8 +213,15 @@ const expandWideChars = (
 ): { expanded: string; wideChars: string[] } => {
   const wideChars: string[] = [];
   let expanded = "";
-  for (const grapheme of graphemes(source)) {
-    if (visibleWidth(grapheme) === 2) {
+  // NFC folds combining sequences into single codepoints so both sides of
+  // the shim count the same widths; zero-width characters are dropped since
+  // the library would count them but terminals never draw them.
+  for (const grapheme of graphemes(source.normalize("NFC"))) {
+    const width = visibleWidth(grapheme);
+    if (width === 0 && grapheme !== "\n") {
+      continue;
+    }
+    if (width === 2) {
       const index = wideChars.length;
       wideChars.push(grapheme);
       expanded +=
@@ -262,7 +269,8 @@ const squareBracketsBalanced = (source: string): boolean => {
 // so reject obviously broken bodies instead of annotating a partial diagram:
 // unbalanced node brackets and arrows without targets.
 const diagramBodySane = (source: string): boolean => {
-  if (!squareBracketsBalanced(source)) {
+  const flowchart = FLOWCHART_HEADER_PATTERN.test(source);
+  if (flowchart && !squareBracketsBalanced(source)) {
     return false;
   }
   for (const line of source.split("\n")) {

--- a/extensions/mermaid/src/mermaid-art-worker.ts
+++ b/extensions/mermaid/src/mermaid-art-worker.ts
@@ -1,0 +1,346 @@
+import { parentPort } from "node:worker_threads";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { renderMermaidASCII } from "beautiful-mermaid";
+
+const MAX_SOURCE_LENGTH = 32_768;
+const MAX_ART_LINES = 80;
+const MAX_EXPANDED_EDGES = 200;
+const MAX_NODES = 200;
+const MAX_PLACEHOLDER_INDICES = 16_384;
+const RESERVED_PUA_PATTERN = /[\uE000-\uE07F]/;
+const HEADER_SEMICOLON_PATTERN =
+  /^(\s*(?:graph|flowchart)\s+[A-Za-z]{2})\s*;+\s*/;
+const TRAILING_SEMICOLON_PATTERN = /;[ \t]*$/gm;
+const FLOWCHART_HEADER_PATTERN = /^\s*(?:graph|flowchart)\b/m;
+const ARROW_TOKEN = "(-->>|->>|-->|->|==>|-.->)";
+const ARROW_PREFIX = "([\\w\\]\\)}\"'가-힯])";
+const ARROW_BEFORE_NODE_PATTERN = new RegExp(
+  `${ARROW_PREFIX}${ARROW_TOKEN}(?=[^\\s|])`,
+  "gu"
+);
+const ARROW_BEFORE_LABEL_PATTERN = new RegExp(
+  `${ARROW_PREFIX}${ARROW_TOKEN}(?=\\|)`,
+  "gu"
+);
+const ARROW_BEFORE_SPACE_PATTERN = new RegExp(
+  `${ARROW_PREFIX}${ARROW_TOKEN}(?=\\s)`,
+  "gu"
+);
+const EDGE_LABEL_TARGET_PATTERN = /((?:-->|->>|-->>|->)\|[^|\n]+\|)(?=\S)/g;
+const TIGHT_BARE_LINK_PATTERN = /(\w)--(\w)/g;
+const EDGE_RUN_PATTERN = /-{2,}|-\.|-|={2,}|\.\./;
+const AMPERSAND_PATTERN = /&/g;
+const NODE_DECLARATION_PATTERN = /[[({][^\](){}]*[\])}]/g;
+const ARROW_TOKEN_PATTERN = /-{1,2}>+|-{1,2}\+{1,2}>/;
+const PLACEHOLDER_BASE = 0xe0_00;
+const PLACEHOLDER_DIGIT = 0x7f;
+const PLACEHOLDER_PATTERN = /[\uE000-\uE07F]{2}/g;
+
+interface AsciiPreset {
+  readonly boxBorderPadding: number;
+  readonly paddingX: number;
+  readonly paddingY: number;
+}
+
+const DEFAULT_PRESET: AsciiPreset = {
+  boxBorderPadding: 1,
+  paddingX: 5,
+  paddingY: 5,
+};
+const TIGHT_PRESET: AsciiPreset = {
+  boxBorderPadding: 1,
+  paddingX: 2,
+  paddingY: 2,
+};
+
+// beautiful-mermaid accepts the header only alone on the first line, while
+// mermaid itself also allows `graph LR;` and single-line diagrams. Its
+// flowchart parser likewise requires whitespace around arrows, so common
+// idioms like `A-->B` and `A-->|yes|B` are spaced out here first - outside
+// bracket and pipe spans, where arrow-like text is content. Nesting a
+// bracket inside a label makes the source unsupported instead.
+const spaceSegment = (text: string): string =>
+  text
+    .replace(ARROW_BEFORE_LABEL_PATTERN, "$1 $2")
+    .replace(ARROW_BEFORE_NODE_PATTERN, "$1 $2 ")
+    .replace(ARROW_BEFORE_SPACE_PATTERN, "$1 $2")
+    .replace(EDGE_LABEL_TARGET_PATTERN, "$1 ")
+    .replace(TIGHT_BARE_LINK_PATTERN, "$1 -- $2");
+
+const isSpanOpener = (char: string): boolean =>
+  char === "[" || char === "{" || char === "(";
+
+const isSpanCloser = (char: string): boolean =>
+  char === "]" || char === "}" || char === ")";
+
+const readBracketSpan = (
+  line: string,
+  start: number
+): { end: number; span: string } | undefined => {
+  let depth = 0;
+  for (let index = start; index < line.length; index += 1) {
+    const char = line[index] ?? "";
+    if (isSpanOpener(char)) {
+      depth += 1;
+    } else if (isSpanCloser(char)) {
+      depth -= 1;
+    }
+    if (depth > 1) {
+      return;
+    }
+    if (depth === 0) {
+      return { end: index + 1, span: line.slice(start, index + 1) };
+    }
+  }
+  return { end: line.length, span: line.slice(start) };
+};
+
+const spaceArrowsOutsideSpans = (line: string): string | undefined => {
+  let output = "";
+  let segment = "";
+  let pipe = false;
+  const flush = (suffix?: string): void => {
+    const spaced = spaceSegment(segment + (suffix ?? ""));
+    output += suffix === undefined ? spaced : spaced.slice(0, -suffix.length);
+    segment = "";
+  };
+  let index = 0;
+  while (index < line.length) {
+    const char = line[index] ?? "";
+    if (!pipe && isSpanOpener(char)) {
+      flush();
+      const span = readBracketSpan(line, index);
+      if (span === undefined) {
+        return;
+      }
+      output += span.span;
+      index = span.end;
+      continue;
+    }
+    if (char === "|") {
+      if (pipe) {
+        pipe = false;
+        output += `${char} `;
+      } else {
+        flush("|");
+        pipe = true;
+        output += char;
+      }
+      index += 1;
+      continue;
+    }
+    if (pipe) {
+      output += char;
+    } else {
+      segment += char;
+    }
+    index += 1;
+  }
+  flush();
+  return output;
+};
+
+const normalizeDiagramSource = (source: string): string | undefined => {
+  const match = HEADER_SEMICOLON_PATTERN.exec(source);
+  const headerSplit =
+    match === null ? source : `${match[1]}\n${source.slice(match[0].length)}`;
+  const trimmed = headerSplit.replace(TRAILING_SEMICOLON_PATTERN, "");
+  if (!FLOWCHART_HEADER_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  const lines: string[] = [];
+  for (const line of trimmed.split("\n")) {
+    const spaced = spaceArrowsOutsideSpans(line);
+    if (spaced === undefined) {
+      return;
+    }
+    lines.push(spaced);
+  }
+  return lines.join("\n");
+};
+
+const ampCount = (text: string): number =>
+  text.match(AMPERSAND_PATTERN)?.length ?? 0;
+
+// Split each statement into the node groups between edge runs and sum the
+// cartesian product of every adjacent pair: `A & B --> C & D` is 4 edges, a
+// one-line chain counts every hop, and group sizes double as the node
+// estimate. Declaration-only lines contribute bracketed declarations or one
+// bare node. The worker timeout is the hard bound; this estimate is the
+// cheap pre-filter for obviously degenerate input.
+const exceedsComplexityBudget = (source: string): boolean => {
+  let expandedEdges = 0;
+  let nodeEstimate = 0;
+  for (const line of source.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("%%") || trimmed.length === 0) {
+      continue;
+    }
+    if (EDGE_RUN_PATTERN.test(trimmed)) {
+      const sizes = trimmed
+        .split(EDGE_RUN_PATTERN)
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0)
+        .map((segment) => ampCount(segment) + 1);
+      for (let index = 0; index + 1 < sizes.length; index += 1) {
+        expandedEdges += (sizes[index] ?? 1) * (sizes[index + 1] ?? 1);
+      }
+      nodeEstimate += sizes.reduce((total, size) => total + size, 0);
+    } else {
+      nodeEstimate +=
+        (trimmed.match(NODE_DECLARATION_PATTERN)?.length ?? 0) || 1;
+    }
+    if (nodeEstimate > MAX_NODES || expandedEdges > MAX_EXPANDED_EDGES) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const graphemes = (text: string): string[] => {
+  const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+  return [...segmenter.segment(text)].map((part) => part.segment);
+};
+
+// beautiful-mermaid pads box art by UTF-16 length, so East Asian wide
+// labels break alignment. Expand every wide grapheme into a private-use
+// pair (two narrow columns, self-describing index), let the library lay out
+// with correct widths, then collapse each pair back to the original glyph.
+// The pair alphabet is reserved: sources already using it render as plain
+// fences rather than risking mis-decoded annotations.
+const expandWideChars = (
+  source: string
+): { expanded: string; wideChars: string[] } => {
+  const wideChars: string[] = [];
+  let expanded = "";
+  for (const grapheme of graphemes(source)) {
+    if (visibleWidth(grapheme) === 2) {
+      const index = wideChars.length;
+      wideChars.push(grapheme);
+      expanded +=
+        String.fromCodePoint(
+          PLACEHOLDER_BASE + Math.floor(index / (PLACEHOLDER_DIGIT + 1))
+        ) +
+        String.fromCodePoint(
+          PLACEHOLDER_BASE + (index % (PLACEHOLDER_DIGIT + 1))
+        );
+    } else {
+      expanded += grapheme;
+    }
+  }
+  return { expanded, wideChars };
+};
+
+const collapsePlaceholders = (
+  art: string,
+  wideChars: readonly string[]
+): string =>
+  art.replace(PLACEHOLDER_PATTERN, (pair) => {
+    const index =
+      ((pair.codePointAt(0) ?? 0) - PLACEHOLDER_BASE) *
+        (PLACEHOLDER_DIGIT + 1) +
+      ((pair.codePointAt(1) ?? 0) - PLACEHOLDER_BASE);
+    return wideChars[index] ?? "";
+  });
+
+const squareBracketsBalanced = (source: string): boolean => {
+  let square = 0;
+  for (const char of source) {
+    if (char === "[") {
+      square += 1;
+    } else if (char === "]") {
+      square -= 1;
+    }
+    if (square < 0) {
+      return false;
+    }
+  }
+  return square === 0;
+};
+
+// beautiful-mermaid parses permissively and silently drops malformed tails,
+// so reject obviously broken bodies instead of annotating a partial diagram:
+// unbalanced node brackets and arrows without targets.
+const diagramBodySane = (source: string): boolean => {
+  if (!squareBracketsBalanced(source)) {
+    return false;
+  }
+  for (const line of source.split("\n")) {
+    const arrow = ARROW_TOKEN_PATTERN.exec(line);
+    if (
+      arrow !== null &&
+      line.slice(arrow.index + arrow[0].length).trim().length === 0
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const trimArtLines = (art: string): string[] => {
+  const lines = art.split("\n").map((line) => line.trimEnd());
+  while (lines.length > 0 && (lines.at(-1) ?? "").length === 0) {
+    lines.pop();
+  }
+  return lines;
+};
+
+/** Render diagram source to box-art lines, or undefined when unsupported. */
+export const renderDiagramArt = (source: string): string[] | undefined => {
+  const normalized = normalizeDiagramSource(source.trim());
+  if (
+    normalized === undefined ||
+    normalized.length === 0 ||
+    normalized.length > MAX_SOURCE_LENGTH ||
+    RESERVED_PUA_PATTERN.test(normalized) ||
+    exceedsComplexityBudget(normalized) ||
+    !diagramBodySane(normalized)
+  ) {
+    return;
+  }
+  const { expanded, wideChars } = expandWideChars(normalized);
+  if (wideChars.length >= MAX_PLACEHOLDER_INDICES) {
+    return;
+  }
+  let lines: string[];
+  try {
+    lines = trimArtLines(
+      collapsePlaceholders(
+        renderMermaidASCII(expanded, { ...DEFAULT_PRESET, colorMode: "none" }),
+        wideChars
+      )
+    );
+  } catch {
+    return;
+  }
+  if (lines.length > MAX_ART_LINES) {
+    try {
+      lines = trimArtLines(
+        collapsePlaceholders(
+          renderMermaidASCII(expanded, { ...TIGHT_PRESET, colorMode: "none" }),
+          wideChars
+        )
+      );
+    } catch {
+      return;
+    }
+  }
+  return lines.length > MAX_ART_LINES || lines.length === 0 ? undefined : lines;
+};
+
+if (parentPort) {
+  const port = parentPort;
+  port.on("message", (request: { id: number; source: string }) => {
+    try {
+      port.postMessage({
+        art: renderDiagramArt(request.source),
+        id: request.id,
+      });
+    } catch {
+      port.postMessage({
+        art: undefined,
+        id: request.id,
+      });
+    }
+  });
+}

--- a/extensions/mermaid/src/mermaid-markdown.test.ts
+++ b/extensions/mermaid/src/mermaid-markdown.test.ts
@@ -191,6 +191,35 @@ describe("renderDiagramArt", () => {
     expect(art?.join("\n")).toContain("사용자");
   });
 
+  it("renders sequence diagrams with textual brackets", () => {
+    expect(renderDiagramArt("sequenceDiagram\nA->>B: array[0")).toBeDefined();
+  });
+
+  it("does not mistake a participant named graph for a flowchart", () => {
+    const art = renderDiagramArt(
+      "sequenceDiagram\n  participant graph\n  graph->>B: x-->y"
+    );
+
+    expect(art).toBeDefined();
+    expect(art?.join("\n")).toContain("x-->y");
+  });
+
+  it("aligns ZWJ emoji and combining-accent labels", () => {
+    const emoji = renderDiagramArt(
+      "graph LR\nA[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}]-->B"
+    );
+    const accent = renderDiagramArt("graph LR\nA[cafe\u0301]-->B");
+
+    expect(emoji).toBeDefined();
+    expect(accent).toBeDefined();
+    expect(new Set((emoji ?? []).map((line) => visibleWidth(line))).size).toBe(
+      1
+    );
+    expect(new Set((accent ?? []).map((line) => visibleWidth(line))).size).toBe(
+      1
+    );
+  });
+
   it("renders subgraph clusters without a stray end node", () => {
     const art = renderDiagramArt(`graph TD;
   subgraph client[클라이언트]
@@ -299,8 +328,8 @@ describe("MermaidMarkdown", () => {
     });
   });
 
-  it("renders no art when PSS_MERMAID is 0", () => {
-    withMermaidEnv("0", () => {
+  it("renders no art when PSS_MERMAID is 0", async () => {
+    await withMermaidEnv("0", () => {
       const view = new MermaidMarkdown("", 1, 0, markdownTheme);
       view.setText("```mermaid\ngraph TD;\n  A-->B;\n```\n");
       const output = view.render(80).join("\n");
@@ -311,8 +340,8 @@ describe("MermaidMarkdown", () => {
     });
   });
 
-  it("passes non-mermaid markdown through to the delegate", () => {
-    withMermaidEnv(undefined, () => {
+  it("passes non-mermaid markdown through to the delegate", async () => {
+    await withMermaidEnv(undefined, () => {
       const delegated: string[] = [];
       const view = new MermaidMarkdown("", 1, 0, markdownTheme, {
         delegate: (text) => {
@@ -323,6 +352,26 @@ describe("MermaidMarkdown", () => {
       view.setText("just prose");
       expect(view.render(80)).toEqual(["D:just prose"]);
       expect(delegated).toEqual(["just prose"]);
+      view.dispose();
+    });
+  });
+
+  it("saturates instead of re-enqueueing evicted diagram jobs", async () => {
+    await withMermaidEnv(undefined, () => {
+      const fences = Array.from(
+        { length: 130 },
+        (_, i) => `\`\`\`mermaid\ngraph LR\nA${i}-->B${i}\n\`\`\`\n`
+      );
+      const view = new MermaidMarkdown("", 1, 0, markdownTheme);
+      view.setText(fences.join("\n"));
+      view.setText(`${fences.join("\n")}\ntail\n`);
+      const output = view.render(200).join("\n");
+
+      expect(output).toContain("A0-->B0");
+      expect(output).toContain("A129-->B129");
+      const states = (view as unknown as { renderStates: Map<string, unknown> })
+        .renderStates;
+      expect(states.size).toBeLessThanOrEqual(128);
       view.dispose();
     });
   });

--- a/extensions/mermaid/src/mermaid-markdown.test.ts
+++ b/extensions/mermaid/src/mermaid-markdown.test.ts
@@ -4,11 +4,8 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 const ARROW_GLYPH = /[►▶▼◀▲]/u;
 
 import { describe, expect, it } from "vitest";
-import {
-  extractMermaidBlocks,
-  MermaidMarkdown,
-  renderDiagramArt,
-} from "./mermaid-markdown";
+import { renderDiagramArt } from "./mermaid-art-worker";
+import { extractMermaidBlocks, MermaidMarkdown } from "./mermaid-markdown";
 
 const markdownTheme: MarkdownTheme = {
   bold: (text) => text,
@@ -167,6 +164,25 @@ describe("renderDiagramArt", () => {
     expect(renderDiagramArt(nodes)).toBeUndefined();
   });
 
+  it("counts bare and curly nodes and adjacent cartesian groups", () => {
+    const bare = `graph TD\n${Array.from(
+      { length: 250 },
+      (_, i) => `N${i}`
+    ).join("\n")}`;
+    const curly = `graph TD\n${Array.from(
+      { length: 250 },
+      (_, i) => `N${i}{node ${i}}`
+    ).join("\n")}`;
+    const left = Array.from({ length: 30 }, (_, i) => `L${i}`).join(" & ");
+    const mid = Array.from({ length: 30 }, (_, i) => `M${i}`).join(" & ");
+
+    expect(renderDiagramArt(bare)).toBeUndefined();
+    expect(renderDiagramArt(curly)).toBeUndefined();
+    expect(
+      renderDiagramArt(`graph LR\n  A ==> ${left} ==> ${mid} ==> D`)
+    ).toBeUndefined();
+  });
+
   it("renders sequence diagrams", () => {
     const art = renderDiagramArt(
       "sequenceDiagram\n  participant U as 사용자\n  U->>U: ping"
@@ -199,8 +215,10 @@ describe("renderDiagramArt", () => {
     expect(renderDiagramArt("graph TD\n  A[unterminated")).toBeUndefined();
   });
 
-  it("rejects bare links the engine cannot render", () => {
-    expect(renderDiagramArt("graph TD\n  A--B")).toBeUndefined();
+  it("renders tight bare links as plain links", () => {
+    const art = renderDiagramArt("graph TD\n  A--B");
+
+    expect(art).toBeDefined();
   });
 
   it("rejects cartesian expansions beyond the edge budget", () => {
@@ -219,7 +237,10 @@ describe("renderDiagramArt", () => {
 });
 
 describe("MermaidMarkdown", () => {
-  const withMermaidEnv = (value: string | undefined, run: () => void): void => {
+  const withMermaidEnv = async (
+    value: string | undefined,
+    run: () => Promise<void> | void
+  ): Promise<void> => {
     const original = process.env.PSS_MERMAID;
     if (value === undefined) {
       delete process.env.PSS_MERMAID;
@@ -227,7 +248,7 @@ describe("MermaidMarkdown", () => {
       process.env.PSS_MERMAID = value;
     }
     try {
-      run();
+      await run();
     } finally {
       if (original === undefined) {
         delete process.env.PSS_MERMAID;
@@ -237,10 +258,17 @@ describe("MermaidMarkdown", () => {
     }
   };
 
-  it("appends box art below the preserved source fence", () => {
-    withMermaidEnv(undefined, () => {
-      const view = new MermaidMarkdown("", 1, 0, markdownTheme);
+  it("appends box art below the preserved source fence", async () => {
+    await withMermaidEnv(undefined, async () => {
+      let notifyReady: (() => void) | undefined;
+      const ready = new Promise<void>((resolve) => {
+        notifyReady = resolve;
+      });
+      const view = new MermaidMarkdown("", 1, 0, markdownTheme, {
+        requestRender: () => notifyReady?.(),
+      });
       view.setText("before\n\n```mermaid\ngraph TD;\n  A-->B;\n```\n\nafter\n");
+      await ready;
       const output = view.render(80).join("\n");
 
       expect(output).toContain("```mermaid");
@@ -252,10 +280,17 @@ describe("MermaidMarkdown", () => {
     });
   });
 
-  it("falls back to the source fence when the diagram is invalid", () => {
-    withMermaidEnv(undefined, () => {
-      const view = new MermaidMarkdown("", 1, 0, markdownTheme);
+  it("falls back to the source fence when the diagram is invalid", async () => {
+    await withMermaidEnv(undefined, async () => {
+      let notifyReady: (() => void) | undefined;
+      const ready = new Promise<void>((resolve) => {
+        notifyReady = resolve;
+      });
+      const view = new MermaidMarkdown("", 1, 0, markdownTheme, {
+        requestRender: () => notifyReady?.(),
+      });
       view.setText("```mermaid\nthis is not a diagram\n```\n");
+      await ready;
       const output = view.render(80).join("\n");
 
       expect(output).toContain("this is not a diagram");

--- a/extensions/mermaid/src/mermaid-markdown.test.ts
+++ b/extensions/mermaid/src/mermaid-markdown.test.ts
@@ -136,6 +136,37 @@ describe("renderDiagramArt", () => {
     expect(art?.join("\n")).toContain("yes");
   });
 
+  it("renders class and ER operators without mangling them", () => {
+    expect(renderDiagramArt("classDiagram\n  Animal <|-- Dog")).toBeDefined();
+    expect(
+      renderDiagramArt("erDiagram\n  CUSTOMER ||--o{ ORDER : places")
+    ).toBeDefined();
+    expect(
+      renderDiagramArt("erDiagram\n  CUSTOMER ||--|| ORDER : places")
+    ).toBeDefined();
+  });
+
+  it("leaves arrow-like text inside bracket labels untouched", () => {
+    const art = renderDiagramArt('graph LR\n  A["x-->y"] --> B');
+
+    expect(art).toBeDefined();
+    expect(art?.join("\n")).toContain("x-->y");
+  });
+
+  it("rejects single-line chains and arrowless node floods", () => {
+    const chain = `graph LR\n${Array.from(
+      { length: 300 },
+      (_, i) => `N${i}-->N${i + 1}`
+    ).join(" ")}`;
+    const nodes = `graph TD\n${Array.from(
+      { length: 250 },
+      (_, i) => `N${i}[node ${i}]`
+    ).join("\n")}`;
+
+    expect(renderDiagramArt(chain)).toBeUndefined();
+    expect(renderDiagramArt(nodes)).toBeUndefined();
+  });
+
   it("renders sequence diagrams", () => {
     const art = renderDiagramArt(
       "sequenceDiagram\n  participant U as 사용자\n  U->>U: ping"

--- a/extensions/mermaid/src/mermaid-markdown.test.ts
+++ b/extensions/mermaid/src/mermaid-markdown.test.ts
@@ -1,0 +1,220 @@
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import {
+  extractMermaidBlocks,
+  MermaidMarkdown,
+  renderDiagramArt,
+} from "./mermaid-markdown";
+
+const markdownTheme: MarkdownTheme = {
+  bold: (text) => text,
+  code: (text) => text,
+  codeBlock: (text) => text,
+  codeBlockBorder: (text) => text,
+  heading: (text) => text,
+  hr: (text) => text,
+  italic: (text) => text,
+  link: (text) => text,
+  linkUrl: (text) => text,
+  listBullet: (text) => text,
+  quote: (text) => text,
+  quoteBorder: (text) => text,
+  strikethrough: (text) => text,
+  underline: (text) => text,
+};
+
+describe("extractMermaidBlocks", () => {
+  it("splits a complete mermaid fence from surrounding prose", () => {
+    const text = "Before\n\n```mermaid\ngraph TD;\n  A-->B;\n```\n\nAfter\n";
+    const parts = extractMermaidBlocks(text);
+
+    expect(parts.map((part) => part.type)).toEqual([
+      "markdown",
+      "mermaid",
+      "markdown",
+    ]);
+    expect(parts[1]?.source).toBe("graph TD;\n  A-->B;");
+    expect(parts[1]?.raw).toContain("```mermaid");
+  });
+
+  it("keeps an unclosed fence as markdown while streaming", () => {
+    const text = "Intro\n\n```mermaid\ngraph TD;\n  A-->B;\n";
+
+    expect(extractMermaidBlocks(text)).toEqual([
+      { raw: text, type: "markdown" },
+    ]);
+  });
+
+  it("ignores a mermaid fence nested inside a larger code fence", () => {
+    const text = "````markdown\n```mermaid\ngraph TD;\n```\n````\n";
+
+    expect(extractMermaidBlocks(text)).toEqual([
+      { raw: text, type: "markdown" },
+    ]);
+  });
+
+  it("accepts tilde fences and case-insensitive language tags", () => {
+    const text = "~~~Mermaid\ngraph TD;\n~~~\n";
+    const parts = extractMermaidBlocks(text);
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0]?.type).toBe("mermaid");
+    expect(parts[0]?.source).toBe("graph TD;");
+  });
+
+  it("treats extra info text after the language tag as a plain fence", () => {
+    const text = "```mermaid extra\ngraph TD;\n```\n";
+
+    expect(extractMermaidBlocks(text)).toEqual([
+      { raw: text, type: "markdown" },
+    ]);
+  });
+
+  it("treats an empty diagram body as markdown", () => {
+    const text = "```mermaid\n```\n";
+
+    expect(extractMermaidBlocks(text)).toEqual([
+      { raw: text, type: "markdown" },
+    ]);
+  });
+
+  it("splits multiple diagrams independently", () => {
+    const text =
+      "```mermaid\ngraph TD; A-->B;\n```\nmiddle\n```mermaid\ngraph LR; C-->D;\n```\n";
+    const parts = extractMermaidBlocks(text);
+
+    expect(parts.map((part) => part.type)).toEqual([
+      "mermaid",
+      "markdown",
+      "mermaid",
+    ]);
+    expect(parts[0]?.source).toBe("graph TD; A-->B;");
+    expect(parts[2]?.source).toBe("graph LR; C-->D;");
+  });
+});
+
+describe("renderDiagramArt", () => {
+  it("renders a Korean flowchart as box art", () => {
+    const art = renderDiagramArt("graph TD\n  A[사용자 입력] --> B[pss TUI]");
+
+    expect(art).toBeDefined();
+    expect(art?.join("\n")).toContain("사용자 입력");
+    expect(art?.join("\n")).toContain("┌");
+  });
+
+  it("keeps every art line at the same visible width with CJK labels", () => {
+    const art = renderDiagramArt("graph LR\nA[사용자 입력]-->B[게이트웨이]");
+
+    expect(art).toBeDefined();
+    const widths = new Set((art ?? []).map((line) => visibleWidth(line)));
+    expect(widths.size).toBe(1);
+  });
+
+  it("normalizes single-line and semicolon-terminated headers", () => {
+    expect(renderDiagramArt("graph LR; A-->B;")).toBeDefined();
+    expect(renderDiagramArt("graph LR;\nA-->B;")).toBeDefined();
+  });
+
+  it("renders sequence diagrams", () => {
+    const art = renderDiagramArt(
+      "sequenceDiagram\n  participant U as 사용자\n  U->>U: ping"
+    );
+
+    expect(art?.join("\n")).toContain("사용자");
+  });
+
+  it("renders subgraph clusters without a stray end node", () => {
+    const art = renderDiagramArt(`graph TD;
+  subgraph client[클라이언트]
+    A[input] --> B[tui];
+  end;
+  B --> C[agent];`);
+
+    expect(art).toBeDefined();
+    const joined = art?.join("\n") ?? "";
+    expect(joined).not.toContain("│ end │");
+    expect(joined).not.toContain(" end ");
+  });
+
+  it("returns undefined for invalid or unsupported sources", () => {
+    expect(renderDiagramArt("not a diagram")).toBeUndefined();
+    expect(renderDiagramArt("gitGraph\n  commit")).toBeUndefined();
+    expect(renderDiagramArt('pie\n  "a": 1')).toBeUndefined();
+  });
+});
+
+describe("MermaidMarkdown", () => {
+  const withMermaidEnv = (value: string | undefined, run: () => void): void => {
+    const original = process.env.PSS_MERMAID;
+    if (value === undefined) {
+      delete process.env.PSS_MERMAID;
+    } else {
+      process.env.PSS_MERMAID = value;
+    }
+    try {
+      run();
+    } finally {
+      if (original === undefined) {
+        delete process.env.PSS_MERMAID;
+      } else {
+        process.env.PSS_MERMAID = original;
+      }
+    }
+  };
+
+  it("appends box art below the preserved source fence", () => {
+    withMermaidEnv(undefined, () => {
+      const view = new MermaidMarkdown("", 1, 0, markdownTheme);
+      view.setText("before\n\n```mermaid\ngraph TD;\n  A-->B;\n```\n\nafter\n");
+      const output = view.render(80).join("\n");
+
+      expect(output).toContain("```mermaid");
+      expect(output).toContain("A-->B");
+      expect(output).toContain("┌");
+      expect(output).toContain("after");
+      expect(output.indexOf("A-->B")).toBeLessThan(output.indexOf("┌"));
+      view.dispose();
+    });
+  });
+
+  it("falls back to the source fence when the diagram is invalid", () => {
+    withMermaidEnv(undefined, () => {
+      const view = new MermaidMarkdown("", 1, 0, markdownTheme);
+      view.setText("```mermaid\nthis is not a diagram\n```\n");
+      const output = view.render(80).join("\n");
+
+      expect(output).toContain("this is not a diagram");
+      expect(output).not.toContain("┌");
+      view.dispose();
+    });
+  });
+
+  it("renders no art when PSS_MERMAID is 0", () => {
+    withMermaidEnv("0", () => {
+      const view = new MermaidMarkdown("", 1, 0, markdownTheme);
+      view.setText("```mermaid\ngraph TD;\n  A-->B;\n```\n");
+      const output = view.render(80).join("\n");
+
+      expect(output).toContain("A-->B");
+      expect(output).not.toContain("┌");
+      view.dispose();
+    });
+  });
+
+  it("passes non-mermaid markdown through to the delegate", () => {
+    withMermaidEnv(undefined, () => {
+      const delegated: string[] = [];
+      const view = new MermaidMarkdown("", 1, 0, markdownTheme, {
+        delegate: (text) => {
+          delegated.push(text);
+          return { render: () => [`D:${text}`] };
+        },
+      });
+      view.setText("just prose");
+      expect(view.render(80)).toEqual(["D:just prose"]);
+      expect(delegated).toEqual(["just prose"]);
+      view.dispose();
+    });
+  });
+});

--- a/extensions/mermaid/src/mermaid-markdown.test.ts
+++ b/extensions/mermaid/src/mermaid-markdown.test.ts
@@ -1,5 +1,8 @@
 import type { MarkdownTheme } from "@earendil-works/pi-tui";
 import { visibleWidth } from "@earendil-works/pi-tui";
+
+const ARROW_GLYPH = /[►▶▼◀▲]/u;
+
 import { describe, expect, it } from "vitest";
 import {
   extractMermaidBlocks,
@@ -116,6 +119,23 @@ describe("renderDiagramArt", () => {
     expect(renderDiagramArt("graph LR;\nA-->B;")).toBeDefined();
   });
 
+  it("renders unspaced arrows with both endpoints and the edge", () => {
+    const art = renderDiagramArt("graph LR\nA-->B");
+    const joined = art?.join("\n") ?? "";
+
+    expect(art).toBeDefined();
+    expect(joined).toContain("A");
+    expect(joined).toContain("B");
+    expect(joined).toMatch(ARROW_GLYPH);
+  });
+
+  it("renders unspaced edge labels", () => {
+    const art = renderDiagramArt("graph LR\nA-->|yes|B");
+
+    expect(art).toBeDefined();
+    expect(art?.join("\n")).toContain("yes");
+  });
+
   it("renders sequence diagrams", () => {
     const art = renderDiagramArt(
       "sequenceDiagram\n  participant U as 사용자\n  U->>U: ping"
@@ -141,6 +161,29 @@ describe("renderDiagramArt", () => {
     expect(renderDiagramArt("not a diagram")).toBeUndefined();
     expect(renderDiagramArt("gitGraph\n  commit")).toBeUndefined();
     expect(renderDiagramArt('pie\n  "a": 1')).toBeUndefined();
+  });
+
+  it("rejects malformed bodies that render as partial diagrams", () => {
+    expect(renderDiagramArt("graph TD\n  A -->")).toBeUndefined();
+    expect(renderDiagramArt("graph TD\n  A[unterminated")).toBeUndefined();
+  });
+
+  it("rejects bare links the engine cannot render", () => {
+    expect(renderDiagramArt("graph TD\n  A--B")).toBeUndefined();
+  });
+
+  it("rejects cartesian expansions beyond the edge budget", () => {
+    const left = Array.from({ length: 50 }, (_, i) => `A${i}`).join(" & ");
+    const right = Array.from({ length: 50 }, (_, i) => `B${i}`).join(" & ");
+    const source = `graph TD\n  ${left} --> ${right}`;
+
+    expect(renderDiagramArt(source)).toBeUndefined();
+  });
+
+  it("rejects sources that already use the reserved placeholder range", () => {
+    expect(
+      renderDiagramArt("graph TD\n  A[\uE000\uE001] --> B[ok]")
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/mermaid/src/mermaid-markdown.test.ts
+++ b/extensions/mermaid/src/mermaid-markdown.test.ts
@@ -209,15 +209,15 @@ describe("renderDiagramArt", () => {
       "graph LR\nA[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}]-->B"
     );
     const accent = renderDiagramArt("graph LR\nA[cafe\u0301]-->B");
+    const combining = renderDiagramArt("graph LR\nA[q\u0301]-->B");
+    const zeroWidth = renderDiagramArt("graph LR\nA[ab\u200Bcd]-->B");
 
-    expect(emoji).toBeDefined();
-    expect(accent).toBeDefined();
-    expect(new Set((emoji ?? []).map((line) => visibleWidth(line))).size).toBe(
-      1
-    );
-    expect(new Set((accent ?? []).map((line) => visibleWidth(line))).size).toBe(
-      1
-    );
+    for (const art of [emoji, accent, combining, zeroWidth]) {
+      expect(art).toBeDefined();
+      expect(new Set((art ?? []).map((line) => visibleWidth(line))).size).toBe(
+        1
+      );
+    }
   });
 
   it("renders subgraph clusters without a stray end node", () => {

--- a/extensions/mermaid/src/mermaid-markdown.ts
+++ b/extensions/mermaid/src/mermaid-markdown.ts
@@ -1,0 +1,463 @@
+import {
+  type Component,
+  Markdown,
+  type MarkdownTheme,
+  truncateToWidth,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
+import { renderMermaidAscii } from "beautiful-mermaid";
+
+const MAX_SOURCE_LENGTH = 32_768;
+const MAX_ART_LINES = 80;
+const MAX_ART_CACHE_ENTRIES = 128;
+const MARKDOWN_LINES_PATTERN = /.*(?:\n|$)/g;
+const FENCE_LINE_PATTERN = /^ {0,3}(`{3,}|~{3,})[ \t]*(.*?)[ \t]*$/;
+const HEADER_SEMICOLON_PATTERN =
+  /^(\s*(?:graph|flowchart)\s+[A-Za-z]{2})\s*;+\s*/;
+const TRAILING_SEMICOLON_PATTERN = /;[ \t]*$/gm;
+const WIDE_CHAR_PATTERN =
+  /[ᄀ-ᄟ⺠-〿ㄱ-㆏ㇰ-ㇿ㐀-䶿一-鿿ꥠ-꥿가-힯豈-﫿︰-﹯＀-￠￠-￦𛀀-𛅒𠀀-𪛟𪜀-𫜯😀-🯿]/gu;
+const PLACEHOLDER_BASE = 0xe0_00;
+const PLACEHOLDER_DIGIT = 0x7f;
+const PLACEHOLDER_PATTERN = /[\uE000-\uE07F]{2}/g;
+
+export interface MermaidBlockPart {
+  raw: string;
+  source?: string;
+  type: "markdown" | "mermaid";
+}
+
+interface FenceMarker {
+  char: string;
+  info: string;
+  length: number;
+}
+
+interface ActiveMermaidFence {
+  char: string;
+  length: number;
+  lines: string[];
+  start: number;
+}
+
+interface MarkdownTextStyle {
+  bold?: boolean;
+  color?: (text: string) => string;
+  italic?: boolean;
+  strikethrough?: boolean;
+  underline?: boolean;
+}
+
+interface MermaidMarkdownOptions {
+  defaultTextStyle?: MarkdownTextStyle;
+  delegate?: (text: string) => {
+    dispose?(): void;
+    render(width: number): string[];
+  };
+}
+
+const fenceMarker = (line: string): FenceMarker | undefined => {
+  const marker = FENCE_LINE_PATTERN.exec(line);
+  if (!marker?.[1]) {
+    return;
+  }
+  return {
+    char: marker[1][0] ?? "`",
+    info: marker[2] ?? "",
+    length: marker[1].length,
+  };
+};
+
+const closesFence = (
+  marker: FenceMarker,
+  active: { char: string; length: number }
+): boolean =>
+  marker.char === active.char &&
+  marker.length >= active.length &&
+  marker.info === "";
+
+const pushMermaidPart = (
+  parts: MermaidBlockPart[],
+  text: string,
+  mermaid: ActiveMermaidFence,
+  markdownStart: number,
+  end: number
+): number => {
+  const source = mermaid.lines.join("\n").trim();
+  const raw = text.slice(mermaid.start, end);
+  if (markdownStart < mermaid.start) {
+    parts.push({
+      raw: text.slice(markdownStart, mermaid.start),
+      type: "markdown",
+    });
+  }
+  if (source.length > 0 && source.length <= MAX_SOURCE_LENGTH) {
+    parts.push({ raw, source, type: "mermaid" });
+  } else {
+    parts.push({ raw, type: "markdown" });
+  }
+  return end;
+};
+
+interface ScanState {
+  fence?: FenceMarker;
+  markdownStart: number;
+  mermaid?: ActiveMermaidFence;
+  parts: MermaidBlockPart[];
+}
+
+const scanLine = (
+  state: ScanState,
+  text: string,
+  line: string,
+  offset: number,
+  end: number
+): void => {
+  const marker = fenceMarker(line);
+  if (state.mermaid !== undefined) {
+    if (marker && closesFence(marker, state.mermaid)) {
+      state.markdownStart = pushMermaidPart(
+        state.parts,
+        text,
+        state.mermaid,
+        state.markdownStart,
+        end
+      );
+      state.mermaid = undefined;
+      return;
+    }
+    state.mermaid.lines.push(line);
+    return;
+  }
+  if (state.fence !== undefined) {
+    if (marker && closesFence(marker, state.fence)) {
+      state.fence = undefined;
+    }
+    return;
+  }
+  if (marker === undefined) {
+    return;
+  }
+  if (marker.info.toLowerCase() === "mermaid") {
+    state.mermaid = { ...marker, lines: [], start: offset };
+  } else {
+    state.fence = marker;
+  }
+};
+
+/** Split complete mermaid fences out of Markdown, leaving the rest intact. */
+export const extractMermaidBlocks = (text: string): MermaidBlockPart[] => {
+  const state: ScanState = { markdownStart: 0, parts: [] };
+  let offset = 0;
+
+  for (const lineWithNewline of text.match(MARKDOWN_LINES_PATTERN) ?? []) {
+    if (lineWithNewline.length === 0) {
+      continue;
+    }
+    const line = lineWithNewline.endsWith("\n")
+      ? lineWithNewline.slice(0, -1)
+      : lineWithNewline;
+    scanLine(state, text, line, offset, offset + lineWithNewline.length);
+    offset += lineWithNewline.length;
+  }
+
+  if (state.markdownStart < text.length) {
+    state.parts.push({
+      raw: text.slice(state.markdownStart),
+      type: "markdown",
+    });
+  }
+  return state.parts.length === 0
+    ? [{ raw: text, type: "markdown" }]
+    : state.parts;
+};
+
+interface AsciiPreset {
+  readonly boxBorderPadding: number;
+  readonly paddingX: number;
+  readonly paddingY: number;
+}
+
+const DEFAULT_PRESET: AsciiPreset = {
+  boxBorderPadding: 1,
+  paddingX: 5,
+  paddingY: 5,
+};
+const TIGHT_PRESET: AsciiPreset = {
+  boxBorderPadding: 1,
+  paddingX: 2,
+  paddingY: 2,
+};
+
+// beautiful-mermaid accepts the header only alone on the first line, while
+// mermaid itself also allows `graph LR;` and single-line diagrams.
+const normalizeDiagramSource = (source: string): string => {
+  const match = HEADER_SEMICOLON_PATTERN.exec(source);
+  const headerSplit =
+    match === null ? source : `${match[1]}\n${source.slice(match[0].length)}`;
+  return headerSplit.replace(TRAILING_SEMICOLON_PATTERN, "");
+};
+
+// beautiful-mermaid pads box art by UTF-16 length, so East Asian wide
+// labels break alignment. Expand every wide label char into a private-use
+// pair (two narrow columns, self-describing index), let the library lay out
+// with correct widths, then collapse each pair back to the original glyph.
+const expandWideChars = (
+  source: string
+): { expanded: string; wideChars: string[] } => {
+  const wideChars: string[] = [];
+  const expanded = source.replace(WIDE_CHAR_PATTERN, (char) => {
+    const index = wideChars.length;
+    wideChars.push(char);
+    return (
+      String.fromCodePoint(
+        PLACEHOLDER_BASE + Math.floor(index / (PLACEHOLDER_DIGIT + 1))
+      ) +
+      String.fromCodePoint(PLACEHOLDER_BASE + (index % (PLACEHOLDER_DIGIT + 1)))
+    );
+  });
+  return { expanded, wideChars };
+};
+
+const collapsePlaceholders = (
+  art: string,
+  wideChars: readonly string[]
+): string =>
+  art.replace(PLACEHOLDER_PATTERN, (pair) => {
+    const index =
+      ((pair.codePointAt(0) ?? 0) - PLACEHOLDER_BASE) *
+        (PLACEHOLDER_DIGIT + 1) +
+      ((pair.codePointAt(1) ?? 0) - PLACEHOLDER_BASE);
+    return wideChars[index] ?? "";
+  });
+
+/** Render diagram source to box-art lines, or undefined when unsupported. */
+export const renderDiagramArt = (source: string): string[] | undefined => {
+  const normalized = normalizeDiagramSource(source.trim());
+  if (normalized.length === 0 || normalized.length > MAX_SOURCE_LENGTH) {
+    return;
+  }
+  const { expanded, wideChars } = expandWideChars(normalized);
+  const render = (preset: AsciiPreset): string[] =>
+    trimArtLines(
+      collapsePlaceholders(
+        renderMermaidAscii(expanded, { ...preset, colorMode: "none" }),
+        wideChars
+      )
+    );
+  let lines: string[];
+  try {
+    lines = render(DEFAULT_PRESET);
+  } catch {
+    return;
+  }
+  if (lines.length > MAX_ART_LINES) {
+    try {
+      lines = render(TIGHT_PRESET);
+    } catch {
+      return;
+    }
+  }
+  return lines.length > MAX_ART_LINES ? undefined : lines;
+};
+
+const trimArtLines = (art: string): string[] => {
+  const lines = art.split("\n").map((line) => line.trimEnd());
+  while (lines.length > 0 && (lines.at(-1) ?? "").length === 0) {
+    lines.pop();
+  }
+  return lines;
+};
+
+const isBlankRenderLine = (line: string | undefined): boolean =>
+  line !== undefined && line.trim().length === 0;
+
+const appendMarkdownLines = (target: string[], rendered: string[]): void => {
+  const startsWithBlank = isBlankRenderLine(rendered[0]);
+  if (isBlankRenderLine(target.at(-1)) && startsWithBlank) {
+    target.push(...rendered.slice(1));
+  } else {
+    target.push(...rendered);
+  }
+};
+
+/** Markdown component that appends box-art diagrams under mermaid fences. */
+export class MermaidMarkdown implements Component {
+  private readonly artCache = new Map<string, string[] | undefined>();
+  private cachedLines: string[] | undefined;
+  private cachedText: string | undefined;
+  private cachedWidth: number | undefined;
+  private readonly delegateViews = new Map<
+    string,
+    { dispose?(): void; render(width: number): string[] }
+  >();
+  private disposed = false;
+  private readonly options: MermaidMarkdownOptions;
+  private readonly paddingX: number;
+  private readonly paddingY: number;
+  private text: string;
+  private readonly theme: MarkdownTheme;
+
+  constructor(
+    text: string,
+    paddingX: number,
+    paddingY: number,
+    theme: MarkdownTheme,
+    options: MermaidMarkdownOptions = {}
+  ) {
+    this.text = text;
+    this.paddingX = paddingX;
+    this.paddingY = paddingY;
+    this.theme = theme;
+    this.options = options;
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.disposeDelegateViews();
+  }
+
+  setText(text: string): void {
+    if (this.disposed || text === this.text) {
+      return;
+    }
+    this.text = text;
+    this.disposeDelegateViews();
+    this.invalidate();
+  }
+
+  invalidate(): void {
+    this.cachedLines = undefined;
+    this.cachedText = undefined;
+    this.cachedWidth = undefined;
+  }
+
+  render(width: number): string[] {
+    if (
+      this.cachedLines &&
+      this.cachedText === this.text &&
+      this.cachedWidth === width
+    ) {
+      return this.cachedLines;
+    }
+
+    if (!this.mermaidEnabled()) {
+      return this.cache(
+        width,
+        this.renderMarkdown(this.text, this.paddingY, width)
+      );
+    }
+
+    const parts = extractMermaidBlocks(this.text);
+    if (!parts.some((part) => part.type === "mermaid")) {
+      return this.cache(
+        width,
+        this.renderMarkdown(this.text, this.paddingY, width)
+      );
+    }
+
+    const lines: string[] = [];
+    const emptyLine = " ".repeat(width);
+    lines.push(...Array.from({ length: this.paddingY }, () => emptyLine));
+    for (const part of parts) {
+      if (part.type === "mermaid" && part.source) {
+        appendMarkdownLines(lines, this.renderMarkdown(part.raw, 0, width));
+        const art = this.artFor(part.source);
+        if (art !== undefined) {
+          for (const artLine of art) {
+            lines.push(this.fitArtLine(artLine, width));
+          }
+          lines.push("");
+        }
+      } else if (part.raw.length > 0) {
+        appendMarkdownLines(lines, this.renderMarkdown(part.raw, 0, width));
+      }
+    }
+    lines.push(...Array.from({ length: this.paddingY }, () => emptyLine));
+    return this.cache(width, lines);
+  }
+
+  private artFor(source: string): string[] | undefined {
+    const cached = this.artCache.get(source);
+    if (cached !== undefined || this.artCache.has(source)) {
+      return cached;
+    }
+    const art = renderDiagramArt(source);
+    if (this.artCache.size >= MAX_ART_CACHE_ENTRIES) {
+      const oldest = this.artCache.keys().next().value;
+      if (oldest !== undefined) {
+        this.artCache.delete(oldest);
+      }
+    }
+    this.artCache.set(source, art);
+    return art;
+  }
+
+  private fitArtLine(line: string, width: number): string {
+    const available = Math.max(1, width - this.paddingX * 2);
+    const clipped =
+      visibleWidth(line) > available ? truncateToWidth(line, available) : line;
+    return " ".repeat(this.paddingX) + clipped;
+  }
+
+  private renderMarkdown(
+    text: string,
+    paddingY: number,
+    width: number
+  ): string[] {
+    const delegate = this.options.delegate;
+    if (delegate === undefined) {
+      return new Markdown(
+        text,
+        this.paddingX,
+        paddingY,
+        this.theme,
+        this.options.defaultTextStyle
+      ).render(width);
+    }
+    const lines = this.delegateMarkdown(delegate, text).render(width);
+    if (paddingY <= 0) {
+      return lines;
+    }
+    const emptyLine = " ".repeat(width);
+    const margin = Array.from({ length: paddingY }, () => emptyLine);
+    return [...margin, ...lines, ...margin];
+  }
+
+  private delegateMarkdown(
+    delegate: (text: string) => {
+      dispose?(): void;
+      render(width: number): string[];
+    },
+    text: string
+  ): { dispose?(): void; render(width: number): string[] } {
+    const existing = this.delegateViews.get(text);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const view = delegate(text);
+    this.delegateViews.set(text, view);
+    return view;
+  }
+
+  private disposeDelegateViews(): void {
+    for (const view of this.delegateViews.values()) {
+      view.dispose?.();
+    }
+    this.delegateViews.clear();
+  }
+
+  private cache(width: number, lines: string[]): string[] {
+    this.cachedLines = lines;
+    this.cachedText = this.text;
+    this.cachedWidth = width;
+    return lines;
+  }
+
+  private mermaidEnabled(): boolean {
+    return process.env.PSS_MERMAID !== "0";
+  }
+}

--- a/extensions/mermaid/src/mermaid-markdown.ts
+++ b/extensions/mermaid/src/mermaid-markdown.ts
@@ -5,18 +5,37 @@ import {
   truncateToWidth,
   visibleWidth,
 } from "@earendil-works/pi-tui";
-import { renderMermaidAscii } from "beautiful-mermaid";
+import { renderMermaidASCII } from "beautiful-mermaid";
 
 const MAX_SOURCE_LENGTH = 32_768;
 const MAX_ART_LINES = 80;
 const MAX_ART_CACHE_ENTRIES = 128;
+const MAX_EXPANDED_EDGES = 300;
+const MAX_NODES = 500;
+const MAX_PLACEHOLDER_INDICES = 16_384;
+const RESERVED_PUA_PATTERN = /[\uE000-\uE07F]/;
 const MARKDOWN_LINES_PATTERN = /.*(?:\n|$)/g;
 const FENCE_LINE_PATTERN = /^ {0,3}(`{3,}|~{3,})[ \t]*(.*?)[ \t]*$/;
 const HEADER_SEMICOLON_PATTERN =
   /^(\s*(?:graph|flowchart)\s+[A-Za-z]{2})\s*;+\s*/;
 const TRAILING_SEMICOLON_PATTERN = /;[ \t]*$/gm;
+const ARROW_TOKEN = "(-->>|->>|-->|->|==>|-\\.->)";
+const ARROW_PREFIX = "([\\w\\]\\)}\"'가-힯])";
+const ARROW_BEFORE_NODE_PATTERN = new RegExp(
+  `${ARROW_PREFIX}${ARROW_TOKEN}(?=[^\\s|])`,
+  "gu"
+);
+const ARROW_BEFORE_LABEL_PATTERN = new RegExp(
+  `${ARROW_PREFIX}${ARROW_TOKEN}(?=\\|)`,
+  "gu"
+);
+const ARROW_BEFORE_SPACE_PATTERN = new RegExp(
+  `${ARROW_PREFIX}${ARROW_TOKEN}(?=\\s)`,
+  "gu"
+);
+const EDGE_LABEL_TARGET_PATTERN = /(\|[^|\n]*\|)(?=\S)/g;
 const WIDE_CHAR_PATTERN =
-  /[ᄀ-ᄟ⺠-〿ㄱ-㆏ㇰ-ㇿ㐀-䶿一-鿿ꥠ-꥿가-힯豈-﫿︰-﹯＀-￠￠-￦𛀀-𛅒𠀀-𪛟𪜀-𫜯😀-🯿]/gu;
+  /[\u1100-\u11FF\u2E80-\u2FDF\u3000-\u3029\u3040-\u30FF\u3130-\u318F\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFF\uA960-\uA97F\uAC00-\uD7AF\uF900-\uFAFF\uFE30-\uFE6F\uFF00-\uFF60\uFFE0-\uFFE6\u{1B000}-\u{1B152}\u{1F300}-\u{1FAFF}\u{20000}-\u{2EBEF}]/gu;
 const PLACEHOLDER_BASE = 0xe0_00;
 const PLACEHOLDER_DIGIT = 0x7f;
 const PLACEHOLDER_PATTERN = /[\uE000-\uE07F]{2}/g;
@@ -190,18 +209,59 @@ const TIGHT_PRESET: AsciiPreset = {
 };
 
 // beautiful-mermaid accepts the header only alone on the first line, while
-// mermaid itself also allows `graph LR;` and single-line diagrams.
+// mermaid itself also allows `graph LR;` and single-line diagrams. Its
+// parser likewise requires whitespace around arrows, so common idioms like
+// `A-->B` and `A-->|yes|B` are spaced out here first.
 const normalizeDiagramSource = (source: string): string => {
   const match = HEADER_SEMICOLON_PATTERN.exec(source);
   const headerSplit =
     match === null ? source : `${match[1]}\n${source.slice(match[0].length)}`;
-  return headerSplit.replace(TRAILING_SEMICOLON_PATTERN, "");
+  return headerSplit
+    .replace(TRAILING_SEMICOLON_PATTERN, "")
+    .replace(ARROW_BEFORE_LABEL_PATTERN, "$1 $2")
+    .replace(ARROW_BEFORE_NODE_PATTERN, "$1 $2 ")
+    .replace(ARROW_BEFORE_SPACE_PATTERN, "$1 $2")
+    .replace(EDGE_LABEL_TARGET_PATTERN, "$1 ");
 };
 
 // beautiful-mermaid pads box art by UTF-16 length, so East Asian wide
 // labels break alignment. Expand every wide label char into a private-use
 // pair (two narrow columns, self-describing index), let the library lay out
 // with correct widths, then collapse each pair back to the original glyph.
+// The pair alphabet is reserved: sources already using it render as plain
+// fences rather than risking mis-decoded annotations.
+const ARROW_STATEMENT_PATTERN = /-{1,2}>+|-{1,2}\+{1,2}>/;
+const AMPERSAND_PATTERN = /&/g;
+const NODE_TOKEN_PATTERN = /[[(][^\]()\n]*[\])]/g;
+
+const ampCount = (text: string): number =>
+  text.match(AMPERSAND_PATTERN)?.length ?? 0;
+
+// Mermaid shorthand like `A & B --> C & D` expands cartesianly into
+// lhs * rhs edges per statement; rendering is synchronous, so bound the
+// expansion before it can monopolize the TUI process.
+const exceedsComplexityBudget = (source: string): boolean => {
+  let expandedEdges = 0;
+  let nodeTokens = 0;
+  for (const line of source.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("%%") || trimmed.length === 0) {
+      continue;
+    }
+    nodeTokens += trimmed.match(NODE_TOKEN_PATTERN)?.length ?? 0;
+    const arrowIndex = trimmed.search(ARROW_STATEMENT_PATTERN);
+    if (arrowIndex === -1) {
+      continue;
+    }
+    const left = trimmed.slice(0, arrowIndex);
+    const right = trimmed.slice(arrowIndex);
+    expandedEdges += Math.max(1, ampCount(left)) * Math.max(1, ampCount(right));
+    if (expandedEdges > MAX_EXPANDED_EDGES || nodeTokens > MAX_NODES) {
+      return true;
+    }
+  }
+  return false;
+};
 const expandWideChars = (
   source: string
 ): { expanded: string; wideChars: string[] } => {
@@ -231,20 +291,78 @@ const collapsePlaceholders = (
     return wideChars[index] ?? "";
   });
 
+const bracketsBalanced = (source: string): boolean => {
+  let curly = 0;
+  let round = 0;
+  let square = 0;
+  for (const char of source) {
+    if (char === "[") {
+      square += 1;
+    } else if (char === "]") {
+      square -= 1;
+    } else if (char === "{") {
+      curly += 1;
+    } else if (char === "}") {
+      curly -= 1;
+    } else if (char === "(") {
+      round += 1;
+    } else if (char === ")") {
+      round -= 1;
+    }
+    if (square < 0 || curly < 0 || round < 0) {
+      return false;
+    }
+  }
+  return square === 0 && curly === 0 && round === 0;
+};
+
+// beautiful-mermaid parses permissively and silently drops malformed tails,
+// so reject obviously broken bodies instead of annotating a partial diagram.
+const BARE_LINK_PATTERN = /(?<![-<>])--(?![->])/u;
+const ARROW_GLYPH_PATTERN = /[►▶▼◀▲]/u;
+
+// beautiful-mermaid parses permissively and silently drops malformed tails,
+// so reject obviously broken bodies instead of annotating a partial diagram.
+const diagramBodySane = (source: string, art: string): boolean => {
+  if (!bracketsBalanced(source) || BARE_LINK_PATTERN.test(source)) {
+    return false;
+  }
+  let arrows = 0;
+  for (const line of source.split("\n")) {
+    const arrow = ARROW_STATEMENT_PATTERN.exec(line);
+    if (arrow === null) {
+      continue;
+    }
+    arrows += 1;
+    if (line.slice(arrow.index + arrow[0].length).trim().length === 0) {
+      return false;
+    }
+  }
+  return arrows === 0 || ARROW_GLYPH_PATTERN.test(art);
+};
+
 /** Render diagram source to box-art lines, or undefined when unsupported. */
 export const renderDiagramArt = (source: string): string[] | undefined => {
   const normalized = normalizeDiagramSource(source.trim());
-  if (normalized.length === 0 || normalized.length > MAX_SOURCE_LENGTH) {
+  if (
+    normalized.length === 0 ||
+    normalized.length > MAX_SOURCE_LENGTH ||
+    RESERVED_PUA_PATTERN.test(normalized) ||
+    exceedsComplexityBudget(normalized)
+  ) {
     return;
   }
   const { expanded, wideChars } = expandWideChars(normalized);
-  const render = (preset: AsciiPreset): string[] =>
-    trimArtLines(
-      collapsePlaceholders(
-        renderMermaidAscii(expanded, { ...preset, colorMode: "none" }),
-        wideChars
-      )
+  if (wideChars.length >= MAX_PLACEHOLDER_INDICES) {
+    return;
+  }
+  const render = (preset: AsciiPreset): string[] => {
+    const art = collapsePlaceholders(
+      renderMermaidASCII(expanded, { ...preset, colorMode: "none" }),
+      wideChars
     );
+    return diagramBodySane(normalized, art) ? trimArtLines(art) : [];
+  };
   let lines: string[];
   try {
     lines = render(DEFAULT_PRESET);
@@ -258,7 +376,7 @@ export const renderDiagramArt = (source: string): string[] | undefined => {
       return;
     }
   }
-  return lines.length > MAX_ART_LINES ? undefined : lines;
+  return lines.length > MAX_ART_LINES || lines.length === 0 ? undefined : lines;
 };
 
 const trimArtLines = (art: string): string[] => {
@@ -383,6 +501,8 @@ export class MermaidMarkdown implements Component {
   private artFor(source: string): string[] | undefined {
     const cached = this.artCache.get(source);
     if (cached !== undefined || this.artCache.has(source)) {
+      this.artCache.delete(source);
+      this.artCache.set(source, cached);
       return cached;
     }
     const art = renderDiagramArt(source);

--- a/extensions/mermaid/src/mermaid-markdown.ts
+++ b/extensions/mermaid/src/mermaid-markdown.ts
@@ -10,8 +10,8 @@ import { renderMermaidASCII } from "beautiful-mermaid";
 const MAX_SOURCE_LENGTH = 32_768;
 const MAX_ART_LINES = 80;
 const MAX_ART_CACHE_ENTRIES = 128;
-const MAX_EXPANDED_EDGES = 300;
-const MAX_NODES = 500;
+const MAX_EXPANDED_EDGES = 200;
+const MAX_NODES = 200;
 const MAX_PLACEHOLDER_INDICES = 16_384;
 const RESERVED_PUA_PATTERN = /[\uE000-\uE07F]/;
 const MARKDOWN_LINES_PATTERN = /.*(?:\n|$)/g;
@@ -33,9 +33,7 @@ const ARROW_BEFORE_SPACE_PATTERN = new RegExp(
   `${ARROW_PREFIX}${ARROW_TOKEN}(?=\\s)`,
   "gu"
 );
-const EDGE_LABEL_TARGET_PATTERN = /(\|[^|\n]*\|)(?=\S)/g;
-const WIDE_CHAR_PATTERN =
-  /[\u1100-\u11FF\u2E80-\u2FDF\u3000-\u3029\u3040-\u30FF\u3130-\u318F\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFF\uA960-\uA97F\uAC00-\uD7AF\uF900-\uFAFF\uFE30-\uFE6F\uFF00-\uFF60\uFFE0-\uFFE6\u{1B000}-\u{1B152}\u{1F300}-\u{1FAFF}\u{20000}-\u{2EBEF}]/gu;
+const EDGE_LABEL_TARGET_PATTERN = /((?:-->|->>|-->>|->)\|[^|\n]+\|)(?=\S)/g;
 const PLACEHOLDER_BASE = 0xe0_00;
 const PLACEHOLDER_DIGIT = 0x7f;
 const PLACEHOLDER_PATTERN = /[\uE000-\uE07F]{2}/g;
@@ -211,17 +209,51 @@ const TIGHT_PRESET: AsciiPreset = {
 // beautiful-mermaid accepts the header only alone on the first line, while
 // mermaid itself also allows `graph LR;` and single-line diagrams. Its
 // parser likewise requires whitespace around arrows, so common idioms like
-// `A-->B` and `A-->|yes|B` are spaced out here first.
+// `A-->B` and `A-->|yes|B` are spaced out here first - outside bracket
+// labels, where arrow-like text is content.
+const spaceArrowsOutsideBrackets = (line: string): string => {
+  let output = "";
+  let segment = "";
+  let depth = 0;
+  const flushSegment = (): void => {
+    output += segment
+      .replace(ARROW_BEFORE_LABEL_PATTERN, "$1 $2")
+      .replace(ARROW_BEFORE_NODE_PATTERN, "$1 $2 ")
+      .replace(ARROW_BEFORE_SPACE_PATTERN, "$1 $2")
+      .replace(EDGE_LABEL_TARGET_PATTERN, "$1 ");
+    segment = "";
+  };
+  for (const char of line) {
+    if (depth === 0 && (char === "[" || char === "{" || char === "(")) {
+      flushSegment();
+      depth = 1;
+      output += char;
+      continue;
+    }
+    if (depth > 0) {
+      output += char;
+      if (char === "[" || char === "{" || char === "(") {
+        depth += 1;
+      } else if (char === "]" || char === "}" || char === ")") {
+        depth -= 1;
+      }
+      continue;
+    }
+    segment += char;
+  }
+  flushSegment();
+  return output;
+};
+
 const normalizeDiagramSource = (source: string): string => {
   const match = HEADER_SEMICOLON_PATTERN.exec(source);
   const headerSplit =
     match === null ? source : `${match[1]}\n${source.slice(match[0].length)}`;
   return headerSplit
     .replace(TRAILING_SEMICOLON_PATTERN, "")
-    .replace(ARROW_BEFORE_LABEL_PATTERN, "$1 $2")
-    .replace(ARROW_BEFORE_NODE_PATTERN, "$1 $2 ")
-    .replace(ARROW_BEFORE_SPACE_PATTERN, "$1 $2")
-    .replace(EDGE_LABEL_TARGET_PATTERN, "$1 ");
+    .split("\n")
+    .map(spaceArrowsOutsideBrackets)
+    .join("\n");
 };
 
 // beautiful-mermaid pads box art by UTF-16 length, so East Asian wide
@@ -230,16 +262,20 @@ const normalizeDiagramSource = (source: string): string => {
 // with correct widths, then collapse each pair back to the original glyph.
 // The pair alphabet is reserved: sources already using it render as plain
 // fences rather than risking mis-decoded annotations.
-const ARROW_STATEMENT_PATTERN = /-{1,2}>+|-{1,2}\+{1,2}>/;
+// Edge runs approximate operator count for the budget: every mermaid edge
+// operator carries exactly one of these runs, while the node-token pattern
+// catches bracketed node declarations.
+const EDGE_RUN_PATTERN = /-{2,}|-\.|-|={2,}|\.\./g;
 const AMPERSAND_PATTERN = /&/g;
 const NODE_TOKEN_PATTERN = /[[(][^\]()\n]*[\])]/g;
 
 const ampCount = (text: string): number =>
   text.match(AMPERSAND_PATTERN)?.length ?? 0;
 
-// Mermaid shorthand like `A & B --> C & D` expands cartesianly into
-// lhs * rhs edges per statement; rendering is synchronous, so bound the
-// expansion before it can monopolize the TUI process.
+// Rendering is synchronous, so bound the graph before it can monopolize
+// the TUI process. Count every edge run (mermaid chains statements on one
+// line) and estimate cartesian groups as (left ampersands + 1) x (right
+// ampersands + 1); node tokens accumulate even without operators.
 const exceedsComplexityBudget = (source: string): boolean => {
   let expandedEdges = 0;
   let nodeTokens = 0;
@@ -249,14 +285,20 @@ const exceedsComplexityBudget = (source: string): boolean => {
       continue;
     }
     nodeTokens += trimmed.match(NODE_TOKEN_PATTERN)?.length ?? 0;
-    const arrowIndex = trimmed.search(ARROW_STATEMENT_PATTERN);
-    if (arrowIndex === -1) {
+    if (nodeTokens > MAX_NODES) {
+      return true;
+    }
+    const runs = [...trimmed.matchAll(EDGE_RUN_PATTERN)];
+    if (runs.length === 0) {
       continue;
     }
-    const left = trimmed.slice(0, arrowIndex);
-    const right = trimmed.slice(arrowIndex);
-    expandedEdges += Math.max(1, ampCount(left)) * Math.max(1, ampCount(right));
-    if (expandedEdges > MAX_EXPANDED_EDGES || nodeTokens > MAX_NODES) {
+    const leftAmp = ampCount(trimmed.slice(0, runs[0]?.index ?? 0));
+    const lastRun = runs.at(-1);
+    const rightAmp = ampCount(
+      trimmed.slice((lastRun?.index ?? 0) + (lastRun?.[0].length ?? 0))
+    );
+    expandedEdges += runs.length * (leftAmp + 1) * (rightAmp + 1);
+    if (expandedEdges > MAX_EXPANDED_EDGES) {
       return true;
     }
   }
@@ -266,16 +308,24 @@ const expandWideChars = (
   source: string
 ): { expanded: string; wideChars: string[] } => {
   const wideChars: string[] = [];
-  const expanded = source.replace(WIDE_CHAR_PATTERN, (char) => {
-    const index = wideChars.length;
-    wideChars.push(char);
-    return (
-      String.fromCodePoint(
-        PLACEHOLDER_BASE + Math.floor(index / (PLACEHOLDER_DIGIT + 1))
-      ) +
-      String.fromCodePoint(PLACEHOLDER_BASE + (index % (PLACEHOLDER_DIGIT + 1)))
-    );
-  });
+  let expanded = "";
+  for (const char of source) {
+    // Per-glyph terminal width is the ground truth for the art alignment
+    // shim: expand exactly the characters the terminal draws two cells wide.
+    if (visibleWidth(char) === 2) {
+      const index = wideChars.length;
+      wideChars.push(char);
+      expanded +=
+        String.fromCodePoint(
+          PLACEHOLDER_BASE + Math.floor(index / (PLACEHOLDER_DIGIT + 1))
+        ) +
+        String.fromCodePoint(
+          PLACEHOLDER_BASE + (index % (PLACEHOLDER_DIGIT + 1))
+        );
+    } else {
+      expanded += char;
+    }
+  }
   return { expanded, wideChars };
 };
 
@@ -291,45 +341,46 @@ const collapsePlaceholders = (
     return wideChars[index] ?? "";
   });
 
-const bracketsBalanced = (source: string): boolean => {
-  let curly = 0;
-  let round = 0;
+const squareBracketsBalanced = (source: string): boolean => {
   let square = 0;
   for (const char of source) {
     if (char === "[") {
       square += 1;
     } else if (char === "]") {
       square -= 1;
-    } else if (char === "{") {
-      curly += 1;
-    } else if (char === "}") {
-      curly -= 1;
-    } else if (char === "(") {
-      round += 1;
-    } else if (char === ")") {
-      round -= 1;
     }
-    if (square < 0 || curly < 0 || round < 0) {
+    if (square < 0) {
       return false;
     }
   }
-  return square === 0 && curly === 0 && round === 0;
+  return square === 0;
 };
 
-// beautiful-mermaid parses permissively and silently drops malformed tails,
-// so reject obviously broken bodies instead of annotating a partial diagram.
-const BARE_LINK_PATTERN = /(?<![-<>])--(?![->])/u;
+const FLOWCHART_HEADER_PATTERN = /^\s*(?:graph|flowchart)\b/m;
+const ARROW_TOKEN_PATTERN = /-{1,2}>+|-{1,2}\+{1,2}>/;
 const ARROW_GLYPH_PATTERN = /[►▶▼◀▲]/u;
+const DASH_RUN_PATTERN = /-{2,}/;
+const BRACKET_CONTENTS_PATTERN = /[[{(][^[\]{}()]*[\]})]/g;
 
 // beautiful-mermaid parses permissively and silently drops malformed tails,
-// so reject obviously broken bodies instead of annotating a partial diagram.
+// so reject obviously broken bodies instead of annotating a partial diagram:
+// unbalanced node brackets, arrows without targets, and bare dash links the
+// engine cannot draw (valid class/ER operators carry no dash-run of 2+
+// outside brackets, so they pass through).
 const diagramBodySane = (source: string, art: string): boolean => {
-  if (!bracketsBalanced(source) || BARE_LINK_PATTERN.test(source)) {
+  if (!squareBracketsBalanced(source)) {
     return false;
   }
+  const flowchart = FLOWCHART_HEADER_PATTERN.test(source);
   let arrows = 0;
   for (const line of source.split("\n")) {
-    const arrow = ARROW_STATEMENT_PATTERN.exec(line);
+    if (flowchart) {
+      const stripped = line.replace(BRACKET_CONTENTS_PATTERN, "");
+      if (DASH_RUN_PATTERN.test(stripped) && !stripped.includes(">")) {
+        return false;
+      }
+    }
+    const arrow = ARROW_TOKEN_PATTERN.exec(line);
     if (arrow === null) {
       continue;
     }
@@ -338,7 +389,7 @@ const diagramBodySane = (source: string, art: string): boolean => {
       return false;
     }
   }
-  return arrows === 0 || ARROW_GLYPH_PATTERN.test(art);
+  return !flowchart || arrows === 0 || ARROW_GLYPH_PATTERN.test(art);
 };
 
 /** Render diagram source to box-art lines, or undefined when unsupported. */

--- a/extensions/mermaid/src/mermaid-markdown.ts
+++ b/extensions/mermaid/src/mermaid-markdown.ts
@@ -302,14 +302,14 @@ export class MermaidMarkdown implements Component {
       if (this.renderStates.has(source)) {
         continue;
       }
+      // Evicting here would re-enqueue the source on the next streaming
+      // update, and inserting a marker would grow the map without bound;
+      // skip entirely so a diagram flood degrades to source-only output.
+      if (this.renderStates.size >= MAX_ART_CACHE_ENTRIES) {
+        continue;
+      }
       const state: DiagramRenderState = { status: "pending" };
       this.renderStates.set(source, state);
-      if (this.renderStates.size > MAX_ART_CACHE_ENTRIES) {
-        const oldest = this.renderStates.keys().next().value;
-        if (oldest !== undefined) {
-          this.renderStates.delete(oldest);
-        }
-      }
       renderMermaidArt(source, this.signal).then(
         (art) => {
           if (this.signal.aborted) {

--- a/extensions/mermaid/src/mermaid-markdown.ts
+++ b/extensions/mermaid/src/mermaid-markdown.ts
@@ -5,38 +5,12 @@ import {
   truncateToWidth,
   visibleWidth,
 } from "@earendil-works/pi-tui";
-import { renderMermaidASCII } from "beautiful-mermaid";
+import { renderMermaidArt } from "./mermaid-renderer";
 
 const MAX_SOURCE_LENGTH = 32_768;
-const MAX_ART_LINES = 80;
 const MAX_ART_CACHE_ENTRIES = 128;
-const MAX_EXPANDED_EDGES = 200;
-const MAX_NODES = 200;
-const MAX_PLACEHOLDER_INDICES = 16_384;
-const RESERVED_PUA_PATTERN = /[\uE000-\uE07F]/;
 const MARKDOWN_LINES_PATTERN = /.*(?:\n|$)/g;
 const FENCE_LINE_PATTERN = /^ {0,3}(`{3,}|~{3,})[ \t]*(.*?)[ \t]*$/;
-const HEADER_SEMICOLON_PATTERN =
-  /^(\s*(?:graph|flowchart)\s+[A-Za-z]{2})\s*;+\s*/;
-const TRAILING_SEMICOLON_PATTERN = /;[ \t]*$/gm;
-const ARROW_TOKEN = "(-->>|->>|-->|->|==>|-\\.->)";
-const ARROW_PREFIX = "([\\w\\]\\)}\"'가-힯])";
-const ARROW_BEFORE_NODE_PATTERN = new RegExp(
-  `${ARROW_PREFIX}${ARROW_TOKEN}(?=[^\\s|])`,
-  "gu"
-);
-const ARROW_BEFORE_LABEL_PATTERN = new RegExp(
-  `${ARROW_PREFIX}${ARROW_TOKEN}(?=\\|)`,
-  "gu"
-);
-const ARROW_BEFORE_SPACE_PATTERN = new RegExp(
-  `${ARROW_PREFIX}${ARROW_TOKEN}(?=\\s)`,
-  "gu"
-);
-const EDGE_LABEL_TARGET_PATTERN = /((?:-->|->>|-->>|->)\|[^|\n]+\|)(?=\S)/g;
-const PLACEHOLDER_BASE = 0xe0_00;
-const PLACEHOLDER_DIGIT = 0x7f;
-const PLACEHOLDER_PATTERN = /[\uE000-\uE07F]{2}/g;
 
 export interface MermaidBlockPart {
   raw: string;
@@ -71,6 +45,13 @@ interface MermaidMarkdownOptions {
     dispose?(): void;
     render(width: number): string[];
   };
+  requestRender?: () => void;
+  signal?: AbortSignal;
+}
+
+interface DiagramRenderState {
+  art?: readonly string[];
+  status: "failed" | "pending" | "ready";
 }
 
 const fenceMarker = (line: string): FenceMarker | undefined => {
@@ -189,255 +170,6 @@ export const extractMermaidBlocks = (text: string): MermaidBlockPart[] => {
     : state.parts;
 };
 
-interface AsciiPreset {
-  readonly boxBorderPadding: number;
-  readonly paddingX: number;
-  readonly paddingY: number;
-}
-
-const DEFAULT_PRESET: AsciiPreset = {
-  boxBorderPadding: 1,
-  paddingX: 5,
-  paddingY: 5,
-};
-const TIGHT_PRESET: AsciiPreset = {
-  boxBorderPadding: 1,
-  paddingX: 2,
-  paddingY: 2,
-};
-
-// beautiful-mermaid accepts the header only alone on the first line, while
-// mermaid itself also allows `graph LR;` and single-line diagrams. Its
-// parser likewise requires whitespace around arrows, so common idioms like
-// `A-->B` and `A-->|yes|B` are spaced out here first - outside bracket
-// labels, where arrow-like text is content.
-const spaceArrowsOutsideBrackets = (line: string): string => {
-  let output = "";
-  let segment = "";
-  let depth = 0;
-  const flushSegment = (): void => {
-    output += segment
-      .replace(ARROW_BEFORE_LABEL_PATTERN, "$1 $2")
-      .replace(ARROW_BEFORE_NODE_PATTERN, "$1 $2 ")
-      .replace(ARROW_BEFORE_SPACE_PATTERN, "$1 $2")
-      .replace(EDGE_LABEL_TARGET_PATTERN, "$1 ");
-    segment = "";
-  };
-  for (const char of line) {
-    if (depth === 0 && (char === "[" || char === "{" || char === "(")) {
-      flushSegment();
-      depth = 1;
-      output += char;
-      continue;
-    }
-    if (depth > 0) {
-      output += char;
-      if (char === "[" || char === "{" || char === "(") {
-        depth += 1;
-      } else if (char === "]" || char === "}" || char === ")") {
-        depth -= 1;
-      }
-      continue;
-    }
-    segment += char;
-  }
-  flushSegment();
-  return output;
-};
-
-const normalizeDiagramSource = (source: string): string => {
-  const match = HEADER_SEMICOLON_PATTERN.exec(source);
-  const headerSplit =
-    match === null ? source : `${match[1]}\n${source.slice(match[0].length)}`;
-  return headerSplit
-    .replace(TRAILING_SEMICOLON_PATTERN, "")
-    .split("\n")
-    .map(spaceArrowsOutsideBrackets)
-    .join("\n");
-};
-
-// beautiful-mermaid pads box art by UTF-16 length, so East Asian wide
-// labels break alignment. Expand every wide label char into a private-use
-// pair (two narrow columns, self-describing index), let the library lay out
-// with correct widths, then collapse each pair back to the original glyph.
-// The pair alphabet is reserved: sources already using it render as plain
-// fences rather than risking mis-decoded annotations.
-// Edge runs approximate operator count for the budget: every mermaid edge
-// operator carries exactly one of these runs, while the node-token pattern
-// catches bracketed node declarations.
-const EDGE_RUN_PATTERN = /-{2,}|-\.|-|={2,}|\.\./g;
-const AMPERSAND_PATTERN = /&/g;
-const NODE_TOKEN_PATTERN = /[[(][^\]()\n]*[\])]/g;
-
-const ampCount = (text: string): number =>
-  text.match(AMPERSAND_PATTERN)?.length ?? 0;
-
-// Rendering is synchronous, so bound the graph before it can monopolize
-// the TUI process. Count every edge run (mermaid chains statements on one
-// line) and estimate cartesian groups as (left ampersands + 1) x (right
-// ampersands + 1); node tokens accumulate even without operators.
-const exceedsComplexityBudget = (source: string): boolean => {
-  let expandedEdges = 0;
-  let nodeTokens = 0;
-  for (const line of source.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith("%%") || trimmed.length === 0) {
-      continue;
-    }
-    nodeTokens += trimmed.match(NODE_TOKEN_PATTERN)?.length ?? 0;
-    if (nodeTokens > MAX_NODES) {
-      return true;
-    }
-    const runs = [...trimmed.matchAll(EDGE_RUN_PATTERN)];
-    if (runs.length === 0) {
-      continue;
-    }
-    const leftAmp = ampCount(trimmed.slice(0, runs[0]?.index ?? 0));
-    const lastRun = runs.at(-1);
-    const rightAmp = ampCount(
-      trimmed.slice((lastRun?.index ?? 0) + (lastRun?.[0].length ?? 0))
-    );
-    expandedEdges += runs.length * (leftAmp + 1) * (rightAmp + 1);
-    if (expandedEdges > MAX_EXPANDED_EDGES) {
-      return true;
-    }
-  }
-  return false;
-};
-const expandWideChars = (
-  source: string
-): { expanded: string; wideChars: string[] } => {
-  const wideChars: string[] = [];
-  let expanded = "";
-  for (const char of source) {
-    // Per-glyph terminal width is the ground truth for the art alignment
-    // shim: expand exactly the characters the terminal draws two cells wide.
-    if (visibleWidth(char) === 2) {
-      const index = wideChars.length;
-      wideChars.push(char);
-      expanded +=
-        String.fromCodePoint(
-          PLACEHOLDER_BASE + Math.floor(index / (PLACEHOLDER_DIGIT + 1))
-        ) +
-        String.fromCodePoint(
-          PLACEHOLDER_BASE + (index % (PLACEHOLDER_DIGIT + 1))
-        );
-    } else {
-      expanded += char;
-    }
-  }
-  return { expanded, wideChars };
-};
-
-const collapsePlaceholders = (
-  art: string,
-  wideChars: readonly string[]
-): string =>
-  art.replace(PLACEHOLDER_PATTERN, (pair) => {
-    const index =
-      ((pair.codePointAt(0) ?? 0) - PLACEHOLDER_BASE) *
-        (PLACEHOLDER_DIGIT + 1) +
-      ((pair.codePointAt(1) ?? 0) - PLACEHOLDER_BASE);
-    return wideChars[index] ?? "";
-  });
-
-const squareBracketsBalanced = (source: string): boolean => {
-  let square = 0;
-  for (const char of source) {
-    if (char === "[") {
-      square += 1;
-    } else if (char === "]") {
-      square -= 1;
-    }
-    if (square < 0) {
-      return false;
-    }
-  }
-  return square === 0;
-};
-
-const FLOWCHART_HEADER_PATTERN = /^\s*(?:graph|flowchart)\b/m;
-const ARROW_TOKEN_PATTERN = /-{1,2}>+|-{1,2}\+{1,2}>/;
-const ARROW_GLYPH_PATTERN = /[►▶▼◀▲]/u;
-const DASH_RUN_PATTERN = /-{2,}/;
-const BRACKET_CONTENTS_PATTERN = /[[{(][^[\]{}()]*[\]})]/g;
-
-// beautiful-mermaid parses permissively and silently drops malformed tails,
-// so reject obviously broken bodies instead of annotating a partial diagram:
-// unbalanced node brackets, arrows without targets, and bare dash links the
-// engine cannot draw (valid class/ER operators carry no dash-run of 2+
-// outside brackets, so they pass through).
-const diagramBodySane = (source: string, art: string): boolean => {
-  if (!squareBracketsBalanced(source)) {
-    return false;
-  }
-  const flowchart = FLOWCHART_HEADER_PATTERN.test(source);
-  let arrows = 0;
-  for (const line of source.split("\n")) {
-    if (flowchart) {
-      const stripped = line.replace(BRACKET_CONTENTS_PATTERN, "");
-      if (DASH_RUN_PATTERN.test(stripped) && !stripped.includes(">")) {
-        return false;
-      }
-    }
-    const arrow = ARROW_TOKEN_PATTERN.exec(line);
-    if (arrow === null) {
-      continue;
-    }
-    arrows += 1;
-    if (line.slice(arrow.index + arrow[0].length).trim().length === 0) {
-      return false;
-    }
-  }
-  return !flowchart || arrows === 0 || ARROW_GLYPH_PATTERN.test(art);
-};
-
-/** Render diagram source to box-art lines, or undefined when unsupported. */
-export const renderDiagramArt = (source: string): string[] | undefined => {
-  const normalized = normalizeDiagramSource(source.trim());
-  if (
-    normalized.length === 0 ||
-    normalized.length > MAX_SOURCE_LENGTH ||
-    RESERVED_PUA_PATTERN.test(normalized) ||
-    exceedsComplexityBudget(normalized)
-  ) {
-    return;
-  }
-  const { expanded, wideChars } = expandWideChars(normalized);
-  if (wideChars.length >= MAX_PLACEHOLDER_INDICES) {
-    return;
-  }
-  const render = (preset: AsciiPreset): string[] => {
-    const art = collapsePlaceholders(
-      renderMermaidASCII(expanded, { ...preset, colorMode: "none" }),
-      wideChars
-    );
-    return diagramBodySane(normalized, art) ? trimArtLines(art) : [];
-  };
-  let lines: string[];
-  try {
-    lines = render(DEFAULT_PRESET);
-  } catch {
-    return;
-  }
-  if (lines.length > MAX_ART_LINES) {
-    try {
-      lines = render(TIGHT_PRESET);
-    } catch {
-      return;
-    }
-  }
-  return lines.length > MAX_ART_LINES || lines.length === 0 ? undefined : lines;
-};
-
-const trimArtLines = (art: string): string[] => {
-  const lines = art.split("\n").map((line) => line.trimEnd());
-  while (lines.length > 0 && (lines.at(-1) ?? "").length === 0) {
-    lines.pop();
-  }
-  return lines;
-};
-
 const isBlankRenderLine = (line: string | undefined): boolean =>
   line !== undefined && line.trim().length === 0;
 
@@ -452,10 +184,10 @@ const appendMarkdownLines = (target: string[], rendered: string[]): void => {
 
 /** Markdown component that appends box-art diagrams under mermaid fences. */
 export class MermaidMarkdown implements Component {
-  private readonly artCache = new Map<string, string[] | undefined>();
   private cachedLines: string[] | undefined;
   private cachedText: string | undefined;
   private cachedWidth: number | undefined;
+  private readonly controller = new AbortController();
   private readonly delegateViews = new Map<
     string,
     { dispose?(): void; render(width: number): string[] }
@@ -464,6 +196,8 @@ export class MermaidMarkdown implements Component {
   private readonly options: MermaidMarkdownOptions;
   private readonly paddingX: number;
   private readonly paddingY: number;
+  private readonly renderStates = new Map<string, DiagramRenderState>();
+  private readonly signal: AbortSignal;
   private text: string;
   private readonly theme: MarkdownTheme;
 
@@ -479,6 +213,11 @@ export class MermaidMarkdown implements Component {
     this.paddingY = paddingY;
     this.theme = theme;
     this.options = options;
+    this.signal =
+      options.signal === undefined
+        ? this.controller.signal
+        : AbortSignal.any([this.controller.signal, options.signal]);
+    this.startRenderJobs();
   }
 
   dispose(): void {
@@ -487,6 +226,7 @@ export class MermaidMarkdown implements Component {
     }
     this.disposed = true;
     this.disposeDelegateViews();
+    this.controller.abort();
   }
 
   setText(text: string): void {
@@ -496,6 +236,7 @@ export class MermaidMarkdown implements Component {
     this.text = text;
     this.disposeDelegateViews();
     this.invalidate();
+    this.startRenderJobs();
   }
 
   invalidate(): void {
@@ -534,9 +275,9 @@ export class MermaidMarkdown implements Component {
     for (const part of parts) {
       if (part.type === "mermaid" && part.source) {
         appendMarkdownLines(lines, this.renderMarkdown(part.raw, 0, width));
-        const art = this.artFor(part.source);
-        if (art !== undefined) {
-          for (const artLine of art) {
+        const state = this.renderStates.get(part.source);
+        if (state?.status === "ready" && state.art !== undefined) {
+          for (const artLine of state.art) {
             lines.push(this.fitArtLine(artLine, width));
           }
           lines.push("");
@@ -549,22 +290,46 @@ export class MermaidMarkdown implements Component {
     return this.cache(width, lines);
   }
 
-  private artFor(source: string): string[] | undefined {
-    const cached = this.artCache.get(source);
-    if (cached !== undefined || this.artCache.has(source)) {
-      this.artCache.delete(source);
-      this.artCache.set(source, cached);
-      return cached;
+  private startRenderJobs(): void {
+    if (this.signal.aborted || !this.mermaidEnabled()) {
+      return;
     }
-    const art = renderDiagramArt(source);
-    if (this.artCache.size >= MAX_ART_CACHE_ENTRIES) {
-      const oldest = this.artCache.keys().next().value;
-      if (oldest !== undefined) {
-        this.artCache.delete(oldest);
+    for (const part of extractMermaidBlocks(this.text)) {
+      if (!(part.type === "mermaid" && part.source)) {
+        continue;
       }
+      const source = part.source;
+      if (this.renderStates.has(source)) {
+        continue;
+      }
+      const state: DiagramRenderState = { status: "pending" };
+      this.renderStates.set(source, state);
+      if (this.renderStates.size > MAX_ART_CACHE_ENTRIES) {
+        const oldest = this.renderStates.keys().next().value;
+        if (oldest !== undefined) {
+          this.renderStates.delete(oldest);
+        }
+      }
+      renderMermaidArt(source, this.signal).then(
+        (art) => {
+          if (this.signal.aborted) {
+            return;
+          }
+          state.art = art;
+          state.status = art === undefined ? "failed" : "ready";
+          this.invalidate();
+          this.options.requestRender?.();
+        },
+        () => {
+          if (this.signal.aborted) {
+            return;
+          }
+          state.status = "failed";
+          this.invalidate();
+          this.options.requestRender?.();
+        }
+      );
     }
-    this.artCache.set(source, art);
-    return art;
   }
 
   private fitArtLine(line: string, width: number): string {

--- a/extensions/mermaid/src/mermaid-renderer.test.ts
+++ b/extensions/mermaid/src/mermaid-renderer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { renderMermaidArt } from "./mermaid-renderer";
+
+const gridExplosionSource = (hops: number): string =>
+  `graph LR\n${Array.from({ length: hops }, (_, i) => `N${i} --> N${i + 1}`).join("\n")}`;
+
+describe("renderMermaidArt queue bounds", () => {
+  it("resolves undefined instead of queueing beyond the in-flight cap", async () => {
+    const controller = new AbortController();
+    const source = gridExplosionSource(40);
+    const pending = Array.from({ length: 33 }, () =>
+      renderMermaidArt(source, controller.signal).catch(() => undefined)
+    );
+    const overflow = await renderMermaidArt(source, controller.signal);
+
+    expect(overflow).toBeUndefined();
+    controller.abort();
+    await Promise.all(pending);
+  }, 60_000);
+
+  it("keeps rendering after a worker was destroyed by a pathological job", async () => {
+    await renderMermaidArt(gridExplosionSource(40)).catch(() => undefined);
+    const art = await renderMermaidArt("graph LR\nA-->B");
+
+    expect(art?.join("\n")).toContain("A");
+  }, 60_000);
+});

--- a/extensions/mermaid/src/mermaid-renderer.ts
+++ b/extensions/mermaid/src/mermaid-renderer.ts
@@ -1,0 +1,120 @@
+import { Worker } from "node:worker_threads";
+
+const RENDER_TIMEOUT_MS = 5000;
+
+interface WorkerReply {
+  readonly art?: readonly string[];
+  readonly id: number;
+}
+
+interface PendingRender {
+  readonly reject: (error: Error) => void;
+}
+
+let worker: Worker | undefined;
+let pending: PendingRender | undefined;
+let nextRequestId = 1;
+let renderTail = Promise.resolve();
+
+const workerUrl = (): URL => {
+  const extension = import.meta.url.endsWith(".ts") ? "ts" : "js";
+  return new URL(`./mermaid-art-worker.${extension}`, import.meta.url);
+};
+
+const terminateWorker = (instance: Worker, error: Error): void => {
+  if (worker !== instance) {
+    return;
+  }
+  worker = undefined;
+  const current = pending;
+  current?.reject(error);
+  instance.terminate().catch(() => undefined);
+};
+
+const getWorker = (): Worker => {
+  if (worker) {
+    return worker;
+  }
+  const instance = new Worker(workerUrl(), {
+    resourceLimits: {
+      maxOldGenerationSizeMb: 256,
+      stackSizeMb: 4,
+    },
+  });
+  instance.unref();
+  worker = instance;
+  instance.on("error", (error: unknown) =>
+    terminateWorker(
+      instance,
+      error instanceof Error ? error : new Error(String(error))
+    )
+  );
+  instance.on("exit", (code) => {
+    if (worker === instance) {
+      terminateWorker(
+        instance,
+        new Error(`Mermaid art worker exited unexpectedly (${code})`)
+      );
+    }
+  });
+  return instance;
+};
+
+const dispatchRender = (
+  source: string,
+  signal?: AbortSignal
+): Promise<readonly string[] | undefined> => {
+  signal?.throwIfAborted();
+  const instance = getWorker();
+  const id = nextRequestId++;
+  return new Promise((resolve, reject) => {
+    const finish = (callback: () => void): void => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", abort);
+      if (pending) {
+        pending = undefined;
+        instance.off("message", message);
+        callback();
+      }
+    };
+    const abort = (): void => {
+      const reason = signal?.reason;
+      terminateWorker(
+        instance,
+        reason instanceof Error
+          ? reason
+          : new DOMException("The operation was aborted", "AbortError")
+      );
+    };
+    const message = (reply: WorkerReply): void => {
+      if (reply.id !== id) {
+        return;
+      }
+      finish(() => resolve(reply.art));
+    };
+    const timeout = setTimeout(() => {
+      terminateWorker(instance, new Error("Mermaid art render timed out"));
+    }, RENDER_TIMEOUT_MS);
+    pending = { reject: (error) => finish(() => reject(error)) };
+    instance.on("message", message);
+    signal?.addEventListener("abort", abort, { once: true });
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+    instance.postMessage({ id, source });
+  });
+};
+
+/** Render diagram source to box-art lines in a bounded worker, if possible. */
+export const renderMermaidArt = (
+  source: string,
+  signal?: AbortSignal
+): Promise<readonly string[] | undefined> => {
+  const result = renderTail.then(() => dispatchRender(source, signal));
+  renderTail = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+};

--- a/extensions/mermaid/src/mermaid-renderer.ts
+++ b/extensions/mermaid/src/mermaid-renderer.ts
@@ -1,6 +1,7 @@
 import { Worker } from "node:worker_threads";
 
 const RENDER_TIMEOUT_MS = 5000;
+const MAX_IN_FLIGHT = 32;
 
 interface WorkerReply {
   readonly art?: readonly string[];
@@ -107,11 +108,22 @@ const dispatchRender = (
 };
 
 /** Render diagram source to box-art lines in a bounded worker, if possible. */
+let inFlight = 0;
+
+/** Render diagram source to box-art lines in a bounded worker, if possible. */
 export const renderMermaidArt = (
   source: string,
   signal?: AbortSignal
 ): Promise<readonly string[] | undefined> => {
+  if (inFlight >= MAX_IN_FLIGHT) {
+    return Promise.resolve(undefined);
+  }
+  inFlight += 1;
   const result = renderTail.then(() => dispatchRender(source, signal));
+  const settle = (): void => {
+    inFlight -= 1;
+  };
+  result.then(settle, settle);
   renderTail = result.then(
     () => undefined,
     () => undefined

--- a/extensions/mermaid/tsconfig.json
+++ b/extensions/mermaid/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "customConditions": ["@minpeter/pss-source"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/extensions/mermaid/tsdown.config.ts
+++ b/extensions/mermaid/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  dts: true,
+  entry: ["src/index.ts"],
+  fixedExtension: false,
+  root: "src",
+  sourcemap: true,
+  unbundle: true,
+});

--- a/extensions/mermaid/tsdown.config.ts
+++ b/extensions/mermaid/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   dts: true,
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/mermaid-art-worker.ts"],
   fixedExtension: false,
   root: "src",
   sourcemap: true,

--- a/extensions/mermaid/vitest.config.ts
+++ b/extensions/mermaid/vitest.config.ts
@@ -1,0 +1,28 @@
+import { resolve } from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@minpeter\/pss-coding-agent\/extension$/,
+        replacement: resolve(
+          import.meta.dirname,
+          "../../apps/coding-agent/src/extensions/index.ts"
+        ),
+      },
+      {
+        find: /^@minpeter\/pss-runtime$/,
+        replacement: resolve(
+          import.meta.dirname,
+          "../../packages/runtime/src/index.ts"
+        ),
+      },
+    ],
+    conditions: ["@minpeter/pss-source", "import", "module", "default"],
+  },
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@minpeter/pss-extension-latex':
         specifier: workspace:^
         version: link:../../extensions/latex
+      '@minpeter/pss-extension-mermaid':
+        specifier: workspace:^
+        version: link:../../extensions/mermaid
       '@minpeter/pss-extension-web':
         specifier: workspace:^
         version: link:../../extensions/web
@@ -480,6 +483,25 @@ importers:
       mathjax:
         specifier: 4.1.3
         version: 4.1.3
+    devDependencies:
+      playwright-core:
+        specifier: 1.62.0
+        version: 1.62.0
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(yaml@2.9.0)
+
+  extensions/mermaid:
+    dependencies:
+      beautiful-mermaid:
+        specifier: 1.1.3
+        version: 1.1.3
     devDependencies:
       tsdown:
         specifier: ^0.22.14
@@ -2376,6 +2398,9 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  beautiful-mermaid@1.1.3:
+    resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -2688,6 +2713,9 @@ packages:
 
   electron-to-chromium@1.5.396:
     resolution: {integrity: sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==}
+
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -3870,6 +3898,11 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -6216,6 +6249,11 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  beautiful-mermaid@1.1.3:
+    dependencies:
+      elkjs: 0.11.1
+      entities: 7.0.1
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -6557,6 +6595,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.396: {}
+
+  elkjs@0.11.1: {}
 
   emoji-regex@10.6.0: {}
 
@@ -7919,6 +7959,8 @@ snapshots:
   pify@3.0.0: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.62.0: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/scripts/extension-packages.test.mjs
+++ b/scripts/extension-packages.test.mjs
@@ -6,6 +6,10 @@ const packageCases = [
     directory: "extensions/latex",
     name: "@minpeter/pss-extension-latex",
   },
+  {
+    directory: "extensions/mermaid",
+    name: "@minpeter/pss-extension-mermaid",
+  },
 ];
 
 describe("official extension packages", () => {

--- a/scripts/tegami-config.test.mjs
+++ b/scripts/tegami-config.test.mjs
@@ -48,11 +48,12 @@ describe("Tegami release configuration", () => {
     expect(script).toContain('repo: "minpeter/pss-runtime"');
     expect(script).toContain('base: "main"');
     expect(script).toContain('workflow: "release.yml"');
-    expect(script.match(/prerelease: "next"/g)).toHaveLength(4);
-    expect(script.match(/distTag: "next"/g)).toHaveLength(4);
+    expect(script.match(/prerelease: "next"/g)).toHaveLength(5);
+    expect(script.match(/distTag: "next"/g)).toHaveLength(5);
     expect(script).toContain('"@minpeter/pss-runtime"');
     expect(script).toContain('"@minpeter/pss-coding-agent"');
     expect(script).toContain('"@minpeter/pss-extension-latex"');
+    expect(script).toContain('"@minpeter/pss-extension-mermaid"');
     expect(script).toContain('"@minpeter/pss-extension-web"');
   });
 
@@ -108,6 +109,7 @@ describe("Tegami release configuration", () => {
       "packages/runtime/package.json",
       "apps/coding-agent/package.json",
       "extensions/latex/package.json",
+      "extensions/mermaid/package.json",
       "extensions/web/package.json",
     ]) {
       const manifest = JSON.parse(readFileSync(path, "utf8"));

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -60,6 +60,12 @@ const paper = tegami({
         distTag: "next",
       },
     },
+    "@minpeter/pss-extension-mermaid": {
+      prerelease: "next",
+      npm: {
+        distTag: "next",
+      },
+    },
     "@minpeter/pss-extension-web": {
       prerelease: "next",
       npm: {


### PR DESCRIPTION
## Summary

Compose fallback assistant renderers into an ordered chain (replacing the single-slot model), and add `@minpeter/pss-extension-mermaid` which renders mermaid fences in assistant output as Unicode box art below the preserved fence source.

## Commits

- **feat(coding-agent): compose fallback assistant renderers into a chain** — multiple `{ fallback: true }` renderers compose (last-registered outermost), each delegating unhandled Markdown inward via a new `context.delegate`; async inner renders invalidate outer cached frames through the requestRender chain. Override/exclusive registration semantics are unchanged. The LaTeX extension renders non-math Markdown through the delegate.
- **feat(extensions): add mermaid ASCII diagram renderer** — synchronous beautiful-mermaid rendering (zero DOM, no worker/cache/image protocol), following the pi ecosystem's pi-mermaid pattern. CJK-wide label characters are expanded into self-describing private-use pairs before layout and collapsed after, so box borders stay aligned. Invalid/unsupported/unclosed/oversized diagrams fall back to the source fence. `PSS_MERMAID=0` disables.
- **fix(qa): restore playwright-core for web terminal visual QA** — the QA harness resolves playwright-core through the LaTeX package; it was dropped in an earlier cleanup.

## Verification

- Tests: coding-agent 755, mermaid 20, latex 22 pass; root `pnpm test` (turbo 11 tasks + script invariants incl. tegami config) exit 0
- `tsc --noEmit` and ultracite clean on all touched packages
- Visual QA harness (`script/qa/web-terminal-visual-qa.mjs`) passes in light and dark themes; evidence in `.omo/evidence/2026-08-04-mermaid-ascii-cjk/` (math image + aligned CJK box art)
- New `pnpm preview:assistant` preview script exercises the composed chain end to end

Tegami entry included: `.tegami/2026-08-04-mermaid-ascii-renderer.md` (patch-level).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes assistant renderers into an ordered fallback chain with delegation, and adds `@minpeter/pss-extension-mermaid` to render Mermaid fences as CJK- and emoji-safe Unicode box diagrams beneath the original fence using a bounded worker and capped queue.

- **New Features**
  - Assistant renderer chain: multiple `{ fallback: true }` renderers compose in registration order (last is outermost), with `context.delegate` forwarding unhandled Markdown inward and plain Markdown at the bottom; async inner renders invalidate outer cached frames; `{ override: true }` still replaces the chain end-to-end. LaTeX delegates non-math Markdown when a delegate is present. New `pnpm preview:assistant` previews the composed chain.
  - `@minpeter/pss-extension-mermaid`: worker-based `beautiful-mermaid` rendering (5s timeout, 256 MB heap, serialized queue capped at 32). On timeout/abort/worker-failure or unsupported/oversized/invalid input, falls back to the source fence. Flowchart-only normalization spaces arrows and edge labels outside bracket spans; validation is diagram-type aware (e.g., sequence diagram brackets and participants named “graph” are accepted). Prefilter caps at 200 expanded edges and 200 nodes. Grapheme-based widening (NFC + ZWJ/combining-safe) keeps borders aligned, with single-placeholders for width-1 multi-codepoint graphemes and zero-width graphemes dropped; reserved PUA inputs are rejected. Saturates render states without inserting markers so the bounded in-memory art cache stays ≤128. Set `PSS_MERMAID=0` to disable. Included by default after `@minpeter/pss-extension-latex`.

- **Dependencies**
  - Added `@minpeter/pss-extension-mermaid` (uses `beautiful-mermaid`).
  - Restored `playwright-core` as a dev dependency in `@minpeter/pss-extension-latex` for the web terminal visual QA harness.

<sup>Written for commit 3a789e2412d0380deeea6107bfc51978a241c001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

