### PR TITLE
feat(runtime): add platform-neutral SQL queue host

### DIFF
--- a/.tegami/2026-08-06-sql-queue-host.md
+++ b/.tegami/2026-08-06-sql-queue-host.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+Add a platform-neutral SQL store and durable queue host adapter with injected wake signaling and shared contract coverage.

--- a/.tegami/2026-08-06-sql-queue-host.md
+++ b/.tegami/2026-08-06-sql-queue-host.md
@@ -4,4 +4,4 @@ packages:
     type: patch
 ---
 
-Add a platform-neutral SQL store and durable queue host adapter with injected wake signaling and shared contract coverage.
+Add platform-neutral SQL store and leased durable-queue integration ports, worker draining, and queued-run reconciliation with in-memory reference contract coverage.

--- a/.tegami/2026-08-06-sql-queue-host.md
+++ b/.tegami/2026-08-06-sql-queue-host.md
@@ -4,4 +4,4 @@ packages:
     type: patch
 ---
 
-Add platform-neutral SQL store and leased durable-queue integration ports, worker draining, and queued-run reconciliation with in-memory reference contract coverage.
+Add platform-neutral SQL store and leased durable-queue integration ports, worker draining, and exact-work outbox reconciliation with in-memory reference contract coverage.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1367,8 +1367,16 @@ become claimable again.
 only after success, and nacks handler failures for retry. `onError` can report
 the original handler error after nack succeeds. Renewal and ack failures surface
 directly without nack because ownership or ack outcome is uncertain; lease
-expiry is the safe recovery path. Each work ID is handled at most once per
-drain invocation, including when `retryDelayMs` is zero.
+expiry is the safe recovery path. Heartbeats use the current lease's absolute
+deadline, so renewal response latency consumes the next wait instead of
+shifting cadence past expiry. Each work ID is handled at most once per drain
+invocation, including when `retryDelayMs` is zero.
+
+Queue delivery remains **at least once**. A renewal outage or latency beyond the
+remaining lease can let another worker reclaim work while the original handler
+is still running; the adapter cannot cancel arbitrary handler side effects.
+Handlers must therefore be idempotent and safe under concurrent duplicate
+execution.
 
 The adapter calls `wake` only after durable enqueue resolves. Wake is advisory:
 a wake failure can reject scheduling even though the item is safely queued, so

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1312,20 +1312,33 @@ any app-owned background run cancellation, cleanup, and notification policy.
 
 ## SQL + durable queue host
 
-`@minpeter/pss-runtime/platform/sql-queue` is a platform-neutral production
-host boundary for conventional servers. It deliberately does not select a SQL
-client or queue vendor:
+`@minpeter/pss-runtime/platform/sql-queue` is a platform-neutral integration
+boundary for conventional production servers. It deliberately does not select
+a SQL client, schema, queue vendor, or migration framework:
 
 ```ts
-import { createSqlQueueHost } from "@minpeter/pss-runtime/platform/sql-queue";
+import {
+  createSqlQueueHost,
+  drainSqlQueue,
+  reconcileSqlQueuedRuns,
+} from "@minpeter/pss-runtime/platform/sql-queue";
 
 const host = createSqlQueueHost({
   store: postgresStorePort,
-  queue: {
-    // Must be durable and idempotent by work.workId.
-    enqueue: (work) => jobs.insertOnConflictDoNothing(work),
-  },
+  queue: postgresQueuePort, // enqueue + leased claim/ack/nack
   // Optional fast-path signal; durable queue polling remains the fallback.
+  wake: (dueAtMs) => workerWake.publish({ dueAtMs }),
+});
+
+await drainSqlQueue({
+  queue: postgresQueuePort,
+  handle: (work) => dispatchWork(work),
+});
+
+// Run periodically as well as at worker startup.
+await reconcileSqlQueuedRuns({
+  queue: postgresQueuePort,
+  runs: postgresQueuedRunQuery,
   wake: (dueAtMs) => workerWake.publish({ dueAtMs }),
 });
 ```
@@ -1334,17 +1347,36 @@ A `SqlHostStorePort` exposes the normal runtime stores and an atomic
 `transaction` callback. A PostgreSQL implementation should acquire one pooled
 connection, issue `BEGIN`, create transaction-scoped store ports for that
 connection, then `COMMIT` on success or `ROLLBACK` on failure. Optimistic
-thread/checkpoint writes and queue inserts should use unique constraints or
-compare-and-swap predicates rather than process locks.
+thread/checkpoint writes should use unique constraints or compare-and-swap
+predicates rather than process locks.
 
-`SqlQueuePort.enqueue` receives either run or thread-prompt work with a stable
-`workId` and `dueAtMs`. Persist it with a unique key (for example `INSERT ...
-ON CONFLICT (work_id) DO NOTHING`). The adapter calls `wake` only after enqueue
-resolves. Wake is advisory: workers must poll the durable queue for due,
-unacked work, and a wake failure may reject scheduling even though the item is
-already safely queued. Retrying is therefore safe and expected.
+`SqlQueuePort.enqueue` receives run or thread-prompt work with a stable
+`workId` and `dueAtMs`; persist it with a unique key (`INSERT ... ON CONFLICT
+(work_id) DO NOTHING`). `claim` must atomically lease one due item and fence
+workers with its `claimId`; expired leases must become claimable. `list` exposes
+due work for bounded inspection without claiming it. `ack` removes only a
+currently fenced claim, while `nack` retains it until `retryAtMs`.
+`drainSqlQueue` acknowledges only after the handler succeeds, nacks failures
+for retry, and leaves work recoverable through lease expiry if a worker dies.
 
-The package contract suite runs this adapter against an in-memory reference
-SQL port and queue. Production database drivers remain application-owned so
-the runtime does not impose a PostgreSQL client, pool, migration system, or
-message broker.
+The adapter calls `wake` only after durable enqueue resolves. Wake is advisory:
+a wake failure can reject scheduling even though the item is safely queued, so
+retry is safe and expected.
+
+### Store-to-queue crash recovery
+
+Creating a queued turn and calling `HostScheduler.enqueueRun` are not one
+atomic operation. A process can crash after the store transaction commits but
+before queue insertion. Deployments must either implement a transactional
+outbox in their SQL port or run `reconcileSqlQueuedRuns` periodically. Its
+`SqlQueuedRunSource` should query every durable, runnable queued turn (including
+recovery statuses selected by the deployment). Reconciliation recreates the
+stable `run:<runId>` work item idempotently, so existing queue rows are safe and
+orphaned turns are repaired. An enqueue failure stops the pass without changing
+the durable turn; a later pass retries it.
+
+The package runs the shared `HostStore` and `HostScheduler` suites through the
+adapter using `InMemoryExecutionStore` and a leased-map reference queue, plus
+consumer/reconciliation behavior tests. These prove adapter delegation and
+queue semantics, **not PostgreSQL SQL correctness**. Production database
+implementations and integration tests remain application-owned.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1308,3 +1308,43 @@ idempotent execution or a manual recovery flow.
 Cancellation is persisted before aborting active work. `delete()` and `dispose()`
 stop the current session's in-process work; durable hosts remain responsible for
 any app-owned background run cancellation, cleanup, and notification policy.
+
+
+## SQL + durable queue host
+
+`@minpeter/pss-runtime/platform/sql-queue` is a platform-neutral production
+host boundary for conventional servers. It deliberately does not select a SQL
+client or queue vendor:
+
+```ts
+import { createSqlQueueHost } from "@minpeter/pss-runtime/platform/sql-queue";
+
+const host = createSqlQueueHost({
+  store: postgresStorePort,
+  queue: {
+    // Must be durable and idempotent by work.workId.
+    enqueue: (work) => jobs.insertOnConflictDoNothing(work),
+  },
+  // Optional fast-path signal; durable queue polling remains the fallback.
+  wake: (dueAtMs) => workerWake.publish({ dueAtMs }),
+});
+```
+
+A `SqlHostStorePort` exposes the normal runtime stores and an atomic
+`transaction` callback. A PostgreSQL implementation should acquire one pooled
+connection, issue `BEGIN`, create transaction-scoped store ports for that
+connection, then `COMMIT` on success or `ROLLBACK` on failure. Optimistic
+thread/checkpoint writes and queue inserts should use unique constraints or
+compare-and-swap predicates rather than process locks.
+
+`SqlQueuePort.enqueue` receives either run or thread-prompt work with a stable
+`workId` and `dueAtMs`. Persist it with a unique key (for example `INSERT ...
+ON CONFLICT (work_id) DO NOTHING`). The adapter calls `wake` only after enqueue
+resolves. Wake is advisory: workers must poll the durable queue for due,
+unacked work, and a wake failure may reject scheduling even though the item is
+already safely queued. Retrying is therefore safe and expected.
+
+The package contract suite runs this adapter against an in-memory reference
+SQL port and queue. Production database drivers remain application-owned so
+the runtime does not impose a PostgreSQL client, pool, migration system, or
+message broker.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1353,11 +1353,22 @@ predicates rather than process locks.
 `SqlQueuePort.enqueue` receives run or thread-prompt work with a stable
 `workId` and `dueAtMs`; persist it with a unique key (`INSERT ... ON CONFLICT
 (work_id) DO NOTHING`). `claim` must atomically lease one due item and fence
-workers with its `claimId`; expired leases must become claimable. `list` exposes
-due work for bounded inspection without claiming it. `ack` removes only a
-currently fenced claim, while `nack` retains it until `retryAtMs`.
-`drainSqlQueue` acknowledges only after the handler succeeds, nacks failures
-for retry, and leaves work recoverable through lease expiry if a worker dies.
+workers with its `claimId`. Its `attempt` is 1-based and increments after every
+successful reclaim. It must also honor `excludeWorkIds`, which prevents a
+zero-delay poison item from being claimed repeatedly in one drain pass while
+other work starves. `list` exposes due work for bounded inspection.
+
+`renewLease` must validate both the claim fence and that the existing lease has
+not expired before extending it. `ack` and `nack` also validate the current
+fence; ack removes work and nack retains it until `retryAtMs`. Expired leases
+become claimable again.
+
+`drainSqlQueue` heartbeats `renewLease` during unbounded handlers, acknowledges
+only after success, and nacks handler failures for retry. `onError` can report
+the original handler error after nack succeeds. Renewal and ack failures surface
+directly without nack because ownership or ack outcome is uncertain; lease
+expiry is the safe recovery path. Each work ID is handled at most once per
+drain invocation, including when `retryDelayMs` is zero.
 
 The adapter calls `wake` only after durable enqueue resolves. Wake is advisory:
 a wake failure can reject scheduling even though the item is safely queued, so
@@ -1366,8 +1377,8 @@ retry is safe and expected.
 ### Store-to-queue crash recovery
 
 Committing durable scheduling state and calling `HostScheduler.enqueueRun` or
-`HostScheduler.resumeThread` are not one atomic operation. A process can crash after the store transaction commits but
-before queue insertion. Deployments must either implement a transactional
+`HostScheduler.resumeThread` are not one atomic operation. A process can crash after the store transaction commits but before queue
+insertion. Deployments must either implement a transactional
 outbox in their SQL port or run `reconcileSqlQueuedWork` periodically. Its
 `SqlQueuedWorkSource` must return the exact original `SqlQueueWork`, including
 kind, due time, payload, and stable ID. This is naturally an outbox query; a

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1320,7 +1320,7 @@ a SQL client, schema, queue vendor, or migration framework:
 import {
   createSqlQueueHost,
   drainSqlQueue,
-  reconcileSqlQueuedRuns,
+  reconcileSqlQueuedWork,
 } from "@minpeter/pss-runtime/platform/sql-queue";
 
 const host = createSqlQueueHost({
@@ -1336,9 +1336,9 @@ await drainSqlQueue({
 });
 
 // Run periodically as well as at worker startup.
-await reconcileSqlQueuedRuns({
+await reconcileSqlQueuedWork({
   queue: postgresQueuePort,
-  runs: postgresQueuedRunQuery,
+  source: postgresQueuedWorkOutbox,
   wake: (dueAtMs) => workerWake.publish({ dueAtMs }),
 });
 ```
@@ -1365,15 +1365,18 @@ retry is safe and expected.
 
 ### Store-to-queue crash recovery
 
-Creating a queued turn and calling `HostScheduler.enqueueRun` are not one
-atomic operation. A process can crash after the store transaction commits but
+Committing durable scheduling state and calling `HostScheduler.enqueueRun` or
+`HostScheduler.resumeThread` are not one atomic operation. A process can crash after the store transaction commits but
 before queue insertion. Deployments must either implement a transactional
-outbox in their SQL port or run `reconcileSqlQueuedRuns` periodically. Its
-`SqlQueuedRunSource` should query every durable, runnable queued turn (including
-recovery statuses selected by the deployment). Reconciliation recreates the
-stable `run:<runId>` work item idempotently, so existing queue rows are safe and
-orphaned turns are repaired. An enqueue failure stops the pass without changing
-the durable turn; a later pass retries it.
+outbox in their SQL port or run `reconcileSqlQueuedWork` periodically. Its
+`SqlQueuedWorkSource` must return the exact original `SqlQueueWork`, including
+kind, due time, payload, and stable ID. This is naturally an outbox query; a
+reconstruction query must join notification data so thread prompts keep their
+thread and idempotency context. A turn row by itself is not sufficient because
+notification work must remain `thread-prompt`, not become `run:<runId>`.
+Reconciliation inserts exact work idempotently, so existing rows and concurrent
+passes remain safe. An enqueue failure stops the pass without changing the
+durable source; a later pass retries it.
 
 The package runs the shared `HostStore` and `HostScheduler` suites through the
 adapter using `InMemoryExecutionStore` and a leased-map reference queue, plus

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -69,6 +69,11 @@
       "@minpeter/pss-source": "./src/testing/index.ts",
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"
+    },
+    "./platform/sql-queue": {
+      "@minpeter/pss-source": "./src/platform/sql-queue/index.ts",
+      "types": "./dist/platform/sql-queue/index.d.ts",
+      "import": "./dist/platform/sql-queue/index.js"
     }
   },
   "bin": {

--- a/packages/runtime/src/contracts/package-subpaths.test.ts
+++ b/packages/runtime/src/contracts/package-subpaths.test.ts
@@ -68,6 +68,20 @@ describe("runtime package subpaths", () => {
     expect(packageJson.exports["./node"]).toBeUndefined();
   });
 
+  it("declares the SQL queue adapter as a platform implementation subpath", async () => {
+    const packageJson = await readRuntimePackageJson();
+    const sqlQueue = await import("../platform/sql-queue");
+
+    expect(packageJson.exports["./platform/sql-queue"]).toMatchObject({
+      "@minpeter/pss-source": "./src/platform/sql-queue/index.ts",
+      import: "./dist/platform/sql-queue/index.js",
+      types: "./dist/platform/sql-queue/index.d.ts",
+    });
+    expect(sqlQueue).toHaveProperty("createSqlQueueHost");
+    expect(sqlQueue).toHaveProperty("SqlHostStore");
+    expect(sqlQueue).toHaveProperty("SqlQueueScheduler");
+  });
+
   it("declares the OpenTelemetry observability subpath", async () => {
     const packageJson = await readRuntimePackageJson();
     const root = await import("../index");

--- a/packages/runtime/src/platform/sql-queue/drainer.ts
+++ b/packages/runtime/src/platform/sql-queue/drainer.ts
@@ -1,0 +1,63 @@
+import type { SqlQueueClaim, SqlQueuePort, SqlQueueWork } from "./queue";
+
+export interface SqlQueueDrainOptions {
+  readonly clock?: () => number;
+  readonly handle: (work: SqlQueueWork, claim: SqlQueueClaim) => Promise<void>;
+  readonly leaseMs?: number;
+  readonly limit?: number;
+  readonly queue: SqlQueuePort;
+  readonly retryDelayMs?: number | ((attempt: number) => number);
+}
+
+export interface SqlQueueDrainResult {
+  readonly claimed: number;
+  readonly failed: number;
+  readonly succeeded: number;
+}
+
+/**
+ * Claims due work and acknowledges only successful handlers. Failed handlers
+ * are nacked with a retry time; a nack failure is surfaced so the lease can
+ * expire and another worker can safely reclaim the item.
+ */
+export async function drainSqlQueue({
+  clock = Date.now,
+  handle,
+  leaseMs = 30_000,
+  limit = 100,
+  queue,
+  retryDelayMs = 1000,
+}: SqlQueueDrainOptions): Promise<SqlQueueDrainResult> {
+  let claimed = 0;
+  let failed = 0;
+  let succeeded = 0;
+  const normalizedLimit = Math.max(0, Math.floor(limit));
+  const normalizedLeaseMs = Math.max(1, Math.floor(leaseMs));
+
+  while (claimed < normalizedLimit) {
+    const claim = await queue.claim({
+      leaseMs: normalizedLeaseMs,
+      nowMs: clock(),
+    });
+    if (!claim) {
+      break;
+    }
+    claimed += 1;
+    try {
+      await handle(claim.work, claim);
+      await queue.ack(claim);
+      succeeded += 1;
+    } catch {
+      const configuredDelay =
+        typeof retryDelayMs === "function"
+          ? retryDelayMs(claim.attempt)
+          : retryDelayMs;
+      await queue.nack(claim, {
+        retryAtMs: clock() + Math.max(0, Math.floor(configuredDelay)),
+      });
+      failed += 1;
+    }
+  }
+
+  return { claimed, failed, succeeded };
+}

--- a/packages/runtime/src/platform/sql-queue/drainer.ts
+++ b/packages/runtime/src/platform/sql-queue/drainer.ts
@@ -1,10 +1,21 @@
 import type { SqlQueueClaim, SqlQueuePort, SqlQueueWork } from "./queue";
 
+export interface SqlQueueHandlerErrorContext {
+  readonly claim: SqlQueueClaim;
+  readonly error: unknown;
+  readonly work: SqlQueueWork;
+}
+
 export interface SqlQueueDrainOptions {
   readonly clock?: () => number;
   readonly handle: (work: SqlQueueWork, claim: SqlQueueClaim) => Promise<void>;
+  readonly heartbeatMs?: number;
   readonly leaseMs?: number;
   readonly limit?: number;
+  /** Observes handler failures after the work has been safely nacked. */
+  readonly onError?: (
+    context: SqlQueueHandlerErrorContext
+  ) => Promise<void> | void;
   readonly queue: SqlQueuePort;
   readonly retryDelayMs?: number | ((attempt: number) => number);
 }
@@ -15,27 +26,47 @@ export interface SqlQueueDrainResult {
   readonly succeeded: number;
 }
 
+type HandlerOutcome =
+  | { readonly claim: SqlQueueClaim; readonly ok: true }
+  | {
+      readonly claim: SqlQueueClaim;
+      readonly error: unknown;
+      readonly ok: false;
+    };
+
 /**
- * Claims due work and acknowledges only successful handlers. Failed handlers
- * are nacked with a retry time; a nack failure is surfaced so the lease can
- * expire and another worker can safely reclaim the item.
+ * Claims due work, renews its fenced lease during handling, and acknowledges
+ * only successful handlers. Handler failures are nacked for retry and exposed
+ * through `onError`. Ack and renewal failures surface without nack because
+ * their outcome or claim ownership is uncertain; lease expiry enables retry.
  */
 export async function drainSqlQueue({
   clock = Date.now,
   handle,
+  heartbeatMs,
   leaseMs = 30_000,
   limit = 100,
+  onError,
   queue,
   retryDelayMs = 1000,
 }: SqlQueueDrainOptions): Promise<SqlQueueDrainResult> {
   let claimed = 0;
   let failed = 0;
   let succeeded = 0;
+  const seenWorkIds = new Set<string>();
   const normalizedLimit = Math.max(0, Math.floor(limit));
   const normalizedLeaseMs = Math.max(1, Math.floor(leaseMs));
+  const normalizedHeartbeatMs = Math.max(
+    1,
+    Math.min(
+      Math.floor(heartbeatMs ?? normalizedLeaseMs / 3),
+      Math.max(1, Math.floor(normalizedLeaseMs / 2))
+    )
+  );
 
   while (claimed < normalizedLimit) {
     const claim = await queue.claim({
+      excludeWorkIds: [...seenWorkIds],
       leaseMs: normalizedLeaseMs,
       nowMs: clock(),
     });
@@ -43,21 +74,103 @@ export async function drainSqlQueue({
       break;
     }
     claimed += 1;
-    try {
-      await handle(claim.work, claim);
-      await queue.ack(claim);
+    seenWorkIds.add(claim.work.workId);
+
+    const outcome = await handleWithHeartbeat({
+      claim,
+      clock,
+      handle,
+      heartbeatMs: normalizedHeartbeatMs,
+      leaseMs: normalizedLeaseMs,
+      queue,
+    });
+    if (outcome.ok) {
+      // Keep ack outside handler error handling. An uncertain ack must surface
+      // and remain recoverable by lease expiry, never be converted to a nack.
+      await queue.ack(outcome.claim);
       succeeded += 1;
-    } catch {
-      const configuredDelay =
-        typeof retryDelayMs === "function"
-          ? retryDelayMs(claim.attempt)
-          : retryDelayMs;
-      await queue.nack(claim, {
-        retryAtMs: clock() + Math.max(0, Math.floor(configuredDelay)),
-      });
-      failed += 1;
+      continue;
     }
+
+    const configuredDelay =
+      typeof retryDelayMs === "function"
+        ? retryDelayMs(outcome.claim.attempt)
+        : retryDelayMs;
+    await queue.nack(outcome.claim, {
+      retryAtMs: clock() + Math.max(0, Math.floor(configuredDelay)),
+    });
+    failed += 1;
+    await onError?.({
+      claim: outcome.claim,
+      error: outcome.error,
+      work: outcome.claim.work,
+    });
   }
 
   return { claimed, failed, succeeded };
+}
+
+interface HeartbeatHandlerOptions {
+  readonly claim: SqlQueueClaim;
+  readonly clock: () => number;
+  readonly handle: (work: SqlQueueWork, claim: SqlQueueClaim) => Promise<void>;
+  readonly heartbeatMs: number;
+  readonly leaseMs: number;
+  readonly queue: SqlQueuePort;
+}
+
+async function handleWithHeartbeat({
+  claim,
+  clock,
+  handle,
+  heartbeatMs,
+  leaseMs,
+  queue,
+}: HeartbeatHandlerOptions): Promise<HandlerOutcome> {
+  let active = true;
+  let currentClaim = claim;
+  let renewalError: unknown;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let renewal = Promise.resolve();
+
+  const scheduleRenewal = (): void => {
+    timer = setTimeout(() => {
+      const nowMs = clock();
+      renewal = queue
+        .renewLease(currentClaim, {
+          leaseUntilMs: nowMs + leaseMs,
+          nowMs,
+        })
+        .then((renewed) => {
+          currentClaim = renewed;
+          if (active) {
+            scheduleRenewal();
+          }
+        })
+        .catch((error: unknown) => {
+          renewalError = error;
+        });
+    }, heartbeatMs);
+  };
+  scheduleRenewal();
+
+  let handlerError: unknown;
+  let handlerFailed = false;
+  try {
+    await handle(claim.work, claim);
+  } catch (error) {
+    handlerError = error;
+    handlerFailed = true;
+  } finally {
+    active = false;
+    clearTimeout(timer);
+    await renewal;
+  }
+
+  if (renewalError !== undefined) {
+    throw renewalError;
+  }
+  return handlerFailed
+    ? { claim: currentClaim, error: handlerError, ok: false }
+    : { claim: currentClaim, ok: true };
 }

--- a/packages/runtime/src/platform/sql-queue/drainer.ts
+++ b/packages/runtime/src/platform/sql-queue/drainer.ts
@@ -39,6 +39,8 @@ type HandlerOutcome =
  * only successful handlers. Handler failures are nacked for retry and exposed
  * through `onError`. Ack and renewal failures surface without nack because
  * their outcome or claim ownership is uncertain; lease expiry enables retry.
+ * A lost renewal cannot cancel an already-running handler, so handlers must be
+ * idempotent and tolerate concurrent duplicate execution (at-least-once).
  */
 export async function drainSqlQueue({
   clock = Date.now,
@@ -134,6 +136,13 @@ async function handleWithHeartbeat({
   let renewal = Promise.resolve();
 
   const scheduleRenewal = (): void => {
+    // Anchor cadence to the lease's absolute deadline. A slow renewal response
+    // must consume the next delay rather than shift the whole cadence later.
+    const remainingMs = currentClaim.leaseUntilMs - clock();
+    const delayMs = Math.max(
+      0,
+      Math.min(heartbeatMs, remainingMs - heartbeatMs)
+    );
     timer = setTimeout(() => {
       const nowMs = clock();
       renewal = queue
@@ -150,7 +159,7 @@ async function handleWithHeartbeat({
         .catch((error: unknown) => {
           renewalError = error;
         });
-    }, heartbeatMs);
+    }, delayMs);
   };
   scheduleRenewal();
 

--- a/packages/runtime/src/platform/sql-queue/host.ts
+++ b/packages/runtime/src/platform/sql-queue/host.ts
@@ -1,0 +1,36 @@
+import type { RuntimeDiagnosticsSink } from "../../diagnostics";
+import { noopRuntimeDiagnostics } from "../../diagnostics";
+import type { AgentHost } from "../../execution/host/types";
+import type { HostAttachmentStore } from "../../thread/input/attachments";
+import type { SqlQueueSchedulerOptions } from "./scheduler";
+import { SqlQueueScheduler } from "./scheduler";
+import type { SqlHostStorePort } from "./store";
+import { SqlHostStore } from "./store";
+
+export interface SqlQueueHostOptions extends SqlQueueSchedulerOptions {
+  readonly attachmentStore?: HostAttachmentStore;
+  readonly diagnostics?: RuntimeDiagnosticsSink;
+  readonly store: SqlHostStorePort;
+}
+
+export interface SqlQueueHost extends AgentHost {
+  readonly scheduler: SqlQueueScheduler;
+  readonly store: SqlHostStore;
+}
+
+/** Creates a platform-neutral host backed by an injected SQL store and queue. */
+export function createSqlQueueHost({
+  attachmentStore,
+  clock,
+  diagnostics = noopRuntimeDiagnostics,
+  queue,
+  store,
+  wake,
+}: SqlQueueHostOptions): SqlQueueHost {
+  return {
+    attachmentStore,
+    diagnostics,
+    scheduler: new SqlQueueScheduler({ clock, queue, wake }),
+    store: new SqlHostStore(store),
+  };
+}

--- a/packages/runtime/src/platform/sql-queue/index.ts
+++ b/packages/runtime/src/platform/sql-queue/index.ts
@@ -4,6 +4,7 @@ export {
   drainSqlQueue,
   type SqlQueueDrainOptions,
   type SqlQueueDrainResult,
+  type SqlQueueHandlerErrorContext,
 } from "./drainer";
 export {
   createSqlQueueHost,
@@ -17,6 +18,7 @@ export type {
   SqlQueueNackOptions,
   SqlQueuePort,
   SqlQueueProducerPort,
+  SqlQueueRenewLeaseOptions,
   SqlQueueRunWork,
   SqlQueueThreadPromptWork,
   SqlQueueWork,

--- a/packages/runtime/src/platform/sql-queue/index.ts
+++ b/packages/runtime/src/platform/sql-queue/index.ts
@@ -22,9 +22,8 @@ export type {
   SqlQueueWork,
 } from "./queue";
 export {
-  reconcileSqlQueuedRuns,
-  type SqlQueuedRunCandidate,
-  type SqlQueuedRunSource,
+  reconcileSqlQueuedWork,
+  type SqlQueuedWorkSource,
   type SqlQueueReconciliationOptions,
   type SqlQueueReconciliationResult,
 } from "./reconciliation";

--- a/packages/runtime/src/platform/sql-queue/index.ts
+++ b/packages/runtime/src/platform/sql-queue/index.ts
@@ -1,16 +1,35 @@
 // biome-ignore-all lint/performance/noBarrelFile: Public package subpath entrypoint required by package exports.
 
 export {
+  drainSqlQueue,
+  type SqlQueueDrainOptions,
+  type SqlQueueDrainResult,
+} from "./drainer";
+export {
   createSqlQueueHost,
   type SqlQueueHost,
   type SqlQueueHostOptions,
 } from "./host";
+export type {
+  SqlQueueClaim,
+  SqlQueueClaimOptions,
+  SqlQueueListOptions,
+  SqlQueueNackOptions,
+  SqlQueuePort,
+  SqlQueueProducerPort,
+  SqlQueueRunWork,
+  SqlQueueThreadPromptWork,
+  SqlQueueWork,
+} from "./queue";
 export {
-  type SqlQueuePort,
-  type SqlQueueRunWork,
+  reconcileSqlQueuedRuns,
+  type SqlQueuedRunCandidate,
+  type SqlQueuedRunSource,
+  type SqlQueueReconciliationOptions,
+  type SqlQueueReconciliationResult,
+} from "./reconciliation";
+export {
   SqlQueueScheduler,
   type SqlQueueSchedulerOptions,
-  type SqlQueueThreadPromptWork,
-  type SqlQueueWork,
 } from "./scheduler";
 export { SqlHostStore, type SqlHostStorePort } from "./store";

--- a/packages/runtime/src/platform/sql-queue/index.ts
+++ b/packages/runtime/src/platform/sql-queue/index.ts
@@ -1,0 +1,16 @@
+// biome-ignore-all lint/performance/noBarrelFile: Public package subpath entrypoint required by package exports.
+
+export {
+  createSqlQueueHost,
+  type SqlQueueHost,
+  type SqlQueueHostOptions,
+} from "./host";
+export {
+  type SqlQueuePort,
+  type SqlQueueRunWork,
+  SqlQueueScheduler,
+  type SqlQueueSchedulerOptions,
+  type SqlQueueThreadPromptWork,
+  type SqlQueueWork,
+} from "./scheduler";
+export { SqlHostStore, type SqlHostStorePort } from "./store";

--- a/packages/runtime/src/platform/sql-queue/queue.ts
+++ b/packages/runtime/src/platform/sql-queue/queue.ts
@@ -59,6 +59,10 @@ export interface SqlQueueProducerPort {
  * successful reclaim. Expired leases become claimable again. `ack`, `nack`,
  * and `renewLease` must validate the claim fence. Renewal must fail for an
  * expired or replaced claim; nack retains the item for `retryAtMs`.
+ *
+ * These leases provide at-least-once delivery, not exclusive side-effect
+ * execution: an outage or renewal delay can expire a lease while its handler
+ * is still running, allowing a concurrent duplicate handler.
  */
 export interface SqlQueuePort extends SqlQueueProducerPort {
   ack(claim: SqlQueueClaim): Promise<void>;

--- a/packages/runtime/src/platform/sql-queue/queue.ts
+++ b/packages/runtime/src/platform/sql-queue/queue.ts
@@ -17,6 +17,7 @@ export interface SqlQueueThreadPromptWork {
 export type SqlQueueWork = SqlQueueRunWork | SqlQueueThreadPromptWork;
 
 export interface SqlQueueClaim {
+  /** 1-based number of times this work item has been successfully claimed. */
   readonly attempt: number;
   readonly claimId: string;
   readonly leaseUntilMs: number;
@@ -24,6 +25,8 @@ export interface SqlQueueClaim {
 }
 
 export interface SqlQueueClaimOptions {
+  /** Work IDs already handled by this drain pass and ineligible for reclaim. */
+  readonly excludeWorkIds?: readonly string[];
   readonly leaseMs: number;
   readonly nowMs: number;
 }
@@ -37,6 +40,11 @@ export interface SqlQueueNackOptions {
   readonly retryAtMs: number;
 }
 
+export interface SqlQueueRenewLeaseOptions {
+  readonly leaseUntilMs: number;
+  readonly nowMs: number;
+}
+
 /** Producer-only subset useful to reconciliation and scheduling helpers. */
 export interface SqlQueueProducerPort {
   /** Must durably insert idempotently by `work.workId`. */
@@ -47,12 +55,18 @@ export interface SqlQueueProducerPort {
  * Durable queue boundary for producers and workers.
  *
  * `claim` must atomically lease one due, unacked item and fence competing
- * workers with `claimId`. Expired leases become claimable again. `ack` and
- * `nack` must validate that fence; nack retains the item for `retryAtMs`.
+ * workers with `claimId`. `attempt` starts at 1 and increments on every
+ * successful reclaim. Expired leases become claimable again. `ack`, `nack`,
+ * and `renewLease` must validate the claim fence. Renewal must fail for an
+ * expired or replaced claim; nack retains the item for `retryAtMs`.
  */
 export interface SqlQueuePort extends SqlQueueProducerPort {
   ack(claim: SqlQueueClaim): Promise<void>;
   claim(options: SqlQueueClaimOptions): Promise<SqlQueueClaim | null>;
   list(options: SqlQueueListOptions): Promise<readonly SqlQueueWork[]>;
   nack(claim: SqlQueueClaim, options: SqlQueueNackOptions): Promise<void>;
+  renewLease(
+    claim: SqlQueueClaim,
+    options: SqlQueueRenewLeaseOptions
+  ): Promise<SqlQueueClaim>;
 }

--- a/packages/runtime/src/platform/sql-queue/queue.ts
+++ b/packages/runtime/src/platform/sql-queue/queue.ts
@@ -1,0 +1,58 @@
+import type { ScheduledThreadPrompt } from "../../execution/scheduled-work";
+
+export interface SqlQueueRunWork {
+  readonly dueAtMs: number;
+  readonly kind: "run";
+  readonly runId: string;
+  readonly workId: string;
+}
+
+export interface SqlQueueThreadPromptWork {
+  readonly dueAtMs: number;
+  readonly kind: "thread-prompt";
+  readonly prompt: ScheduledThreadPrompt;
+  readonly workId: string;
+}
+
+export type SqlQueueWork = SqlQueueRunWork | SqlQueueThreadPromptWork;
+
+export interface SqlQueueClaim {
+  readonly attempt: number;
+  readonly claimId: string;
+  readonly leaseUntilMs: number;
+  readonly work: SqlQueueWork;
+}
+
+export interface SqlQueueClaimOptions {
+  readonly leaseMs: number;
+  readonly nowMs: number;
+}
+
+export interface SqlQueueListOptions {
+  readonly limit?: number;
+  readonly nowMs: number;
+}
+
+export interface SqlQueueNackOptions {
+  readonly retryAtMs: number;
+}
+
+/** Producer-only subset useful to reconciliation and scheduling helpers. */
+export interface SqlQueueProducerPort {
+  /** Must durably insert idempotently by `work.workId`. */
+  enqueue(work: SqlQueueWork): Promise<void>;
+}
+
+/**
+ * Durable queue boundary for producers and workers.
+ *
+ * `claim` must atomically lease one due, unacked item and fence competing
+ * workers with `claimId`. Expired leases become claimable again. `ack` and
+ * `nack` must validate that fence; nack retains the item for `retryAtMs`.
+ */
+export interface SqlQueuePort extends SqlQueueProducerPort {
+  ack(claim: SqlQueueClaim): Promise<void>;
+  claim(options: SqlQueueClaimOptions): Promise<SqlQueueClaim | null>;
+  list(options: SqlQueueListOptions): Promise<readonly SqlQueueWork[]>;
+  nack(claim: SqlQueueClaim, options: SqlQueueNackOptions): Promise<void>;
+}

--- a/packages/runtime/src/platform/sql-queue/reconciliation.ts
+++ b/packages/runtime/src/platform/sql-queue/reconciliation.ts
@@ -1,0 +1,50 @@
+import type { SqlQueueProducerPort, SqlQueueRunWork } from "./queue";
+
+export interface SqlQueuedRunCandidate {
+  readonly dueAtMs?: number;
+  readonly runId: string;
+}
+
+/** Database query boundary for durable runs which should have queue work. */
+export interface SqlQueuedRunSource {
+  listQueuedRuns(): AsyncIterable<SqlQueuedRunCandidate>;
+}
+
+export interface SqlQueueReconciliationOptions {
+  readonly clock?: () => number;
+  readonly queue: SqlQueueProducerPort;
+  readonly runs: SqlQueuedRunSource;
+  readonly wake?: (dueAtMs: number) => Promise<void> | void;
+}
+
+export interface SqlQueueReconciliationResult {
+  readonly enqueued: number;
+}
+
+/**
+ * Idempotently recreates queue work for durable queued runs.
+ *
+ * Run this periodically to close the crash gap between a committed HostStore
+ * transaction and scheduling. The source should query all runnable queued
+ * turns; unique work IDs make replay safe even when work already exists.
+ */
+export async function reconcileSqlQueuedRuns({
+  clock = Date.now,
+  queue,
+  runs,
+  wake,
+}: SqlQueueReconciliationOptions): Promise<SqlQueueReconciliationResult> {
+  let enqueued = 0;
+  for await (const candidate of runs.listQueuedRuns()) {
+    const work: SqlQueueRunWork = {
+      dueAtMs: candidate.dueAtMs ?? clock(),
+      kind: "run",
+      runId: candidate.runId,
+      workId: `run:${candidate.runId}`,
+    };
+    await queue.enqueue(work);
+    await wake?.(work.dueAtMs);
+    enqueued += 1;
+  }
+  return { enqueued };
+}

--- a/packages/runtime/src/platform/sql-queue/reconciliation.ts
+++ b/packages/runtime/src/platform/sql-queue/reconciliation.ts
@@ -1,19 +1,17 @@
-import type { SqlQueueProducerPort, SqlQueueRunWork } from "./queue";
+import type { SqlQueueProducerPort, SqlQueueWork } from "./queue";
 
-export interface SqlQueuedRunCandidate {
-  readonly dueAtMs?: number;
-  readonly runId: string;
-}
-
-/** Database query boundary for durable runs which should have queue work. */
-export interface SqlQueuedRunSource {
-  listQueuedRuns(): AsyncIterable<SqlQueuedRunCandidate>;
+/**
+ * Database/outbox query boundary for exact durable work which should exist in
+ * the queue. Sources must preserve the original kind, payload, due time, and
+ * stable work ID; a run record alone is insufficient for thread prompts.
+ */
+export interface SqlQueuedWorkSource {
+  listQueuedWork(): AsyncIterable<SqlQueueWork>;
 }
 
 export interface SqlQueueReconciliationOptions {
-  readonly clock?: () => number;
   readonly queue: SqlQueueProducerPort;
-  readonly runs: SqlQueuedRunSource;
+  readonly source: SqlQueuedWorkSource;
   readonly wake?: (dueAtMs: number) => Promise<void> | void;
 }
 
@@ -22,26 +20,19 @@ export interface SqlQueueReconciliationResult {
 }
 
 /**
- * Idempotently recreates queue work for durable queued runs.
+ * Idempotently restores exact queue work from a durable source or outbox.
  *
  * Run this periodically to close the crash gap between a committed HostStore
- * transaction and scheduling. The source should query all runnable queued
- * turns; unique work IDs make replay safe even when work already exists.
+ * transaction and scheduling. Stable work IDs make replay safe when an item
+ * already exists or concurrent reconcilers race.
  */
-export async function reconcileSqlQueuedRuns({
-  clock = Date.now,
+export async function reconcileSqlQueuedWork({
   queue,
-  runs,
+  source,
   wake,
 }: SqlQueueReconciliationOptions): Promise<SqlQueueReconciliationResult> {
   let enqueued = 0;
-  for await (const candidate of runs.listQueuedRuns()) {
-    const work: SqlQueueRunWork = {
-      dueAtMs: candidate.dueAtMs ?? clock(),
-      kind: "run",
-      runId: candidate.runId,
-      workId: `run:${candidate.runId}`,
-    };
+  for await (const work of source.listQueuedWork()) {
     await queue.enqueue(work);
     await wake?.(work.dueAtMs);
     enqueued += 1;

--- a/packages/runtime/src/platform/sql-queue/scheduler.ts
+++ b/packages/runtime/src/platform/sql-queue/scheduler.ts
@@ -5,29 +5,7 @@ import {
   threadPromptScheduledWorkId,
 } from "../../execution/scheduled-work";
 
-export interface SqlQueueRunWork {
-  readonly dueAtMs: number;
-  readonly kind: "run";
-  readonly runId: string;
-  readonly workId: string;
-}
-
-export interface SqlQueueThreadPromptWork {
-  readonly dueAtMs: number;
-  readonly kind: "thread-prompt";
-  readonly prompt: ScheduledThreadPrompt;
-  readonly workId: string;
-}
-
-export type SqlQueueWork = SqlQueueRunWork | SqlQueueThreadPromptWork;
-
-/**
- * Durable queue boundary. `enqueue` must be idempotent by `work.workId`.
- * A PostgreSQL implementation can use `INSERT ... ON CONFLICT DO NOTHING`.
- */
-export interface SqlQueuePort {
-  enqueue(work: SqlQueueWork): Promise<void>;
-}
+import type { SqlQueuePort, SqlQueueWork } from "./queue";
 
 export interface SqlQueueSchedulerOptions {
   readonly clock?: () => number;

--- a/packages/runtime/src/platform/sql-queue/scheduler.ts
+++ b/packages/runtime/src/platform/sql-queue/scheduler.ts
@@ -1,0 +1,90 @@
+import type { ResumeThreadOptions } from "../../execution/host/scheduler-options";
+import type { HostScheduler } from "../../execution/host/types";
+import {
+  type ScheduledThreadPrompt,
+  threadPromptScheduledWorkId,
+} from "../../execution/scheduled-work";
+
+export interface SqlQueueRunWork {
+  readonly dueAtMs: number;
+  readonly kind: "run";
+  readonly runId: string;
+  readonly workId: string;
+}
+
+export interface SqlQueueThreadPromptWork {
+  readonly dueAtMs: number;
+  readonly kind: "thread-prompt";
+  readonly prompt: ScheduledThreadPrompt;
+  readonly workId: string;
+}
+
+export type SqlQueueWork = SqlQueueRunWork | SqlQueueThreadPromptWork;
+
+/**
+ * Durable queue boundary. `enqueue` must be idempotent by `work.workId`.
+ * A PostgreSQL implementation can use `INSERT ... ON CONFLICT DO NOTHING`.
+ */
+export interface SqlQueuePort {
+  enqueue(work: SqlQueueWork): Promise<void>;
+}
+
+export interface SqlQueueSchedulerOptions {
+  readonly clock?: () => number;
+  readonly queue: SqlQueuePort;
+  /**
+   * Signals a worker after durable enqueue. It may publish to a broker,
+   * `NOTIFY` PostgreSQL, or update a process timer. The queue remains the
+   * source of truth if this callback fails.
+   */
+  readonly wake?: (dueAtMs: number) => Promise<void> | void;
+}
+
+export class SqlQueueScheduler implements HostScheduler {
+  readonly #clock: () => number;
+  readonly #queue: SqlQueuePort;
+  readonly #wake: ((dueAtMs: number) => Promise<void> | void) | undefined;
+
+  constructor({ clock = Date.now, queue, wake }: SqlQueueSchedulerOptions) {
+    this.#clock = clock;
+    this.#queue = queue;
+    this.#wake = wake;
+  }
+
+  async enqueueRun(
+    runId: string,
+    options: { readonly runAfterMs?: number } = {}
+  ): Promise<void> {
+    const dueAtMs =
+      this.#clock() + Math.max(0, Math.floor(options.runAfterMs ?? 0));
+    await this.#persistAndWake({
+      dueAtMs,
+      kind: "run",
+      runId,
+      workId: `run:${runId}`,
+    });
+  }
+
+  async resumeThread(
+    threadKey: string,
+    options: ResumeThreadOptions
+  ): Promise<void> {
+    const prompt: ScheduledThreadPrompt = {
+      idempotencyKey: options.idempotencyKey,
+      notificationId: options.notificationId,
+      runId: options.runId,
+      threadKey,
+    };
+    await this.#persistAndWake({
+      dueAtMs: this.#clock(),
+      kind: "thread-prompt",
+      prompt,
+      workId: `thread-prompt:${threadPromptScheduledWorkId(prompt)}`,
+    });
+  }
+
+  async #persistAndWake(work: SqlQueueWork): Promise<void> {
+    await this.#queue.enqueue(work);
+    await this.#wake?.(work.dueAtMs);
+  }
+}

--- a/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
+++ b/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
@@ -12,6 +12,7 @@ import type {
   SqlQueueListOptions,
   SqlQueueNackOptions,
   SqlQueuePort,
+  SqlQueueRenewLeaseOptions,
   SqlQueueWork,
 } from "./queue";
 import { reconcileSqlQueuedWork } from "./reconciliation";
@@ -40,6 +41,7 @@ class ReferenceQueue implements SqlQueuePort {
       const lease = this.#leases.get(item.workId);
       return (
         item.dueAtMs <= options.nowMs &&
+        !options.excludeWorkIds?.includes(item.workId) &&
         (!lease || lease.leaseUntilMs <= options.nowMs)
       );
     });
@@ -84,6 +86,20 @@ class ReferenceQueue implements SqlQueuePort {
       dueAtMs: options.retryAtMs,
     });
     return Promise.resolve();
+  }
+
+  renewLease(
+    claim: SqlQueueClaim,
+    options: SqlQueueRenewLeaseOptions
+  ): Promise<SqlQueueClaim> {
+    this.#assertCurrentClaim(claim);
+    const current = this.#leases.get(claim.work.workId);
+    if (!(current && current.leaseUntilMs > options.nowMs)) {
+      return Promise.reject(new Error("queue lease expired"));
+    }
+    const renewed = { ...current, leaseUntilMs: options.leaseUntilMs };
+    this.#leases.set(claim.work.workId, renewed);
+    return Promise.resolve(structuredClone(renewed));
   }
 
   #assertCurrentClaim(claim: SqlQueueClaim): void {
@@ -154,6 +170,7 @@ describe("SQL queue wake behavior", () => {
       },
       list: () => Promise.resolve([]),
       nack: () => Promise.resolve(),
+      renewLease: (claim) => Promise.resolve(claim),
     };
     const host = createSqlQueueHost({
       clock: () => 1000,
@@ -261,6 +278,128 @@ describe("SQL queue consumer contract", () => {
       attempt: 2,
       work: { workId: "run:run-1" },
     });
+  });
+
+  it("renews a long handler lease before another worker can reclaim it", async () => {
+    const queue = new ReferenceQueue();
+    await queue.enqueue({
+      dueAtMs: 0,
+      kind: "run",
+      runId: "run-long",
+      workId: "run:run-long",
+    });
+    let nowMs = 0;
+
+    await drainSqlQueue({
+      clock: () => nowMs,
+      handle: async () => {
+        nowMs = 20;
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        await expect(
+          queue.claim({ leaseMs: 30, nowMs: 31 })
+        ).resolves.toBeNull();
+      },
+      heartbeatMs: 5,
+      leaseMs: 30,
+      queue,
+    });
+
+    expect(queue.work.size).toBe(0);
+  });
+
+  it("reports handler failures through onError after nacking", async () => {
+    const queue = new ReferenceQueue();
+    const error = new Error("handler failed");
+    const observed: unknown[] = [];
+    await queue.enqueue({
+      dueAtMs: 0,
+      kind: "run",
+      runId: "run-error",
+      workId: "run:run-error",
+    });
+
+    await drainSqlQueue({
+      clock: () => 0,
+      handle: () => Promise.reject(error),
+      onError: (context) => {
+        observed.push(context);
+      },
+      queue,
+    });
+
+    expect(observed).toEqual([
+      expect.objectContaining({
+        error,
+        work: expect.objectContaining({ workId: "run:run-error" }),
+      }),
+    ]);
+  });
+
+  it("surfaces uncertain ack errors without nacking", async () => {
+    const queue = new ReferenceQueue();
+    let nackCalls = 0;
+    await queue.enqueue({
+      dueAtMs: 0,
+      kind: "run",
+      runId: "run-ack",
+      workId: "run:run-ack",
+    });
+    const uncertainAckQueue: SqlQueuePort = {
+      ack: () => Promise.reject(new Error("ack result unknown")),
+      claim: queue.claim.bind(queue),
+      enqueue: queue.enqueue.bind(queue),
+      list: queue.list.bind(queue),
+      nack: (...args) => {
+        nackCalls += 1;
+        return queue.nack(...args);
+      },
+      renewLease: queue.renewLease.bind(queue),
+    };
+
+    await expect(
+      drainSqlQueue({
+        clock: () => 0,
+        handle: () => Promise.resolve(),
+        queue: uncertainAckQueue,
+      })
+    ).rejects.toThrow("ack result unknown");
+    expect(nackCalls).toBe(0);
+    expect(queue.work.has("run:run-ack")).toBe(true);
+  });
+
+  it("handles zero-delay poison work at most once per drain pass", async () => {
+    const queue = new ReferenceQueue();
+    await queue.enqueue({
+      dueAtMs: 0,
+      kind: "run",
+      runId: "poison",
+      workId: "run:poison",
+    });
+    await queue.enqueue({
+      dueAtMs: 0,
+      kind: "run",
+      runId: "healthy",
+      workId: "run:healthy",
+    });
+    const handled: string[] = [];
+
+    const result = await drainSqlQueue({
+      clock: () => 0,
+      handle: (work) => {
+        handled.push(work.workId);
+        return work.workId === "run:poison"
+          ? Promise.reject(new Error("poison"))
+          : Promise.resolve();
+      },
+      limit: 10,
+      queue,
+      retryDelayMs: 0,
+    });
+
+    expect(result).toEqual({ claimed: 2, failed: 1, succeeded: 1 });
+    expect(handled).toEqual(["run:poison", "run:healthy"]);
+    expect(queue.work.has("run:poison")).toBe(true);
+    expect(queue.work.has("run:healthy")).toBe(false);
   });
 
   it("makes unacked work claimable after its lease expires", async () => {

--- a/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
+++ b/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
@@ -4,23 +4,92 @@ import { describeExecutionStoreContract } from "../../contracts/execution-store/
 import type { ScheduledThreadPrompt } from "../../execution/scheduled-work";
 import { threadPromptScheduledWorkId } from "../../execution/scheduled-work";
 import { InMemoryExecutionStore } from "../memory/execution/store";
+import { drainSqlQueue } from "./drainer";
 import { createSqlQueueHost } from "./host";
-import type { SqlQueuePort, SqlQueueWork } from "./scheduler";
+import type {
+  SqlQueueClaim,
+  SqlQueueClaimOptions,
+  SqlQueueListOptions,
+  SqlQueueNackOptions,
+  SqlQueuePort,
+  SqlQueueWork,
+} from "./queue";
+import { reconcileSqlQueuedRuns } from "./reconciliation";
 import { SqlHostStore } from "./store";
 
 describeExecutionStoreContract({
   createStore: () => new SqlHostStore(new InMemoryExecutionStore()),
-  name: "SQL port reference",
+  name: "SQL port adapter (in-memory reference)",
 });
 
 class ReferenceQueue implements SqlQueuePort {
+  readonly #attempts = new Map<string, number>();
+  readonly #leases = new Map<string, SqlQueueClaim>();
+  #nextClaimId = 1;
   readonly work = new Map<string, SqlQueueWork>();
+
+  ack(claim: SqlQueueClaim): Promise<void> {
+    this.#assertCurrentClaim(claim);
+    this.#leases.delete(claim.work.workId);
+    this.work.delete(claim.work.workId);
+    return Promise.resolve();
+  }
+
+  claim(options: SqlQueueClaimOptions): Promise<SqlQueueClaim | null> {
+    const work = [...this.work.values()].find((item) => {
+      const lease = this.#leases.get(item.workId);
+      return (
+        item.dueAtMs <= options.nowMs &&
+        (!lease || lease.leaseUntilMs <= options.nowMs)
+      );
+    });
+    if (!work) {
+      return Promise.resolve(null);
+    }
+    const attempt = (this.#attempts.get(work.workId) ?? 0) + 1;
+    this.#attempts.set(work.workId, attempt);
+    const claim: SqlQueueClaim = {
+      attempt,
+      claimId: `claim-${this.#nextClaimId++}`,
+      leaseUntilMs: options.nowMs + options.leaseMs,
+      work: structuredClone(work),
+    };
+    this.#leases.set(work.workId, claim);
+    return Promise.resolve(claim);
+  }
 
   enqueue(item: SqlQueueWork): Promise<void> {
     if (!this.work.has(item.workId)) {
       this.work.set(item.workId, structuredClone(item));
     }
     return Promise.resolve();
+  }
+
+  list(options: SqlQueueListOptions): Promise<readonly SqlQueueWork[]> {
+    const due = [...this.work.values()].filter(
+      (item) => item.dueAtMs <= options.nowMs
+    );
+    return Promise.resolve(
+      due
+        .slice(0, options.limit ?? Number.POSITIVE_INFINITY)
+        .map((item) => structuredClone(item))
+    );
+  }
+
+  nack(claim: SqlQueueClaim, options: SqlQueueNackOptions): Promise<void> {
+    this.#assertCurrentClaim(claim);
+    this.#leases.delete(claim.work.workId);
+    this.work.set(claim.work.workId, {
+      ...claim.work,
+      dueAtMs: options.retryAtMs,
+    });
+    return Promise.resolve();
+  }
+
+  #assertCurrentClaim(claim: SqlQueueClaim): void {
+    if (this.#leases.get(claim.work.workId)?.claimId !== claim.claimId) {
+      throw new Error("stale queue claim");
+    }
   }
 }
 
@@ -77,10 +146,14 @@ describe("SQL queue wake behavior", () => {
   it("persists work before signaling wake", async () => {
     const calls: string[] = [];
     const queue: SqlQueuePort = {
+      ack: () => Promise.resolve(),
+      claim: () => Promise.resolve(null),
       enqueue: () => {
         calls.push("enqueue");
         return Promise.resolve();
       },
+      list: () => Promise.resolve([]),
+      nack: () => Promise.resolve(),
     };
     const host = createSqlQueueHost({
       clock: () => 1000,
@@ -113,5 +186,153 @@ describe("SQL queue wake behavior", () => {
       kind: "run",
       runId: "run-1",
     });
+  });
+});
+
+describe("SQL queue consumer contract", () => {
+  it("lists due work for inspection with a limit", async () => {
+    const queue = new ReferenceQueue();
+    await queue.enqueue({
+      dueAtMs: 100,
+      kind: "run",
+      runId: "run-1",
+      workId: "run:run-1",
+    });
+    await queue.enqueue({
+      dueAtMs: 200,
+      kind: "run",
+      runId: "run-2",
+      workId: "run:run-2",
+    });
+
+    await expect(queue.list({ limit: 1, nowMs: 150 })).resolves.toEqual([
+      expect.objectContaining({ workId: "run:run-1" }),
+    ]);
+    await expect(queue.list({ nowMs: 99 })).resolves.toEqual([]);
+  });
+
+  it("acks work only after its handler succeeds", async () => {
+    const queue = new ReferenceQueue();
+    await queue.enqueue({
+      dueAtMs: 100,
+      kind: "run",
+      runId: "run-1",
+      workId: "run:run-1",
+    });
+    const handled: string[] = [];
+
+    const result = await drainSqlQueue({
+      clock: () => 100,
+      handle: (work) => {
+        handled.push(work.workId);
+        return Promise.resolve();
+      },
+      queue,
+    });
+
+    expect(result).toEqual({ claimed: 1, failed: 0, succeeded: 1 });
+    expect(handled).toEqual(["run:run-1"]);
+    expect(queue.work.size).toBe(0);
+  });
+
+  it("nacks failed handlers for a later retry without losing work", async () => {
+    const queue = new ReferenceQueue();
+    await queue.enqueue({
+      dueAtMs: 100,
+      kind: "run",
+      runId: "run-1",
+      workId: "run:run-1",
+    });
+
+    const result = await drainSqlQueue({
+      clock: () => 100,
+      handle: () => Promise.reject(new Error("worker failed")),
+      queue,
+      retryDelayMs: 50,
+    });
+
+    expect(result).toEqual({ claimed: 1, failed: 1, succeeded: 0 });
+    await expect(
+      queue.claim({ leaseMs: 1000, nowMs: 149 })
+    ).resolves.toBeNull();
+    await expect(
+      queue.claim({ leaseMs: 1000, nowMs: 150 })
+    ).resolves.toMatchObject({
+      attempt: 2,
+      work: { workId: "run:run-1" },
+    });
+  });
+
+  it("makes unacked work claimable after its lease expires", async () => {
+    const queue = new ReferenceQueue();
+    await queue.enqueue({
+      dueAtMs: 0,
+      kind: "run",
+      runId: "run-1",
+      workId: "run:run-1",
+    });
+
+    await expect(
+      queue.claim({ leaseMs: 100, nowMs: 0 })
+    ).resolves.toMatchObject({
+      attempt: 1,
+    });
+    await expect(queue.claim({ leaseMs: 100, nowMs: 99 })).resolves.toBeNull();
+    await expect(
+      queue.claim({ leaseMs: 100, nowMs: 100 })
+    ).resolves.toMatchObject({
+      attempt: 2,
+    });
+  });
+});
+
+describe("SQL queue reconciliation", () => {
+  it("recreates queue work for a durable orphaned queued run", async () => {
+    const queue = new ReferenceQueue();
+    const runs = {
+      async *listQueuedRuns() {
+        await Promise.resolve();
+        yield { dueAtMs: 500, runId: "orphan-run" };
+      },
+    };
+
+    await expect(reconcileSqlQueuedRuns({ queue, runs })).resolves.toEqual({
+      enqueued: 1,
+    });
+    expect(queue.work.get("run:orphan-run")).toEqual({
+      dueAtMs: 500,
+      kind: "run",
+      runId: "orphan-run",
+      workId: "run:orphan-run",
+    });
+  });
+
+  it("can retry reconciliation after enqueue fails", async () => {
+    const durableQueue = new ReferenceQueue();
+    let shouldFail = true;
+    const queue = {
+      enqueue: async (work: SqlQueueWork) => {
+        if (shouldFail) {
+          shouldFail = false;
+          throw new Error("queue unavailable");
+        }
+        await durableQueue.enqueue(work);
+      },
+    };
+    const runs = {
+      async *listQueuedRuns() {
+        await Promise.resolve();
+        yield { runId: "run-1" };
+      },
+    };
+
+    await expect(
+      reconcileSqlQueuedRuns({ clock: () => 100, queue, runs })
+    ).rejects.toThrow("queue unavailable");
+    expect(durableQueue.work.size).toBe(0);
+    await expect(
+      reconcileSqlQueuedRuns({ clock: () => 100, queue, runs })
+    ).resolves.toEqual({ enqueued: 1 });
+    expect(durableQueue.work.has("run:run-1")).toBe(true);
   });
 });

--- a/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
+++ b/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { describeExecutionSchedulerContract } from "../../contracts/execution-scheduler/contract";
 import { describeExecutionStoreContract } from "../../contracts/execution-store/contract";
 import type { ScheduledThreadPrompt } from "../../execution/scheduled-work";
@@ -308,46 +308,53 @@ describe("SQL queue consumer contract", () => {
   });
 
   it("anchors heartbeat timing to the lease deadline after a delayed renewal", async () => {
-    const queue = new ReferenceQueue();
-    await queue.enqueue({
-      dueAtMs: 0,
-      kind: "run",
-      runId: "run-delayed-renewal",
-      workId: "run:run-delayed-renewal",
-    });
-    let renewalCalls = 0;
-    const delayedRenewalQueue: SqlQueuePort = {
-      ack: queue.ack.bind(queue),
-      claim: queue.claim.bind(queue),
-      enqueue: queue.enqueue.bind(queue),
-      list: queue.list.bind(queue),
-      nack: queue.nack.bind(queue),
-      renewLease: async (claim, options) => {
-        const renewed = await queue.renewLease(claim, options);
-        renewalCalls += 1;
-        if (renewalCalls === 1) {
-          // The database committed the renewal, but its response consumed most
-          // of that lease. A response-relative cadence would renew too late.
-          await new Promise((resolve) => setTimeout(resolve, 70));
-        }
-        return renewed;
-      },
-    };
+    vi.useFakeTimers({ now: 0 });
+    try {
+      const queue = new ReferenceQueue();
+      await queue.enqueue({
+        dueAtMs: 0,
+        kind: "run",
+        runId: "run-delayed-renewal",
+        workId: "run:run-delayed-renewal",
+      });
+      let renewalCalls = 0;
+      const delayedRenewalQueue: SqlQueuePort = {
+        ack: queue.ack.bind(queue),
+        claim: queue.claim.bind(queue),
+        enqueue: queue.enqueue.bind(queue),
+        list: queue.list.bind(queue),
+        nack: queue.nack.bind(queue),
+        renewLease: async (claim, options) => {
+          const renewed = await queue.renewLease(claim, options);
+          renewalCalls += 1;
+          if (renewalCalls === 1) {
+            // The database committed the renewal, but its response consumed
+            // most of that lease. Response-relative cadence renews too late.
+            await new Promise((resolve) => setTimeout(resolve, 70));
+          }
+          return renewed;
+        },
+      };
 
-    await drainSqlQueue({
-      handle: async () => {
-        await new Promise((resolve) => setTimeout(resolve, 160));
-        await expect(
-          queue.claim({ leaseMs: 100, nowMs: Date.now() })
-        ).resolves.toBeNull();
-      },
-      heartbeatMs: 50,
-      leaseMs: 100,
-      queue: delayedRenewalQueue,
-    });
+      const draining = drainSqlQueue({
+        handle: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 160));
+          await expect(
+            queue.claim({ leaseMs: 100, nowMs: Date.now() })
+          ).resolves.toBeNull();
+        },
+        heartbeatMs: 50,
+        leaseMs: 100,
+        queue: delayedRenewalQueue,
+      });
+      await vi.advanceTimersByTimeAsync(160);
+      await draining;
 
-    expect(renewalCalls).toBeGreaterThanOrEqual(2);
-    expect(queue.work.size).toBe(0);
+      expect(renewalCalls).toBeGreaterThanOrEqual(2);
+      expect(queue.work.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reports handler failures through onError after nacking", async () => {

--- a/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
+++ b/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
@@ -307,6 +307,49 @@ describe("SQL queue consumer contract", () => {
     expect(queue.work.size).toBe(0);
   });
 
+  it("anchors heartbeat timing to the lease deadline after a delayed renewal", async () => {
+    const queue = new ReferenceQueue();
+    await queue.enqueue({
+      dueAtMs: 0,
+      kind: "run",
+      runId: "run-delayed-renewal",
+      workId: "run:run-delayed-renewal",
+    });
+    let renewalCalls = 0;
+    const delayedRenewalQueue: SqlQueuePort = {
+      ack: queue.ack.bind(queue),
+      claim: queue.claim.bind(queue),
+      enqueue: queue.enqueue.bind(queue),
+      list: queue.list.bind(queue),
+      nack: queue.nack.bind(queue),
+      renewLease: async (claim, options) => {
+        const renewed = await queue.renewLease(claim, options);
+        renewalCalls += 1;
+        if (renewalCalls === 1) {
+          // The database committed the renewal, but its response consumed most
+          // of that lease. A response-relative cadence would renew too late.
+          await new Promise((resolve) => setTimeout(resolve, 70));
+        }
+        return renewed;
+      },
+    };
+
+    await drainSqlQueue({
+      handle: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 160));
+        await expect(
+          queue.claim({ leaseMs: 100, nowMs: Date.now() })
+        ).resolves.toBeNull();
+      },
+      heartbeatMs: 50,
+      leaseMs: 100,
+      queue: delayedRenewalQueue,
+    });
+
+    expect(renewalCalls).toBeGreaterThanOrEqual(2);
+    expect(queue.work.size).toBe(0);
+  });
+
   it("reports handler failures through onError after nacking", async () => {
     const queue = new ReferenceQueue();
     const error = new Error("handler failed");

--- a/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
+++ b/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
@@ -14,7 +14,7 @@ import type {
   SqlQueuePort,
   SqlQueueWork,
 } from "./queue";
-import { reconcileSqlQueuedRuns } from "./reconciliation";
+import { reconcileSqlQueuedWork } from "./reconciliation";
 import { SqlHostStore } from "./store";
 
 describeExecutionStoreContract({
@@ -287,24 +287,65 @@ describe("SQL queue consumer contract", () => {
 });
 
 describe("SQL queue reconciliation", () => {
-  it("recreates queue work for a durable orphaned queued run", async () => {
-    const queue = new ReferenceQueue();
-    const runs = {
-      async *listQueuedRuns() {
-        await Promise.resolve();
-        yield { dueAtMs: 500, runId: "orphan-run" };
-      },
-    };
+  const runWork: SqlQueueWork = {
+    dueAtMs: 500,
+    kind: "run",
+    runId: "orphan-run",
+    workId: "run:orphan-run",
+  };
+  const notificationPrompt: ScheduledThreadPrompt = {
+    idempotencyKey: "notify-idem",
+    notificationId: "notification-1",
+    runId: "notification-run",
+    threadKey: "thread-1",
+  };
+  const promptWork: SqlQueueWork = {
+    dueAtMs: 700,
+    kind: "thread-prompt",
+    prompt: notificationPrompt,
+    workId: `thread-prompt:${threadPromptScheduledWorkId(notificationPrompt)}`,
+  };
 
-    await expect(reconcileSqlQueuedRuns({ queue, runs })).resolves.toEqual({
-      enqueued: 1,
+  const sourceFor = (...items: readonly SqlQueueWork[]) => ({
+    async *listQueuedWork() {
+      await Promise.resolve();
+      yield* items;
+    },
+  });
+
+  it("recreates exact run work for a durable orphan", async () => {
+    const queue = new ReferenceQueue();
+
+    await expect(
+      reconcileSqlQueuedWork({ queue, source: sourceFor(runWork) })
+    ).resolves.toEqual({ enqueued: 1 });
+    expect(queue.work.get(runWork.workId)).toEqual(runWork);
+  });
+
+  it("recreates an exact missed thread prompt without converting it to run work", async () => {
+    const queue = new ReferenceQueue();
+
+    await reconcileSqlQueuedWork({
+      queue,
+      source: sourceFor(promptWork),
     });
-    expect(queue.work.get("run:orphan-run")).toEqual({
-      dueAtMs: 500,
-      kind: "run",
-      runId: "orphan-run",
-      workId: "run:orphan-run",
-    });
+
+    expect(queue.work.get(promptWork.workId)).toEqual(promptWork);
+    expect(queue.work.has("run:notification-run")).toBe(false);
+    expect(queue.work.size).toBe(1);
+  });
+
+  it("keeps an existing notification row singular across racing reconciliation", async () => {
+    const queue = new ReferenceQueue();
+    await queue.enqueue(promptWork);
+
+    await Promise.all([
+      reconcileSqlQueuedWork({ queue, source: sourceFor(promptWork) }),
+      reconcileSqlQueuedWork({ queue, source: sourceFor(promptWork) }),
+    ]);
+
+    expect([...queue.work.values()]).toEqual([promptWork]);
+    expect(queue.work.has("run:notification-run")).toBe(false);
   });
 
   it("can retry reconciliation after enqueue fails", async () => {
@@ -319,20 +360,14 @@ describe("SQL queue reconciliation", () => {
         await durableQueue.enqueue(work);
       },
     };
-    const runs = {
-      async *listQueuedRuns() {
-        await Promise.resolve();
-        yield { runId: "run-1" };
-      },
-    };
 
     await expect(
-      reconcileSqlQueuedRuns({ clock: () => 100, queue, runs })
+      reconcileSqlQueuedWork({ queue, source: sourceFor(runWork) })
     ).rejects.toThrow("queue unavailable");
     expect(durableQueue.work.size).toBe(0);
     await expect(
-      reconcileSqlQueuedRuns({ clock: () => 100, queue, runs })
+      reconcileSqlQueuedWork({ queue, source: sourceFor(runWork) })
     ).resolves.toEqual({ enqueued: 1 });
-    expect(durableQueue.work.has("run:run-1")).toBe(true);
+    expect(durableQueue.work.get(runWork.workId)).toEqual(runWork);
   });
 });

--- a/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
+++ b/packages/runtime/src/platform/sql-queue/sql-queue-contract.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { describeExecutionSchedulerContract } from "../../contracts/execution-scheduler/contract";
+import { describeExecutionStoreContract } from "../../contracts/execution-store/contract";
+import type { ScheduledThreadPrompt } from "../../execution/scheduled-work";
+import { threadPromptScheduledWorkId } from "../../execution/scheduled-work";
+import { InMemoryExecutionStore } from "../memory/execution/store";
+import { createSqlQueueHost } from "./host";
+import type { SqlQueuePort, SqlQueueWork } from "./scheduler";
+import { SqlHostStore } from "./store";
+
+describeExecutionStoreContract({
+  createStore: () => new SqlHostStore(new InMemoryExecutionStore()),
+  name: "SQL port reference",
+});
+
+class ReferenceQueue implements SqlQueuePort {
+  readonly work = new Map<string, SqlQueueWork>();
+
+  enqueue(item: SqlQueueWork): Promise<void> {
+    if (!this.work.has(item.workId)) {
+      this.work.set(item.workId, structuredClone(item));
+    }
+    return Promise.resolve();
+  }
+}
+
+describeExecutionSchedulerContract({
+  createHarness: () => {
+    const queue = new ReferenceQueue();
+    const scheduler = createSqlQueueHost({
+      queue,
+      store: new InMemoryExecutionStore(),
+    }).scheduler;
+    return {
+      ackRun: (runId: string) => {
+        queue.work.delete(`run:${runId}`);
+        return Promise.resolve();
+      },
+      ackThreadPrompt: (prompt: ScheduledThreadPrompt) => {
+        queue.work.delete(
+          `thread-prompt:${threadPromptScheduledWorkId(prompt)}`
+        );
+        return Promise.resolve();
+      },
+      listRuns: (options: { limit?: number; nowMs?: number } = {}) =>
+        Promise.resolve(
+          [...queue.work.values()]
+            .filter(
+              (item) =>
+                item.kind === "run" &&
+                item.dueAtMs <= (options.nowMs ?? Date.now())
+            )
+            .slice(0, options.limit ?? Number.POSITIVE_INFINITY)
+            .map((item) => (item.kind === "run" ? item.runId : ""))
+        ),
+      listThreadPrompts: (options: { limit?: number; nowMs?: number } = {}) =>
+        Promise.resolve(
+          [...queue.work.values()]
+            .filter(
+              (item) =>
+                item.kind === "thread-prompt" &&
+                item.dueAtMs <= (options.nowMs ?? Date.now())
+            )
+            .slice(0, options.limit ?? Number.POSITIVE_INFINITY)
+            .flatMap((item) =>
+              item.kind === "thread-prompt" ? [item.prompt] : []
+            )
+        ),
+      scheduler,
+    };
+  },
+  name: "SQL queue reference",
+  supportsDueTimeFiltering: true,
+});
+
+describe("SQL queue wake behavior", () => {
+  it("persists work before signaling wake", async () => {
+    const calls: string[] = [];
+    const queue: SqlQueuePort = {
+      enqueue: () => {
+        calls.push("enqueue");
+        return Promise.resolve();
+      },
+    };
+    const host = createSqlQueueHost({
+      clock: () => 1000,
+      queue,
+      store: new InMemoryExecutionStore(),
+      wake: (dueAtMs) => {
+        calls.push(`wake:${dueAtMs}`);
+      },
+    });
+
+    await host.scheduler.enqueueRun("run-1", { runAfterMs: 250 });
+
+    expect(calls).toEqual(["enqueue", "wake:1250"]);
+  });
+
+  it("leaves durably enqueued work available when wake fails", async () => {
+    const queue = new ReferenceQueue();
+    const host = createSqlQueueHost({
+      queue,
+      store: new InMemoryExecutionStore(),
+      wake: () => {
+        throw new Error("broker unavailable");
+      },
+    });
+
+    await expect(host.scheduler.enqueueRun("run-1")).rejects.toThrow(
+      "broker unavailable"
+    );
+    expect(queue.work.get("run:run-1")).toMatchObject({
+      kind: "run",
+      runId: "run-1",
+    });
+  });
+});

--- a/packages/runtime/src/platform/sql-queue/store.ts
+++ b/packages/runtime/src/platform/sql-queue/store.ts
@@ -1,0 +1,73 @@
+import type {
+  CheckpointStore,
+  EventStore,
+  HostStore,
+  HostStoreTransaction,
+  NotificationInbox,
+  ThreadEventLog,
+  ThreadInputInbox,
+  TurnStore,
+} from "../../execution/host/types";
+import type { ThreadStore } from "../../thread/store/types";
+
+/**
+ * Database boundary for the SQL/queue host.
+ *
+ * Implementations normally bind these ports to a connection pool and pass a
+ * transaction-scoped set of ports to `transaction`. The callback must commit
+ * atomically on success and roll back on rejection.
+ */
+export interface SqlHostStorePort {
+  readonly checkpoints: CheckpointStore;
+  deleteThread?(threadKey: string): Promise<void>;
+  readonly events: EventStore;
+  readonly inputs: ThreadInputInbox;
+  readonly notifications: NotificationInbox;
+  readonly threadEvents?: ThreadEventLog;
+  readonly threads: ThreadStore;
+  transaction<T>(fn: (tx: HostStoreTransaction) => Promise<T>): Promise<T>;
+  readonly turns: TurnStore;
+}
+
+/** Adapts a database implementation to the runtime's stable HostStore API. */
+export class SqlHostStore implements HostStore {
+  readonly #port: SqlHostStorePort;
+  readonly deleteThread: HostStore["deleteThread"];
+
+  constructor(port: SqlHostStorePort) {
+    this.#port = port;
+    this.deleteThread = port.deleteThread?.bind(port);
+  }
+
+  get checkpoints(): CheckpointStore {
+    return this.#port.checkpoints;
+  }
+
+  get events(): EventStore {
+    return this.#port.events;
+  }
+
+  get inputs(): ThreadInputInbox {
+    return this.#port.inputs;
+  }
+
+  get notifications(): NotificationInbox {
+    return this.#port.notifications;
+  }
+
+  get threadEvents(): ThreadEventLog | undefined {
+    return this.#port.threadEvents;
+  }
+
+  get threads(): ThreadStore {
+    return this.#port.threads;
+  }
+
+  get turns(): TurnStore {
+    return this.#port.turns;
+  }
+
+  transaction<T>(fn: (tx: HostStoreTransaction) => Promise<T>): Promise<T> {
+    return this.#port.transaction(fn);
+  }
+}

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     "src/platform/cloudflare/image-codecs-edge.ts",
     "src/platform/file/index.ts",
     "src/platform/memory/index.ts",
+    "src/platform/sql-queue/index.ts",
     "src/execution/index.ts",
     "src/namespace.ts",
     "src/evals/index.ts",


### PR DESCRIPTION
## Summary
- add a platform-neutral `platform/sql-queue` host adapter around an injected transactional SQL store port
- add a complete durable queue port: idempotent enqueue, bounded list, fenced leased claim/renewal, success ack, and retry nack
- add `drainSqlQueue` with absolute-deadline heartbeat renewal, success-only ack, handler error observation, poison-work pass isolation, and lease-expiry recovery
- add exact-work `reconcileSqlQueuedWork` to repair the store-commit → enqueue crash gap without changing run vs thread-prompt shape
- document PostgreSQL/outbox reconciliation and at-least-once/concurrent-side-effect limitations

## Tests
- `pnpm --filter @minpeter/pss-runtime exec vitest run src/platform/sql-queue/sql-queue-contract.test.ts src/contracts/package-subpaths.test.ts` (51 passed, 1 skipped conditional scheduler case)
- repeated SQL queue contract run for timing stability
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm --filter @minpeter/pss-runtime build`

## Scope
This intentionally provides clean production integration ports rather than selecting a PostgreSQL driver, migration framework, pool, or broker. Shared HostStore/HostScheduler tests delegate through `InMemoryExecutionStore`; queue consumer and exact-work reconciliation behavior use a fenced leased-map reference queue. These validate adapter and queue semantics, not live PostgreSQL SQL correctness, which remains application-owned. Delivery is at least once: renewal outages or excessive latency can permit concurrent duplicate handlers, so side effects must be idempotent.
