### PR TITLE
feat(runtime): make compaction summaries configurable

### DIFF
--- a/.tegami/2026-08-04-configurable-semantic-compaction.md
+++ b/.tegami/2026-08-04-configurable-semantic-compaction.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Make compaction summary policy configurable
+
+Allow compaction policies to supply summary instructions and omit raw deterministic tool evidence, while preventing the default handoff from serializing tool-call protocol as text.

--- a/experimental/compaction-score/SCREENING.md
+++ b/experimental/compaction-score/SCREENING.md
@@ -9,7 +9,7 @@ Clean campaign metadata from the production full-control screen:
 - Frozen production profile hash at screen time:
   `sha256:30a56d748f4162fb9a195a5c48c606a91f3bed7d68d0bd4655151e21c4274dad`
 - Current production profile hash (after retained Senpi control rules in the
-  builder): `sha256:ff99c46efbb488e877c12fefb198c231cd3c8494a76c80a42ee9bd4e626a483e`
+  builder): `sha256:7ea878eb30458a20fb20ed6e41e2987cf91e1f76e2d8fba46c477cd24f86f38c`
 - Sanitized provider tuple: `current-gateway` / `https://codex.nekos.me` /
   `gpt-5.6-luna`
 - Seedless capability result: the seeded probe was rejected; the seedless probe

--- a/experimental/compaction-score/prompt-profiles.test.ts
+++ b/experimental/compaction-score/prompt-profiles.test.ts
@@ -39,7 +39,7 @@ describe("Senpi compaction prompt profiles", () => {
 
     expect(production?.instructions).toBe(buildCompactionSummaryInstructions());
     expect(production?.hash).toBe(
-      "sha256:ff99c46efbb488e877c12fefb198c231cd3c8494a76c80a42ee9bd4e626a483e"
+      "sha256:7ea878eb30458a20fb20ed6e41e2987cf91e1f76e2d8fba46c477cd24f86f38c"
     );
   });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -177,6 +177,7 @@ export type {
   AgentCompaction,
   AgentCompactionContext,
   AgentCompactionReason,
+  CompactionSummaryOptions,
 } from "./thread/runtime/auto-compaction-types";
 export {
   type SpeculativeCompactionOptions,

--- a/packages/runtime/src/thread/runtime/auto-compaction-runner.test.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-runner.test.ts
@@ -206,6 +206,49 @@ describe("compaction runner concurrency", () => {
     ).resolves.toBe(false);
   });
 
+  it("forwards per-compaction summary options to the summarizer", async () => {
+    const state = new ThreadState({
+      key: "summary-options",
+      store: new MemoryThreadStore(),
+    });
+    await state.ensureLoaded();
+    state.history.appendModelMessage({
+      content: "source context ".repeat(500),
+      role: "user",
+    });
+    state.history.appendModelMessage(assistantMessage("source response"));
+    state.history.appendModelMessage({ content: "tail", role: "user" });
+    let summaryPrompt: readonly ModelMessage[] = [];
+    const summaryModel = createCallbackModel(({ history }) => {
+      summaryPrompt = history;
+      return [assistantMessage("semantic summary")];
+    });
+    const compaction: AgentCompaction = async (context) => {
+      const range = { endSeqExclusive: 2, startSeq: 0 };
+      const summary = await context.summarize(range, {
+        instructions: "CUSTOM SEMANTIC SUMMARY POLICY",
+        toolEvidence: "omit",
+      });
+      return { ...range, summary };
+    };
+
+    await expect(
+      compactThreadBlocking({
+        compaction,
+        model: { model: summaryModel },
+        state,
+        threadKey: "summary-options",
+      })
+    ).resolves.toBe(true);
+
+    expect(JSON.stringify(summaryPrompt)).toContain(
+      "CUSTOM SEMANTIC SUMMARY POLICY"
+    );
+    expect(state.compactionSnapshot()).toMatchObject([
+      { summary: { content: "semantic summary", role: "system" } },
+    ]);
+  });
+
   it("shares calibrated fixed and marginal costs with compaction", async () => {
     const state = await stateWithHistory();
     const registry = new ContextTokenCalibrationRegistry();

--- a/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
@@ -16,6 +16,7 @@ import type {
   AgentCompaction,
   AgentCompactionReason,
   AutoCompactionRange,
+  CompactionSummaryOptions,
   ThreadCompactionHandler,
   ThreadContextTransformObserver,
   ThreadModelContextTransform,
@@ -155,7 +156,10 @@ async function compactThreadOnce(options: RunOptions): Promise<boolean> {
     observedOutput,
   });
   const signal = options.signal ?? new AbortController().signal;
-  const summarize = async (range: AutoCompactionRange): Promise<string> => {
+  const summarize = async (
+    range: AutoCompactionRange,
+    summaryOptions: CompactionSummaryOptions = {}
+  ): Promise<string> => {
     assertRange(range, history.length);
     const summaryHistory = summaryHistoryForRange({
       compactions,
@@ -167,6 +171,8 @@ async function compactThreadOnce(options: RunOptions): Promise<boolean> {
       history: summaryHistory,
       model: { ...options.model, temperature: 0 },
       signal,
+      summaryInstructions: summaryOptions.instructions,
+      toolEvidence: summaryOptions.toolEvidence,
       transformModelContext: options.transformModelContext,
     });
   };

--- a/packages/runtime/src/thread/runtime/auto-compaction-summary.test.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-summary.test.ts
@@ -43,6 +43,8 @@ describe("automatic compaction summary contract", () => {
     expect(headings).toEqual(
       COMPACTION_SUMMARY_CONTRACT.sections.map(({ title }) => `## ${title}`)
     );
+    expect(instructions).toContain("Describe tool activity semantically");
+    expect(instructions).toContain("Never serialize tool invocation syntax");
   });
 
   it("passes deterministic generation controls to the summary model", async () => {
@@ -124,6 +126,36 @@ describe("automatic compaction summary contract", () => {
         model: { model },
       })
     ).resolves.toContain("5 passed, 4 failed");
+  });
+
+  it("omits deterministic tool evidence when requested", async () => {
+    const model = createMockLanguageModelV4(() =>
+      Promise.resolve(mockLanguageModelV4Text("Semantic outcome only."))
+    );
+
+    await expect(
+      summarizeCompactionRange({
+        history: [
+          { content: "context ".repeat(2000), role: "user" },
+          {
+            content: [
+              {
+                output: {
+                  type: "text",
+                  value: '{"action":"get_weather","parameters":{}}',
+                },
+                toolCallId: "tool-1",
+                toolName: "get_weather",
+                type: "tool-result",
+              },
+            ],
+            role: "tool",
+          },
+        ],
+        model: { model },
+        toolEvidence: "omit",
+      })
+    ).resolves.toBe("Semantic outcome only.");
   });
 
   it("carries a prior deterministic tool ledger across another hop", async () => {

--- a/packages/runtime/src/thread/runtime/auto-compaction-summary.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-summary.ts
@@ -111,6 +111,8 @@ export function buildCompactionSummaryInstructions(): string {
     "Preserve the active user request and explicit constraints verbatim when recording the objective and constraints.",
     "Merge any previous summary with newer messages. Resolve contradictions in favor of the latest explicit correction.",
     "Be concise, but never trade away exact identifiers, task state, blockers, next actions, or verification evidence.",
+    "Describe tool activity semantically by its purpose, outcome, and relevant evidence. Never serialize tool invocation syntax, function-call envelopes, call IDs, XML tool tags, or JSON argument wrappers into the summary.",
+    "Preserve exact user-authored code, data, and shell commands when relevant, but never present them as model or provider tool-call protocol.",
     "Distinguish completed work from planned work. Omit filler and repeated acknowledgements.",
     "Output only the handoff sections below. Do not add a preamble, routing line, or conversational reply.",
     "",
@@ -124,6 +126,7 @@ export async function summarizeCompactionRange({
   model,
   signal = new AbortController().signal,
   summaryInstructions,
+  toolEvidence = "deterministic",
   transformModelContext,
 }: {
   readonly estimateTokens?: (messages: readonly ModelMessage[]) => number;
@@ -131,6 +134,7 @@ export async function summarizeCompactionRange({
   readonly model: ModelGenerationOptions;
   readonly signal?: AbortSignal;
   readonly summaryInstructions?: string;
+  readonly toolEvidence?: "deterministic" | "omit";
   readonly transformModelContext?: ThreadModelContextTransform;
 }): Promise<string> {
   const sourceContext = history.map((message) =>
@@ -139,10 +143,13 @@ export async function summarizeCompactionRange({
   const sourceTokens = estimateTokens(sourceContext);
   const measureTokens = (text: string) =>
     estimateTokens([{ content: text, role: "system" }]);
-  const ledger = buildToolEvidenceLedger(history, {
-    budgetTokens: Math.floor(sourceTokens * LEDGER_SOURCE_SHARE),
-    measureTokens,
-  });
+  const ledger =
+    toolEvidence === "omit"
+      ? ""
+      : buildToolEvidenceLedger(history, {
+          budgetTokens: Math.floor(sourceTokens * LEDGER_SOURCE_SHARE),
+          measureTokens,
+        });
   const maxOutputTokens = summaryOutputBudget({
     history,
     ledger,

--- a/packages/runtime/src/thread/runtime/auto-compaction-types.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-types.ts
@@ -9,6 +9,13 @@ export type ThreadTokenEstimator = (
 
 export type AgentCompactionReason = "completed-turn" | "overflow";
 
+export interface CompactionSummaryOptions {
+  /** Replaces the runtime's default continuation-handoff instructions. */
+  readonly instructions?: string;
+  /** Controls whether raw tool-result evidence is appended after model output. */
+  readonly toolEvidence?: "deterministic" | "omit";
+}
+
 export interface AgentCompactionContext {
   readonly compactions: readonly ThreadCompactionRecord[];
   readonly estimatedContextTokens: number;
@@ -22,7 +29,10 @@ export interface AgentCompactionContext {
   readonly modelContext: readonly ModelMessage[];
   readonly reason: AgentCompactionReason;
   readonly signal: AbortSignal;
-  readonly summarize: (range: AutoCompactionRange) => Promise<string>;
+  readonly summarize: (
+    range: AutoCompactionRange,
+    options?: CompactionSummaryOptions
+  ) => Promise<string>;
   /** Opaque, stable identity owned by the runtime for this ThreadState. */
   readonly threadIdentity: Readonly<object>;
   readonly threadKey: string;


### PR DESCRIPTION
## Summary
- allow compaction policies to provide summary instructions and omit deterministic raw tool evidence
- prevent the default summary prompt from serializing tool-call protocol as text
- update the frozen compaction prompt hash and release metadata

## Verification
- full workspace test suite: passed
- runtime typecheck and targeted formatting checks: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes compaction summaries configurable so policies can override summary instructions and choose to omit deterministic tool evidence. The default summary now describes tool activity semantically and never serializes tool-call protocol.

- **New Features**
  - Policies can supply custom summary instructions and control inclusion of deterministic tool evidence.
  - Default summary avoids serializing tool-call protocol and focuses on semantic tool activity; preserves relevant user-authored code and commands.
  - Exported `CompactionSummaryOptions`; updated prompt profile hash and tests.

- **Migration**
  - No action needed.
  - To customize: use context.summarize(range, { instructions: "...", toolEvidence: "omit" }).

<sup>Written for commit f070125539334e4e3edc1b8c80a63523024460ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

