### PR TITLE
ci(release): pack latex and mermaid extensions in dependency resolution check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,12 @@ jobs:
           mkdir -p "$pack_dir" "$install_dir"
           pnpm --filter @minpeter/pss-runtime pack --pack-destination "$pack_dir"
           ln -s "$GITHUB_WORKSPACE/apps/coding-agent" extensions/web/node_modules/@minpeter/pss-coding-agent
+          mkdir -p extensions/latex/node_modules/@minpeter extensions/mermaid/node_modules/@minpeter
+          ln -s "$GITHUB_WORKSPACE/apps/coding-agent" extensions/latex/node_modules/@minpeter/pss-coding-agent
+          ln -s "$GITHUB_WORKSPACE/apps/coding-agent" extensions/mermaid/node_modules/@minpeter/pss-coding-agent
           pnpm --filter @minpeter/pss-extension-web pack --pack-destination "$pack_dir"
+          pnpm --filter @minpeter/pss-extension-latex pack --pack-destination "$pack_dir"
+          pnpm --filter @minpeter/pss-extension-mermaid pack --pack-destination "$pack_dir"
           pnpm --filter @minpeter/pss-coding-agent pack --pack-destination "$pack_dir"
           npm install --package-lock-only --ignore-scripts --prefix "$install_dir" "$pack_dir"/*.tgz
 

--- a/.tegami/2026-08-05-release-verify-pack-extensions.md
+++ b/.tegami/2026-08-05-release-verify-pack-extensions.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Pack all extensions in the release dependency check
+
+Pack the latex and mermaid extensions alongside web in the release
+workflow's coding-agent dependency resolution check, fixing the npm E404
+on the never-published @minpeter/pss-extension-mermaid.

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -33,6 +33,12 @@ describe("release workflow", () => {
     expect(workflow).toContain(
       "pnpm --filter @minpeter/pss-extension-web pack"
     );
+    expect(workflow).toContain(
+      "pnpm --filter @minpeter/pss-extension-latex pack"
+    );
+    expect(workflow).toContain(
+      "pnpm --filter @minpeter/pss-extension-mermaid pack"
+    );
     expect(workflow).toContain("pnpm --filter @minpeter/pss-coding-agent pack");
     expect(workflow).toContain(
       "npm install --package-lock-only --ignore-scripts"


### PR DESCRIPTION
## Problem

The Release workflow's `Verify coding-agent dependency resolution` step has failed on every main push since #330 (run [30974097477](https://github.com/minpeter/pss-runtime/actions/runs/30974097477)):

```
npm error 404 Not Found - GET https://registry.npmjs.org/@minpeter%2fpss-extension-mermaid
npm error 404 '@minpeter/pss-extension-mermaid@^0.0.1-next.0' could not be found
```

PR #330 added `@minpeter/pss-extension-mermaid` as a dependency of `@minpeter/pss-coding-agent`, but that package has never been published to npm. The verify step only packs runtime, web, and coding-agent, so npm falls back to the registry for mermaid (and for any just-bumped latex) and 404s. Because the step runs before `tegami ci`, it also blocks mermaid from ever being published - a deadlock.

## Fix

Pack all workspace extensions into the tarball set so resolution is hermetic:

- `pnpm pack` for `@minpeter/pss-extension-latex` and `@minpeter/pss-extension-mermaid`
- Both extensions declare `@minpeter/pss-coding-agent` as a `workspace:^` peer and `autoInstallPeers: false` means it is not installed, so they get the same coding-agent symlink that web already needed (with `mkdir -p` since their `node_modules/@minpeter` does not exist in CI)

## Verification

Replicated the exact workflow step locally: packed all five tarballs, then `npm install --package-lock-only --ignore-scripts` resolved successfully (previously failed on latex/mermaid pack and reproduced the mermaid E404 without them). `scripts/release-workflow.test.mjs` extended with the new pack lines and passing; biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pack `@minpeter/pss-extension-latex` and `@minpeter/pss-extension-mermaid` in the release verify step to stop npm 404s and make dependency resolution hermetic. This fixes the CI deadlock caused by the unpublished mermaid extension.

- **Bug Fixes**
  - Pack latex and mermaid alongside runtime, web, and coding-agent.
  - Add `@minpeter/pss-coding-agent` peer symlinks in latex/mermaid to satisfy `workspace:^`.
  - Update `scripts/release-workflow.test.mjs` to assert the new pack commands.
  - Add Tegami entry for this fix.

<sup>Written for commit 9c53d238d8a299023bf702991db376bb802b4adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

