### PR TITLE
test(runtime): add AgentHost crash conformance suite

### DIFF
--- a/.tegami/2026-08-05-agent-host-fault-conformance.md
+++ b/.tegami/2026-08-05-agent-host-fault-conformance.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+Add reusable AgentHost fault-injection conformance coverage for durable cursors, leases, inputs, checkpoints, and transaction crash boundaries across memory, file, and Cloudflare hosts.

--- a/packages/runtime/src/contracts/agent-host-fault-contract.ts
+++ b/packages/runtime/src/contracts/agent-host-fault-contract.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import type { AgentHost, ClaimedThreadInput } from "../execution";
+
+export interface AgentHostFaultContractOptions {
+  readonly createHost: () => AgentHost;
+  readonly name: string;
+}
+
+/**
+ * Exercises durable boundaries where a host operation may commit even though
+ * its caller never observes the result. These assertions intentionally cover
+ * runtime-owned state only; hosts cannot make external side effects exactly
+ * once.
+ */
+export function describeAgentHostFaultContract({
+  createHost,
+  name,
+}: AgentHostFaultContractOptions): void {
+  describe(`${name} AgentHost crash-boundary contract`, () => {
+    it("uses exclusive, monotonic cursors when replay resumes after a crash", async () => {
+      const store = createHost().store;
+      const first = await store.events.append("run-cursor", {
+        type: "turn-start",
+      });
+      const second = await store.events.append("run-cursor", {
+        text: "durable",
+        type: "assistant-output",
+      });
+      const third = await store.events.append("run-cursor", {
+        type: "turn-end",
+      });
+
+      expect([first.offset, second.offset, third.offset]).toEqual([1, 2, 3]);
+      expect(await collect(store.events.read("run-cursor", first))).toEqual([
+        expect.objectContaining({ cursor: second }),
+        expect.objectContaining({ cursor: third }),
+      ]);
+      expect(await collect(store.events.read("run-cursor", second))).toEqual([
+        expect.objectContaining({ cursor: third }),
+      ]);
+      expect(await collect(store.events.read("run-cursor", third))).toEqual([]);
+    });
+
+    it("keeps a committed lease when the claim response is lost", async () => {
+      const store = createHost().store;
+      await store.turns.create(queuedRun("run-lease"));
+
+      await expect(
+        loseResponse(() =>
+          store.turns.claim("run-lease", {
+            attempt: 1,
+            leaseId: "lease-lost-response",
+            leaseMs: 100,
+            nowMs: 1000,
+          })
+        )
+      ).rejects.toThrow(LostHostResponseError);
+      await expect(
+        store.turns.claim("run-lease", {
+          attempt: 2,
+          leaseId: "lease-too-early",
+          leaseMs: 100,
+          nowMs: 1099,
+        })
+      ).resolves.toEqual({ ok: false, reason: "leased" });
+      await expect(
+        store.turns.claim("run-lease", {
+          attempt: 2,
+          leaseId: "lease-after-expiry",
+          leaseMs: 50,
+          nowMs: 1100,
+        })
+      ).resolves.toMatchObject({
+        lease: {
+          attempt: 2,
+          leaseId: "lease-after-expiry",
+          leaseUntilMs: 1150,
+        },
+        ok: true,
+      });
+    });
+
+    it("makes admission retry-safe and recovers a claim lost at a crash boundary", async () => {
+      const store = createHost().store;
+      const admission = {
+        admittedAtMs: 10,
+        input: { text: "retry me", type: "user-input" } as const,
+        kind: "send" as const,
+        messageId: "input-lost-response",
+        threadKey: "thread-input-crash",
+      };
+
+      await expect(
+        loseResponse(() => store.inputs.admit(admission))
+      ).rejects.toThrow(LostHostResponseError);
+      await expect(store.inputs.admit(admission)).resolves.toMatchObject({
+        duplicate: true,
+        record: { admittedAtMs: 10, admittedSeq: 1, status: "pending" },
+      });
+      const claimed = await requireClaimed(
+        store.inputs.claimNext("thread-input-crash", "turn-idle")
+      );
+
+      await expect(
+        store.inputs.recoverClaims("thread-input-crash")
+      ).resolves.toEqual({
+        acked: [],
+        released: [expect.objectContaining({ status: "pending" })],
+      });
+      const reclaimed = await requireClaimed(
+        store.inputs.claimNext("thread-input-crash", "turn-idle")
+      );
+      expect(reclaimed.messageId).toBe(claimed.messageId);
+      expect(reclaimed.claimId).not.toBe(claimed.claimId);
+    });
+
+    it("detects a checkpoint committed before its response was lost", async () => {
+      const store = createHost().store;
+      await store.turns.create(queuedRun("run-checkpoint"));
+      const checkpoint = {
+        checkpointId: "checkpoint-after-tool",
+        phase: "after-tool" as const,
+        runId: "run-checkpoint",
+        runtimeState: { toolCall: "call-1" },
+        threadSnapshot: { messages: [] },
+        version: 1,
+      };
+
+      await expect(
+        loseResponse(() =>
+          store.checkpoints.append(checkpoint, { expectedVersion: 0 })
+        )
+      ).rejects.toThrow(LostHostResponseError);
+      await expect(
+        store.checkpoints.append(checkpoint, { expectedVersion: 0 })
+      ).resolves.toEqual({
+        currentVersion: 1,
+        ok: false,
+        reason: "stale-version",
+      });
+      await expect(store.checkpoints.latest("run-checkpoint")).resolves.toEqual(
+        checkpoint
+      );
+    });
+
+    it("does not expose partial runtime state when a transaction crashes", async () => {
+      const store = createHost().store;
+
+      await expect(
+        store.transaction(async (tx) => {
+          await tx.turns.create(queuedRun("run-transaction-crash"));
+          await tx.events.append("run-transaction-crash", {
+            type: "turn-start",
+          });
+          throw new InjectedHostCrashError();
+        })
+      ).rejects.toThrow(InjectedHostCrashError);
+
+      await expect(
+        store.turns.get("run-transaction-crash")
+      ).resolves.toBeNull();
+      expect(await collect(store.events.read("run-transaction-crash"))).toEqual(
+        []
+      );
+    });
+  });
+}
+
+class LostHostResponseError extends Error {
+  constructor() {
+    super("injected failure after host commit");
+    this.name = "LostHostResponseError";
+  }
+}
+
+class InjectedHostCrashError extends Error {
+  constructor() {
+    super("injected crash before transaction commit");
+    this.name = "InjectedHostCrashError";
+  }
+}
+
+async function loseResponse<T>(operation: () => Promise<T>): Promise<never> {
+  await operation();
+  throw new LostHostResponseError();
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const collected: T[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+async function requireClaimed(
+  claim: Promise<ClaimedThreadInput | null>
+): Promise<ClaimedThreadInput> {
+  const result = await claim;
+  expect(result).not.toBeNull();
+  if (!result) {
+    throw new Error("Expected claimed input");
+  }
+  return result;
+}
+
+function queuedRun(runId: string) {
+  return {
+    checkpointVersion: 0,
+    kind: "user-turn" as const,
+    rootRunId: runId,
+    runId,
+    status: "queued" as const,
+    threadKey: `thread:${runId}`,
+  };
+}

--- a/packages/runtime/src/contracts/agent-host-fault-contract.ts
+++ b/packages/runtime/src/contracts/agent-host-fault-contract.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { AgentHost, ClaimedThreadInput } from "../execution";
 
+export interface AgentHostFaultContractFixture {
+  readonly cleanup?: () => Promise<void>;
+  readonly host: AgentHost;
+}
+
 export interface AgentHostFaultContractOptions {
-  readonly createHost: () => AgentHost;
+  readonly createHost: () => AgentHostFaultContractFixture;
   readonly name: string;
 }
 
@@ -17,8 +22,21 @@ export function describeAgentHostFaultContract({
   name,
 }: AgentHostFaultContractOptions): void {
   describe(`${name} AgentHost crash-boundary contract`, () => {
+    const cleanups: Array<() => Promise<void>> = [];
+    const host = (): AgentHost => {
+      const fixture = createHost();
+      if (fixture.cleanup) {
+        cleanups.push(fixture.cleanup);
+      }
+      return fixture.host;
+    };
+
+    afterEach(async () => {
+      const pending = cleanups.splice(0);
+      await Promise.all(pending.map((cleanup) => cleanup()));
+    });
     it("uses exclusive, monotonic cursors when replay resumes after a crash", async () => {
-      const store = createHost().store;
+      const store = host().store;
       const first = await store.events.append("run-cursor", {
         type: "turn-start",
       });
@@ -42,7 +60,7 @@ export function describeAgentHostFaultContract({
     });
 
     it("keeps a committed lease when the claim response is lost", async () => {
-      const store = createHost().store;
+      const store = host().store;
       await store.turns.create(queuedRun("run-lease"));
 
       await expect(
@@ -81,7 +99,7 @@ export function describeAgentHostFaultContract({
     });
 
     it("makes admission retry-safe and recovers a claim lost at a crash boundary", async () => {
-      const store = createHost().store;
+      const store = host().store;
       const admission = {
         admittedAtMs: 10,
         input: { text: "retry me", type: "user-input" } as const,
@@ -115,7 +133,7 @@ export function describeAgentHostFaultContract({
     });
 
     it("detects a checkpoint committed before its response was lost", async () => {
-      const store = createHost().store;
+      const store = host().store;
       await store.turns.create(queuedRun("run-checkpoint"));
       const checkpoint = {
         checkpointId: "checkpoint-after-tool",
@@ -144,7 +162,7 @@ export function describeAgentHostFaultContract({
     });
 
     it("does not expose partial runtime state when a transaction crashes", async () => {
-      const store = createHost().store;
+      const store = host().store;
 
       await expect(
         store.transaction(async (tx) => {

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { describeAgentHostFaultContract } from "../../../contracts/agent-host-fault-contract";
 import type { AgentEvent, AgentTurn } from "../../../index";
 import {
   ackScheduledCloudflareRun,
@@ -16,6 +17,16 @@ import {
 } from "../index";
 import { InMemorySqlStorage } from "../sql/node-test/node-sqlite-storage";
 import type { CloudflareDurableObjectTransactionStorage } from "../storage/durable-object/durable-object-storage";
+
+let conformancePrefix = 0;
+describeAgentHostFaultContract({
+  createHost: () =>
+    createCloudflareStorageHost({
+      prefix: `host-conformance-${conformancePrefix++}`,
+      storage: new InMemoryCloudflareDurableObjectStorage(),
+    }),
+  name: "Cloudflare Durable Object",
+});
 
 interface ScheduledWorkProbeRow {
   readonly kind: string;

--- a/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
+++ b/packages/runtime/src/platform/cloudflare/host/durable-object-host.test.ts
@@ -20,11 +20,12 @@ import type { CloudflareDurableObjectTransactionStorage } from "../storage/durab
 
 let conformancePrefix = 0;
 describeAgentHostFaultContract({
-  createHost: () =>
-    createCloudflareStorageHost({
+  createHost: () => ({
+    host: createCloudflareStorageHost({
       prefix: `host-conformance-${conformancePrefix++}`,
       storage: new InMemoryCloudflareDurableObjectStorage(),
     }),
+  }),
   name: "Cloudflare Durable Object",
 });
 

--- a/packages/runtime/src/platform/file/host/file-execution-host.test.ts
+++ b/packages/runtime/src/platform/file/host/file-execution-host.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   mkdir,
   mkdtemp,
@@ -11,6 +12,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { Agent } from "../../../agent/core/agent";
 import { agentNamespace } from "../../../agent/identity/namespace";
+import { describeAgentHostFaultContract } from "../../../contracts/agent-host-fault-contract";
 import { dispatchAgentNotification } from "../../../execution/dispatch/notification-dispatch";
 import {
   assistantMessage,
@@ -28,6 +30,14 @@ import {
   listScheduledNodeRuns,
   listScheduledNodeThreadPrompts,
 } from "./scheduled-work-store";
+
+describeAgentHostFaultContract({
+  createHost: () =>
+    createFileHost({
+      directory: join(tmpdir(), `pss-host-contract-${randomUUID()}`),
+    }),
+  name: "file",
+});
 
 const malformedScheduledWorkPattern =
   /Invalid Node scheduled work file .*invalid JSON/;

--- a/packages/runtime/src/platform/file/host/file-execution-host.test.ts
+++ b/packages/runtime/src/platform/file/host/file-execution-host.test.ts
@@ -35,7 +35,7 @@ describeAgentHostFaultContract({
   createHost: () => {
     const directory = join(tmpdir(), `pss-host-contract-${randomUUID()}`);
     return {
-      cleanup: () => rm(directory, { force: true, recursive: true }),
+      cleanup: () => removeTempDir(directory),
       host: createFileHost({ directory }),
     };
   },

--- a/packages/runtime/src/platform/file/host/file-execution-host.test.ts
+++ b/packages/runtime/src/platform/file/host/file-execution-host.test.ts
@@ -32,10 +32,13 @@ import {
 } from "./scheduled-work-store";
 
 describeAgentHostFaultContract({
-  createHost: () =>
-    createFileHost({
-      directory: join(tmpdir(), `pss-host-contract-${randomUUID()}`),
-    }),
+  createHost: () => {
+    const directory = join(tmpdir(), `pss-host-contract-${randomUUID()}`);
+    return {
+      cleanup: () => rm(directory, { force: true, recursive: true }),
+      host: createFileHost({ directory }),
+    };
+  },
   name: "file",
 });
 

--- a/packages/runtime/src/platform/memory/execution/agent-host-fault-contract.test.ts
+++ b/packages/runtime/src/platform/memory/execution/agent-host-fault-contract.test.ts
@@ -2,6 +2,6 @@ import { describeAgentHostFaultContract } from "../../../contracts/agent-host-fa
 import { createInMemoryHost } from "./execution-host";
 
 describeAgentHostFaultContract({
-  createHost: createInMemoryHost,
+  createHost: () => ({ host: createInMemoryHost() }),
   name: "in-memory",
 });

--- a/packages/runtime/src/platform/memory/execution/agent-host-fault-contract.test.ts
+++ b/packages/runtime/src/platform/memory/execution/agent-host-fault-contract.test.ts
@@ -1,0 +1,7 @@
+import { describeAgentHostFaultContract } from "../../../contracts/agent-host-fault-contract";
+import { createInMemoryHost } from "./execution-host";
+
+describeAgentHostFaultContract({
+  createHost: createInMemoryHost,
+  name: "in-memory",
+});


### PR DESCRIPTION
## Summary
- add a reusable AgentHost fault-injection contract for runtime-owned durable boundaries
- verify cursor replay, lease expiry, input admission/claim recovery, checkpoint CAS, and transaction rollback invariants
- run the same contract against memory, file, and Cloudflare Durable Object hosts

The contract explicitly limits its guarantee to runtime-owned state and does not promise exactly-once external side effects.

## Tests
- `pnpm --filter @minpeter/pss-runtime exec vitest run src/platform/memory/execution/agent-host-fault-contract.test.ts src/platform/file/host/file-execution-host.test.ts src/platform/cloudflare/host/durable-object-host.test.ts` (26 passed)
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm --filter @minpeter/pss-runtime build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable AgentHost crash-boundary conformance suite to `@minpeter/pss-runtime` to verify durable runtime state across in-memory, file, and Cloudflare Durable Object hosts. Also isolates test fixtures and hardens cleanup to prevent cross-talk and leftover files.

- **New Features**
  - Added `describeAgentHostFaultContract` covering exclusive cursor replay, lease expiry, retry-safe admission and claim recovery, checkpoint CAS/versioning, and transactional atomicity.
  - Scope is runtime-owned state only; external side effects are out of scope.
  - Applied the suite to in-memory, file, and Cloudflare Durable Object hosts.

- **Refactors**
  - Isolated Cloudflare tests with unique Durable Object prefixes.
  - Cleaned up file-host temp directories after runs with retry on deletion.

<sup>Written for commit 54f393a299224cd805e3d9830b886948c905d10f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

