### PR TITLE
docs: document the Tegami entry format in AGENTS.md

### DIFF
--- a/.tegami/2026-08-05-coding-agent-pixel-wordmark.md
+++ b/.tegami/2026-08-05-coding-agent-pixel-wordmark.md
@@ -1,8 +1,7 @@
 ---
 packages:
   npm:@minpeter/pss-coding-agent:
-    replay:
-      - exit-prerelease(npm:@minpeter/pss-coding-agent)
+    type: patch
 ---
 
 ## Add a compact pixel wordmark to the coding-agent TUI

--- a/.tegami/2026-08-05-tegami-entry-format-guide.md
+++ b/.tegami/2026-08-05-tegami-entry-format-guide.md
@@ -1,0 +1,12 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Document the Tegami entry format
+
+Show the entry frontmatter template in AGENTS.md and spell out that
+replay/exit-prerelease entries never bump a version, after a feature entry
+used that form and was skipped by the Version Packages PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,22 @@
 - Before merging a pull request, add a Tegami entry with a concise 1–3 line summary of the change.
 - Use a patch-level release unless the pull request or user explicitly specifies a different release level.
 
+# Tegami entries
+
+Entries are `.tegami/YYYY-MM-DD-slug.md` files with frontmatter like:
+
+```yaml
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+```
+
+- Target the published package whose behavior changes: `npm:@minpeter/pss-runtime` or `npm:@minpeter/pss-coding-agent`. Changes under `extensions/` target `npm:@minpeter/pss-coding-agent` because the built-in extensions ship inside its bundle.
+- Always use `type: patch` (or minor/major when asked). The `replay: exit-prerelease(...)` form is reserved for changes that must not bump a version (docs-only, CI-only); using it for a code change makes the Version Packages PR silently skip the entry.
+- Copy the form from this template, not from an arbitrary existing entry.
+
 # Releases
 
 - Never merge the automated `Version Packages` pull request on your own. Merging it publishes to npm, so merge it only when the user explicitly asks to release (e.g. "릴리즈하자").


### PR DESCRIPTION
3714ec3's entry used `replay: exit-prerelease(...)` for a user-facing feature and was silently skipped by the Version Packages PR (#338 fixed the entry itself). Root cause: AGENTS.md required an entry but never showed the format, so agents copy an arbitrary existing entry - and the repo contains both forms.

Adds a Tegami entries section to AGENTS.md: the frontmatter template, which package id to target (including that `extensions/` changes target `npm:@minpeter/pss-coding-agent` since the bundle restructure), and the rule that `replay: exit-prerelease(...)` is no-bump and reserved for docs/CI-only changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a concise Tegami entry template and rules to AGENTS.md (frontmatter, target package, `extensions/` -> `npm:@minpeter/pss-coding-agent`). Prevents skipped releases by reserving `replay: exit-prerelease(...)` for docs/CI; also converts the pixel wordmark entry to a patch bump.

- **Bug Fixes**
  - Updated `.tegami/2026-08-05-coding-agent-pixel-wordmark.md` to `type: patch` for `npm:@minpeter/pss-coding-agent`.

<sup>Written for commit de58fd41037da95af3359fb6d204010df645d465. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

