### PR TITLE
feat(coding-agent): add pixel startup wordmark

### DIFF
--- a/.tegami/2026-08-05-coding-agent-pixel-wordmark.md
+++ b/.tegami/2026-08-05-coding-agent-pixel-wordmark.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+---
+
+## Add a compact pixel wordmark to the coding-agent TUI
+
+Render the startup `pss` title as a low-profile orange bitmap wordmark while preserving the existing model and workspace subtitle.

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -79,6 +79,7 @@ const ANSI_BG_GRAY = "\x1b[100m";
 const ANSI_CYAN = "\x1b[36m";
 const ANSI_BRIGHT_CYAN = "\x1b[96m";
 const ANSI_GRAY = "\x1b[90m";
+const ANSI_ORANGE = "\x1b[38;5;208m";
 const ANSI_YELLOW = "\x1b[33m";
 const ANSI_RED = "\x1b[31m";
 const CTRL_C_ETX = "\u0003";
@@ -726,8 +727,8 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     const footer = sanitizeTerminalText(config.footer?.text ?? "").trim();
     title.setText(
       subtitle
-        ? `${style(`${ANSI_BOLD}${ANSI_BRIGHT_CYAN}`, headerTitle)}\n${style(ANSI_DIM, subtitle)}`
-        : style(`${ANSI_BOLD}${ANSI_BRIGHT_CYAN}`, headerTitle)
+        ? `${style(`${ANSI_BOLD}${ANSI_ORANGE}`, headerTitle)}\n${style(ANSI_DIM, subtitle)}`
+        : style(`${ANSI_BOLD}${ANSI_ORANGE}`, headerTitle)
     );
     footerStatusBar.setRightText(footer);
     tui.requestRender();

--- a/apps/coding-agent/src/tui/app-renderers.test.ts
+++ b/apps/coding-agent/src/tui/app-renderers.test.ts
@@ -58,6 +58,24 @@ const withIsolatedTuiEnvironment = async (
 };
 
 describe("TUI extension renderer merging", () => {
+  it("renders the pss startup title as a pixel wordmark", async () => {
+    await withIsolatedTuiEnvironment(async () => {
+      const exitCode = await startTui(
+        { model },
+        {
+          createTui: (config) => {
+            expect(config.header?.title).toBe(
+              ["█▀▙ ▟▀▘ ▟▀▘", "█▀▘ ▄▄▛ ▄▄▛"].join("\n")
+            );
+            return Promise.resolve();
+          },
+        }
+      );
+
+      expect(exitCode).toBe(0);
+    });
+  });
+
   it("prints the command for resuming the exited session", async () => {
     await withIsolatedTuiEnvironment(async () => {
       const output: string[] = [];

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -85,6 +85,7 @@ interface StartTuiDependencies {
 }
 
 const RECOVERY_ACTIVATION_TIMEOUT_MS = 60_000;
+const PSS_PIXEL_WORDMARK = ["█▀▙ ▟▀▘ ▟▀▘", "█▀▘ ▄▄▛ ▄▄▛"].join("\n");
 
 const selectedThreadConfig = async (
   config: ReturnType<typeof resolveCodingAgentThreadConfig>,
@@ -346,7 +347,7 @@ export async function startTui(
         ? base
         : `${base}\nsession: ${currentSession.name}`;
     };
-    const header = { title: "pss", subtitle: buildSubtitle() };
+    const header = { title: PSS_PIXEL_WORDMARK, subtitle: buildSubtitle() };
 
     const currentInstructions = (): string =>
       [


### PR DESCRIPTION
## Summary

- render the coding-agent startup title as a compact orange pixel wordmark
- preserve the existing model and workspace subtitle
- cover the startup header wiring with a regression test

## Verification

- `pnpm test` (18/18 Turbo tasks; 62/62 root script tests after rebasing onto current `origin/main`)
- xterm.js visual QA in light and dark themes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the coding-agent startup title with a compact two-line orange pixel wordmark, keeping the existing model/workspace subtitle. Added a regression test to lock the header rendering.

- **New Features**
  - Introduced `PSS_PIXEL_WORDMARK` for the startup title.
  - Switched header title color to ANSI orange (`\x1b[38;5;208m`).
  - Added a test that asserts the exact wordmark string during TUI creation.

<sup>Written for commit aa01a4412fe2c25145f11947f265c268a3dd8f2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

