### PR TITLE
chore(runtime): remove verified dead declarations

### DIFF
--- a/.tegami/2026-08-06-remove-dead-runtime-declarations.md
+++ b/.tegami/2026-08-06-remove-dead-runtime-declarations.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+Remove verified unused runtime declarations and internal test helpers.

--- a/packages/runtime/src/agent/core/thread-entry.ts
+++ b/packages/runtime/src/agent/core/thread-entry.ts
@@ -52,5 +52,3 @@ export function threadStoreKey(thread: ThreadKey): string {
     thread.key
   )}`;
 }
-
-export const normalizeThreadKey = threadStoreKey;

--- a/packages/runtime/src/execution/host/unsupported-thread-input-inbox.ts
+++ b/packages/runtime/src/execution/host/unsupported-thread-input-inbox.ts
@@ -1,41 +1,7 @@
-import type {
-  AdmitReceipt,
-  ClaimedThreadInput,
-  RecoverThreadInputClaimsResult,
-  ThreadInputInbox,
-  ThreadInputRecord,
-} from "./types";
-
 export class ThreadInputInboxUnavailableError extends Error {
   readonly name = "ThreadInputInboxUnavailableError";
 
   constructor() {
     super("ThreadInputInbox is not implemented for this execution store.");
-  }
-}
-
-export class UnsupportedThreadInputInbox implements ThreadInputInbox {
-  admit(): Promise<AdmitReceipt> {
-    return Promise.reject(new ThreadInputInboxUnavailableError());
-  }
-
-  claimNext(): Promise<ClaimedThreadInput | null> {
-    return Promise.reject(new ThreadInputInboxUnavailableError());
-  }
-
-  releaseClaim(): Promise<ThreadInputRecord | null> {
-    return Promise.reject(new ThreadInputInboxUnavailableError());
-  }
-
-  markPromoted(): Promise<ThreadInputRecord | null> {
-    return Promise.reject(new ThreadInputInboxUnavailableError());
-  }
-
-  recoverClaims(): Promise<RecoverThreadInputClaimsResult> {
-    return Promise.reject(new ThreadInputInboxUnavailableError());
-  }
-
-  ack(): Promise<ThreadInputRecord | null> {
-    return Promise.reject(new ThreadInputInboxUnavailableError());
   }
 }

--- a/packages/runtime/src/llm/model-step-selection.ts
+++ b/packages/runtime/src/llm/model-step-selection.ts
@@ -3,7 +3,6 @@ import { isRecord as isObjectRecord } from "../internal/guards";
 import { ModelToolSelectionError } from "./model-step-error";
 import type {
   PreparedModelToolChoice,
-  PrepareModelStep,
   PrepareModelStepResult,
 } from "./model-step-preparation-types";
 import {
@@ -18,27 +17,6 @@ import {
 import { snapshotToolNames } from "./tool-registry-snapshot";
 
 const PREPARED_RESULT_KEYS = new Set(["activeTools", "model", "toolChoice"]);
-
-export function mapPrepareModelStepModel(
-  prepareModelStep: PrepareModelStep,
-  mapModel: (
-    model: Exclude<LanguageModel, string>
-  ) => Exclude<LanguageModel, string>
-): PrepareModelStep {
-  return async (input) => {
-    const prepared = parsePrepareModelStepResult(
-      await prepareModelStep(input),
-      Object.keys(input.tools).length
-    );
-    if (prepared?.model === undefined) {
-      return prepared;
-    }
-    return {
-      ...prepared,
-      model: mapModel(prepared.model),
-    };
-  };
-}
 
 export function parsePrepareModelStepResult(
   value: unknown,

--- a/packages/runtime/src/llm/model-step-types.ts
+++ b/packages/runtime/src/llm/model-step-types.ts
@@ -15,7 +15,6 @@ export type AgentToolChoice = PreparedModelToolChoice;
 export type ModelStepOutput = Awaited<
   ReturnType<typeof generateText>
 >["responseMessages"];
-export type ModelStepOutputPart = ModelStepOutput[number];
 
 export interface ModelStepResult {
   readonly contextUsage?: import("./context-tokens").ContextUsageSnapshot;

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.ts
@@ -13,8 +13,6 @@ import {
   ackScheduledThreadPrompt,
   appendScheduledRun,
   appendScheduledThreadPrompt,
-  claimScheduledRun,
-  claimScheduledThreadPrompt,
   listScheduledRuns,
   listScheduledThreadPrompts,
 } from "./scheduled-work-queue";
@@ -120,14 +118,6 @@ export async function ackScheduledCloudflareRun(
   await ackScheduledRun(storage, runId, options, defaultPrefix);
 }
 
-export async function claimScheduledCloudflareRun(
-  storage: CloudflareDurableObjectStorage,
-  runId: string,
-  options: { readonly prefix?: string } = {}
-): Promise<boolean> {
-  return await claimScheduledRun(storage, runId, options, defaultPrefix);
-}
-
 export async function listScheduledCloudflareThreadPrompts(
   storage: CloudflareDurableObjectStorage,
   options: { readonly limit?: number; readonly prefix?: string } = {}
@@ -141,19 +131,6 @@ export async function ackScheduledCloudflareThreadPrompt(
   options: { readonly prefix?: string } = {}
 ): Promise<void> {
   await ackScheduledThreadPrompt(storage, prompt, options, defaultPrefix);
-}
-
-export async function claimScheduledCloudflareThreadPrompt(
-  storage: CloudflareDurableObjectStorage,
-  prompt: CloudflareScheduledThreadPrompt,
-  options: { readonly prefix?: string } = {}
-): Promise<boolean> {
-  return await claimScheduledThreadPrompt(
-    storage,
-    prompt,
-    options,
-    defaultPrefix
-  );
 }
 
 function executionStoreWithThreads(

--- a/packages/runtime/src/platform/cloudflare/host/scheduled-work-retry.ts
+++ b/packages/runtime/src/platform/cloudflare/host/scheduled-work-retry.ts
@@ -2,18 +2,6 @@ import type { TurnRecord, TurnStatus } from "../../../execution";
 import type { CloudflareDurableObjectStorage } from "../storage/durable-object/durable-object-storage";
 import { createCloudflareStorageHost } from "./durable-object-host";
 
-export async function shouldRetryScheduledRun(
-  storage: CloudflareDurableObjectStorage,
-  prefix: string,
-  runId: string
-): Promise<boolean> {
-  const run = await createCloudflareStorageHost({
-    prefix,
-    storage,
-  }).store.turns.get(runId);
-  return run?.kind === "notification" && isRetryableRunStatus(run.status);
-}
-
 export async function shouldRetryNotClaimableScheduledRun(
   storage: CloudflareDurableObjectStorage,
   prefix: string,

--- a/packages/runtime/src/platform/cloudflare/storage/execution/records.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/records.ts
@@ -1,14 +1,3 @@
-import type { CloudflareDurableObjectTransactionStorage } from "../durable-object/durable-object-storage";
-
-export async function readList<T>(
-  storage: CloudflareDurableObjectTransactionStorage,
-  storageKey: string
-): Promise<T[]> {
-  return ((await storage.get<readonly T[]>(storageKey)) ?? []).map((item) =>
-    structuredClone(item)
-  );
-}
-
 export function storeKey(prefix: string, kind: string, id: string): string {
   return `${prefix}:${kind}:${id}`;
 }

--- a/packages/runtime/src/testing/input-fixtures.ts
+++ b/packages/runtime/src/testing/input-fixtures.ts
@@ -21,12 +21,6 @@ export const userMessage = (content: UserMessageContent): UserMessage => ({
   content,
 });
 
-export const sentUserMessage = (content: UserMessageContent): UserMessage => ({
-  content,
-  meta: { source: "send" },
-  type: "user-input",
-});
-
 export const steerRuntimeInput = (
   text: UserTextContent,
   placement: "step-end" | "step-start" | "turn-start"
@@ -65,20 +59,6 @@ export const overlayRuntimeInput = (
     type: "user-input" as const,
   },
   meta: { source: "overlay" as const },
-  placement,
-  type: "runtime-input" as const,
-});
-
-export const steerRuntimeInputMessage = (
-  content: UserMessageContent,
-  placement: "step-end" | "step-start" | "turn-start"
-) => ({
-  input: {
-    content,
-    meta: { source: "steer" as const, streaming: "steer" as const },
-    type: "user-input" as const,
-  },
-  meta: { source: "steer" as const, streaming: "steer" as const },
   placement,
   type: "runtime-input" as const,
 });

--- a/packages/runtime/src/testing/llm-test-utils.ts
+++ b/packages/runtime/src/testing/llm-test-utils.ts
@@ -98,13 +98,6 @@ export async function collectRun(run: { events(): AsyncIterable<AgentEvent> }) {
   return events;
 }
 
-export function lastGenerateTextTools(): ToolSet {
-  const call = generateTextMock.mock.calls.at(-1)?.[0] as
-    | { tools?: ToolSet }
-    | undefined;
-  return call?.tools ?? {};
-}
-
 export function executableTool(tools: ToolSet, name: string): Tool {
   const candidate = tools[name];
   expect(candidate).toBeDefined();

--- a/packages/runtime/src/thread/handle/test-support.ts
+++ b/packages/runtime/src/thread/handle/test-support.ts
@@ -62,23 +62,6 @@ export class SpyStore implements ThreadStore {
   }
 }
 
-export class ConflictOnceStore extends SpyStore {
-  conflictNextCommit = true;
-
-  override commit(
-    key: string,
-    next: ThreadStoreCommit,
-    options: { expectedVersion: string | null }
-  ): Promise<CommitResult> {
-    if (this.conflictNextCommit) {
-      this.conflictNextCommit = false;
-      return Promise.resolve({ ok: false, reason: "conflict" });
-    }
-
-    return super.commit(key, next, options);
-  }
-}
-
 export class ConflictOnCommitStore extends SpyStore {
   commitCount = 0;
   conflictOnCommit = 1;

--- a/packages/runtime/src/thread/runtime/durable-input-claims.ts
+++ b/packages/runtime/src/thread/runtime/durable-input-claims.ts
@@ -3,7 +3,6 @@ import type {
   ClaimedThreadInput,
   RecoverThreadInputClaimsResult,
   ThreadInputBoundary,
-  ThreadInputRecord,
 } from "../../execution/host/types";
 import { ThreadInputInboxUnavailableError } from "../../execution/host/unsupported-thread-input-inbox";
 
@@ -42,24 +41,6 @@ export async function claimDurableThreadInput({
     }
     throw error;
   }
-}
-
-export async function promoteAndAckDurableThreadInput({
-  executionHost,
-  record,
-}: {
-  readonly executionHost: AgentHost | undefined;
-  readonly record: ClaimedThreadInput;
-}): Promise<ThreadInputRecord | null> {
-  if (!executionHost) {
-    return null;
-  }
-
-  const promoted = await executionHost.store.inputs.markPromoted(record);
-  if (!promoted) {
-    return null;
-  }
-  return await executionHost.store.inputs.ack(promoted);
 }
 
 export async function recoverDurableThreadInputs({


### PR DESCRIPTION
## Summary
- remove audited, unreferenced runtime declarations and Cloudflare scheduling wrappers
- remove unused internal test helpers while retaining `ThreadInputInboxUnavailableError`
- add a patch Tegami entry for `@minpeter/pss-runtime`

## Tests
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm --filter @minpeter/pss-runtime test` (142 files, 857 passed, 3 skipped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed verified dead declarations and Cloudflare scheduling claim wrappers in `@minpeter/pss-runtime` to simplify the runtime API and testing surface. No functional changes.

- **Refactors**
  - Deleted unreferenced helpers: `normalizeThreadKey`, `mapPrepareModelStepModel`, `ModelStepOutputPart`, storage `readList`, durable input `promoteAndAckDurableThreadInput`.
  - Removed Cloudflare scheduled run/prompt claim functions and a retry helper.
  - Dropped unsupported inbox stub; kept `ThreadInputInboxUnavailableError`.
  - Removed unused test helpers: sentUserMessage, steerRuntimeInputMessage, lastGenerateTextTools, ConflictOnceStore.

- **Dependencies**
  - Added a Tegami patch entry for `@minpeter/pss-runtime`.

<sup>Written for commit db385f3a6f97d6fd1b96986598e15eb52699a98b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

