### PR TITLE
docs: require explicit user approval before merging Version Packages

### DIFF
--- a/.tegami/2026-08-05-release-approval-policy.md
+++ b/.tegami/2026-08-05-release-approval-policy.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Require explicit approval before releasing
+
+Record that the automated Version Packages pull request, which publishes
+to npm on merge, is merged only when the user explicitly asks to release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,7 @@
 
 - Before merging a pull request, add a Tegami entry with a concise 1–3 line summary of the change.
 - Use a patch-level release unless the pull request or user explicitly specifies a different release level.
+
+# Releases
+
+- Never merge the automated `Version Packages` pull request on your own. Merging it publishes to npm, so merge it only when the user explicitly asks to release (e.g. "릴리즈하자").


### PR DESCRIPTION
Adds a Releases section to AGENTS.md: the automated `Version Packages` PR publishes to npm on merge, so it is merged only when the user explicitly asks to release (e.g. "릴리즈하자"). Requested by the user after the #333 release.

Tegami entry follows the docs-only precedent of `2026-08-03-document-pr-tegami-policy.md` (replay / exit-prerelease).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit user approval before merging the automated `Version Packages` PR, since merging publishes to npm. Added a Tegami entry to record this rule and replay `exit-prerelease` for `npm:@minpeter/pss-runtime`.

<sup>Written for commit 9891ec82e2e5c5009e33f08b83009ae78f6d89b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

