### PR TITLE
Consolidate extension authoring API

### DIFF
--- a/.tegami/2026-08-06-extension-authoring-api.md
+++ b/.tegami/2026-08-06-extension-authoring-api.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+Make the extension factory API canonical, add typed event maps and explicit renderer modes, and preserve the deprecated registry API through a legacy subpath.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -76,6 +76,7 @@ runtime hooks, activation cleanup, and durable thread migrations:
 ```ts
 import {
   command,
+  defineCodingAgentExtension,
   instructions,
   modelProvider,
   threadMigration,
@@ -84,7 +85,7 @@ import {
   type ExtensionAPI,
 } from "@minpeter/pss-coding-agent/extension";
 
-export default function workspacePolicy(pss: ExtensionAPI) {
+export default defineCodingAgentExtension(function workspacePolicy(pss: ExtensionAPI) {
   pss.provide(
     instructions("Keep all file operations in the workspace."),
   );
@@ -140,7 +141,7 @@ export default function workspacePolicy(pss: ExtensionAPI) {
       await child.dispose();
     };
   });
-}
+});
 ```
 
 The factory object deliberately remains only `pss.on`, `pss.use`, and
@@ -165,7 +166,12 @@ cannot register arbitrary raw TUI components or persisted message/entry
 renderers because those have no extension-owned runtime domain.
 
 Extensions configure sequentially, use stable IDs, and cannot register new
-contributions after the factory resolves. Activation callbacks run after agent
+contributions after the factory resolves. The old registry-object shape remains
+supported for compatibility, but is deprecated and documented separately at
+`@minpeter/pss-coding-agent/extension/legacy`; new extensions should use the
+factory API above. Foreign capability-shaped objects remain runtime-compatible,
+while the TypeScript API brands every value returned by a capability factory.
+ Activation callbacks run after agent
 creation; cleanups run in reverse order. `pss.use()` composes control-flow
 hooks, `pss.on()` observes runtime and activation events, and overloaded
 `pss.provide()` accepts branded instruction, tool, command, migration, model
@@ -269,8 +275,10 @@ const unsubscribe = services.events.on("checkpoint:saved", (payload) => {
 services.events.emit("checkpoint:saved", { revision: 7 });
 ```
 
-Payloads are JSON values cloned per delivery, handlers run under the host
-timeout/abort boundary, and failures are attributed to the subscribing
+Event payloads can be shared across packages with declaration merging of
+`CodingAgentExtensionEventMap`; `emit` and `on` then infer the payload from the
+event name. Payloads are JSON values cloned per delivery, handlers run under the
+host timeout/abort boundary, and failures are attributed to the subscribing
 extension without affecting the publisher. The `host:` and `provider:`
 namespaces are reserved for host-originated events; extensions can subscribe
 to them but cannot publish into them.
@@ -395,9 +403,10 @@ bottom. This uses the same extension registration, conflict attribution, and
 
 Bundled LaTeX and Mermaid register as fallback assistant renderers; later
 registrations delegate unhandled Markdown to earlier ones. A third-party
-renderer can join the chain with `{ fallback: true }` or replace it entirely
-by explicitly registering with `{ override: true }`; a bare second exclusive
-renderer remains a source-attributed configuration error. Renderer contexts
+renderer can join the chain with `{ mode: "fallback" }` or replace it entirely
+with `{ mode: "override" }`; the default `"exclusive"` mode remains a
+source-attributed conflict when another renderer is already registered. The
+older boolean options remain accepted for compatibility. Renderer contexts
 receive an `AbortSignal`, session-scoped `notifyOnce`, a redraw callback, and
 a `delegate` that renders unhandled text through the next inner renderer.
 Optional view disposal runs when the transcript is cleared or the TUI stops.

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -69,7 +69,6 @@
       "@minpeter/pss-source": "./src/extensions/legacy.ts",
       "types": "./dist/extensions/legacy.d.ts",
       "import": "./dist/extensions/legacy.js"
-
     }
   },
   "bin": {

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -64,6 +64,12 @@
       "@minpeter/pss-source": "./src/provider-registry.ts",
       "types": "./dist/provider-registry.d.ts",
       "import": "./dist/provider-registry.js"
+    },
+    "./extension/legacy": {
+      "@minpeter/pss-source": "./src/extensions/legacy.ts",
+      "types": "./dist/extensions/legacy.d.ts",
+      "import": "./dist/extensions/legacy.js"
+
     }
   },
   "bin": {

--- a/apps/coding-agent/src/extensions/assistant-renderer-mode.ts
+++ b/apps/coding-agent/src/extensions/assistant-renderer-mode.ts
@@ -1,0 +1,56 @@
+import type {
+  AssistantRendererMode,
+  AssistantRendererRegistrationOptions,
+} from "../tui/assistant-renderer";
+
+const ASSISTANT_RENDERER_MODES = new Set<AssistantRendererMode>([
+  "exclusive",
+  "fallback",
+  "override",
+]);
+
+/** Parse both canonical renderer modes and deprecated boolean options. */
+export function parseAssistantRendererMode(
+  options: AssistantRendererRegistrationOptions
+): AssistantRendererMode {
+  if (
+    typeof options !== "object" ||
+    options === null ||
+    Array.isArray(options)
+  ) {
+    throw new TypeError("Assistant renderer options must be an object");
+  }
+  const hasMode = Object.hasOwn(options, "mode");
+  const hasFallback = Object.hasOwn(options, "fallback");
+  const hasOverride = Object.hasOwn(options, "override");
+  if (hasMode && (hasFallback || hasOverride)) {
+    throw new TypeError(
+      "Assistant renderer mode cannot be combined with legacy fallback or override options"
+    );
+  }
+  if (hasFallback && hasOverride) {
+    throw new TypeError(
+      "Assistant renderer fallback and override options cannot be combined"
+    );
+  }
+  if (hasMode) {
+    const mode: unknown = Reflect.get(options, "mode");
+    if (!ASSISTANT_RENDERER_MODES.has(mode as AssistantRendererMode)) {
+      throw new TypeError(`Invalid assistant renderer mode "${String(mode)}"`);
+    }
+    return mode as AssistantRendererMode;
+  }
+  if (hasFallback) {
+    if (Reflect.get(options, "fallback") !== true) {
+      throw new TypeError("Assistant renderer fallback option must be true");
+    }
+    return "fallback";
+  }
+  if (hasOverride) {
+    if (Reflect.get(options, "override") !== true) {
+      throw new TypeError("Assistant renderer override option must be true");
+    }
+    return "override";
+  }
+  return "exclusive";
+}

--- a/apps/coding-agent/src/extensions/assistant-renderer-mode.ts
+++ b/apps/coding-agent/src/extensions/assistant-renderer-mode.ts
@@ -20,9 +20,16 @@ export function parseAssistantRendererMode(
   ) {
     throw new TypeError("Assistant renderer options must be an object");
   }
-  const hasMode = Object.hasOwn(options, "mode");
-  const hasFallback = Object.hasOwn(options, "fallback");
-  const hasOverride = Object.hasOwn(options, "override");
+  assertSupportedOptionKeys(options);
+  const modeValue: unknown = Reflect.get(options, "mode");
+  const fallbackValue: unknown = Reflect.get(options, "fallback");
+  const overrideValue: unknown = Reflect.get(options, "override");
+  // Optional properties emitted as `undefined` are semantically absent.
+  const hasMode = Object.hasOwn(options, "mode") && modeValue !== undefined;
+  const hasFallback =
+    Object.hasOwn(options, "fallback") && fallbackValue !== undefined;
+  const hasOverride =
+    Object.hasOwn(options, "override") && overrideValue !== undefined;
   if (hasMode && (hasFallback || hasOverride)) {
     throw new TypeError(
       "Assistant renderer mode cannot be combined with legacy fallback or override options"
@@ -34,23 +41,34 @@ export function parseAssistantRendererMode(
     );
   }
   if (hasMode) {
-    const mode: unknown = Reflect.get(options, "mode");
-    if (!ASSISTANT_RENDERER_MODES.has(mode as AssistantRendererMode)) {
-      throw new TypeError(`Invalid assistant renderer mode "${String(mode)}"`);
+    if (!ASSISTANT_RENDERER_MODES.has(modeValue as AssistantRendererMode)) {
+      throw new TypeError(
+        `Invalid assistant renderer mode "${String(modeValue)}"`
+      );
     }
-    return mode as AssistantRendererMode;
+    return modeValue as AssistantRendererMode;
   }
   if (hasFallback) {
-    if (Reflect.get(options, "fallback") !== true) {
+    if (fallbackValue !== true) {
       throw new TypeError("Assistant renderer fallback option must be true");
     }
     return "fallback";
   }
   if (hasOverride) {
-    if (Reflect.get(options, "override") !== true) {
+    if (overrideValue !== true) {
       throw new TypeError("Assistant renderer override option must be true");
     }
     return "override";
   }
   return "exclusive";
+}
+
+function assertSupportedOptionKeys(options: object): void {
+  for (const key of Reflect.ownKeys(options)) {
+    if (key !== "mode" && key !== "fallback" && key !== "override") {
+      throw new TypeError(
+        `Unsupported assistant renderer option "${String(key)}"`
+      );
+    }
+  }
 }

--- a/apps/coding-agent/src/extensions/capabilities.ts
+++ b/apps/coding-agent/src/extensions/capabilities.ts
@@ -3,6 +3,7 @@ import type { ToolSet } from "ai";
 import type { CodingAgentSessionGuard } from "../sessions/session-guards";
 import type {
   AssistantRenderer,
+  AssistantRendererMode,
   AssistantRendererRegistrationOptions,
 } from "../tui/assistant-renderer";
 import type { TuiCommand } from "../tui/command";
@@ -21,6 +22,7 @@ interface Capability<Kind extends string> {
 export interface AssistantRendererCapability
   extends Capability<"assistant-renderer"> {
   readonly fallback: boolean;
+  readonly mode: AssistantRendererMode;
   readonly override: boolean;
   readonly renderer: AssistantRenderer;
 }
@@ -77,82 +79,87 @@ export function assistantRenderer(
   renderer: AssistantRenderer,
   options: AssistantRendererRegistrationOptions = {}
 ): AssistantRendererCapability {
-  return Object.freeze({
-    [extensionCapabilityBrand]: true as const,
-    fallback: options.fallback === true,
+  const mode = resolveAssistantRendererMode(options);
+  return capability({
+    fallback: mode === "fallback",
     kind: "assistant-renderer",
-    override: options.override === true,
+    mode,
+    override: mode === "override",
     renderer,
   });
 }
 
 export function instructions(...fragments: string[]): InstructionsCapability {
-  return Object.freeze({
-    [extensionCapabilityBrand]: true as const,
+  return capability({
     fragments: Object.freeze([...fragments]),
     kind: "instructions",
   });
 }
 
 export function tools(definitions: ToolSet): ToolsCapability {
-  return Object.freeze({
-    kind: "tools",
-    tools: definitions,
-  }) as ToolsCapability;
+  return capability({ kind: "tools", tools: definitions });
 }
 
 export function command(definition: TuiCommand): CommandCapability {
-  return Object.freeze({
-    command: definition,
-    kind: "command",
-  }) as CommandCapability;
+  return capability({ command: definition, kind: "command" });
 }
 
 export function modelProvider(
   provider: CodingAgentExtensionModelProvider
 ): ModelProviderCapability {
-  return Object.freeze({
-    kind: "model-provider",
-    provider,
-  }) as ModelProviderCapability;
+  return capability({ kind: "model-provider", provider });
 }
 
 export function sessionGuard(
   guard: CodingAgentSessionGuard
 ): SessionGuardCapability {
-  return Object.freeze({
-    guard,
-    kind: "session-guard",
-  }) as SessionGuardCapability;
+  return capability({ guard, kind: "session-guard" });
 }
 
 export function resources(options: {
   readonly prompts?: readonly string[];
   readonly skills?: readonly string[];
 }): ResourcesCapability {
-  return Object.freeze({
+  return capability({
     kind: "resources",
     prompts: Object.freeze([...(options.prompts ?? [])]),
     skills: Object.freeze([...(options.skills ?? [])]),
-  }) as ResourcesCapability;
+  });
 }
 
 export function threadMigration(
   migration: ThreadStateMigration
 ): ThreadMigrationCapability {
-  return Object.freeze({
-    kind: "thread-migration",
-    migration,
-  }) as ThreadMigrationCapability;
+  return capability({ kind: "thread-migration", migration });
 }
 
 export function toolRenderer(
   toolName: string,
   renderer: ToolRendererMap[string]
 ): ToolRendererCapability {
+  return capability({ kind: "tool-renderer", renderer, toolName });
+}
+
+function capability<Value extends { readonly kind: string }>(
+  value: Value
+): Value & Capability<Value["kind"]> {
   return Object.freeze({
-    kind: "tool-renderer",
-    renderer,
-    toolName,
-  }) as ToolRendererCapability;
+    ...value,
+    [extensionCapabilityBrand]: true as const,
+  });
+}
+
+function resolveAssistantRendererMode(
+  options: AssistantRendererRegistrationOptions
+): AssistantRendererMode {
+  if ("mode" in options && options.mode !== undefined) {
+    return options.mode;
+  }
+  if ("fallback" in options && options.fallback === true) {
+    return "fallback";
+  }
+  if ("override" in options && options.override === true) {
+    return "override";
+  }
+  return "exclusive";
 }

--- a/apps/coding-agent/src/extensions/capabilities.ts
+++ b/apps/coding-agent/src/extensions/capabilities.ts
@@ -8,6 +8,7 @@ import type {
 } from "../tui/assistant-renderer";
 import type { TuiCommand } from "../tui/command";
 import type { ToolRendererMap } from "../tui/tool-call-view";
+import { parseAssistantRendererMode } from "./assistant-renderer-mode";
 import type { CodingAgentExtensionModelProvider } from "./types";
 
 export const extensionCapabilityBrand: unique symbol = Symbol.for(
@@ -79,7 +80,7 @@ export function assistantRenderer(
   renderer: AssistantRenderer,
   options: AssistantRendererRegistrationOptions = {}
 ): AssistantRendererCapability {
-  const mode = resolveAssistantRendererMode(options);
+  const mode = parseAssistantRendererMode(options);
   return capability({
     fallback: mode === "fallback",
     kind: "assistant-renderer",
@@ -147,19 +148,4 @@ function capability<Value extends { readonly kind: string }>(
     ...value,
     [extensionCapabilityBrand]: true as const,
   });
-}
-
-function resolveAssistantRendererMode(
-  options: AssistantRendererRegistrationOptions
-): AssistantRendererMode {
-  if ("mode" in options && options.mode !== undefined) {
-    return options.mode;
-  }
-  if ("fallback" in options && options.fallback === true) {
-    return "fallback";
-  }
-  if ("override" in options && options.override === true) {
-    return "override";
-  }
-  return "exclusive";
 }

--- a/apps/coding-agent/src/extensions/capability-host.test.ts
+++ b/apps/coding-agent/src/extensions/capability-host.test.ts
@@ -96,6 +96,7 @@ describe("coding-agent extension capabilities", () => {
       { fallback: true, override: true },
       { mode: "replace" },
       { fallback: false },
+      { fallback: true, fallbak: true },
     ] as const;
 
     for (const options of malformed) {
@@ -115,6 +116,41 @@ describe("coding-agent extension capabilities", () => {
           },
         ])
       ).rejects.toMatchObject({ cause: expect.any(TypeError) });
+    }
+  });
+
+  it("treats own undefined renderer options as absent on both paths", async () => {
+    const renderer = () => ({
+      invalidate() {
+        return;
+      },
+      render() {
+        return [];
+      },
+      setText() {
+        return;
+      },
+    });
+    const optionalUndefined = [
+      { mode: undefined },
+      { fallback: undefined },
+      { override: undefined },
+    ] as const;
+
+    for (const options of optionalUndefined) {
+      expect(assistantRenderer(renderer, options as never).mode).toBe(
+        "exclusive"
+      );
+      const host = await createCodingAgentExtensionHost([
+        {
+          configure(registry) {
+            registry.tui.registerAssistantRenderer(renderer, options as never);
+          },
+          id: "undefined-renderer-option",
+        },
+      ]);
+      expect(host.assistantRenderer).toBe(renderer);
+      await host.dispose();
     }
   });
 

--- a/apps/coding-agent/src/extensions/capability-host.test.ts
+++ b/apps/coding-agent/src/extensions/capability-host.test.ts
@@ -79,6 +79,45 @@ describe("coding-agent extension capabilities", () => {
     );
   });
 
+  it("rejects malformed renderer options through factory and legacy registry paths", async () => {
+    const renderer = () => ({
+      invalidate() {
+        return;
+      },
+      render() {
+        return [];
+      },
+      setText() {
+        return;
+      },
+    });
+    const malformed = [
+      { fallback: true, mode: "fallback" },
+      { fallback: true, override: true },
+      { mode: "replace" },
+      { fallback: false },
+    ] as const;
+
+    for (const options of malformed) {
+      expect(() => assistantRenderer(renderer, options as never)).toThrow(
+        TypeError
+      );
+      await expect(
+        createCodingAgentExtensionHost([
+          {
+            configure(registry) {
+              registry.tui.registerAssistantRenderer(
+                renderer,
+                options as never
+              );
+            },
+            id: "malformed-renderer-options",
+          },
+        ])
+      ).rejects.toMatchObject({ cause: expect.any(TypeError) });
+    }
+  });
+
   it("registers one assistant renderer through the capability API", async () => {
     const renderer = () => ({
       invalidate() {

--- a/apps/coding-agent/src/extensions/capability-host.test.ts
+++ b/apps/coding-agent/src/extensions/capability-host.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   assistantRenderer,
   command,
+  extensionCapabilityBrand,
   instructions,
   threadMigration,
   toolRenderer,
@@ -22,6 +23,12 @@ const qaTool = tool({
 });
 
 describe("coding-agent extension capabilities", () => {
+  it("brands every capability factory consistently", () => {
+    const capability = tools({ qa_tool: qaTool });
+
+    expect(capability[extensionCapabilityBrand]).toBe(true);
+    expect(Reflect.ownKeys(capability)).toContain(extensionCapabilityBrand);
+  });
   it("creates immutable instruction capabilities", () => {
     const capability = instructions("first", "second");
 
@@ -31,6 +38,7 @@ describe("coding-agent extension capabilities", () => {
     });
     expect(Object.isFrozen(capability)).toBe(true);
     expect(Object.isFrozen(capability.fragments)).toBe(true);
+    expect(capability[extensionCapabilityBrand]).toBe(true);
   });
 
   it("normalizes assistant renderer registration options", () => {
@@ -48,17 +56,27 @@ describe("coding-agent extension capabilities", () => {
 
     expect(assistantRenderer(renderer)).toMatchObject({
       fallback: false,
+      mode: "exclusive",
       override: false,
       renderer,
     });
-    expect(assistantRenderer(renderer, { fallback: true })).toMatchObject({
+    expect(assistantRenderer(renderer, { mode: "fallback" })).toMatchObject({
       fallback: true,
+      mode: "fallback",
       override: false,
     });
-    expect(assistantRenderer(renderer, { override: true })).toMatchObject({
+    expect(assistantRenderer(renderer, { mode: "override" })).toMatchObject({
       fallback: false,
+      mode: "override",
       override: true,
     });
+    // Deprecated boolean forms remain runtime-compatible.
+    expect(assistantRenderer(renderer, { fallback: true }).mode).toBe(
+      "fallback"
+    );
+    expect(assistantRenderer(renderer, { override: true }).mode).toBe(
+      "override"
+    );
   });
 
   it("registers one assistant renderer through the capability API", async () => {

--- a/apps/coding-agent/src/extensions/capability-validation.ts
+++ b/apps/coding-agent/src/extensions/capability-validation.ts
@@ -69,33 +69,7 @@ export function validateExtensionCapability(
   const kind = requiredString(capability.kind, "Extension capability kind");
   switch (kind) {
     case "assistant-renderer":
-      assertKeys(
-        capability,
-        ["fallback", "kind", "override", "renderer"],
-        "Extension capability"
-      );
-      if (typeof capability.renderer !== "function") {
-        throw new TypeError("Assistant renderer must be a function");
-      }
-      if (
-        typeof capability.fallback !== "boolean" ||
-        typeof capability.override !== "boolean"
-      ) {
-        throw new TypeError(
-          "Assistant renderer fallback and override must be booleans"
-        );
-      }
-      if (capability.fallback && capability.override) {
-        throw new TypeError(
-          "Assistant renderer cannot be both a fallback and an override"
-        );
-      }
-      return {
-        fallback: capability.fallback,
-        kind,
-        override: capability.override,
-        renderer: capability.renderer as AssistantRenderer,
-      };
+      return snapshotAssistantRendererCapability(capability);
     case "command":
       assertKeys(capability, ["command", "kind"], "Extension capability");
       return { command: snapshotCommand(capability.command), kind };
@@ -180,6 +154,50 @@ export function validateExtensionCapability(
     default:
       throw new TypeError(`Unknown extension capability kind "${kind}"`);
   }
+}
+
+function snapshotAssistantRendererCapability(
+  capability: Readonly<Record<string, unknown>>
+): Extract<ValidatedCapability, { readonly kind: "assistant-renderer" }> {
+  assertKeys(
+    capability,
+    ["fallback", "kind", "mode", "override", "renderer"],
+    "Extension capability",
+    ["fallback", "kind", "override", "renderer"]
+  );
+  if (typeof capability.renderer !== "function") {
+    throw new TypeError("Assistant renderer must be a function");
+  }
+  if (
+    typeof capability.fallback !== "boolean" ||
+    typeof capability.override !== "boolean"
+  ) {
+    throw new TypeError(
+      "Assistant renderer fallback and override must be booleans"
+    );
+  }
+  if (capability.fallback && capability.override) {
+    throw new TypeError(
+      "Assistant renderer cannot be both a fallback and an override"
+    );
+  }
+  let expectedMode = "exclusive";
+  if (capability.fallback) {
+    expectedMode = "fallback";
+  } else if (capability.override) {
+    expectedMode = "override";
+  }
+  if (capability.mode !== undefined && capability.mode !== expectedMode) {
+    throw new TypeError(
+      `Assistant renderer mode must be "${expectedMode}" for its compatibility flags`
+    );
+  }
+  return {
+    fallback: capability.fallback,
+    kind: "assistant-renderer",
+    override: capability.override,
+    renderer: capability.renderer as AssistantRenderer,
+  };
 }
 
 export function snapshotCommand(value: unknown): TuiCommand {

--- a/apps/coding-agent/src/extensions/extension-authoring-api.test.ts
+++ b/apps/coding-agent/src/extensions/extension-authoring-api.test.ts
@@ -27,7 +27,6 @@ describe("extension authoring API compatibility", () => {
   it("supports typed event maps while retaining arbitrary JSON events", () => {
     interface Events {
       readonly "checkpoint:saved": { readonly revision: number };
-      readonly [type: string]: import("./types").ExtensionJsonValue | undefined;
     }
     const events = null as unknown as CodingAgentExtensionEvents<Events>;
 
@@ -39,7 +38,6 @@ describe("extension authoring API compatibility", () => {
       typedEvents.on("checkpoint:saved", (payload) => {
         expectTypeOf(payload.revision).toEqualTypeOf<number>();
       });
-      typedEvents.emit("other:event", { compatible: true });
     };
     expectTypeOf(checkContract).toBeFunction();
     expect(events).toBeNull();

--- a/apps/coding-agent/src/extensions/extension-authoring-api.test.ts
+++ b/apps/coding-agent/src/extensions/extension-authoring-api.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { instructions } from "./capabilities";
+import { defineLegacyCodingAgentExtension } from "./legacy";
+import {
+  type CodingAgentExtensionEvents,
+  type CodingAgentExtensionFactory,
+  defineCodingAgentExtension,
+} from "./types";
+
+describe("extension authoring API compatibility", () => {
+  it("keeps factory authoring canonical and legacy registry objects available", () => {
+    const factory = defineCodingAgentExtension((pss) => {
+      pss.provide(instructions("canonical"));
+    });
+    const legacy = defineLegacyCodingAgentExtension({
+      configure(registry) {
+        registry.instructions.append("legacy");
+      },
+      id: "legacy-extension",
+    });
+
+    expectTypeOf(factory).toEqualTypeOf<CodingAgentExtensionFactory>();
+    expect(typeof factory).toBe("function");
+    expect(legacy.id).toBe("legacy-extension");
+  });
+
+  it("supports typed event maps while retaining arbitrary JSON events", () => {
+    interface Events {
+      readonly "checkpoint:saved": { readonly revision: number };
+      readonly [type: string]: import("./types").ExtensionJsonValue | undefined;
+    }
+    const events = null as unknown as CodingAgentExtensionEvents<Events>;
+
+    expectTypeOf<CodingAgentExtensionEvents<Events>["emit"]>().toBeFunction();
+    expectTypeOf<CodingAgentExtensionEvents<Events>["on"]>().toBeFunction();
+    // Compile-time contract: named events infer their declared payload.
+    const checkContract = (typedEvents: CodingAgentExtensionEvents<Events>) => {
+      typedEvents.emit("checkpoint:saved", { revision: 7 });
+      typedEvents.on("checkpoint:saved", (payload) => {
+        expectTypeOf(payload.revision).toEqualTypeOf<number>();
+      });
+      typedEvents.emit("other:event", { compatible: true });
+    };
+    expectTypeOf(checkContract).toBeFunction();
+    expect(events).toBeNull();
+  });
+});

--- a/apps/coding-agent/src/extensions/factory-host.test.ts
+++ b/apps/coding-agent/src/extensions/factory-host.test.ts
@@ -9,8 +9,18 @@ import type {
   CodingAgentExtensionInput,
   CodingAgentExtensionModule,
 } from "./types";
+import { defineCodingAgentExtension } from "./types";
 
 describe("default-export coding agent extensions", () => {
+  it("defines the canonical factory without changing its identity", () => {
+    const factory = defineCodingAgentExtension((pss) => {
+      pss.provide(instructions("defined factory"));
+    });
+
+    expect(typeof factory).toBe("function");
+    expect(defineCodingAgentExtension(factory)).toBe(factory);
+  });
+
   it("configures and activates a default-export factory", async () => {
     // Given
     const lifecycle: string[] = [];

--- a/apps/coding-agent/src/extensions/index.ts
+++ b/apps/coding-agent/src/extensions/index.ts
@@ -13,6 +13,7 @@ export type { SessionLifecycleReason } from "../sessions/session-manager";
 export type {
   AssistantRenderer,
   AssistantRendererContext,
+  AssistantRendererMode,
   AssistantRendererNotifications,
   AssistantRendererRegistrationOptions,
   AssistantTextView,
@@ -73,6 +74,7 @@ export {
   type CodingAgentExtensionCleanup,
   type CodingAgentExtensionEventContext,
   type CodingAgentExtensionEventHandler,
+  type CodingAgentExtensionEventMap,
   type CodingAgentExtensionEvents,
   type CodingAgentExtensionExec,
   type CodingAgentExtensionExecResult,
@@ -85,6 +87,7 @@ export {
   type CodingAgentExtensionModelSelector,
   type CodingAgentExtensionModule,
   type CodingAgentExtensionRegistry,
+  type CodingAgentExtensionRuntimeEventMap,
   type CodingAgentExtensionServices,
   type CodingAgentExtensionSetupContext,
   type CodingAgentExtensionState,

--- a/apps/coding-agent/src/extensions/legacy.ts
+++ b/apps/coding-agent/src/extensions/legacy.ts
@@ -1,0 +1,20 @@
+/**
+ * Compatibility API for registry-based extensions.
+ *
+ * New extensions should default-export a factory using `ExtensionAPI` from
+ * `@minpeter/pss-coding-agent/extension`.
+ */
+export type {
+  CodingAgentExtension,
+  CodingAgentExtensionRegistry,
+  CodingAgentExtensionSetupContext,
+} from "./types";
+
+import type { CodingAgentExtension } from "./types";
+
+/** @deprecated Default-export a factory function instead. */
+export function defineLegacyCodingAgentExtension(
+  extension: CodingAgentExtension
+): CodingAgentExtension {
+  return extension;
+}

--- a/apps/coding-agent/src/extensions/registry.ts
+++ b/apps/coding-agent/src/extensions/registry.ts
@@ -79,8 +79,8 @@ export function createCodingAgentExtensionRegistry({
     if (typeof renderer !== "function") {
       throw new TypeError("Assistant renderer must be a function");
     }
-    const fallback = options.fallback === true;
-    const override = options.override === true;
+    const fallback = options.fallback === true || options.mode === "fallback";
+    const override = options.override === true || options.mode === "override";
     if (fallback && override) {
       throw new TypeError(
         "Assistant renderer cannot be both a fallback and an override"
@@ -322,7 +322,7 @@ function registerEvent<Type extends AgentEvent["type"]>(
       context: CodingAgentExtensionEventContext
     ) => {
       await handler(
-        event as Extract<AgentEvent, { readonly type: Type }>,
+        event as Parameters<CodingAgentExtensionEventHandler<Type>>[0],
         context
       );
     },

--- a/apps/coding-agent/src/extensions/registry.ts
+++ b/apps/coding-agent/src/extensions/registry.ts
@@ -4,6 +4,7 @@ import type {
   AssistantRendererRegistrationOptions,
 } from "../tui/assistant-renderer";
 import type { ToolRendererMap } from "../tui/tool-call-view";
+import { parseAssistantRendererMode } from "./assistant-renderer-mode";
 import type { ExtensionCapability } from "./capabilities";
 import {
   snapshotCommand,
@@ -79,8 +80,9 @@ export function createCodingAgentExtensionRegistry({
     if (typeof renderer !== "function") {
       throw new TypeError("Assistant renderer must be a function");
     }
-    const fallback = options.fallback === true || options.mode === "fallback";
-    const override = options.override === true || options.mode === "override";
+    const mode = parseAssistantRendererMode(options);
+    const fallback = mode === "fallback";
+    const override = mode === "override";
     if (fallback && override) {
       throw new TypeError(
         "Assistant renderer cannot be both a fallback and an override"

--- a/apps/coding-agent/src/extensions/types.ts
+++ b/apps/coding-agent/src/extensions/types.ts
@@ -113,8 +113,13 @@ export interface CodingAgentExtensionEventMap {
   readonly [type: string]: ExtensionJsonValue | undefined;
 }
 
+type CodingAgentExtensionEventMapConstraint<EventMap> = {
+  readonly [Type in keyof EventMap]: ExtensionJsonValue | undefined;
+};
+
 export interface CodingAgentExtensionEvents<
-  EventMap extends CodingAgentExtensionEventMap = CodingAgentExtensionEventMap,
+  EventMap extends
+    CodingAgentExtensionEventMapConstraint<EventMap> = CodingAgentExtensionEventMap,
 > {
   emit<Type extends keyof EventMap & string>(
     type: Type,

--- a/apps/coding-agent/src/extensions/types.ts
+++ b/apps/coding-agent/src/extensions/types.ts
@@ -98,11 +98,33 @@ export interface CodingAgentExtensionState {
  * Host-originated events use reserved namespaces (`host:`, `provider:`)
  * that extensions can subscribe to but never publish.
  */
-export interface CodingAgentExtensionEvents {
-  emit(type: string, payload?: ExtensionJsonValue): void;
-  on(
-    type: string,
-    handler: (payload: ExtensionJsonValue | undefined) => Promise<void> | void
+/**
+ * Extension event payloads. Extend this interface with module augmentation to
+ * share event contracts between publishers and subscribers.
+ *
+ * @example
+ * declare module "@minpeter/pss-coding-agent/extension" {
+ *   interface CodingAgentExtensionEventMap {
+ *     "checkpoint:saved": { readonly revision: number };
+ *   }
+ * }
+ */
+export interface CodingAgentExtensionEventMap {
+  readonly [type: string]: ExtensionJsonValue | undefined;
+}
+
+export interface CodingAgentExtensionEvents<
+  EventMap extends CodingAgentExtensionEventMap = CodingAgentExtensionEventMap,
+> {
+  emit<Type extends keyof EventMap & string>(
+    type: Type,
+    ...payload: undefined extends EventMap[Type]
+      ? [payload?: EventMap[Type]]
+      : [payload: EventMap[Type]]
+  ): void;
+  on<Type extends keyof EventMap & string>(
+    type: Type,
+    handler: (payload: EventMap[Type]) => Promise<void> | void
   ): () => void;
 }
 
@@ -149,12 +171,21 @@ export interface CodingAgentExtensionEventContext
   readonly stream: boolean;
 }
 
-export type CodingAgentExtensionEventHandler<Type extends AgentEvent["type"]> =
-  (
-    event: Extract<AgentEvent, { readonly type: Type }>,
-    context: CodingAgentExtensionEventContext
-  ) => Promise<void> | void;
+export type CodingAgentExtensionRuntimeEventMap = {
+  readonly [Type in AgentEvent["type"]]: Extract<
+    AgentEvent,
+    { readonly type: Type }
+  >;
+};
 
+export type CodingAgentExtensionEventHandler<
+  Type extends keyof CodingAgentExtensionRuntimeEventMap,
+> = (
+  event: CodingAgentExtensionRuntimeEventMap[Type],
+  context: CodingAgentExtensionEventContext
+) => Promise<void> | void;
+
+/** @deprecated Use the factory `ExtensionAPI` instead. */
 export interface CodingAgentExtensionRegistry {
   readonly commands: {
     register(command: TuiCommand): void;
@@ -205,6 +236,7 @@ export type CodingAgentExtensionFactory = (
   pss: CodingAgentExtensionApi
 ) => Promise<void> | void;
 
+/** @deprecated Use a default-export `CodingAgentExtensionFactory` instead. */
 export interface CodingAgentExtension {
   readonly activate?: CodingAgentExtensionActivationHandler;
   readonly config?: Readonly<Record<string, ExtensionJsonValue>>;
@@ -235,8 +267,16 @@ export interface CodingAgentExtensionHostOptions {
   readonly workspace?: string;
 }
 
+/** Identity helper for the canonical default-export extension factory. */
+export function defineCodingAgentExtension(
+  factory: CodingAgentExtensionFactory
+): CodingAgentExtensionFactory;
+/** @deprecated Export a factory function instead of the registry-based object. */
 export function defineCodingAgentExtension(
   extension: CodingAgentExtension
-): CodingAgentExtension {
+): CodingAgentExtension;
+export function defineCodingAgentExtension(
+  extension: CodingAgentExtensionFactory | CodingAgentExtension
+): CodingAgentExtensionFactory | CodingAgentExtension {
   return extension;
 }

--- a/apps/coding-agent/src/tui/assistant-renderer.ts
+++ b/apps/coding-agent/src/tui/assistant-renderer.ts
@@ -77,10 +77,27 @@ export const composeAssistantRenderers = (
   };
 };
 
+/** How an assistant renderer participates in renderer composition. */
+export type AssistantRendererMode = "exclusive" | "fallback" | "override";
+
 export type AssistantRendererRegistrationOptions =
-  | { readonly fallback?: never; readonly override?: never }
-  | { readonly fallback: true; readonly override?: never }
-  | { readonly fallback?: never; readonly override: true };
+  | {
+      readonly mode?: AssistantRendererMode;
+      readonly fallback?: never;
+      readonly override?: never;
+    }
+  /** @deprecated Use `{ mode: "fallback" }`. */
+  | {
+      readonly fallback: true;
+      readonly mode?: never;
+      readonly override?: never;
+    }
+  /** @deprecated Use `{ mode: "override" }`. */
+  | {
+      readonly fallback?: never;
+      readonly mode?: never;
+      readonly override: true;
+    };
 
 export interface AssistantRendererNotifications {
   readonly notify: (message: string) => void;

--- a/apps/coding-agent/tsdown.config.ts
+++ b/apps/coding-agent/tsdown.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
     "src/cli.ts",
     "src/env.ts",
     "src/extensions/index.ts",
+    "src/extensions/legacy.ts",
     "src/instructions.ts",
     "src/model.ts",
     "src/provider-registry.ts",


### PR DESCRIPTION
## Summary
- make `defineCodingAgentExtension` factory-first while preserving and deprecating registry-object authoring
- consistently brand capability factory results, add typed runtime/bus event maps, and introduce explicit assistant renderer modes with legacy boolean compatibility
- publish the legacy registry helper at `@minpeter/pss-coding-agent/extension/legacy` and update extension authoring documentation

## Compatibility
- existing registry-shaped extensions and the old `defineCodingAgentExtension(object)` overload remain supported
- `{ fallback: true }` and `{ override: true }` renderer options remain accepted
- unbranded capability-shaped JavaScript values remain runtime-compatible; capability factories now consistently expose the existing brand

## Tests
- `pnpm --filter @minpeter/pss-coding-agent test` (112 files, 770 tests)
- `pnpm --filter @minpeter/pss-coding-agent typecheck`
- `pnpm --filter @minpeter/pss-coding-agent lint`
- `pnpm --filter @minpeter/pss-coding-agent build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the extension authoring API around a canonical factory, adds explicit assistant renderer modes and typed event maps, and applies consistent option parsing/validation across both factory and registry paths. Keeps the legacy registry API via `@minpeter/pss-coding-agent/extension/legacy` and treats own `undefined` options as absent.

- **New Features**
  - Canonical default-export factory with `defineCodingAgentExtension`; legacy registry helper `defineLegacyCodingAgentExtension` published under `@minpeter/pss-coding-agent/extension/legacy`.
  - Assistant renderer registration uses `mode: "exclusive" | "fallback" | "override"` with exported `AssistantRendererMode`; deprecated booleans still accepted and parsed via `parseAssistantRendererMode`.
  - Typed extension events via `CodingAgentExtensionEventMap` and runtime `CodingAgentExtensionRuntimeEventMap`; event handlers use the runtime map. Capability factories now brand values consistently.

- **Migration**
  - Prefer a default-export factory using `ExtensionAPI` and `defineCodingAgentExtension` (identity helper returns the same factory).
  - Existing registry-shaped extensions continue to work; optionally use `defineLegacyCodingAgentExtension` from `@minpeter/pss-coding-agent/extension/legacy`.
  - Switch renderer options to `{ mode: "fallback" | "override" }`; booleans still work but cannot be combined with `mode` and must be `true` if present.

<sup>Written for commit b44228ab06ff20a33cdda26a356ddb03d58bfa79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

