### PR TITLE
fix(runtime): harden notification dispatch retries

### DIFF
--- a/.tegami/2026-08-06-notification-dispatch-retries.md
+++ b/.tegami/2026-08-06-notification-dispatch-retries.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+Prevent idempotent notification retries from rescheduling terminal runs and fail safely when deduplicated notification records are missing or inconsistent.

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -104,19 +104,9 @@ describe("dispatchAgentNotification", () => {
   });
 
   it("reschedules an active run on an idempotent retry", async () => {
-    const baseHost = createInMemoryHost();
-    let resumeCalls = 0;
-    const host = {
-      ...baseHost,
-      scheduler: {
-        enqueueRun: (runId, options) =>
-          baseHost.scheduler.enqueueRun(runId, options),
-        resumeThread: async (threadKey, options) => {
-          resumeCalls += 1;
-          await baseHost.scheduler.resumeThread(threadKey, options);
-        },
-      },
-    } satisfies AgentHost;
+    const { host, resumeCallCount } = hostWithResumeCounter(
+      createInMemoryHost()
+    );
     const input = {
       host,
       idempotencyKey: "reminder:retry",
@@ -129,25 +119,15 @@ describe("dispatchAgentNotification", () => {
     const retry = await dispatchAgentNotification(input);
 
     expect(retry).toEqual({ ...first, deduplicated: true });
-    expect(resumeCalls).toBe(2);
+    expect(resumeCallCount()).toBe(2);
   });
 
   it.each(["cancelled", "completed", "error", "needs-recovery"] as const)(
     "returns a deduplicated result without rescheduling a %s run",
     async (status) => {
-      const baseHost = createInMemoryHost();
-      let resumeCalls = 0;
-      const host = {
-        ...baseHost,
-        scheduler: {
-          enqueueRun: (runId, options) =>
-            baseHost.scheduler.enqueueRun(runId, options),
-          resumeThread: async (threadKey, options) => {
-            resumeCalls += 1;
-            await baseHost.scheduler.resumeThread(threadKey, options);
-          },
-        },
-      } satisfies AgentHost;
+      const { host, resumeCallCount } = hostWithResumeCounter(
+        createInMemoryHost()
+      );
       const input = {
         host,
         idempotencyKey: `reminder:terminal:${status}`,
@@ -165,7 +145,7 @@ describe("dispatchAgentNotification", () => {
       const retry = await dispatchAgentNotification(input);
 
       expect(retry).toEqual({ ...first, deduplicated: true });
-      expect(resumeCalls).toBe(1);
+      expect(resumeCallCount()).toBe(1);
     }
   );
 
@@ -390,6 +370,27 @@ describe("dispatchAgentNotification", () => {
     await expect(attachmentStore.get(deletedRef)).resolves.toBeNull();
   });
 });
+
+function hostWithResumeCounter(baseHost: AgentHost): {
+  readonly host: AgentHost;
+  readonly resumeCallCount: () => number;
+} {
+  let resumeCalls = 0;
+  return {
+    host: {
+      ...baseHost,
+      scheduler: {
+        enqueueRun: (runId, options) =>
+          baseHost.scheduler.enqueueRun(runId, options),
+        resumeThread: async (threadKey, options) => {
+          resumeCalls += 1;
+          await baseHost.scheduler.resumeThread(threadKey, options);
+        },
+      },
+    },
+    resumeCallCount: () => resumeCalls,
+  };
+}
 
 function hostWithNotificationLookup(
   host: AgentHost,

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -7,8 +7,18 @@ import {
   isRuntimeAttachmentData,
   type RuntimeAttachmentReference,
 } from "../../thread/input/attachments";
-import type { AgentHost, TurnRecord, TurnStore } from "../host/types";
+import type {
+  AgentHost,
+  NotificationInbox,
+  NotificationRecord,
+  TurnRecord,
+  TurnStore,
+} from "../host/types";
 import { dispatchAgentNotification } from "./notification-dispatch";
+
+const MISSING_NOTIFICATION_RECORD_PATTERN = /has no notification record/;
+const CORRUPT_NOTIFICATION_RECORD_PATTERN =
+  /does not match the deduplicated run/;
 
 describe("dispatchAgentNotification", () => {
   it("creates and schedules an idempotent notification run", async () => {
@@ -92,6 +102,146 @@ describe("dispatchAgentNotification", () => {
       threadKey: "room:1:user:2",
     });
   });
+
+  it("reschedules an active run on an idempotent retry", async () => {
+    const baseHost = createInMemoryHost();
+    let resumeCalls = 0;
+    const host = {
+      ...baseHost,
+      scheduler: {
+        enqueueRun: (runId, options) =>
+          baseHost.scheduler.enqueueRun(runId, options),
+        resumeThread: async (threadKey, options) => {
+          resumeCalls += 1;
+          await baseHost.scheduler.resumeThread(threadKey, options);
+        },
+      },
+    } satisfies AgentHost;
+    const input = {
+      host,
+      idempotencyKey: "reminder:retry",
+      input: { text: "Reminder fired", type: "user-input" } as const,
+      namespace: "agent-a",
+      threadKey: "room:1:user:2",
+    };
+
+    const first = await dispatchAgentNotification(input);
+    const retry = await dispatchAgentNotification(input);
+
+    expect(retry).toEqual({ ...first, deduplicated: true });
+    expect(resumeCalls).toBe(2);
+  });
+
+  it.each(["cancelled", "completed", "error"] as const)(
+    "returns a deduplicated result without rescheduling a %s run",
+    async (status) => {
+      const baseHost = createInMemoryHost();
+      let resumeCalls = 0;
+      const host = {
+        ...baseHost,
+        scheduler: {
+          enqueueRun: (runId, options) =>
+            baseHost.scheduler.enqueueRun(runId, options),
+          resumeThread: async (threadKey, options) => {
+            resumeCalls += 1;
+            await baseHost.scheduler.resumeThread(threadKey, options);
+          },
+        },
+      } satisfies AgentHost;
+      const input = {
+        host,
+        idempotencyKey: `reminder:terminal:${status}`,
+        input: { text: "Reminder fired", type: "user-input" } as const,
+        namespace: "agent-a",
+        threadKey: "room:1:user:2",
+      };
+      const first = await dispatchAgentNotification(input);
+      const run = await host.store.turns.get(first.runId);
+      if (!run) {
+        throw new Error("expected notification run");
+      }
+      await host.store.turns.update({ ...run, status });
+
+      const retry = await dispatchAgentNotification(input);
+
+      expect(retry).toEqual({ ...first, deduplicated: true });
+      expect(resumeCalls).toBe(1);
+    }
+  );
+
+  it("rejects a deduplicated run with a missing notification record", async () => {
+    const baseHost = createInMemoryHost();
+    const input = {
+      host: baseHost,
+      idempotencyKey: "reminder:missing-record",
+      input: { text: "Reminder fired", type: "user-input" } as const,
+      namespace: "agent-a",
+      threadKey: "room:1:user:2",
+    };
+    await dispatchAgentNotification(input);
+    const host = hostWithNotificationLookup(baseHost, () => null);
+
+    await expect(dispatchAgentNotification({ ...input, host })).rejects.toThrow(
+      MISSING_NOTIFICATION_RECORD_PATTERN
+    );
+  });
+
+  it.each([
+    [
+      "run id",
+      (record: NotificationRecord) => ({ ...record, runId: "wrong-run" }),
+    ],
+    [
+      "idempotency key",
+      (record: NotificationRecord) => ({
+        ...record,
+        idempotencyKey: "wrong-key",
+      }),
+    ],
+    [
+      "owner namespace",
+      (record: NotificationRecord) => ({
+        ...record,
+        ownerNamespace: agentNamespace("agent-b"),
+      }),
+    ],
+    [
+      "thread key",
+      (record: NotificationRecord) => ({
+        ...record,
+        threadKey: "wrong-thread",
+      }),
+    ],
+    [
+      "notification id",
+      (record: NotificationRecord) => ({ ...record, notificationId: "" }),
+    ],
+  ] as const)(
+    "rejects a notification record with a corrupt %s",
+    async (_field, corrupt) => {
+      const baseHost = createInMemoryHost();
+      const input = {
+        host: baseHost,
+        idempotencyKey: `reminder:corrupt:${_field}`,
+        input: { text: "Reminder fired", type: "user-input" } as const,
+        namespace: "agent-a",
+        threadKey: "room:1:user:2",
+      };
+      const first = await dispatchAgentNotification(input);
+      const run = await baseHost.store.turns.get(first.runId);
+      const record = await baseHost.store.notifications.getByIdempotencyKey(
+        run?.dedupeKey ?? ""
+      );
+      if (!record) {
+        throw new Error("expected notification record");
+      }
+      const host = hostWithNotificationLookup(baseHost, () => corrupt(record));
+
+      await expect(
+        dispatchAgentNotification({ ...input, host })
+      ).rejects.toThrow(CORRUPT_NOTIFICATION_RECORD_PATTERN);
+    }
+  );
 
   it("stages notification file bytes before durable enqueue", async () => {
     const host = createInMemoryHost();
@@ -240,6 +390,37 @@ describe("dispatchAgentNotification", () => {
     await expect(attachmentStore.get(deletedRef)).resolves.toBeNull();
   });
 });
+
+function hostWithNotificationLookup(
+  host: AgentHost,
+  lookup: (idempotencyKey: string) => NotificationRecord | null
+): AgentHost {
+  const notifications = {
+    claimByIdempotencyKey: (idempotencyKey) =>
+      host.store.notifications.claimByIdempotencyKey(idempotencyKey),
+    enqueue: (record) => host.store.notifications.enqueue(record),
+    getByIdempotencyKey: async (idempotencyKey) => lookup(idempotencyKey),
+    releaseByIdempotencyKey: (idempotencyKey) =>
+      host.store.notifications.releaseByIdempotencyKey(idempotencyKey),
+  } satisfies NotificationInbox;
+
+  return {
+    ...host,
+    store: {
+      ...host.store,
+      notifications,
+      transaction: (callback) =>
+        callback({
+          checkpoints: host.store.checkpoints,
+          events: host.store.events,
+          inputs: host.store.inputs,
+          notifications,
+          threads: host.store.threads,
+          turns: host.store.turns,
+        }),
+    },
+  };
+}
 
 function trackingAttachmentStore(
   store: HostAttachmentStore | undefined,

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.test.ts
@@ -132,7 +132,7 @@ describe("dispatchAgentNotification", () => {
     expect(resumeCalls).toBe(2);
   });
 
-  it.each(["cancelled", "completed", "error"] as const)(
+  it.each(["cancelled", "completed", "error", "needs-recovery"] as const)(
     "returns a deduplicated result without rescheduling a %s run",
     async (status) => {
       const baseHost = createInMemoryHost();

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.ts
@@ -239,7 +239,12 @@ function scheduleAgentNotification(
 }
 
 function isTerminalTurnStatus(status: TurnRecord["status"]): boolean {
-  return status === "cancelled" || status === "completed" || status === "error";
+  return (
+    status === "cancelled" ||
+    status === "completed" ||
+    status === "error" ||
+    status === "needs-recovery"
+  );
 }
 
 function dispatchedAgentNotification(

--- a/packages/runtime/src/execution/dispatch/notification-dispatch.ts
+++ b/packages/runtime/src/execution/dispatch/notification-dispatch.ts
@@ -26,6 +26,7 @@ export interface DispatchedAgentNotification {
 }
 
 interface SchedulableAgentNotification extends DispatchedAgentNotification {
+  readonly shouldSchedule: boolean;
   readonly storageIdempotencyKey: string;
   readonly threadKey: string;
 }
@@ -134,6 +135,7 @@ export async function dispatchAgentNotification(
       idempotencyKey: input.idempotencyKey,
       notificationId,
       runId,
+      shouldSchedule: true,
       threadKey: input.threadKey,
       storageIdempotencyKey,
     } satisfies SchedulableAgentNotification;
@@ -193,11 +195,29 @@ async function queuedNotificationRun({
 
   const existingNotification =
     await host.store.notifications.getByIdempotencyKey(storageIdempotencyKey);
+  if (!existingNotification) {
+    throw new Error(
+      `Notification dispatch integrity error: run ${existingRun.runId} has no notification record.`
+    );
+  }
+  if (
+    existingNotification.idempotencyKey !== storageIdempotencyKey ||
+    existingNotification.runId !== existingRun.runId ||
+    existingNotification.ownerNamespace !== ownerNamespace ||
+    existingNotification.threadKey !== threadKey ||
+    !existingNotification.notificationId
+  ) {
+    throw new Error(
+      `Notification dispatch integrity error: notification record for run ${existingRun.runId} does not match the deduplicated run.`
+    );
+  }
+
   return {
     deduplicated: true,
     idempotencyKey,
-    notificationId: existingNotification?.notificationId ?? existingRun.runId,
+    notificationId: existingNotification.notificationId,
     runId: existingRun.runId,
+    shouldSchedule: !isTerminalTurnStatus(existingRun.status),
     threadKey: existingRun.threadKey,
     storageIdempotencyKey,
   };
@@ -207,11 +227,19 @@ function scheduleAgentNotification(
   host: AgentHost,
   notification: SchedulableAgentNotification
 ): Promise<void> {
+  if (!notification.shouldSchedule) {
+    return Promise.resolve();
+  }
+
   return host.scheduler.resumeThread(notification.threadKey, {
     idempotencyKey: notification.storageIdempotencyKey,
     notificationId: notification.notificationId,
     runId: notification.runId,
   });
+}
+
+function isTerminalTurnStatus(status: TurnRecord["status"]): boolean {
+  return status === "cancelled" || status === "completed" || status === "error";
 }
 
 function dispatchedAgentNotification(


### PR DESCRIPTION
## Summary
- keep idempotent retries useful for active notification runs while avoiding new scheduling work for cancelled, completed, or errored runs
- validate the durable notification record before returning a deduplicated result instead of synthesizing an unsafe notification ID for missing or inconsistent data
- cover active retry, all terminal outcomes, missing records, and corrupt record associations; add the runtime patch Tegami entry

## Tests
- `pnpm --filter @minpeter/pss-runtime test` (142 files, 866 passed, 3 skipped)
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm exec ultracite check packages/runtime/src/execution/dispatch/notification-dispatch.ts packages/runtime/src/execution/dispatch/notification-dispatch.test.ts .tegami/2026-08-06-notification-dispatch-retries.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened notification dispatch retries in `@minpeter/pss-runtime` to stop unsafe rescheduling and validate deduplicated runs against stored records. Retries now only resume active runs; terminal runs return a deduplicated result without scheduling.

- **Bug Fixes**
  - Never reschedule cancelled, completed, errored, or needs-recovery runs.
  - Validate the durable notification record (runId, idempotencyKey, owner namespace, thread key, notificationId); require the stored notificationId and throw on mismatch or missing data. Tests add a shared resume counter and notification lookup helpers; Tegami patch entry added.

<sup>Written for commit 3997c91d29733364006758b5f8dd74d028c0dbac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

