### PR TITLE
chore(release): add patch entries for the built-in extensions

### DIFF
--- a/.tegami/2026-08-05-publish-builtin-extensions.md
+++ b/.tegami/2026-08-05-publish-builtin-extensions.md
@@ -1,0 +1,13 @@
+---
+packages:
+  npm:@minpeter/pss-extension-latex:
+    type: patch
+  npm:@minpeter/pss-extension-mermaid:
+    type: patch
+  npm:@minpeter/pss-extension-web:
+    type: patch
+---
+
+## Publish built-in extensions as installable packages
+
+First publish of the three built-in extensions with their publishable manifests (no private flag, concrete peer ranges), enabling `pss extension install`/`update` to deliver them between coding-agent releases.


### PR DESCRIPTION
## Summary

The shadowing PR (#340) made the three built-in extensions publishable but no Tegami entry targets them, so the Version Packages PR (#341) only bumps `@minpeter/pss-coding-agent` — the stale pre-#335 extension builds would stay on npm. This adds patch entries for all three so the release publishes fresh packages.

## Verification

Entry follows the repo template (root AGENTS.md); `pnpm vitest run scripts/tegami-config.test.mjs` passes locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Tegami patch entries to publish the three built-in extensions: `@minpeter/pss-extension-latex`, `@minpeter/pss-extension-mermaid`, and `@minpeter/pss-extension-web`.
This ensures npm gets the updated manifests (no private flag, concrete peer ranges) and enables `pss extension install`/`update` between coding-agent releases.

<sup>Written for commit f1c08849c02cdcb83290e36379352c73e4cd48e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

