### PR TITLE
ci(release): publish built-in extensions to the latest dist-tag

### DIFF
--- a/.tegami/2026-08-05-extension-latest-dist-tag.md
+++ b/.tegami/2026-08-05-extension-latest-dist-tag.md
@@ -1,0 +1,13 @@
+---
+packages:
+  npm:@minpeter/pss-extension-latex:
+    type: patch
+  npm:@minpeter/pss-extension-mermaid:
+    type: patch
+  npm:@minpeter/pss-extension-web:
+    type: patch
+---
+
+## Publish built-in extensions to the latest dist-tag
+
+The extension manager resolves tagless installs through `latest`, so the built-in extensions now publish there instead of `next`; this release also moves `latest` off the stale pre-#335 builds.

--- a/scripts/tegami-config.test.mjs
+++ b/scripts/tegami-config.test.mjs
@@ -49,7 +49,8 @@ describe("Tegami release configuration", () => {
     expect(script).toContain('base: "main"');
     expect(script).toContain('workflow: "release.yml"');
     expect(script.match(/prerelease: "next"/g)).toHaveLength(5);
-    expect(script.match(/distTag: "next"/g)).toHaveLength(5);
+    expect(script.match(/distTag: "next"/g)).toHaveLength(2);
+    expect(script.match(/distTag: "latest"/g)).toHaveLength(3);
     expect(script).toContain('"@minpeter/pss-runtime"');
     expect(script).toContain('"@minpeter/pss-coding-agent"');
   });

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -4,7 +4,10 @@ import { github } from "tegami/plugins/github";
 
 // Built-in extensions publish on their own so `pss extension install/update`
 // can deliver them between coding-agent releases; the coding-agent bundle
-// still inlines them as the default fallback.
+// still inlines them as the default fallback. They publish to `latest`
+// (not `next`) because the extension manager resolves tagless installs
+// through the latest dist-tag, and the extensions have no stable line to
+// keep separate.
 const builtinExtensions = new Set([
   "@minpeter/pss-extension-latex",
   "@minpeter/pss-extension-mermaid",
@@ -80,19 +83,19 @@ const paper = tegami({
     "@minpeter/pss-extension-latex": {
       prerelease: "next",
       npm: {
-        distTag: "next",
+        distTag: "latest",
       },
     },
     "@minpeter/pss-extension-mermaid": {
       prerelease: "next",
       npm: {
-        distTag: "next",
+        distTag: "latest",
       },
     },
     "@minpeter/pss-extension-web": {
       prerelease: "next",
       npm: {
-        distTag: "next",
+        distTag: "latest",
       },
     },
   },


### PR DESCRIPTION
## Summary

Tagless `pss extension install` resolves through the `latest` dist-tag, which still points at the stale pre-#335 builds (latex/mermaid `0.0.1-next.1`, web `0.0.1-next.0`). Publish the three built-in extensions to `latest` — they have no stable line to keep separate — while runtime and coding-agent stay on `next`. The included patch entries make this release move `latest` off the stale builds.

## Verification

- RED: pinned tegami-config test failed on the dist-tag change; GREEN after pinning the new shape (5 prerelease, 2 next, 3 latest).
- `pnpm vitest run scripts/tegami-config.test.mjs scripts/extension-packages.test.mjs` 9/9, `pnpm lint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the three built-in extensions to the `latest` dist-tag so tagless `pss extension install` resolves to current builds; keep runtime and coding-agent on `next`. Updates release config and tests to move `latest` off the stale pre-#335 builds.

- **Refactors**
  - Set `distTag: "latest"` for `@minpeter/pss-extension-latex`, `@minpeter/pss-extension-mermaid`, `@minpeter/pss-extension-web`.
  - Updated `scripts/tegami-config.test.mjs` to expect 3 `latest` and 2 `next` dist-tags.
  - Added Tegami patch entries to publish these extensions on `latest`.

<sup>Written for commit e1f038f3d25acd56207fab469c3c6e108587b83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

