### PR TITLE
Fix falsy BufferedAgentTurn errors

### DIFF
--- a/.tegami/2026-08-06-buffered-turn-falsy-errors.md
+++ b/.tegami/2026-08-06-buffered-turn-falsy-errors.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+Separate successful and failed buffered turn closure so every JavaScript falsy value remains observable as an iterator rejection.

--- a/packages/runtime/src/thread/protocol/turn.test.ts
+++ b/packages/runtime/src/thread/protocol/turn.test.ts
@@ -9,6 +9,32 @@ const expectPending = async (promise: Promise<unknown>) => {
   );
 };
 
+const falsyErrors: readonly unknown[] = [
+  false,
+  0,
+  -0,
+  0n,
+  "",
+  null,
+  undefined,
+  Number.NaN,
+];
+
+const expectRejectedWith = async (
+  promise: Promise<unknown>,
+  expected: unknown
+) => {
+  const result = await promise.then(
+    () => ({ status: "fulfilled" as const }),
+    (error: unknown) => ({ error, status: "rejected" as const })
+  );
+
+  expect(result.status).toBe("rejected");
+  if (result.status === "rejected") {
+    expect(Object.is(result.error, expected)).toBe(true);
+  }
+};
+
 describe("AgentTurn", () => {
   it("binds one stable optional durable run id", () => {
     const local = new BufferedAgentTurn();
@@ -160,6 +186,59 @@ describe("AgentTurn", () => {
       value: undefined,
     });
   });
+
+  it("close() completes a pending next request successfully", async () => {
+    const run = new BufferedAgentTurn();
+    const iterator = run.events()[Symbol.asyncIterator]();
+    const next = iterator.next();
+
+    run.close();
+
+    await expect(next).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it("preserves the first successful or failed closure outcome", async () => {
+    const successfulRun = new BufferedAgentTurn();
+    successfulRun.close();
+    successfulRun.closeWithError(new Error("late failure"));
+    const successfulIterator = successfulRun.events()[Symbol.asyncIterator]();
+    await expect(successfulIterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    const failure = new Error("first failure");
+    const failedRun = new BufferedAgentTurn();
+    failedRun.closeWithError(failure);
+    failedRun.close();
+    const failedIterator = failedRun.events()[Symbol.asyncIterator]();
+    await expectRejectedWith(failedIterator.next(), failure);
+  });
+
+  it.each(falsyErrors)(
+    "closeWithError rejects a future next request with falsy error %#",
+    async (error) => {
+      const run = new BufferedAgentTurn();
+      run.closeWithError(error);
+      run.emit({ type: "turn-start" });
+      const iterator = run.events()[Symbol.asyncIterator]();
+
+      await expectRejectedWith(iterator.next(), error);
+    }
+  );
+
+  it.each(falsyErrors)(
+    "closeWithError rejects a pending next request with falsy error %#",
+    async (error) => {
+      const run = new BufferedAgentTurn();
+      const iterator = run.events()[Symbol.asyncIterator]();
+      const next = iterator.next();
+
+      run.closeWithError(error);
+
+      await expectRejectedWith(next, error);
+    }
+  );
 
   it("close() settles queued boundary acknowledgements", async () => {
     const run = new BufferedAgentTurn();

--- a/packages/runtime/src/thread/protocol/turn.ts
+++ b/packages/runtime/src/thread/protocol/turn.ts
@@ -17,9 +17,11 @@ interface NextWaiter {
 }
 
 /** Producer side: whether the turn still accepts events. */
-type TurnChannelState =
-  | { readonly tag: "open" }
-  | { readonly tag: "closed"; readonly error: unknown };
+type TurnTerminalState =
+  | { readonly tag: "closed" }
+  | { readonly tag: "failed"; readonly error: unknown };
+
+type TurnChannelState = { readonly tag: "open" } | TurnTerminalState;
 
 /**
  * Consumer side of the event iterator.
@@ -44,8 +46,9 @@ const createChannelMachine = () =>
     initial: { tag: "open" },
     name: "agent-turn-channel",
     transitions: {
-      open: ["closed"],
+      open: ["closed", "failed"],
       closed: [],
+      failed: [],
     },
   });
 
@@ -91,7 +94,7 @@ export class BufferedAgentTurn implements AgentTurn {
   }
 
   emit(event: AgentEvent): void {
-    if (this.#channel.state.tag === "closed") {
+    if (this.#channel.state.tag !== "open") {
       return;
     }
 
@@ -99,7 +102,7 @@ export class BufferedAgentTurn implements AgentTurn {
   }
 
   emitBoundary(event: AgentEvent): Promise<void> {
-    if (this.#channel.state.tag === "closed") {
+    if (this.#channel.state.tag !== "open") {
       return Promise.resolve();
     }
 
@@ -108,26 +111,12 @@ export class BufferedAgentTurn implements AgentTurn {
     });
   }
 
-  close(error?: unknown): void {
-    if (this.#channel.state.tag === "closed") {
-      return;
-    }
+  close(): void {
+    this.#finish({ tag: "closed" });
+  }
 
-    this.#channel.to({ tag: "closed", error });
-    this.#settlePendingAck();
-    this.#settleQueuedAcks();
-
-    const consumer = this.#consumer.state;
-    if (consumer.tag !== "waiting") {
-      return;
-    }
-
-    this.#consumer.to({ tag: "idle" });
-    if (error) {
-      consumer.waiter.reject(error);
-      return;
-    }
-    consumer.waiter.resolve({ done: true, value: undefined });
+  closeWithError(error: unknown): void {
+    this.#finish({ tag: "failed", error });
   }
 
   events(): AsyncIterable<AgentEvent> {
@@ -163,6 +152,28 @@ export class BufferedAgentTurn implements AgentTurn {
     this.#events.push(event);
   }
 
+  #finish(state: TurnTerminalState): void {
+    if (this.#channel.state.tag !== "open") {
+      return;
+    }
+
+    this.#channel.to(state);
+    this.#settlePendingAck();
+    this.#settleQueuedAcks();
+
+    const consumer = this.#consumer.state;
+    if (consumer.tag !== "waiting") {
+      return;
+    }
+
+    this.#consumer.to({ tag: "idle" });
+    if (state.tag === "failed") {
+      consumer.waiter.reject(state.error);
+      return;
+    }
+    consumer.waiter.resolve({ done: true, value: undefined });
+  }
+
   #next(): Promise<IteratorResult<AgentEvent>> {
     const consumer = this.#consumer.state;
     if (consumer.tag === "delivering" || consumer.tag === "waiting") {
@@ -179,10 +190,10 @@ export class BufferedAgentTurn implements AgentTurn {
     }
 
     const channel = this.#channel.state;
+    if (channel.tag === "failed") {
+      return Promise.reject(channel.error);
+    }
     if (channel.tag === "closed") {
-      if (channel.error) {
-        return Promise.reject(channel.error);
-      }
       return Promise.resolve({ done: true, value: undefined });
     }
 


### PR DESCRIPTION
## Summary
- split successful `close()` from explicit `closeWithError(error)` channel termination
- model closed and failed turns as distinct FSM states so falsy rejection reasons are never mistaken for successful completion
- cover every JavaScript falsy value for both already-closed and pending iterator requests, plus terminal-outcome idempotency

## Tests
- `pnpm --filter @minpeter/pss-runtime test` (875 passed, 3 skipped)
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm exec ultracite check packages/runtime/src/thread/protocol/turn.ts packages/runtime/src/thread/protocol/turn.test.ts`
- `pnpm --filter @minpeter/pss-runtime build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes falsy BufferedAgentTurn errors in `@minpeter/pss-runtime` by separating successful `close()` from `closeWithError(error)` and adding explicit `closed` vs `failed` states. Iterator consumers now get exact rejections for all falsy reasons, and the first terminal outcome is preserved.

- **Bug Fixes**
  - Split `close()` (success) and `closeWithError(error)` with explicit `closed`/`failed` states so falsy errors reject both pending and future `next()` calls.
  - `close()` resolves a pending `next()` with done=true; `closeWithError(error)` rejects with the exact error.

- **Migration**
  - Replace any `close(error)` calls with `closeWithError(error)`; use `close()` for successful completion.

<sup>Written for commit b95a8f5488f37013aab32dff357e6d6ed7b611ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

