### PR TITLE
chore(release): make the pixel wordmark entry a patch bump

### DIFF
--- a/.tegami/2026-08-05-coding-agent-pixel-wordmark.md
+++ b/.tegami/2026-08-05-coding-agent-pixel-wordmark.md
@@ -1,8 +1,7 @@
 ---
 packages:
   npm:@minpeter/pss-coding-agent:
-    replay:
-      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+    type: patch
 ---
 
 ## Add a compact pixel wordmark to the coding-agent TUI


### PR DESCRIPTION
3714ec3's tegami entry used `replay: exit-prerelease(...)`, which replays a release action **without** requesting a version bump - so tegami left it out of Version Packages PR #336. Switch to `type: patch` so the entry is consumed as a normal patch bump on the next Release run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Tegami entry for `npm:@minpeter/pss-coding-agent` to `type: patch` so the pixel wordmark TUI change ships as a normal patch release. This replaces `replay: exit-prerelease(...)`, which replays without a version bump.

<sup>Written for commit 486c85b3873c65582ccb266b6ac201c64e79561a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

