### PR TITLE
feat(coding-agent): let installed extensions shadow bundled defaults

### DIFF
--- a/.tegami/2026-08-05-shadow-bundled-extensions.md
+++ b/.tegami/2026-08-05-shadow-bundled-extensions.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Shadow bundled extensions with installed ones
+
+An installed extension whose id matches a bundled default (latex, mermaid, web) now replaces the bundled copy instead of crashing host creation with a duplicate-id error. The three built-in extension packages are publishable, so `pss extension install`/`update` can deliver them between coding-agent releases.

--- a/apps/coding-agent/src/extensions/defaults.test.ts
+++ b/apps/coding-agent/src/extensions/defaults.test.ts
@@ -164,6 +164,39 @@ describe("default coding-agent extensions", () => {
     await host.dispose();
   });
 
+  it("keeps duplicate same-id inputs visible to host validation", () => {
+    const duplicate: CodingAgentExtensionInput = {
+      configure() {
+        return;
+      },
+      id: "@minpeter/pss-extension-latex",
+    };
+
+    const merged = withDefaultCodingAgentExtensions([duplicate, duplicate]);
+
+    expect(merged.filter((extension) => extension === duplicate)).toHaveLength(
+      2
+    );
+  });
+
+  it("replaces a shadowed mermaid default in its original slot", () => {
+    const shadowMermaid: CodingAgentExtensionInput = {
+      configure() {
+        return;
+      },
+      id: "@minpeter/pss-extension-mermaid",
+    };
+
+    const merged = withDefaultCodingAgentExtensions([shadowMermaid]);
+
+    expect(merged.map((extension) => extension.id)).toStrictEqual([
+      "@minpeter/pss-extension-latex",
+      "@minpeter/pss-extension-mermaid",
+      "@minpeter/pss-extension-web",
+    ]);
+    expect(merged[1]).toBe(shadowMermaid);
+  });
+
   it("restores the default fallback after an override is removed", async () => {
     const overrideRenderer = () => ({
       invalidate() {

--- a/apps/coding-agent/src/extensions/defaults.test.ts
+++ b/apps/coding-agent/src/extensions/defaults.test.ts
@@ -111,6 +111,59 @@ describe("default coding-agent extensions", () => {
     ]);
   });
 
+  it("replaces a shadowed bundled default in its original slot", () => {
+    const shadowLatex: CodingAgentExtensionInput = {
+      configure() {
+        return;
+      },
+      id: "@minpeter/pss-extension-latex",
+    };
+
+    const merged = withDefaultCodingAgentExtensions([shadowLatex]);
+
+    expect(merged.map((extension) => extension.id)).toStrictEqual([
+      "@minpeter/pss-extension-latex",
+      "@minpeter/pss-extension-mermaid",
+      "@minpeter/pss-extension-web",
+    ]);
+    expect(merged[0]).toBe(shadowLatex);
+  });
+
+  it("keeps the mermaid renderer owner when latex is shadowed", async () => {
+    const shadowRenderer = () => ({
+      invalidate() {
+        return;
+      },
+      render() {
+        return ["shadow"];
+      },
+      setText() {
+        return;
+      },
+    });
+    const shadowLatex: CodingAgentExtensionInput = {
+      configure(registry) {
+        registry.tui.registerAssistantRenderer(shadowRenderer, {
+          fallback: true,
+        });
+      },
+      id: "@minpeter/pss-extension-latex",
+    };
+
+    const host = await createCodingAgentExtensionHostWithDefaults([
+      shadowLatex,
+    ]);
+
+    expect(host.getAssistantRendererOwner()).toBe(
+      "@minpeter/pss-extension-mermaid"
+    );
+    expect(host.getAssistantRendererChainOwners()).toEqual([
+      "@minpeter/pss-extension-latex",
+      "@minpeter/pss-extension-mermaid",
+    ]);
+    await host.dispose();
+  });
+
   it("restores the default fallback after an override is removed", async () => {
     const overrideRenderer = () => ({
       invalidate() {

--- a/apps/coding-agent/src/extensions/defaults.test.ts
+++ b/apps/coding-agent/src/extensions/defaults.test.ts
@@ -56,6 +56,61 @@ describe("default coding-agent extensions", () => {
     await host.dispose();
   });
 
+  it("lets an installed extension shadow a bundled default with the same id", () => {
+    const shadowLatex: CodingAgentExtensionInput = {
+      configure() {
+        return;
+      },
+      id: "@minpeter/pss-extension-latex",
+    };
+    const shadowMermaid: CodingAgentExtensionInput = {
+      configure() {
+        return;
+      },
+      id: "@minpeter/pss-extension-mermaid",
+    };
+    const shadowWeb: CodingAgentExtensionInput = {
+      configure() {
+        return;
+      },
+      id: "@minpeter/pss-extension-web",
+    };
+
+    const withShadows = withDefaultCodingAgentExtensions([
+      shadowLatex,
+      shadowMermaid,
+      shadowWeb,
+    ]);
+    const byId = new Map(
+      withShadows.map((extension) => [extension.id, extension])
+    );
+
+    expect(withShadows).toHaveLength(3);
+    expect(byId.get("@minpeter/pss-extension-latex")).toBe(shadowLatex);
+    expect(byId.get("@minpeter/pss-extension-mermaid")).toBe(shadowMermaid);
+    expect(byId.get("@minpeter/pss-extension-web")).toBe(shadowWeb);
+  });
+
+  it("keeps every bundled default when no installed id collides", () => {
+    const extra: CodingAgentExtensionInput = {
+      configure() {
+        return;
+      },
+      id: "extra-extension",
+    };
+
+    const ids = withDefaultCodingAgentExtensions([extra]).map(
+      (extension) => extension.id
+    );
+
+    expect(ids).toStrictEqual([
+      "@minpeter/pss-extension-latex",
+      "@minpeter/pss-extension-mermaid",
+      "@minpeter/pss-extension-web",
+      "extra-extension",
+    ]);
+  });
+
   it("restores the default fallback after an override is removed", async () => {
     const overrideRenderer = () => ({
       invalidate() {

--- a/apps/coding-agent/src/extensions/defaults.ts
+++ b/apps/coding-agent/src/extensions/defaults.ts
@@ -34,17 +34,19 @@ export const withDefaultCodingAgentExtensions = (
   // and with it renderer priority — identical to the bundled defaults. Only
   // the first provided extension with a given id is consumed here, so a
   // second one still reaches the host's duplicate-id validation.
-  const consumed = new Set<CodingAgentExtensionInput>();
+  const consumed = new Set<number>();
   const takeReplacement = (
     id: string
   ): CodingAgentExtensionInput | undefined => {
-    const replacement = extensions.find(
-      (extension) => extension.id === id && !consumed.has(extension)
+    const index = extensions.findIndex(
+      (extension, extensionIndex) =>
+        extension.id === id && !consumed.has(extensionIndex)
     );
-    if (replacement !== undefined) {
-      consumed.add(replacement);
+    if (index === -1) {
+      return;
     }
-    return replacement;
+    consumed.add(index);
+    return extensions[index];
   };
   const latexReplacement = takeReplacement(latexModule.id);
   const mermaidReplacement = takeReplacement(mermaidModule.id);
@@ -63,7 +65,7 @@ export const withDefaultCodingAgentExtensions = (
     latexReplacement ?? latexModule,
     mermaidReplacement ?? mermaidModule,
     ...(webModule === undefined ? [] : [webModule]),
-    ...extensions.filter((extension) => !consumed.has(extension)),
+    ...extensions.filter((_, index) => !consumed.has(index)),
   ];
 };
 

--- a/apps/coding-agent/src/extensions/defaults.ts
+++ b/apps/coding-agent/src/extensions/defaults.ts
@@ -28,23 +28,43 @@ export const withDefaultCodingAgentExtensions = (
   extensions: readonly CodingAgentExtensionInput[],
   options: DefaultCodingAgentExtensionsOptions = {}
 ): readonly CodingAgentExtensionInput[] => {
-  const webModule: CodingAgentExtensionModule | undefined =
+  // An installed extension with a bundled default's id replaces the bundled
+  // copy in its original slot, mirroring how CLI extensions replace
+  // configured ones by id. Replacing in place keeps registration order —
+  // and with it renderer priority — identical to the bundled defaults. Only
+  // the first provided extension with a given id is consumed here, so a
+  // second one still reaches the host's duplicate-id validation.
+  const consumed = new Set<CodingAgentExtensionInput>();
+  const takeReplacement = (
+    id: string
+  ): CodingAgentExtensionInput | undefined => {
+    const replacement = extensions.find(
+      (extension) => extension.id === id && !consumed.has(extension)
+    );
+    if (replacement !== undefined) {
+      consumed.add(replacement);
+    }
+    return replacement;
+  };
+  const latexReplacement = takeReplacement(latexModule.id);
+  const mermaidReplacement = takeReplacement(mermaidModule.id);
+  const webReplacement =
     options.web === false
       ? undefined
-      : {
+      : takeReplacement("@minpeter/pss-extension-web");
+  const webModule: CodingAgentExtensionInput | undefined =
+    options.web === false
+      ? undefined
+      : (webReplacement ?? {
           default: createWebExtension(options.web),
           id: "@minpeter/pss-extension-web",
-        };
-  // An installed extension with a bundled default's id replaces the bundled
-  // copy, mirroring how CLI extensions replace configured ones by id. This
-  // keeps independently updated extension packages from colliding with the
-  // bundled defaults at host creation.
-  const providedIds = new Set(extensions.map((extension) => extension.id));
-  const bundledModules = [latexModule, mermaidModule, webModule].filter(
-    (module): module is CodingAgentExtensionModule =>
-      module !== undefined && !providedIds.has(module.id)
-  );
-  return [...bundledModules, ...extensions];
+        });
+  return [
+    latexReplacement ?? latexModule,
+    mermaidReplacement ?? mermaidModule,
+    ...(webModule === undefined ? [] : [webModule]),
+    ...extensions.filter((extension) => !consumed.has(extension)),
+  ];
 };
 
 export const createCodingAgentExtensionHostWithDefaults = (

--- a/apps/coding-agent/src/extensions/defaults.ts
+++ b/apps/coding-agent/src/extensions/defaults.ts
@@ -35,12 +35,16 @@ export const withDefaultCodingAgentExtensions = (
           default: createWebExtension(options.web),
           id: "@minpeter/pss-extension-web",
         };
-  return [
-    latexModule,
-    mermaidModule,
-    ...(webModule === undefined ? [] : [webModule]),
-    ...extensions,
-  ];
+  // An installed extension with a bundled default's id replaces the bundled
+  // copy, mirroring how CLI extensions replace configured ones by id. This
+  // keeps independently updated extension packages from colliding with the
+  // bundled defaults at host creation.
+  const providedIds = new Set(extensions.map((extension) => extension.id));
+  const bundledModules = [latexModule, mermaidModule, webModule].filter(
+    (module): module is CodingAgentExtensionModule =>
+      module !== undefined && !providedIds.has(module.id)
+  );
+  return [...bundledModules, ...extensions];
 };
 
 export const createCodingAgentExtensionHostWithDefaults = (

--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1-next.2",
   "description": "Self-contained LaTeX display rendering for the PSS coding-agent TUI.",
   "type": "module",
-  "private": true,
   "engines": {
     "node": ">=24"
   },
@@ -47,7 +46,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-tui": "^0.82.1",
-    "@minpeter/pss-coding-agent": "workspace:^"
+    "@minpeter/pss-coding-agent": "^0.0.14-next.14"
   },
   "devDependencies": {
     "playwright-core": "1.62.0",

--- a/extensions/mermaid/package.json
+++ b/extensions/mermaid/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1-next.1",
   "description": "Self-contained Mermaid diagram rendering for the PSS coding-agent TUI.",
   "type": "module",
-  "private": true,
   "engines": {
     "node": ">=24"
   },
@@ -36,7 +35,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-tui": "^0.82.1",
-    "@minpeter/pss-coding-agent": "workspace:^"
+    "@minpeter/pss-coding-agent": "^0.0.14-next.14"
   },
   "devDependencies": {
     "tsdown": "^0.22.14",

--- a/extensions/web/package.json
+++ b/extensions/web/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1-next.2",
   "description": "OpenSearch-backed web tools for the PSS coding agent.",
   "type": "module",
-  "private": true,
   "engines": {
     "node": ">=24"
   },
@@ -36,7 +35,7 @@
     "ai": "7.0.51"
   },
   "peerDependencies": {
-    "@minpeter/pss-coding-agent": "workspace:^"
+    "@minpeter/pss-coding-agent": "^0.0.14-next.14"
   },
   "devDependencies": {
     "tsdown": "^0.22.14",

--- a/scripts/extension-packages.test.mjs
+++ b/scripts/extension-packages.test.mjs
@@ -10,6 +10,10 @@ const packageCases = [
     directory: "extensions/mermaid",
     name: "@minpeter/pss-extension-mermaid",
   },
+  {
+    directory: "extensions/web",
+    name: "@minpeter/pss-extension-web",
+  },
 ];
 
 describe("official extension packages", () => {
@@ -21,9 +25,13 @@ describe("official extension packages", () => {
       const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 
       expect(manifest.name).toBe(name);
+      // Independently installable via `pss extension install`; a private
+      // manifest can never be published for the manager to fetch.
+      expect(manifest.private).not.toBe(true);
       expect(manifest.repository.directory).toBe(directory);
       expect(manifest.exports["."].import).toBe("./dist/index.js");
       expect(manifest.exports["."].types).toBe("./dist/index.d.ts");
+      expect(manifest.files).toContain("dist");
     }
   );
 });

--- a/scripts/tegami-config.test.mjs
+++ b/scripts/tegami-config.test.mjs
@@ -48,8 +48,8 @@ describe("Tegami release configuration", () => {
     expect(script).toContain('repo: "minpeter/pss-runtime"');
     expect(script).toContain('base: "main"');
     expect(script).toContain('workflow: "release.yml"');
-    expect(script.match(/prerelease: "next"/g)).toHaveLength(2);
-    expect(script.match(/distTag: "next"/g)).toHaveLength(2);
+    expect(script.match(/prerelease: "next"/g)).toHaveLength(5);
+    expect(script.match(/distTag: "next"/g)).toHaveLength(5);
     expect(script).toContain('"@minpeter/pss-runtime"');
     expect(script).toContain('"@minpeter/pss-coding-agent"');
   });

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -2,17 +2,21 @@ import { tegami } from "tegami";
 import { runCli } from "tegami/cli";
 import { github } from "tegami/plugins/github";
 
+// Built-in extensions publish on their own so `pss extension install/update`
+// can deliver them between coding-agent releases; the coding-agent bundle
+// still inlines them as the default fallback.
+const builtinExtensions = new Set([
+  "@minpeter/pss-extension-latex",
+  "@minpeter/pss-extension-mermaid",
+  "@minpeter/pss-extension-web",
+]);
+
 // Tegami propagates dependency bumps through private packages unless they are
 // removed from its graph. Keep every non-release workspace explicit here; the
 // config test derives the expected list from package manifests and fails when a
 // new private or experimental workspace is not added.
 const releaseIgnore = [
   "pss-next",
-  // Built-in extensions are bundled into the coding-agent build instead of
-  // being published on their own.
-  "@minpeter/pss-extension-latex",
-  "@minpeter/pss-extension-mermaid",
-  "@minpeter/pss-extension-web",
   "@minpeter/pss-worker-agent",
   "@minpeter/pss-bench-shared",
   "@minpeter/pss-benchmark-compaction-score",
@@ -34,6 +38,14 @@ const paper = tegami({
     bumpDep: ({ dependent, kind }) => {
       if (releaseIgnore.includes(dependent.name)) {
         return false;
+      }
+      // Built-in extensions peer-depend on the coding agent; a coding-agent
+      // release must refresh their peer range with a patch, never a major.
+      if (
+        kind === "peerDependencies" &&
+        builtinExtensions.has(dependent.name)
+      ) {
+        return "patch";
       }
       switch (kind) {
         case "dependencies":
@@ -60,6 +72,24 @@ const paper = tegami({
       },
     },
     "@minpeter/pss-coding-agent": {
+      prerelease: "next",
+      npm: {
+        distTag: "next",
+      },
+    },
+    "@minpeter/pss-extension-latex": {
+      prerelease: "next",
+      npm: {
+        distTag: "next",
+      },
+    },
+    "@minpeter/pss-extension-mermaid": {
+      prerelease: "next",
+      npm: {
+        distTag: "next",
+      },
+    },
+    "@minpeter/pss-extension-web": {
       prerelease: "next",
       npm: {
         distTag: "next",


### PR DESCRIPTION
## Summary

Built-in extensions (latex, mermaid, web) become independently installable/updatable packages, senpi-style hybrid: the bundle stays the default, and an installed extension with the same id shadows the bundled copy.

- **Shadowing**: `withDefaultCodingAgentExtensions` skips a bundled default when an installed/CLI extension has the same id (previously: host creation crashed with `Duplicate coding agent extension`). Mirrors `mergeCliExtensions`.
- **Publishable manifests**: dropped `private` from the 3 extension packages; concrete peer ranges instead of `workspace:` (pnpm pack cannot resolve the workspace protocol on a clean install; a devDependency on the coding agent creates a turbo cycle).
- **Release graph**: extensions join tegami's next lane with a patch-only peer bump policy, so coding-agent releases refresh their peer ranges without major bumps; extension-only releases are possible via their own Tegami entries.

## Verification

- C1 shadowing: RED (duplicate-id crash via real CLI: install + `pss exec`) → GREEN (unit 5/5 + CLI rerun: installed fixture's configure runs, no duplicate error).
- C2 independent install: pack all 3 (no private/workspace:, workers included) → `pss extension install` exit 0, `extension list` shows them, `pss exec` loads installed copies cleanly.
- C3 workers: installed-layout smoke renders LaTeX PNG (3555B) + mermaid art (15 lines); mutation proof (hide installed worker file → smoke fails → restore → pass).
- C4 regression: full root `pnpm test` (coding-agent 758 tests, extensions, scripts 63), turbo build, typecheck, lint all green; bundled-path smoke unchanged.

## Notes

- Next Version Packages PR will include the 3 extension packages as publish candidates (nothing publishes until that PR is merged).
- The extension manager still rejects direct `.tgz` file installs; npm/git/local-directory sources work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installed extensions now replace bundled defaults by id and in the same slot, keeping registration order and renderer priority stable. LaTeX, Mermaid, and Web are now publishable packages on the next lane for independent updates.

- **New Features**
  - `withDefaultCodingAgentExtensions` replaces bundled `@minpeter/pss-extension-latex`, `@minpeter/pss-extension-mermaid`, and `@minpeter/pss-extension-web` in-place when an installed/CLI extension has the same id, avoiding duplicate-id crashes and keeping renderer ownership stable.
  - Replacements are consumed by index, so duplicate same-id inputs still reach host validation.
  - Defaults remain when no match; the bundled `web` module isn’t constructed if it will be shadowed.

- **Dependencies**
  - Publishable packages: `@minpeter/pss-extension-latex`, `@minpeter/pss-extension-mermaid`, `@minpeter/pss-extension-web` with peers pinned to `@minpeter/pss-coding-agent` `^0.0.14-next.14`.
  - Added to Tegami’s next lane with `prerelease: "next"` and `distTag: "next"`; coding-agent releases refresh their peer ranges with patch-only bumps.

<sup>Written for commit dfcc2214c03e7325b50e7fd68778a5aa47d8d3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

