### PR TITLE
feat(coding-agent): add lazy provider registry

### DIFF
--- a/.tegami/2026-08-06-provider-registry.md
+++ b/.tegami/2026-08-06-provider-registry.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+Add lazy Anthropic, OpenAI, and OpenAI-compatible provider descriptors with API-key selection for headless and library use while preserving legacy AI environment behavior.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -590,9 +590,41 @@ a run is active, submitting text calls `thread.steer(trimmed)` so the text lands
 in the current turn and renders as dim `runtime: ...` input instead of a new human
 turn.
 
+## Model providers
+
+`pss exec` and the provider library select an AI SDK adapter from API keys:
+
+| Provider | Selection | Optional model override | Default model |
+| --- | --- | --- | --- |
+| Anthropic | `ANTHROPIC_API_KEY` | `ANTHROPIC_MODEL` | `claude-sonnet-4-6` |
+| OpenAI | `OPENAI_API_KEY` | `OPENAI_MODEL` | `gpt-5.4` |
+| OpenAI-compatible | `AI_API_KEY` and optional `AI_BASE_URL` | `AI_MODEL` | existing gateway default |
+
+Existing `AI_*` configurations take priority and are unchanged. Set
+`AI_PROVIDER=anthropic|openai|openai-compatible` to choose explicitly; with an
+explicit provider, `AI_API_KEY` can be used as the credential and `AI_MODEL`
+as the model override. With no key or endpoint, the existing keyless OpenCode
+Zen free tier remains the fallback. Provider adapters are dynamically imported,
+so unused official SDKs do not load at startup. The interactive TUI currently
+retains its OpenAI-compatible session catalog and switching behavior; official
+provider auto-selection applies to `pss exec` and the library API.
+
+```ts
+import {
+  createProviderModelFromEnv,
+  PROVIDER_DESCRIPTORS,
+} from "@minpeter/pss-coding-agent/providers";
+
+console.table(PROVIDER_DESCRIPTORS);
+const model = await createProviderModelFromEnv();
+```
+
+OAuth is not part of this API-key-based provider slice.
+
 ## Env
 
-Set `AI_API_KEY`, `AI_BASE_URL`, and `AI_MODEL` for the model.
+Set one of the provider API keys above, or use the legacy `AI_API_KEY`,
+`AI_BASE_URL`, and `AI_MODEL` variables.
 
 The TUI persists runtime-owned thread state to files by default:
 

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -59,6 +59,11 @@
       "@minpeter/pss-source": "./src/extensions/index.ts",
       "types": "./dist/extensions/index.d.ts",
       "import": "./dist/extensions/index.js"
+    },
+    "./providers": {
+      "@minpeter/pss-source": "./src/provider-registry.ts",
+      "types": "./dist/provider-registry.d.ts",
+      "import": "./dist/provider-registry.js"
     }
   },
   "bin": {
@@ -90,6 +95,8 @@
     "preview:assistant": "tsx --conditions=@minpeter/pss-source scripts/preview-assistant-render.ts"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "4.0.32",
+    "@ai-sdk/openai": "4.0.31",
     "@ai-sdk/openai-compatible": "3.0.20",
     "@earendil-works/pi-tui": "^0.83.0",
     "@fontsource-variable/noto-sans": "5.3.0",

--- a/apps/coding-agent/src/exec-cli.ts
+++ b/apps/coding-agent/src/exec-cli.ts
@@ -10,11 +10,11 @@ import {
   resolveCliExtensionTargets,
 } from "./extensions/manager/cli-extensions";
 import { loadConfiguredCodingAgentExtensions } from "./extensions/manager/loader";
-import { createOpenAICompatibleModelFromEnv } from "./model";
 import {
   createProviderObservationFetch,
   type ProviderObservationEmitter,
 } from "./provider-observation";
+import { createProviderModelFromEnv } from "./provider-registry";
 import type { WebToolsAvailability } from "./tools";
 
 interface ExecArguments {
@@ -245,7 +245,7 @@ export async function runExecCli({
     },
     extensions,
     home,
-    model: createOpenAICompatibleModelFromEnv({
+    model: await createProviderModelFromEnv({
       fetch: createProviderObservationFetch(providerEmitter),
       runtimeEnv,
     }),

--- a/apps/coding-agent/src/provider-registry.test.ts
+++ b/apps/coding-agent/src/provider-registry.test.ts
@@ -85,6 +85,23 @@ describe("provider registry", () => {
     expect(compatibleFactory).not.toHaveBeenCalled();
   });
 
+  it("ignores a stale generic model during automatic native selection", async () => {
+    const { createProviderModelFromEnv, resolveProviderSelection } =
+      await import("./provider-registry");
+    const runtimeEnv = {
+      AI_MODEL: "minimax/MiniMax-M3",
+      ANTHROPIC_API_KEY: "anthropic-key",
+    };
+
+    expect(resolveProviderSelection(runtimeEnv)).toMatchObject({
+      descriptor: { id: "anthropic" },
+      modelId: "claude-sonnet-4-6",
+    });
+    await createProviderModelFromEnv({ runtimeEnv });
+
+    expect(anthropicProvider).toHaveBeenCalledWith("claude-sonnet-4-6");
+  });
+
   it("detects OpenAI and supports an injected fetch", async () => {
     const { createProviderModelFromEnv } = await import("./provider-registry");
     const fetch = vi.fn<typeof globalThis.fetch>();
@@ -118,8 +135,18 @@ describe("provider registry", () => {
     );
   });
 
-  it("keeps the keyless compatible free tier as the empty-env fallback", async () => {
-    const { createProviderModelFromEnv } = await import("./provider-registry");
+  it("keeps compatible selection and creation aligned on the free tier", async () => {
+    const { createProviderModelFromEnv, resolveProviderSelection } =
+      await import("./provider-registry");
+    const selection = resolveProviderSelection({});
+
+    expect(selection).toMatchObject({
+      descriptor: {
+        defaultModelId: "mimo-v2.5-free",
+        id: "openai-compatible",
+      },
+      modelId: "mimo-v2.5-free",
+    });
     await createProviderModelFromEnv({ runtimeEnv: {} });
     expect(compatibleFactory).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -128,6 +155,6 @@ describe("provider registry", () => {
         name: "opencode-zen",
       })
     );
-    expect(compatibleProvider).toHaveBeenCalledWith("mimo-v2.5-free");
+    expect(compatibleProvider).toHaveBeenCalledWith(selection.modelId);
   });
 });

--- a/apps/coding-agent/src/provider-registry.test.ts
+++ b/apps/coding-agent/src/provider-registry.test.ts
@@ -1,0 +1,133 @@
+import type { LanguageModel } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  anthropicFactory,
+  anthropicProvider,
+  compatibleFactory,
+  compatibleProvider,
+  openaiFactory,
+  openaiProvider,
+} = vi.hoisted(() => ({
+  anthropicFactory: vi.fn(),
+  anthropicProvider: vi.fn(),
+  compatibleFactory: vi.fn(),
+  compatibleProvider: vi.fn(),
+  openaiFactory: vi.fn(),
+  openaiProvider: vi.fn(),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic: anthropicFactory }));
+vi.mock("@ai-sdk/openai", () => ({ createOpenAI: openaiFactory }));
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: compatibleFactory,
+}));
+
+describe("provider registry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    anthropicFactory.mockReturnValue(anthropicProvider);
+    openaiFactory.mockReturnValue(openaiProvider);
+    compatibleFactory.mockReturnValue(compatibleProvider);
+    for (const provider of [
+      anthropicProvider,
+      openaiProvider,
+      compatibleProvider,
+    ]) {
+      provider.mockReturnValue({
+        provider: "test",
+      } as unknown as LanguageModel);
+    }
+  });
+
+  it("preserves legacy AI_* selection ahead of provider-native keys", async () => {
+    const { createProviderModelFromEnv, resolveProviderSelection } =
+      await import("./provider-registry");
+    const runtimeEnv = {
+      AI_API_KEY: "legacy-key",
+      AI_BASE_URL: "https://gateway.test/v1",
+      AI_MODEL: "legacy-model",
+      ANTHROPIC_API_KEY: "anthropic-key",
+    };
+
+    expect(resolveProviderSelection(runtimeEnv).descriptor.id).toBe(
+      "openai-compatible"
+    );
+    await createProviderModelFromEnv({ runtimeEnv });
+
+    expect(compatibleFactory).toHaveBeenCalledWith({
+      apiKey: "legacy-key",
+      baseURL: "https://gateway.test/v1",
+      includeUsage: true,
+      name: "custom",
+    });
+    expect(compatibleProvider).toHaveBeenCalledWith("legacy-model");
+    expect(anthropicFactory).not.toHaveBeenCalled();
+  });
+
+  it("detects Anthropic from its native API key and lazily creates its model", async () => {
+    const { createProviderModelFromEnv, resolveProviderSelection } =
+      await import("./provider-registry");
+    const runtimeEnv = {
+      ANTHROPIC_API_KEY: "anthropic-key",
+      ANTHROPIC_MODEL: "claude-custom",
+    };
+
+    expect(resolveProviderSelection(runtimeEnv)).toMatchObject({
+      descriptor: { id: "anthropic" },
+      modelId: "claude-custom",
+    });
+    await createProviderModelFromEnv({ runtimeEnv });
+
+    expect(anthropicFactory).toHaveBeenCalledWith({ apiKey: "anthropic-key" });
+    expect(anthropicProvider).toHaveBeenCalledWith("claude-custom");
+    expect(openaiFactory).not.toHaveBeenCalled();
+    expect(compatibleFactory).not.toHaveBeenCalled();
+  });
+
+  it("detects OpenAI and supports an injected fetch", async () => {
+    const { createProviderModelFromEnv } = await import("./provider-registry");
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    await createProviderModelFromEnv({
+      fetch,
+      runtimeEnv: { OPENAI_API_KEY: "openai-key", OPENAI_MODEL: "gpt-custom" },
+    });
+
+    expect(openaiFactory).toHaveBeenCalledWith({ apiKey: "openai-key", fetch });
+    expect(openaiProvider).toHaveBeenCalledWith("gpt-custom");
+  });
+
+  it("allows explicit selection with the universal AI_API_KEY", async () => {
+    const { createProviderModelFromEnv } = await import("./provider-registry");
+    await createProviderModelFromEnv({
+      runtimeEnv: {
+        AI_API_KEY: "universal-key",
+        AI_PROVIDER: "openai",
+        AI_MODEL: "gpt-explicit",
+      },
+    });
+
+    expect(openaiFactory).toHaveBeenCalledWith({ apiKey: "universal-key" });
+    expect(openaiProvider).toHaveBeenCalledWith("gpt-explicit");
+  });
+
+  it("rejects unknown explicit providers with the available ids", async () => {
+    const { resolveProviderSelection } = await import("./provider-registry");
+    expect(() => resolveProviderSelection({ AI_PROVIDER: "mystery" })).toThrow(
+      "Expected one of: anthropic, openai, openai-compatible"
+    );
+  });
+
+  it("keeps the keyless compatible free tier as the empty-env fallback", async () => {
+    const { createProviderModelFromEnv } = await import("./provider-registry");
+    await createProviderModelFromEnv({ runtimeEnv: {} });
+    expect(compatibleFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "public",
+        baseURL: "https://opencode.ai/zen/v1",
+        name: "opencode-zen",
+      })
+    );
+    expect(compatibleProvider).toHaveBeenCalledWith("mimo-v2.5-free");
+  });
+});

--- a/apps/coding-agent/src/provider-registry.ts
+++ b/apps/coding-agent/src/provider-registry.ts
@@ -1,0 +1,162 @@
+import type { LanguageModel } from "ai";
+import {
+  type CodingAgentRuntimeEnv,
+  DEFAULT_OPENAI_COMPATIBLE_MODEL_ID,
+  readOpenAICompatibleModelEnv,
+} from "./env";
+
+export type BuiltInProviderId = "anthropic" | "openai" | "openai-compatible";
+
+export interface ProviderDescriptor {
+  /** Provider-native API-key variable, in selection priority order. */
+  readonly apiKeyEnv: string;
+  readonly defaultModelId: string;
+  /** Stable value accepted by `AI_PROVIDER`. */
+  readonly id: BuiltInProviderId;
+  readonly label: string;
+  readonly modelEnv: string;
+}
+
+export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] =
+  Object.freeze([
+    Object.freeze({
+      apiKeyEnv: "ANTHROPIC_API_KEY",
+      defaultModelId: "claude-sonnet-4-6",
+      id: "anthropic",
+      label: "Anthropic",
+      modelEnv: "ANTHROPIC_MODEL",
+    }),
+    Object.freeze({
+      apiKeyEnv: "OPENAI_API_KEY",
+      defaultModelId: "gpt-5.4",
+      id: "openai",
+      label: "OpenAI",
+      modelEnv: "OPENAI_MODEL",
+    }),
+    Object.freeze({
+      apiKeyEnv: "AI_API_KEY",
+      defaultModelId: DEFAULT_OPENAI_COMPATIBLE_MODEL_ID,
+      id: "openai-compatible",
+      label: "OpenAI-compatible",
+      modelEnv: "AI_MODEL",
+    }),
+  ]);
+
+export interface ResolvedProviderSelection {
+  readonly descriptor: ProviderDescriptor;
+  readonly modelId: string;
+}
+
+export interface CreateProviderModelFromEnvOptions {
+  readonly fetch?: typeof globalThis.fetch;
+  readonly runtimeEnv?: CodingAgentRuntimeEnv;
+}
+
+const descriptorById = new Map(
+  PROVIDER_DESCRIPTORS.map((descriptor) => [descriptor.id, descriptor])
+);
+
+const nonBlank = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed === undefined || trimmed.length === 0 ? undefined : trimmed;
+};
+
+function explicitProvider(
+  runtimeEnv: CodingAgentRuntimeEnv
+): ProviderDescriptor | undefined {
+  const id = nonBlank(runtimeEnv.AI_PROVIDER);
+  if (id === undefined) {
+    return;
+  }
+  const descriptor = descriptorById.get(id as BuiltInProviderId);
+  if (descriptor === undefined) {
+    throw new Error(
+      `Unknown AI_PROVIDER ${JSON.stringify(id)}. Expected one of: ${PROVIDER_DESCRIPTORS.map(({ id: providerId }) => providerId).join(", ")}.`
+    );
+  }
+  return descriptor;
+}
+
+/**
+ * Select a built-in provider without importing any adapter. Existing
+ * `AI_API_KEY`/`AI_BASE_URL` setups always retain OpenAI-compatible behavior;
+ * otherwise provider-native keys are detected in descriptor order.
+ */
+export function resolveProviderSelection(
+  runtimeEnv: CodingAgentRuntimeEnv = process.env
+): ResolvedProviderSelection {
+  const explicit = explicitProvider(runtimeEnv);
+  let descriptor = explicit;
+  if (descriptor === undefined) {
+    if (
+      nonBlank(runtimeEnv.AI_API_KEY) !== undefined ||
+      nonBlank(runtimeEnv.AI_BASE_URL) !== undefined
+    ) {
+      descriptor = descriptorById.get("openai-compatible");
+    } else {
+      descriptor = PROVIDER_DESCRIPTORS.find(
+        ({ apiKeyEnv }) => nonBlank(runtimeEnv[apiKeyEnv]) !== undefined
+      );
+    }
+  }
+  descriptor ??= descriptorById.get("openai-compatible");
+  if (descriptor === undefined) {
+    throw new Error("The OpenAI-compatible provider descriptor is missing.");
+  }
+  const modelId =
+    nonBlank(runtimeEnv[descriptor.modelEnv]) ??
+    nonBlank(runtimeEnv.AI_MODEL) ??
+    descriptor.defaultModelId;
+  return { descriptor, modelId };
+}
+
+function requiredApiKey(
+  descriptor: ProviderDescriptor,
+  runtimeEnv: CodingAgentRuntimeEnv
+): string {
+  // AI_API_KEY remains a universal explicit credential when AI_PROVIDER is
+  // set, while native variables enable zero-configuration provider detection.
+  const key =
+    nonBlank(runtimeEnv[descriptor.apiKeyEnv]) ??
+    nonBlank(runtimeEnv.AI_API_KEY);
+  if (key === undefined) {
+    throw new Error(
+      `${descriptor.label} requires ${descriptor.apiKeyEnv} (or AI_API_KEY with AI_PROVIDER=${descriptor.id}).`
+    );
+  }
+  return key;
+}
+
+/** Create the selected model, dynamically importing only its adapter. */
+export async function createProviderModelFromEnv({
+  fetch,
+  runtimeEnv = process.env,
+}: CreateProviderModelFromEnvOptions = {}): Promise<LanguageModel> {
+  const { descriptor, modelId } = resolveProviderSelection(runtimeEnv);
+  if (descriptor.id === "openai-compatible") {
+    const env = readOpenAICompatibleModelEnv({ runtimeEnv });
+    const { createOpenAICompatible } = await import(
+      "@ai-sdk/openai-compatible"
+    );
+    return createOpenAICompatible({
+      apiKey: env.AI_API_KEY,
+      baseURL: env.AI_BASE_URL,
+      includeUsage: true,
+      name: env.isFreeTier ? "opencode-zen" : "custom",
+      ...(fetch === undefined ? {} : { fetch }),
+    })(env.AI_MODEL);
+  }
+  const apiKey = requiredApiKey(descriptor, runtimeEnv);
+  if (descriptor.id === "anthropic") {
+    const { createAnthropic } = await import("@ai-sdk/anthropic");
+    return createAnthropic({
+      apiKey,
+      ...(fetch === undefined ? {} : { fetch }),
+    })(modelId);
+  }
+  const { createOpenAI } = await import("@ai-sdk/openai");
+  return createOpenAI({
+    apiKey,
+    ...(fetch === undefined ? {} : { fetch }),
+  })(modelId);
+}

--- a/apps/coding-agent/src/provider-registry.ts
+++ b/apps/coding-agent/src/provider-registry.ts
@@ -1,7 +1,7 @@
 import type { LanguageModel } from "ai";
 import {
   type CodingAgentRuntimeEnv,
-  DEFAULT_OPENAI_COMPATIBLE_MODEL_ID,
+  FREE_TIER_DEFAULT_MODEL_ID,
   readOpenAICompatibleModelEnv,
 } from "./env";
 
@@ -35,7 +35,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] =
     }),
     Object.freeze({
       apiKeyEnv: "AI_API_KEY",
-      defaultModelId: DEFAULT_OPENAI_COMPATIBLE_MODEL_ID,
+      defaultModelId: FREE_TIER_DEFAULT_MODEL_ID,
       id: "openai-compatible",
       label: "OpenAI-compatible",
       modelEnv: "AI_MODEL",
@@ -103,9 +103,15 @@ export function resolveProviderSelection(
   if (descriptor === undefined) {
     throw new Error("The OpenAI-compatible provider descriptor is missing.");
   }
+  if (descriptor.id === "openai-compatible") {
+    return {
+      descriptor,
+      modelId: readOpenAICompatibleModelEnv({ runtimeEnv }).AI_MODEL,
+    };
+  }
   const modelId =
     nonBlank(runtimeEnv[descriptor.modelEnv]) ??
-    nonBlank(runtimeEnv.AI_MODEL) ??
+    (explicit === undefined ? undefined : nonBlank(runtimeEnv.AI_MODEL)) ??
     descriptor.defaultModelId;
   return { descriptor, modelId };
 }
@@ -144,7 +150,7 @@ export async function createProviderModelFromEnv({
       includeUsage: true,
       name: env.isFreeTier ? "opencode-zen" : "custom",
       ...(fetch === undefined ? {} : { fetch }),
-    })(env.AI_MODEL);
+    })(modelId);
   }
   const apiKey = requiredApiKey(descriptor, runtimeEnv);
   if (descriptor.id === "anthropic") {

--- a/apps/coding-agent/tsdown.config.ts
+++ b/apps/coding-agent/tsdown.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     "src/extensions/index.ts",
     "src/instructions.ts",
     "src/model.ts",
+    "src/provider-registry.ts",
     "src/thread-config.ts",
     "src/thread-inspect.ts",
     "src/tools.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,12 @@ importers:
 
   apps/coding-agent:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 4.0.32
+        version: 4.0.32(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: 4.0.31
+        version: 4.0.31(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: 3.0.20
         version: 3.0.20(zod@4.4.3)
@@ -631,6 +637,12 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/anthropic@4.0.32':
+    resolution: {integrity: sha512-uEUIL71aGteKFQewN0Tkx6o5dxc7pSA+vcW23oOQOxvmUT1BPNo+S7V+kC/gn0B/2awwVTg/1lz+aMHJBY1gtQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@2.0.124':
     resolution: {integrity: sha512-qrzQl7/Extk7GRPNYqOq7l/3RkO04pNW2t8Jx3Z6uNctxW/xV26mJ6LxbxAy/daqY7QGMaY/SThpH17GoqFByw==}
     engines: {node: '>=18'}
@@ -645,6 +657,12 @@ packages:
 
   '@ai-sdk/openai-compatible@3.0.20':
     resolution: {integrity: sha512-RsPg+HilsKc/d+jy4zItG7v7RJQm+caUu+iU0a5bx3eyyX5tkayMGDRklXMMMAPa4l34luzQwT3t4cmeHfdiWw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.31':
+    resolution: {integrity: sha512-7oL7cqfbqvb1FiXrcbPblxI1d1mA159I0a+zbSSkUJEIq4fsg/McU7tQE0l2iJfg1oO1Y9QznJm6HYTJRrAvOA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -669,6 +687,12 @@ packages:
 
   '@ai-sdk/provider-utils@5.0.20':
     resolution: {integrity: sha512-9W8c2mXiGgbo9sBBT4ybEWF8znxla2CO8VTim8t5oCCLP4aDH4o6RvkHfwL/iLC6mEbO4a6LpS2FBbQHccU+ig==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.22':
+    resolution: {integrity: sha512-1wEGi9RDCYdNtkSNybUR2BG2UC1tJ3M9do8DNMdc1EtNcHBEgvD8rz6CTfsMIzVGQRFhTv2/m2yKPpxhvbX1zA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4893,6 +4917,12 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/anthropic@4.0.32(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.5
+      '@ai-sdk/provider-utils': 5.0.22(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@2.0.124(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
@@ -4911,6 +4941,12 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 4.0.4
       '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@4.0.31(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.5
+      '@ai-sdk/provider-utils': 5.0.22(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
@@ -4938,6 +4974,15 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.20(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.5
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.22(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.5
       '@standard-schema/spec': 1.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,5 +30,7 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/gateway@4.0.22 || 4.0.40'
   - '@ai-sdk/openai-compatible@3.0.11'
   - ai@7.0.30 || 7.0.51
-  - '@ai-sdk/provider-utils@5.0.20'
+  - '@ai-sdk/provider-utils@5.0.20 || 5.0.22'
   - '@ai-sdk/provider@4.0.5'
+  - '@ai-sdk/anthropic@4.0.32'
+  - '@ai-sdk/openai@4.0.31'


### PR DESCRIPTION
## Summary
- add immutable descriptors and deterministic API-key selection for Anthropic, OpenAI, and OpenAI-compatible AI SDK providers
- dynamically import adapters and wire provider selection into `pss exec`, while preserving legacy `AI_*` configuration and the keyless free-tier fallback
- publish the provider API at `@minpeter/pss-coding-agent/providers` and document configuration, defaults, and current TUI scope

## Tests
- `pnpm --filter @minpeter/pss-coding-agent typecheck`
- `pnpm --filter @minpeter/pss-coding-agent test` (112 files, 772 tests)
- `pnpm --filter @minpeter/pss-coding-agent build`
- `pnpm exec ultracite check apps/coding-agent/src/provider-registry.ts apps/coding-agent/src/provider-registry.test.ts apps/coding-agent/src/exec-cli.ts apps/coding-agent/package.json apps/coding-agent/tsdown.config.ts`

## Scope
OAuth is intentionally out of scope. Official-provider auto-selection is enabled for headless `pss exec` and library use; the interactive TUI retains its existing OpenAI-compatible catalog/session switching until a provider-neutral catalog UX is designed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lazy provider registry that auto-selects Anthropic, OpenAI, or OpenAI-compatible from env and loads only the needed adapter. Updates `pss exec` to use it, keeps legacy `AI_*` behavior, supports explicit `AI_PROVIDER`, and publishes `@minpeter/pss-coding-agent/providers`.

- **New Features**
  - Immutable descriptors for `anthropic`, `openai`, and `openai-compatible` with default models and optional overrides; supports injected fetch.
  - Deterministic selection via `AI_PROVIDER` and native keys (explicit provider can use `AI_API_KEY`/`AI_MODEL`); dynamic import used by `pss exec`; README documents keys and usage.

- **Bug Fixes**
  - Ignore generic `AI_MODEL` during automatic native selection; prefer provider-specific model or default; reject unknown `AI_PROVIDER` with valid ids.
  - Align OpenCode Zen free-tier selection and creation (`mimo-v2.5-free`).

<sup>Written for commit 59570e9670ff6e495e9b30fce871ecf28010f706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

