### PR TITLE
Harden coding agent tool schemas

### DIFF
--- a/.tegami/2026-08-05-harden-coding-agent-tools.md
+++ b/.tegami/2026-08-05-harden-coding-agent-tools.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+Validate built-in web and extension tool schemas before execution, improve model-facing parameter descriptions, and report failed shell commands accurately.

--- a/apps/coding-agent/src/extensions/capability-security.test.ts
+++ b/apps/coding-agent/src/extensions/capability-security.test.ts
@@ -1,7 +1,13 @@
+import { jsonSchema, tool } from "ai";
 import { describe, expect, it } from "vitest";
 import { createCodingAgent } from "../coding-agent";
 import { createCodingAgentExtensionHost } from "./host";
 import type { CodingAgentExtensionModule } from "./types";
+
+const validTool = tool({
+  description: "Valid fixture tool",
+  inputSchema: jsonSchema({ additionalProperties: false, type: "object" }),
+});
 
 describe("coding-agent extension capability security", () => {
   it("rejects malformed assistant renderer capabilities", async () => {
@@ -169,7 +175,7 @@ describe("coding-agent extension capability security", () => {
         default(pss) {
           pss.provide({
             kind: "tools",
-            tools: { shared_tool: {} },
+            tools: { shared_tool: validTool },
           } as never);
         },
         id: "first-provider",
@@ -178,7 +184,7 @@ describe("coding-agent extension capability security", () => {
         default(pss) {
           pss.provide({
             kind: "tools",
-            tools: { shared_tool: {} },
+            tools: { shared_tool: validTool },
           } as never);
         },
         id: "second-provider",
@@ -196,7 +202,7 @@ describe("coding-agent extension capability security", () => {
         default(pss) {
           pss.provide({
             kind: "tools",
-            tools: { shell_execute: {} },
+            tools: { shell_execute: validTool },
           } as never);
         },
         id: "builtin-tool-provider",

--- a/apps/coding-agent/src/extensions/capability-validation.ts
+++ b/apps/coding-agent/src/extensions/capability-validation.ts
@@ -1,6 +1,6 @@
 import { isAbsolute } from "node:path";
 import type { ThreadStateMigration } from "@minpeter/pss-runtime";
-import type { ToolSet } from "ai";
+import { asSchema, type ToolSet } from "ai";
 import type { CodingAgentSessionGuard } from "../sessions/session-guards";
 import type { AssistantRenderer } from "../tui/assistant-renderer";
 import type { TuiCommand } from "../tui/command";
@@ -348,11 +348,95 @@ export function snapshotToolEntry(
   definition: unknown
 ): readonly [string, ToolSet[string]] {
   const name = snapshotToolName(nameValue);
-  if (
-    (typeof definition !== "object" || definition === null) &&
-    typeof definition !== "function"
-  ) {
+  if (typeof definition !== "object" || definition === null) {
     throw new TypeError(`Tool "${name}" must be an object`);
   }
+  if (!("type" in definition && definition.type === "provider")) {
+    if (
+      !("description" in definition) ||
+      (typeof definition.description !== "function" &&
+        (typeof definition.description !== "string" ||
+          definition.description.trim().length === 0))
+    ) {
+      throw new TypeError(`Tool "${name}" must have a non-empty description`);
+    }
+    if (
+      !("inputSchema" in definition) ||
+      definition.inputSchema === undefined
+    ) {
+      throw new TypeError(`Tool "${name}" must have an input schema`);
+    }
+  }
   return Object.freeze([name, definition as ToolSet[string]] as const);
+}
+
+export async function validateExtensionToolSchemas(
+  entries: Readonly<Record<string, ToolSet[string]>>,
+  extensionId: string
+): Promise<void> {
+  for (const [name, definition] of Object.entries(entries)) {
+    if (definition.type === "provider") {
+      continue;
+    }
+    try {
+      const schema = await asSchema(definition.inputSchema).jsonSchema;
+      assertToolInputSchema(schema, "inputSchema", true);
+    } catch (error) {
+      const detail = error instanceof Error ? `: ${error.message}` : "";
+      throw new TypeError(
+        `Extension "${extensionId}" tool "${name}" has an invalid input schema${detail}`,
+        { cause: error }
+      );
+    }
+  }
+}
+
+function assertToolInputSchema(
+  value: unknown,
+  path: string,
+  root = false
+): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${path} must be a JSON Schema object`);
+  }
+  const schema = value as Record<string, unknown>;
+  if (root && schema.type !== "object") {
+    throw new TypeError(`${path} root type must be object`);
+  }
+  for (const keyword of ["allOf", "oneOf", "not"] as const) {
+    if (keyword in schema) {
+      throw new TypeError(`${path} must not use ${keyword}`);
+    }
+  }
+  if (schema.type === "array") {
+    if (!("items" in schema)) {
+      throw new TypeError(`${path} arrays must define items`);
+    }
+    assertToolInputSchema(schema.items, `${path}.items`);
+  }
+  if ("properties" in schema) {
+    if (
+      typeof schema.properties !== "object" ||
+      schema.properties === null ||
+      Array.isArray(schema.properties)
+    ) {
+      throw new TypeError(`${path}.properties must be an object`);
+    }
+    for (const [name, property] of Object.entries(schema.properties)) {
+      assertToolInputSchema(property, `${path}.properties.${name}`);
+    }
+  }
+  assertAnyOf(schema, path);
+}
+
+function assertAnyOf(schema: Record<string, unknown>, path: string): void {
+  if (!("anyOf" in schema)) {
+    return;
+  }
+  if (!Array.isArray(schema.anyOf) || schema.anyOf.length === 0) {
+    throw new TypeError(`${path}.anyOf must be a non-empty array`);
+  }
+  for (const [index, option] of schema.anyOf.entries()) {
+    assertToolInputSchema(option, `${path}.anyOf[${index}]`);
+  }
 }

--- a/apps/coding-agent/src/extensions/factory-host.test.ts
+++ b/apps/coding-agent/src/extensions/factory-host.test.ts
@@ -153,6 +153,65 @@ describe("default-export coding agent extensions", () => {
     });
   });
 
+  it("rejects non-portable and oversized tool names", async () => {
+    const definition = tool({
+      description: "Portable name fixture",
+      inputSchema: jsonSchema({ additionalProperties: false, type: "object" }),
+    });
+    for (const name of ["service.lookup", `t${"x".repeat(64)}`]) {
+      await expect(
+        createCodingAgentExtensionHost([
+          {
+            default(pss) {
+              pss.provide(tools({ [name]: definition }));
+            },
+            id: "invalid-tool-name-provider",
+          },
+        ])
+      ).rejects.toMatchObject({
+        cause: { message: `Invalid tool name "${name}"` },
+      });
+    }
+  });
+
+  it("rejects malformed extension tool definitions during configuration", async () => {
+    const cases = [
+      {
+        definition: {
+          inputSchema: jsonSchema({ type: "object" }),
+        },
+        message: 'Tool "invalid_tool" must have a non-empty description',
+      },
+      {
+        definition: {
+          description: "Missing schema",
+        },
+        message: 'Tool "invalid_tool" must have an input schema',
+      },
+      {
+        definition: tool({
+          description: "Array-root schema",
+          inputSchema: jsonSchema({ items: { type: "string" }, type: "array" }),
+        }),
+        message:
+          'Extension "invalid-tool-provider" tool "invalid_tool" has an invalid input schema: inputSchema root type must be object',
+      },
+    ] as const;
+
+    for (const { definition, message } of cases) {
+      await expect(
+        createCodingAgentExtensionHost([
+          {
+            default(pss) {
+              pss.provide(tools({ invalid_tool: definition as never }));
+            },
+            id: "invalid-tool-provider",
+          },
+        ])
+      ).rejects.toMatchObject({ cause: { message } });
+    }
+  });
+
   it("rejects unknown capability kinds", async () => {
     await expect(
       createCodingAgentExtensionHost([

--- a/apps/coding-agent/src/extensions/host-lifecycle.ts
+++ b/apps/coding-agent/src/extensions/host-lifecycle.ts
@@ -1,6 +1,7 @@
 import type { Agent } from "@minpeter/pss-runtime";
 import { Fsm } from "@minpeter/pss-runtime/fsm";
 import type { TuiCommandContext } from "../tui/command";
+import { validateExtensionToolSchemas } from "./capability-validation";
 import { CodingAgentExtensionError } from "./error";
 import { ExtensionHostEventBus } from "./event-bus";
 import { runExtensionOperation } from "./host-operation";
@@ -163,6 +164,7 @@ export class ExtensionHostLifecycle {
             signal: this.#controller.signal,
           });
           assertOpen();
+          await validateExtensionToolSchemas(staged.tools, extension.id);
           commitExtensionRegistryCollections(
             this.#collections,
             staged,

--- a/apps/coding-agent/src/extensions/name-validation.ts
+++ b/apps/coding-agent/src/extensions/name-validation.ts
@@ -1,7 +1,7 @@
 import { requiredString } from "./data-validation";
 
 const COMMAND_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
-const TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 const RESERVED_COMMAND_NAMES = new Set([
   "clear",
   "fork",

--- a/apps/coding-agent/src/workspace-tools/delete-file.ts
+++ b/apps/coding-agent/src/workspace-tools/delete-file.ts
@@ -10,9 +10,25 @@ import {
 
 const inputSchema = z
   .object({
-    path: z.string().min(1),
-    recursive: z.boolean().optional(),
-    expected_file_hash: z.string().length(8).optional(),
+    path: z
+      .string()
+      .min(1)
+      .describe(
+        "File or directory path relative to the workspace, or an absolute path under it."
+      ),
+    recursive: z
+      .boolean()
+      .optional()
+      .describe(
+        "Required as true to delete a directory; omit or false for files."
+      ),
+    expected_file_hash: z
+      .string()
+      .length(8)
+      .optional()
+      .describe(
+        "8-hex file_hash from the latest read_file; valid only for files and rejects stale content."
+      ),
   })
   .strict();
 

--- a/apps/coding-agent/src/workspace-tools/glob-files.ts
+++ b/apps/coding-agent/src/workspace-tools/glob-files.ts
@@ -7,10 +7,30 @@ import { globPatternToRegExp, walkWorkspaceFiles } from "./walk";
 
 const inputSchema = z
   .object({
-    pattern: z.string().min(1),
-    path: z.string().min(1).optional(),
-    include_ignored: z.boolean().optional(),
-    max_results: z.number().int().positive().max(2000).optional(),
+    pattern: z
+      .string()
+      .min(1)
+      .describe(
+        'Glob relative to path, supporting *, **, and ? (e.g. "src/**/*.ts").'
+      ),
+    path: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Workspace directory to search from (default workspace root)."),
+    include_ignored: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include normally skipped directories such as .git, node_modules, dist, and coverage (default false)."
+      ),
+    max_results: z
+      .number()
+      .int()
+      .positive()
+      .max(2000)
+      .optional()
+      .describe("Maximum file paths to return (default 500, max 2000)."),
   })
   .strict();
 

--- a/apps/coding-agent/src/workspace-tools/grep-files.ts
+++ b/apps/coding-agent/src/workspace-tools/grep-files.ts
@@ -11,13 +11,47 @@ const END_OF_LINE_PATTERN = /\r?\n/u;
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
 const inputSchema = z
   .object({
-    pattern: z.string().min(1),
-    path: z.string().min(1).optional(),
-    include: z.string().min(1).optional(),
-    fixed_strings: z.boolean().optional(),
-    case_sensitive: z.boolean().optional(),
-    include_ignored: z.boolean().optional(),
-    max_results: z.number().int().positive().max(1000).optional(),
+    pattern: z
+      .string()
+      .min(1)
+      .describe(
+        "Regular expression to search for, or literal text when fixed_strings=true."
+      ),
+    path: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Workspace directory to search from (default workspace root)."),
+    include: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        'File glob filter matched against paths and basenames (e.g. "*.ts").'
+      ),
+    fixed_strings: z
+      .boolean()
+      .optional()
+      .describe(
+        "Treat pattern as literal text instead of a regular expression (default false)."
+      ),
+    case_sensitive: z
+      .boolean()
+      .optional()
+      .describe("Use case-sensitive matching (default true)."),
+    include_ignored: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include normally skipped directories such as .git, node_modules, dist, and coverage (default false)."
+      ),
+    max_results: z
+      .number()
+      .int()
+      .positive()
+      .max(1000)
+      .optional()
+      .describe("Maximum matching lines to return (default 200, max 1000)."),
   })
   .strict();
 

--- a/apps/coding-agent/src/workspace-tools/shell-execute.ts
+++ b/apps/coding-agent/src/workspace-tools/shell-execute.ts
@@ -5,8 +5,19 @@ import { truncateToolOutput } from "./output";
 
 const inputSchema = z
   .object({
-    command: z.string().min(1),
-    timeout_seconds: z.number().int().positive().max(600).optional(),
+    command: z
+      .string()
+      .min(1)
+      .describe(
+        "Non-interactive Bash command executed from the workspace directory."
+      ),
+    timeout_seconds: z
+      .number()
+      .int()
+      .positive()
+      .max(600)
+      .optional()
+      .describe("Timeout in seconds (default 120, max 600)."),
   })
   .strict();
 
@@ -16,6 +27,16 @@ interface CommandResult {
   readonly stderr: string;
   readonly stdout: string;
   readonly timedOut: boolean;
+}
+
+function commandStatus(result: CommandResult): string {
+  if (result.timedOut) {
+    return "ERROR - command timed out";
+  }
+  if (result.exitCode !== 0 || result.signal !== null) {
+    return "ERROR - command failed";
+  }
+  return "OK - command finished";
 }
 
 function appendBounded(current: string, chunk: string): string {
@@ -110,9 +131,7 @@ export function createShellExecuteTool(
       );
       return truncateToolOutput(
         [
-          result.timedOut
-            ? "ERROR - command timed out"
-            : "OK - command finished",
+          commandStatus(result),
           `exit_code: ${result.exitCode ?? "null"}`,
           `signal: ${result.signal ?? "none"}`,
           "stdout:",

--- a/apps/coding-agent/src/workspace-tools/workspace-tools.test.ts
+++ b/apps/coding-agent/src/workspace-tools/workspace-tools.test.ts
@@ -120,6 +120,46 @@ describe("workspace coding tools", () => {
     expect(tools.edit_file.description).toMatch(criticalPattern);
   });
 
+  it("describes every built-in input field and keeps schema surfaces stable", async () => {
+    const tools = createWorkspaceTools({ workspace });
+    const expectedProperties: Readonly<Record<string, readonly string[]>> = {
+      delete_file: ["expected_file_hash", "path", "recursive"],
+      edit_file: ["edits", "expected_file_hash", "path"],
+      glob_files: ["include_ignored", "max_results", "path", "pattern"],
+      grep_files: [
+        "case_sensitive",
+        "fixed_strings",
+        "include",
+        "include_ignored",
+        "max_results",
+        "path",
+        "pattern",
+      ],
+      read_file: ["limit", "offset", "path"],
+      shell_execute: ["command", "timeout_seconds"],
+      write_file: ["content", "expected_file_hash", "path"],
+    };
+
+    expect(Object.keys(tools).sort()).toStrictEqual(
+      Object.keys(expectedProperties).sort()
+    );
+    for (const [name, expected] of Object.entries(expectedProperties)) {
+      const definition = tools[name];
+      if (definition?.type === "provider") {
+        throw new TypeError(`Expected function tool: ${name}`);
+      }
+      const schema = await asSchema(definition?.inputSchema).jsonSchema;
+      expect(schema.type).toBe("object");
+      expect(schema.additionalProperties).toBe(false);
+      expect(Object.keys(schema.properties ?? {}).sort()).toStrictEqual(
+        expected
+      );
+      for (const property of Object.values(schema.properties ?? {})) {
+        expect(property).toMatchObject({ description: expect.any(String) });
+      }
+    }
+  });
+
   it("reads hashline anchors and applies deterministic edits", async () => {
     const tools = createWorkspaceTools({ workspace });
     const read = executableTool(tools, "read_file");
@@ -821,6 +861,18 @@ describe("workspace coding tools", () => {
     expect(output).toContain("timed out");
     expect(Date.now() - startedAt).toBeLessThan(15_000);
   }, 20_000);
+
+  it("reports a non-zero shell exit as an error", async () => {
+    const tools = createWorkspaceTools({ workspace });
+    const shell = executableTool(tools, "shell_execute");
+    const output = String(
+      await shell({ command: "printf failure >&2; exit 7" }, executionOptions)
+    );
+
+    expect(output).toContain("ERROR - command failed");
+    expect(output).toContain("exit_code: 7");
+    expect(output).not.toContain("OK - command finished");
+  });
 
   it("withholds provider API keys from shell commands", async () => {
     process.env.AI_API_KEY = "pss-test-secret";

--- a/apps/coding-agent/src/workspace-tools/write-file.ts
+++ b/apps/coding-agent/src/workspace-tools/write-file.ts
@@ -16,9 +16,24 @@ import { resolveWorkspacePath, workspaceRelativePath } from "./path-safety";
 
 const inputSchema = z
   .object({
-    path: z.string().min(1),
-    content: z.string(),
-    expected_file_hash: z.string().length(8).optional(),
+    path: z
+      .string()
+      .min(1)
+      .describe(
+        "File path relative to the workspace, or an absolute path under it."
+      ),
+    content: z
+      .string()
+      .describe(
+        "Complete UTF-8 file content to write, replacing any existing content."
+      ),
+    expected_file_hash: z
+      .string()
+      .length(8)
+      .optional()
+      .describe(
+        "8-hex file_hash from the latest read_file; provide when overwriting to reject stale content."
+      ),
   })
   .strict();
 

--- a/extensions/web/package.json
+++ b/extensions/web/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "@minpeter/opensearch": "0.1.1",
-    "ai": "7.0.51"
+    "ai": "7.0.51",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@minpeter/pss-coding-agent": "^0.0.14-next.14"

--- a/extensions/web/src/web-extension.test.ts
+++ b/extensions/web/src/web-extension.test.ts
@@ -3,7 +3,7 @@ import type {
   ToolRendererMap,
 } from "@minpeter/pss-coding-agent/extension";
 import { createCodingAgentExtensionHost } from "@minpeter/pss-coding-agent/extension";
-import type { ToolExecutionOptions } from "ai";
+import { asSchema, type ToolExecutionOptions } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CodingAgentToolsConfigError,
@@ -91,6 +91,25 @@ describe("web extension tools", () => {
     expect(client.fetch).toHaveBeenCalledWith(["https://example.com/"], {
       maxCharacters: 8000,
     });
+  });
+
+  it("rejects invalid model inputs before calling the client", async () => {
+    const client = createStubClient();
+    const definitions = createCodingAgentTools({ client });
+    const searchSchema = asSchema(definitions.web_search.inputSchema);
+    const fetchSchema = asSchema(definitions.web_fetch.inputSchema);
+
+    await expect(
+      searchSchema.validate?.({ numResults: 99, query: "" })
+    ).resolves.toMatchObject({ success: false });
+    await expect(
+      fetchSchema.validate?.({ maxCharacters: -1, urls: [] })
+    ).resolves.toMatchObject({ success: false });
+    await expect(
+      fetchSchema.validate?.({ urls: ["file:///etc/passwd"] })
+    ).resolves.toMatchObject({ success: false });
+    expect(client.search).not.toHaveBeenCalled();
+    expect(client.fetch).not.toHaveBeenCalled();
   });
 
   it("rejects conflicting client configuration", () => {

--- a/extensions/web/src/web-fetch.ts
+++ b/extensions/web/src/web-fetch.ts
@@ -1,5 +1,6 @@
 import type { FetchOptions, FetchResult } from "@minpeter/opensearch/node";
 import { jsonSchema, type Tool, tool } from "ai";
+import { z } from "zod";
 import { abortIfRequested } from "./errors";
 import type { CodingAgentOpenSearchClient } from "./web-tools";
 
@@ -9,6 +10,22 @@ export interface WebFetchInput {
   readonly maxCharacters?: number;
   readonly urls: readonly string[];
 }
+
+const inputSchema: z.ZodType<WebFetchInput> = z
+  .object({
+    maxCharacters: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Per-page character cap (default 12000)."),
+    urls: z
+      .array(z.url({ protocol: /^https?$/u }))
+      .min(1)
+      .max(MAX_FETCH_URLS)
+      .describe("One to 10 absolute HTTP or HTTPS URLs to fetch."),
+  })
+  .strict();
 
 export type WebFetchTool = Tool<
   WebFetchInput,
@@ -26,31 +43,7 @@ export function createWebFetchTool(
       abortIfRequested(options.abortSignal, "web_fetch");
       return await client.fetch(input.urls, getFetchOptions(input));
     },
-    inputSchema: jsonSchema<WebFetchInput>({
-      additionalProperties: false,
-      properties: {
-        maxCharacters: {
-          description:
-            "Optional per-page character cap. Defaults to 12000 when omitted.",
-          minimum: 1,
-          type: "integer",
-        },
-        urls: {
-          description:
-            "Absolute http or https URLs to fetch. Maximum 10 URLs per request.",
-          items: {
-            description: "Absolute http or https URL.",
-            format: "uri",
-            type: "string",
-          },
-          maxItems: MAX_FETCH_URLS,
-          minItems: 1,
-          type: "array",
-        },
-      },
-      required: ["urls"],
-      type: "object",
-    }),
+    inputSchema,
     outputSchema: jsonSchema<readonly FetchResult[]>({
       items: {
         additionalProperties: false,

--- a/extensions/web/src/web-search.ts
+++ b/extensions/web/src/web-search.ts
@@ -1,5 +1,6 @@
 import type { SearchResult } from "@minpeter/opensearch/node";
 import { jsonSchema, type Tool, tool } from "ai";
+import { z } from "zod";
 import { abortIfRequested } from "./errors";
 import type { CodingAgentOpenSearchClient } from "./web-tools";
 
@@ -10,6 +11,24 @@ export interface WebSearchInput {
   readonly numResults?: number;
   readonly query: string;
 }
+
+const inputSchema: z.ZodType<WebSearchInput> = z
+  .object({
+    numResults: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_SEARCH_RESULTS)
+      .optional()
+      .describe("Result count from 1 to 15 (default 5)."),
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        "Natural-language search query; operators such as site:example.com are allowed."
+      ),
+  })
+  .strict();
 
 export type WebSearchTool = Tool<
   WebSearchInput,
@@ -31,26 +50,7 @@ export function createWebSearchTool(
           input.numResults ?? DEFAULT_SEARCH_RESULT_COUNT
         );
       },
-      inputSchema: jsonSchema<WebSearchInput>({
-        additionalProperties: false,
-        properties: {
-          numResults: {
-            description:
-              "Optional result count from 1 to 15. Defaults to 5 when omitted.",
-            maximum: MAX_SEARCH_RESULTS,
-            minimum: 1,
-            type: "integer",
-          },
-          query: {
-            description:
-              "Non-empty natural-language search query. Search operators such as site:example.com may be included.",
-            minLength: 1,
-            type: "string",
-          },
-        },
-        required: ["query"],
-        type: "object",
-      }),
+      inputSchema,
       outputSchema: jsonSchema<readonly SearchResult[]>({
         items: {
           additionalProperties: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,6 +563,9 @@ importers:
       ai:
         specifier: 7.0.51
         version: 7.0.51(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       tsdown:
         specifier: ^0.22.14
@@ -5483,6 +5486,8 @@ snapshots:
     optional: true
 
   '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-webcontainers-wasm32@0.35.2':


### PR DESCRIPTION
## Summary
- validate web and extension tool inputs before execution
- improve model-facing workspace tool descriptions and portable tool naming
- report failed shell commands accurately and add schema regression coverage

## Verification
- pnpm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened coding agent tools by validating extension and web tool inputs before execution and enforcing portable tool names. Also improved workspace tool parameter descriptions and fixed shell status reporting.

- **New Features**
  - Validate extension tool input schemas at load; require description/inputSchema and reject invalid JSON Schema.
  - Enforce portable tool names: `[A-Za-z0-9][A-Za-z0-9_-]{0,63}`.
  - Add runtime input checks and clearer parameters: web tools switch to `zod`; workspace tools document fields and lock schema surfaces via tests.

- **Bug Fixes**
  - `shell_execute` now reports non-zero exits or signals as errors and includes exit_code and signal in output.

<sup>Written for commit 8dd9667a5a4abe3fe3bff9bf80c333ff1333ed46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

