### PR TITLE
chore(runtime): enforce safe indexed access in production

### DIFF
--- a/.tegami/2026-08-06-runtime-indexed-access-strictness.md
+++ b/.tegami/2026-08-06-runtime-indexed-access-strictness.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Strengthen runtime indexed access checks
+
+Type-check shipped runtime source with `noUncheckedIndexedAccess` and document the staged exact-optional migration baseline without diagnostic suppressions.

--- a/docs/runtime-typescript-strictness.md
+++ b/docs/runtime-typescript-strictness.md
@@ -1,0 +1,70 @@
+# Runtime TypeScript strictness migration
+
+The runtime runs two complementary checks:
+
+- `tsconfig.json` checks the complete source tree, including tests and reusable
+  contract suites, with the repository strict baseline.
+- `tsconfig.production.json` checks shipped runtime source with
+  `noUncheckedIndexedAccess`. It excludes `**/*.test.ts` and `src/contracts/**`
+  because those files are test-only and are not part of a `tsdown` entry graph.
+
+Both checks are part of `pnpm --filter @minpeter/pss-runtime typecheck`. Indexed
+access fixes must narrow or validate possibly missing values; do not use
+non-null assertions or type assertions to silence diagnostics.
+
+## Suppression inventory
+
+As of 2026-08-06, production runtime source has **zero TypeScript diagnostic
+suppressions** (`@ts-ignore`, `@ts-expect-error`, or `@ts-nocheck`) for either
+strictness option. This migration adds none. The production configuration has
+only these test-source exclusions:
+
+| Exclusion | Current files | Reason |
+| --- | ---: | --- |
+| `src/**/*.test.ts` | 141 | Vitest suites; retained in the complete-tree check |
+| `src/contracts/**/*.ts` | 12 | Reusable Vitest contract suites imported only by tests |
+
+Biome suppressions are unrelated to TypeScript strictness and remain
+individually documented at their call sites. New TypeScript diagnostic
+suppressions are not an accepted migration mechanism.
+
+## `exactOptionalPropertyTypes` baseline
+
+Run the next-stage check with:
+
+```sh
+pnpm --filter @minpeter/pss-runtime exec tsc \
+  -p tsconfig.production.json --noEmit --exactOptionalPropertyTypes
+```
+
+The 2026-08-06 baseline is **165 diagnostics in 75 files**:
+
+| Diagnostic | Count | Main meaning |
+| --- | ---: | --- |
+| TS2379 | 109 | An explicit `undefined` is passed to an optional property |
+| TS2375 | 31 | An object literal materializes an optional property as `undefined` |
+| TS2322 | 15 | Assignment does not distinguish absent from `undefined` |
+| TS2412 | 6 | Optional class/object property is assigned `undefined` |
+| TS2345 | 2 | Argument optionality mismatch |
+| TS1360 | 1 | `satisfies` exposes an optionality mismatch |
+| TS2420 | 1 | Implementation and interface optionality differ |
+
+Subsystem distribution: thread 64, platform 53, llm 15, agent 12, evals 12,
+execution 5, otel 2, and testing 2. Refresh this inventory in the same PR that
+changes the baseline.
+
+## Staged plan
+
+1. **Define contracts first.** Audit exported optional properties and decide
+   whether omission has meaning distinct from an explicit `undefined`. Change
+   public types only when `undefined` is intentionally accepted; otherwise
+   omit keys at construction sites.
+2. **Migrate leaf subsystems.** Enable focused temporary checks for `otel`,
+   `execution`, `evals`, and `testing`, then move through `llm` and `agent`.
+   Each slice must keep its diagnostic count at zero without suppressions.
+3. **Migrate storage and thread state.** Handle `platform` and `thread` together
+   where persisted records cross the boundary. Add round-trip tests before any
+   representation change so absent keys and explicit `undefined` cannot drift.
+4. **Enable globally.** Add `exactOptionalPropertyTypes` to
+   `tsconfig.production.json`, then migrate the test-only configuration and
+   remove the exclusions only after the full source tree is clean.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -90,7 +90,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.production.json --noEmit",
     "test": "vitest run",
     "test:storage-stress": "vitest run src/platform/cloudflare/storage/execution/store-stress.test.ts src/platform/cloudflare/storage/execution/store-oversized-payload.test.ts",
     "test:storage-stress:extreme": "PSS_RUNTIME_STORAGE_STRESS_PROFILE=extreme vitest run src/platform/cloudflare/storage/execution/store-stress.test.ts",

--- a/packages/runtime/src/evals/cli.ts
+++ b/packages/runtime/src/evals/cli.ts
@@ -48,6 +48,9 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
   let i = 0;
   while (i < args.length) {
     const arg = args[i++];
+    if (arg === undefined) {
+      break;
+    }
     switch (arg) {
       case "-h":
       case "--help":
@@ -85,12 +88,13 @@ export function compileFilters(
     return;
   }
   if (filters.length === 1) {
-    return toPattern(filters[0]);
+    const [filter] = filters;
+    return filter === undefined ? undefined : toPattern(filter);
   }
   const combined = filters
     .map((f) => {
       const pattern = regexFilterForm.exec(f);
-      return pattern ? pattern[1] : escapeRegExp(f);
+      return pattern?.[1] ?? escapeRegExp(f);
     })
     .join("|");
   return new RegExp(combined);
@@ -98,7 +102,8 @@ export function compileFilters(
 
 function toPattern(filter: string): string | RegExp {
   const pattern = regexFilterForm.exec(filter);
-  return pattern ? new RegExp(pattern[1], pattern[2]) : filter;
+  const source = pattern?.[1];
+  return source === undefined ? filter : new RegExp(source, pattern?.[2]);
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/runtime/src/evals/matchers.test.ts
+++ b/packages/runtime/src/evals/matchers.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { similarity } from "./matchers";
+
+describe("similarity", () => {
+  it("preserves long-comparison scores while using bounded matrix storage", () => {
+    const length = 2048;
+    const expected = "a".repeat(length);
+    const actual = `${"a".repeat(length - 1)}b`;
+
+    const result = similarity(expected).score(actual);
+
+    expect(result.score).toBeCloseTo(1 - 1 / length, 12);
+    expect(result.pass).toBe(false);
+  });
+});

--- a/packages/runtime/src/evals/matchers.ts
+++ b/packages/runtime/src/evals/matchers.ts
@@ -173,22 +173,35 @@ function levenshteinSimilarity(a: string, b: string): number {
 }
 
 function levenshtein(a: string, b: string): number {
-  const matrix: number[][] = [];
-  for (let i = 0; i <= b.length; i++) {
-    matrix[i] = [i];
-  }
-  for (let j = 0; j <= a.length; j++) {
-    matrix[0][j] = j;
-  }
+  const matrix = Array.from({ length: b.length + 1 }, (_, row) =>
+    Array.from({ length: a.length + 1 }, (_, column) =>
+      row === 0 ? column : row
+    )
+  );
   for (let i = 1; i <= b.length; i++) {
+    const row = matrix[i];
+    const previousRow = matrix[i - 1];
+    if (!(row && previousRow)) {
+      throw new Error("Levenshtein matrix row is missing.");
+    }
     for (let j = 1; j <= a.length; j++) {
-      const cost = a[j - 1] === b[i - 1] ? 0 : 1;
-      matrix[i][j] = Math.min(
-        matrix[i - 1][j] + 1,
-        matrix[i][j - 1] + 1,
-        matrix[i - 1][j - 1] + cost
-      );
+      const deletion = previousRow[j];
+      const insertion = row[j - 1];
+      const substitution = previousRow[j - 1];
+      if (
+        deletion === undefined ||
+        insertion === undefined ||
+        substitution === undefined
+      ) {
+        throw new Error("Levenshtein matrix cell is missing.");
+      }
+      const cost = a.charAt(j - 1) === b.charAt(i - 1) ? 0 : 1;
+      row[j] = Math.min(deletion + 1, insertion + 1, substitution + cost);
     }
   }
-  return matrix[b.length][a.length];
+  const distance = matrix.at(-1)?.at(-1);
+  if (distance === undefined) {
+    throw new Error("Levenshtein distance is missing.");
+  }
+  return distance;
 }

--- a/packages/runtime/src/evals/matchers.ts
+++ b/packages/runtime/src/evals/matchers.ts
@@ -173,17 +173,9 @@ function levenshteinSimilarity(a: string, b: string): number {
 }
 
 function levenshtein(a: string, b: string): number {
-  const matrix = Array.from({ length: b.length + 1 }, (_, row) =>
-    Array.from({ length: a.length + 1 }, (_, column) =>
-      row === 0 ? column : row
-    )
-  );
+  let previousRow = Array.from({ length: a.length + 1 }, (_, index) => index);
   for (let i = 1; i <= b.length; i++) {
-    const row = matrix[i];
-    const previousRow = matrix[i - 1];
-    if (!(row && previousRow)) {
-      throw new Error("Levenshtein matrix row is missing.");
-    }
+    const row = [i];
     for (let j = 1; j <= a.length; j++) {
       const deletion = previousRow[j];
       const insertion = row[j - 1];
@@ -198,8 +190,9 @@ function levenshtein(a: string, b: string): number {
       const cost = a.charAt(j - 1) === b.charAt(i - 1) ? 0 : 1;
       row[j] = Math.min(deletion + 1, insertion + 1, substitution + cost);
     }
+    previousRow = row;
   }
-  const distance = matrix.at(-1)?.at(-1);
+  const distance = previousRow[a.length];
   if (distance === undefined) {
     throw new Error("Levenshtein distance is missing.");
   }

--- a/packages/runtime/src/llm/diagnostic-tool-registry.ts
+++ b/packages/runtime/src/llm/diagnostic-tool-registry.ts
@@ -23,6 +23,15 @@ export function diagnosticToolRegistry(tools: ToolSet): ToolSet {
   for (const name of Object.keys(tools)) {
     try {
       const tool = tools[name];
+      if (tool === undefined) {
+        Object.defineProperty(snapshot, name, {
+          configurable: true,
+          enumerable: true,
+          value: undefined,
+          writable: true,
+        });
+        continue;
+      }
       if (!isObjectRecord(tool)) {
         snapshot[name] = tool;
         continue;

--- a/packages/runtime/src/llm/model-step-preparation.ts
+++ b/packages/runtime/src/llm/model-step-preparation.ts
@@ -131,7 +131,7 @@ export async function resolveModelStepOptions({
     ...canonicalRegistryOrder.filter((name) => selectedSet.has(name)),
   ];
   const executableTools = registry
-    ? Object.fromEntries(activeTools.map((name) => [name, registry[name]]))
+    ? selectTools(registry, activeTools)
     : undefined;
   const effectiveToolChoice = snapshotToolChoice(
     prepared?.toolChoice === undefined ? toolChoice : prepared.toolChoice
@@ -166,4 +166,23 @@ export async function resolveModelStepOptions({
       ? {}
       : { startToolCacheFingerprintReport }),
   };
+}
+
+function selectTools(registry: ToolSet, names: readonly string[]): ToolSet {
+  const selected: ToolSet = Object.create(null);
+  const byName = new Map(Object.entries(registry));
+  for (const name of names) {
+    const definition = byName.get(name);
+    if (definition === undefined) {
+      Object.defineProperty(selected, name, {
+        configurable: true,
+        enumerable: true,
+        value: undefined,
+        writable: true,
+      });
+    } else {
+      selected[name] = definition;
+    }
+  }
+  return selected;
 }

--- a/packages/runtime/src/llm/model-step-preparation.ts
+++ b/packages/runtime/src/llm/model-step-preparation.ts
@@ -170,9 +170,10 @@ export async function resolveModelStepOptions({
 
 function selectTools(registry: ToolSet, names: readonly string[]): ToolSet {
   const selected: ToolSet = Object.create(null);
-  const byName = new Map(Object.entries(registry));
   for (const name of names) {
-    const definition = byName.get(name);
+    const definition = Object.hasOwn(registry, name)
+      ? registry[name]
+      : undefined;
     if (definition === undefined) {
       Object.defineProperty(selected, name, {
         configurable: true,

--- a/packages/runtime/src/llm/tool-registry-snapshot.ts
+++ b/packages/runtime/src/llm/tool-registry-snapshot.ts
@@ -47,9 +47,9 @@ export function readonlyToolRegistry(
 ): Readonly<ToolSet> {
   return Object.freeze(
     Object.fromEntries(
-      Object.keys(registry ?? {}).map((name) => [
+      Object.entries(registry ?? {}).map(([name, definition]) => [
         name,
-        readonlyToolFacade((registry as ToolSet)[name]),
+        readonlyToolFacade(definition),
       ])
     )
   );

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql/messages/history.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/thread-store-sql/messages/history.ts
@@ -71,18 +71,24 @@ export function writeThreadHistoryRows(
 
   const existing = readRawActiveThreadMessages(sql, key);
   let prefix = 0;
-  while (
-    prefix < existing.length &&
-    prefix < history.length &&
-    rawThreadMessageEquals(sql, key, existing[prefix], history[prefix])
-  ) {
+  while (prefix < existing.length && prefix < history.length) {
+    const existingMessage = existing[prefix];
+    const historyMessage = history[prefix];
+    if (
+      existingMessage === undefined ||
+      historyMessage === undefined ||
+      !rawThreadMessageEquals(sql, key, existingMessage, historyMessage)
+    ) {
+      break;
+    }
     prefix += 1;
   }
-  if (prefix < existing.length) {
+  const firstStaleMessage = existing[prefix];
+  if (firstStaleMessage !== undefined) {
     sql.exec(
       "UPDATE pss_thread_message SET active = 0 WHERE thread_key = ? AND active = 1 AND seq >= ?",
       key,
-      existing[prefix].seq
+      firstStaleMessage.seq
     );
   }
   return insertThreadMessages({

--- a/packages/runtime/src/platform/file/storage/file-execution-store/checkpoint-store.ts
+++ b/packages/runtime/src/platform/file/storage/file-execution-store/checkpoint-store.ts
@@ -80,12 +80,13 @@ export class FileCheckpointStore implements CheckpointStore {
       .filter((version) => Number.isSafeInteger(version) && version > 0)
       .sort((left, right) => right - left);
 
-    if (versions.length === 0) {
+    const [latestVersion] = versions;
+    if (latestVersion === undefined) {
       return null;
     }
 
     return await readJsonFile(
-      await this.#fileForCheckpoint(runId, versions[0]),
+      await this.#fileForCheckpoint(runId, latestVersion),
       parseRunCheckpoint,
       "checkpoint file"
     );

--- a/packages/runtime/src/thread/runtime/auto-compaction-tool-evidence.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-tool-evidence.ts
@@ -165,7 +165,8 @@ function ledgerEvidence(summary: string): readonly string[] {
     return [];
   }
   return ledger
-    .split("\n## ")[0]
+    .split("\n## ", 1)
+    .join("")
     .split("\n")
     .flatMap((line) => {
       try {

--- a/packages/runtime/tsconfig.production.json
+++ b/packages/runtime/tsconfig.production.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true
+  },
+  "exclude": ["src/**/*.test.ts", "src/contracts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a production runtime TypeScript pass with `noUncheckedIndexedAccess` and make the runtime typecheck script enforce it
- narrow indexed reads without non-null/type assertions or behavior changes
- document the zero-suppression policy, exact-optional baseline (165 diagnostics / 75 files), and staged migration plan

## Scope
The complete runtime source tree still receives the existing strict check. The new production pass excludes only `*.test.ts` files and reusable Vitest contract suites; the inventory and rationale are documented. `exactOptionalPropertyTypes` is intentionally not enabled yet and its current diagnostics are an explicit follow-up baseline.

## Tests
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime test` (142 files, 857 passed, 3 skipped)
- focused Vitest run for evals, model selection/loop, SQLite and file stores, and compaction evidence (134 passed)
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm lint` (passes; existing oversized experimental JSON warning)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `noUncheckedIndexedAccess` in the production TypeScript pass for `@minpeter/pss-runtime` and hardens indexed reads to safely handle missing values without assertions. Reduces allocations in Levenshtein similarity and ledger parsing, and adds strictness docs with a staged plan toward `exactOptionalPropertyTypes`.

- **Refactors**
  - Evals CLI and filter parsing: guard undefined args and regex matches.
  - Levenshtein distance: use bounded row storage and check cells before use.
  - Tool registry: readonly snapshot and selection avoid unsafe indexed reads and preserve missing-definition keys.
  - Cloudflare SQLite thread history: safe prefix comparison; deactivate stale messages via checked seq.
  - File checkpoint store: pick the latest version via a guarded array read.
  - Auto-compaction ledger: use bounded split to reduce allocations.

- **Migration**
  - Production typecheck now enforces `noUncheckedIndexedAccess` and excludes `**/*.test.ts` and `src/contracts/**`.
  - `pnpm --filter @minpeter/pss-runtime typecheck` runs both passes.
  - Docs added with a zero-suppression policy and the `exactOptionalPropertyTypes` baseline (165 diagnostics) plus a staged rollout plan.

<sup>Written for commit 40c13873bb93b18fe62399d164a1034a9bf97a1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

