### PR TITLE
Add durable follow-up queue API

### DIFF
--- a/.tegami/2026-08-06-durable-follow-up-queue.md
+++ b/.tegami/2026-08-06-durable-follow-up-queue.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+Add durable `followUp` turns with FIFO one-at-a-time delivery, recovery semantics, and distinct input metadata.

--- a/.tegami/2026-08-06-durable-follow-up-queue.md
+++ b/.tegami/2026-08-06-durable-follow-up-queue.md
@@ -4,4 +4,4 @@ packages:
     type: patch
 ---
 
-Add durable `followUp` turns with FIFO one-at-a-time delivery, recovery semantics, and distinct input metadata.
+Add durable `followUp` turns with recovery and distinct metadata. FIFO one-at-a-time execution applies within one process/isolate to handles sharing the exact store wrapper.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -945,6 +945,7 @@ on `event.meta?.source`:
 | `source` | Boundary |
 |----------|----------|
 | `send` | `thread.send()` / `agent.send()` |
+| `follow-up` | `thread.followUp()` / `agent.followUp()` |
 | `steer` | `thread.steer()` and drained steering queue |
 | `notify` | host notification runtime input |
 | `delegate` | parent `delegate_to_*` child `thread.send()` |
@@ -997,11 +998,26 @@ const executionAgent = await createAgent({
 The parent coordinator stays unchanged; only the nested child agent carries the
 hook.
 
-## Send, Host Resume, and Steer
+## Send, Follow-up, Host Resume, and Steer
 
 Use `thread.send(input)` for a new user turn. If a turn is already active, the
-turn is queued until the active turn finishes. Use `thread.steer(input)` when
-the input should steer the active turn; if no turn is active, it starts a normal
+turn is queued until the active turn finishes. Use `thread.followUp(input)` (or
+`agent.followUp(input)` for the default thread) when the caller explicitly wants
+a durable follow-up: it is never injected into the active model step and starts
+only after the active turn reaches a terminal boundary. Its input event carries
+`meta.source === "follow-up"` and `meta.streaming === "follow-up"`, so consumers
+can distinguish it from an ordinary send and from steering.
+
+Follow-ups use FIFO, one-at-a-time delivery: every accepted call owns a distinct
+`AgentTurn`, model invocation, durable inbox record, and terminal event. A later
+follow-up remains queued when the active turn is interrupted or fails, and an
+orphaned durable claim is recovered on the next thread admission. The runtime
+does not currently expose an `all` batching policy; batching would collapse
+multiple accepted calls into one turn and conflict with the one-call/one-turn
+contract.
+
+Use `thread.steer(input)` only when the input should affect the active turn; if
+no turn is active, it preserves its existing behavior and starts a normal send
 turn.
 
 Durable hosts resume completed background work by writing a notification record
@@ -1015,7 +1031,7 @@ host. Check `supportsResume` first when you need to distinguish an unsupported
 host from a missing or already-claimed run.
 
 Runtime-originated input is delivered through the host notification inbox and
-internal runtime paths. App code should use `thread.send()`, `thread.steer()`,
+internal runtime paths. App code should use `thread.send()`, `thread.followUp()`, `thread.steer()`,
 or `agent.resume(runId)` for host-scheduled durable work.
 
 Each accepted call returns one `AgentTurn`. Drain that turn's `events()` stream to

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -742,7 +742,7 @@ raw-payload capture mode. The wrapper passes every original event through unchan
 Stopping iteration calls the source iterator's `return()` and closes all open
 spans.
 
-Agent instrumentations run for `send`, `steer`, and durable `resume` turns.
+Agent instrumentations run for `send`, `follow-up`, `steer`, and durable `resume` turns.
 Custom `AgentInstrumentation.wrapTurn(turn, context)` implementations receive
 the operation, canonical thread key, optional agent namespace, and the durable
 run ID for resume operations.
@@ -1008,13 +1008,16 @@ only after the active turn reaches a terminal boundary. Its input event carries
 `meta.source === "follow-up"` and `meta.streaming === "follow-up"`, so consumers
 can distinguish it from an ordinary send and from steering.
 
-Follow-ups use FIFO, one-at-a-time delivery: every accepted call owns a distinct
-`AgentTurn`, model invocation, durable inbox record, and terminal event. A later
-follow-up remains queued when the active turn is interrupted or fails, and an
-orphaned durable claim is recovered on the next thread admission. The runtime
-does not currently expose an `all` batching policy; batching would collapse
-multiple accepted calls into one turn and conflict with the one-call/one-turn
-contract.
+Follow-ups use admitted-sequence FIFO, one-at-a-time delivery: every accepted
+call owns a distinct `AgentTurn`, model invocation, durable inbox record, and
+terminal event. Drain ownership serializes live `Agent` handles that share the
+same host store object and thread key, including the memory, file, and
+Cloudflare adapters. An older recovered record runs before newly admitted work.
+A later follow-up remains queued when the active turn is interrupted or fails,
+and an orphaned durable claim is recovered on the next thread admission. The
+runtime does not currently expose an `all` batching policy; batching would
+collapse multiple accepted calls into one turn and conflict with the
+one-call/one-turn contract.
 
 Use `thread.steer(input)` only when the input should affect the active turn; if
 no turn is active, it preserves its existing behavior and starts a normal send

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1010,11 +1010,15 @@ can distinguish it from an ordinary send and from steering.
 
 Follow-ups use admitted-sequence FIFO, one-at-a-time delivery: every accepted
 call owns a distinct `AgentTurn`, model invocation, durable inbox record, and
-terminal event. Drain ownership serializes live `Agent` handles that share the
-same host store object and thread key, including the memory, file, and
-Cloudflare adapters. An older recovered record runs before newly admitted work.
-A later follow-up remains queued when the active turn is interrupted or fails,
-and an orphaned durable claim is recovered on the next thread admission. The
+terminal event. One-at-a-time drain ownership is process/isolate-local: it
+serializes live `Agent` handles only when they share the exact same host store
+wrapper object and thread key, including one shared memory, file, or Cloudflare
+host instance. It is not a distributed lease and does not serialize separate
+store wrappers or processes that happen to use the same backing storage.
+Durable `admittedSeq` values order inbox records; an older recovered record runs
+before newly admitted work. A later follow-up remains queued when the active
+turn is interrupted or fails, and an orphaned durable claim is recovered on the
+next thread admission. The
 runtime does not currently expose an `all` batching policy; batching would
 collapse multiple accepted calls into one turn and conflict with the
 one-call/one-turn contract.

--- a/packages/runtime/src/agent/core/agent.test.ts
+++ b/packages/runtime/src/agent/core/agent.test.ts
@@ -100,7 +100,7 @@ describe("Agent", () => {
     await expect(agent.send("hello")).resolves.toBeDefined();
   });
 
-  it("wraps send and steer turns with operation context", async () => {
+  it("wraps send, follow-up, and steer turns with operation context", async () => {
     const contexts: AgentInstrumentationContext[] = [];
     const instrumentation: AgentInstrumentation = {
       wrapTurn: (turn, context) => {
@@ -118,12 +118,18 @@ describe("Agent", () => {
     const thread = agent.thread("customer-1");
 
     await collectRun(await thread.send("hello"));
+    await collectRun(await thread.followUp("follow up"));
     await collectRun(await thread.steer("one more thing"));
 
     expect(contexts).toEqual([
       {
         namespace: "support",
         operation: "send",
+        threadKey: "customer-1",
+      },
+      {
+        namespace: "support",
+        operation: "follow-up",
         threadKey: "customer-1",
       },
       {

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -129,6 +129,10 @@ export class Agent {
     return this.thread("default").send(input);
   }
 
+  followUp(input: AgentInput): Promise<AgentTurn> {
+    return this.thread("default").followUp(input);
+  }
+
   overlay(input: AgentInput): ThreadHandle {
     return this.thread("default").overlay(input);
   }

--- a/packages/runtime/src/agent/core/instrumentation.ts
+++ b/packages/runtime/src/agent/core/instrumentation.ts
@@ -1,6 +1,10 @@
 import type { AgentTurn } from "../../thread/protocol/turn";
 
-export type AgentInstrumentationOperation = "resume" | "send" | "steer";
+export type AgentInstrumentationOperation =
+  | "follow-up"
+  | "resume"
+  | "send"
+  | "steer";
 
 export interface AgentInstrumentationContext {
   readonly namespace?: string;

--- a/packages/runtime/src/agent/core/thread-entry.ts
+++ b/packages/runtime/src/agent/core/thread-entry.ts
@@ -25,6 +25,7 @@ export interface ThreadHandle {
   delete(): Promise<void>;
   dispose(): Promise<void>;
   events(options?: ThreadEventReadOptions): AsyncIterable<StoredThreadEvent>;
+  followUp(input: AgentInput): Promise<AgentTurn>;
   interrupt(): void;
   overlay(input: AgentInput): ThreadHandle;
   send(input: AgentInput): Promise<AgentTurn>;

--- a/packages/runtime/src/agent/core/thread-handle-factory.ts
+++ b/packages/runtime/src/agent/core/thread-handle-factory.ts
@@ -36,6 +36,12 @@ export function createThreadPublicHandle({
       await thread.dispose();
     },
     events: (options) => thread.events(options),
+    followUp: async (input) =>
+      instrumentTurn(await thread.followUp(input), {
+        namespace,
+        operation: "follow-up",
+        threadKey: key,
+      }),
     interrupt: () => thread.interrupt(),
     overlay: (input) => {
       thread.overlay(input);

--- a/packages/runtime/src/contracts/execution-store/thread-input-contract.ts
+++ b/packages/runtime/src/contracts/execution-store/thread-input-contract.ts
@@ -157,6 +157,34 @@ export function describeThreadInputInboxContract({
       });
     });
 
+    it("claims follow-ups only when the thread is idle", async () => {
+      const store = createStore();
+      await store.inputs.admit({
+        admittedAtMs: 1,
+        input: { text: "later", type: "user-input" },
+        kind: "follow-up",
+        messageId: "follow-up-1",
+        threadKey: "thread-follow-up",
+      });
+
+      await expect(
+        store.inputs.claimNext("thread-follow-up", "step-end")
+      ).resolves.toBeNull();
+      await expect(
+        store.inputs.claimNext("thread-follow-up", "step-start")
+      ).resolves.toBeNull();
+      await expect(
+        store.inputs.claimNext("thread-follow-up", "turn-start")
+      ).resolves.toBeNull();
+      await expect(
+        store.inputs.claimNext("thread-follow-up", "turn-idle")
+      ).resolves.toMatchObject({
+        kind: "follow-up",
+        messageId: "follow-up-1",
+        status: "claiming",
+      });
+    });
+
     describeThreadInputInboxRecoveryContract({ createStore });
 
     it("releases and reclaims thread input claims with a fresh claim id", async () => {

--- a/packages/runtime/src/execution/host/thread-input-inbox.ts
+++ b/packages/runtime/src/execution/host/thread-input-inbox.ts
@@ -183,7 +183,7 @@ function hasSameSemanticPayload(
 function normalizedPlacement(
   input: AdmitThreadInput
 ): ThreadInputPlacement | undefined {
-  if (input.kind === "send") {
+  if (input.kind !== "steer") {
     return;
   }
   return input.placement ?? "step-end";
@@ -192,7 +192,7 @@ function normalizedPlacement(
 function recordSemanticPlacement(
   record: ThreadInputRecord
 ): ThreadInputPlacement | undefined {
-  if (record.kind === "send") {
+  if (record.kind !== "steer") {
     return;
   }
   return record.placement ?? "step-end";
@@ -216,7 +216,7 @@ function isClaimableAtBoundary(
   record: ThreadInputRecord,
   boundary: ThreadInputBoundary
 ): boolean {
-  if (record.kind === "send") {
+  if (record.kind !== "steer") {
     return boundary === "turn-idle";
   }
   return recordSemanticPlacement(record) === boundary;

--- a/packages/runtime/src/execution/host/types.ts
+++ b/packages/runtime/src/execution/host/types.ts
@@ -205,7 +205,7 @@ export interface NotificationInbox {
   releaseByIdempotencyKey(idempotencyKey: string): Promise<void>;
 }
 
-export type ThreadInputKind = "send" | "steer";
+export type ThreadInputKind = "follow-up" | "send" | "steer";
 export type ThreadInputStatus = "acked" | "claiming" | "pending" | "promoted";
 export type ThreadInputBoundary =
   | "step-end"

--- a/packages/runtime/src/platform/cloudflare/storage/execution/input-record-parser.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/execution/input-record-parser.ts
@@ -145,6 +145,7 @@ function isOptionalInputMeta(
 function isInputSource(value: unknown): value is InputSource {
   return (
     value === "delegate" ||
+    value === "follow-up" ||
     value === "notify" ||
     value === "overlay" ||
     value === "send" ||
@@ -159,7 +160,7 @@ function isOptionalStreaming(
 }
 
 function parseThreadInputKind(value: unknown): ThreadInputKind {
-  if (value === "send" || value === "steer") {
+  if (value === "follow-up" || value === "send" || value === "steer") {
     return value;
   }
   throw new StoredThreadInputRecordParseError();

--- a/packages/runtime/src/platform/file/storage/file-execution-store/thread-input-schema.ts
+++ b/packages/runtime/src/platform/file/storage/file-execution-store/thread-input-schema.ts
@@ -153,6 +153,7 @@ function isOptionalInputMeta(
 function isInputSource(value: unknown): value is InputSource {
   return (
     value === "delegate" ||
+    value === "follow-up" ||
     value === "notify" ||
     value === "overlay" ||
     value === "send" ||
@@ -175,7 +176,7 @@ function isString(value: unknown): value is string {
 }
 
 function isThreadInputKind(value: unknown): value is ThreadInputKind {
-  return value === "send" || value === "steer";
+  return value === "follow-up" || value === "send" || value === "steer";
 }
 
 function isThreadInputPlacement(value: unknown): value is ThreadInputPlacement {

--- a/packages/runtime/src/platform/memory/execution/store.ts
+++ b/packages/runtime/src/platform/memory/execution/store.ts
@@ -37,9 +37,28 @@ export class InMemoryExecutionStore implements HostStore {
     () => this.#state
   );
   readonly events: EventStore = new InMemoryEventStore(() => this.#state);
-  readonly inputs: ThreadInputInbox = new InMemoryThreadInputInbox(
-    () => this.#state
-  );
+  readonly inputs: ThreadInputInbox = {
+    ack: async (record) =>
+      await this.transaction(async (tx) => await tx.inputs.ack(record)),
+    admit: async (input) =>
+      await this.transaction(async (tx) => await tx.inputs.admit(input)),
+    claimNext: async (threadKey, boundary, options) =>
+      await this.transaction(
+        async (tx) => await tx.inputs.claimNext(threadKey, boundary, options)
+      ),
+    markPromoted: async (record) =>
+      await this.transaction(
+        async (tx) => await tx.inputs.markPromoted(record)
+      ),
+    recoverClaims: async (threadKey) =>
+      await this.transaction(
+        async (tx) => await tx.inputs.recoverClaims(threadKey)
+      ),
+    releaseClaim: async (record) =>
+      await this.transaction(
+        async (tx) => await tx.inputs.releaseClaim(record)
+      ),
+  };
   readonly notifications: NotificationInbox = new InMemoryNotificationInbox(
     () => this.#state
   );

--- a/packages/runtime/src/thread/handle/agent-thread-drain.test.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   recoverOrCancelReleasedDrain,
+  removeQueuedInputsByIdentity,
   retryReleasedThreadDrain,
 } from "./agent-thread-drain";
 
@@ -56,5 +57,29 @@ describe("released thread drain restart", () => {
     expect(drain).toHaveBeenCalledTimes(3);
     expect(cancel).toHaveBeenCalledTimes(2);
     expect(onCancelled).not.toHaveBeenCalled();
+  });
+
+  it("removes only snapshotted callers still present after cancellation", async () => {
+    const first = { id: "first" };
+    const second = { id: "second" };
+    const later = { id: "later" };
+    const queue = [first, second];
+    const snapshot = [...queue];
+    const removed: { id: string }[] = [];
+
+    await recoverOrCancelReleasedDrain({
+      cancel: async () => {
+        await Promise.resolve();
+        queue.shift();
+        queue.push(later);
+      },
+      drain: () => Promise.resolve(),
+      onCancelled: () => {
+        removed.push(...removeQueuedInputsByIdentity(queue, snapshot));
+      },
+    });
+
+    expect(removed).toEqual([second]);
+    expect(queue).toEqual([later]);
   });
 });

--- a/packages/runtime/src/thread/handle/agent-thread-drain.test.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { retryReleasedThreadDrain } from "./agent-thread-drain";
+
+describe("released thread drain restart", () => {
+  it("retries a transient restart failure without another notification", async () => {
+    const drain = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("refresh failed"))
+      .mockResolvedValue(undefined);
+    const permanentFailure = vi.fn();
+
+    await retryReleasedThreadDrain(drain, permanentFailure);
+
+    expect(drain).toHaveBeenCalledTimes(2);
+    expect(permanentFailure).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a permanent restart failure after bounded retries", async () => {
+    const failure = new Error("refresh permanently failed");
+    const drain = vi.fn<() => Promise<void>>().mockRejectedValue(failure);
+    const permanentFailure = vi.fn();
+
+    await retryReleasedThreadDrain(drain, permanentFailure);
+
+    expect(drain).toHaveBeenCalledTimes(3);
+    expect(permanentFailure).toHaveBeenCalledWith(failure);
+  });
+});

--- a/packages/runtime/src/thread/handle/agent-thread-drain.test.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { retryReleasedThreadDrain } from "./agent-thread-drain";
+import {
+  recoverOrCancelReleasedDrain,
+  retryReleasedThreadDrain,
+} from "./agent-thread-drain";
 
 describe("released thread drain restart", () => {
   it("retries a transient restart failure without another notification", async () => {
@@ -24,5 +27,34 @@ describe("released thread drain restart", () => {
 
     expect(drain).toHaveBeenCalledTimes(3);
     expect(permanentFailure).toHaveBeenCalledWith(failure);
+  });
+
+  it("recovers normally without a terminal event when cancellation fails once", async () => {
+    const cancel = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("cancel unavailable"));
+    const drain = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const onCancelled = vi.fn();
+
+    await recoverOrCancelReleasedDrain({ cancel, drain, onCancelled });
+
+    expect(drain).toHaveBeenCalledOnce();
+    expect(onCancelled).not.toHaveBeenCalled();
+  });
+
+  it("leaves the caller protected without a terminal event on persistent failure", async () => {
+    const cancel = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(new Error("cancel unavailable"));
+    const drain = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(new Error("refresh unavailable"));
+    const onCancelled = vi.fn();
+
+    await recoverOrCancelReleasedDrain({ cancel, drain, onCancelled });
+
+    expect(drain).toHaveBeenCalledTimes(3);
+    expect(cancel).toHaveBeenCalledTimes(2);
+    expect(onCancelled).not.toHaveBeenCalled();
   });
 });

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -1,5 +1,6 @@
 import { deferred } from "../../internal/deferred";
 import { closeRuntimeInput } from "../input/runtime-input";
+import { cancelQueuedDurableThreadInputs } from "../runtime/durable-input-cancellation";
 import { unregisterLiveThreadInput } from "../runtime/live-input-ownership";
 import type { AgentThreadContext } from "./agent-thread-context";
 import { assertThreadMachineInvariants } from "./agent-thread-machines";
@@ -113,7 +114,7 @@ async function restartReleasedThreadDrain(
 /** @internal exported for retry/observability regression tests. */
 export async function retryReleasedThreadDrain(
   drain: () => Promise<void>,
-  onPermanentFailure: (failure: unknown) => void,
+  onPermanentFailure: (failure: unknown) => Promise<void> | void,
   retryLimit = RELEASED_DRAIN_RETRY_LIMIT
 ): Promise<void> {
   let failure: unknown;
@@ -126,15 +127,33 @@ export async function retryReleasedThreadDrain(
       await Promise.resolve();
     }
   }
-  onPermanentFailure(failure);
+  await onPermanentFailure(failure);
 }
 
-function settleInputsAfterRestartFailure(
+async function settleInputsAfterRestartFailure(
   context: AgentThreadContext,
   failure: unknown
-): void {
+): Promise<void> {
+  const items = [...context.inputQueue];
   const message = `Thread drain restart failed after ${RELEASED_DRAIN_RETRY_LIMIT} attempts: ${errorMessage(failure)}`;
-  for (const item of context.inputQueue.splice(0)) {
+  try {
+    await cancelQueuedDurableThreadInputs({
+      executionHost: context.execution.executionHost,
+      items,
+      threadKey: context.threadKey,
+    });
+  } catch (cancellationFailure) {
+    const recoveryMessage = `${message}; durable cancellation failed and requires recovery: ${errorMessage(cancellationFailure)}`;
+    // Keep callers and protective live ownership open: closing/unregistering
+    // here could allow the durable record to execute after its caller ended.
+    for (const item of items) {
+      item.run.emit({ message: recoveryMessage, type: "turn-error" });
+    }
+    return;
+  }
+
+  context.inputQueue.splice(0, items.length);
+  for (const item of items) {
     if (item.durableMessageId) {
       unregisterLiveThreadInput(
         context.execution.executionHost,

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -146,8 +146,8 @@ async function settleInputsAfterRestartFailure(
       }),
     drain: () => drainAgentThreadInputQueue(context),
     onCancelled: () => {
-      context.inputQueue.splice(0, items.length);
-      for (const item of items) {
+      const removed = removeQueuedInputsByIdentity(context.inputQueue, items);
+      for (const item of removed) {
         if (item.durableMessageId) {
           unregisterLiveThreadInput(
             context.execution.executionHost,
@@ -163,6 +163,21 @@ async function settleInputsAfterRestartFailure(
     },
     retryOnCancellationFailure,
   });
+}
+
+/** @internal exported for queue-mutation regression tests. */
+export function removeQueuedInputsByIdentity<T>(
+  queue: T[],
+  snapshot: readonly T[]
+): T[] {
+  const removed: T[] = [];
+  for (const item of snapshot) {
+    const index = queue.indexOf(item);
+    if (index >= 0) {
+      removed.push(...queue.splice(index, 1));
+    }
+  }
+  return removed;
 }
 
 /** @internal exported for cancellation-recovery regression tests. */

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -107,7 +107,7 @@ async function restartReleasedThreadDrain(
 ): Promise<void> {
   await retryReleasedThreadDrain(
     () => drainAgentThreadInputQueue(context),
-    (failure) => settleInputsAfterRestartFailure(context, failure)
+    (failure) => settleInputsAfterRestartFailure(context, failure, true)
   );
 }
 
@@ -132,39 +132,66 @@ export async function retryReleasedThreadDrain(
 
 async function settleInputsAfterRestartFailure(
   context: AgentThreadContext,
-  failure: unknown
+  failure: unknown,
+  retryOnCancellationFailure: boolean
 ): Promise<void> {
   const items = [...context.inputQueue];
   const message = `Thread drain restart failed after ${RELEASED_DRAIN_RETRY_LIMIT} attempts: ${errorMessage(failure)}`;
-  try {
-    await cancelQueuedDurableThreadInputs({
-      executionHost: context.execution.executionHost,
-      items,
-      threadKey: context.threadKey,
-    });
-  } catch (cancellationFailure) {
-    const recoveryMessage = `${message}; durable cancellation failed and requires recovery: ${errorMessage(cancellationFailure)}`;
-    // Keep callers and protective live ownership open: closing/unregistering
-    // here could allow the durable record to execute after its caller ended.
-    for (const item of items) {
-      item.run.emit({ message: recoveryMessage, type: "turn-error" });
-    }
-    return;
-  }
+  await recoverOrCancelReleasedDrain({
+    cancel: () =>
+      cancelQueuedDurableThreadInputs({
+        executionHost: context.execution.executionHost,
+        items,
+        threadKey: context.threadKey,
+      }),
+    drain: () => drainAgentThreadInputQueue(context),
+    onCancelled: () => {
+      context.inputQueue.splice(0, items.length);
+      for (const item of items) {
+        if (item.durableMessageId) {
+          unregisterLiveThreadInput(
+            context.execution.executionHost,
+            context.threadKey,
+            item.durableMessageId,
+            item.durableOwner
+          );
+        }
+        closeRuntimeInput(item.runtimeInput, message);
+        item.run.emit({ message, type: "turn-error" });
+        item.run.close();
+      }
+    },
+    retryOnCancellationFailure,
+  });
+}
 
-  context.inputQueue.splice(0, items.length);
-  for (const item of items) {
-    if (item.durableMessageId) {
-      unregisterLiveThreadInput(
-        context.execution.executionHost,
-        context.threadKey,
-        item.durableMessageId,
-        item.durableOwner
+/** @internal exported for cancellation-recovery regression tests. */
+export async function recoverOrCancelReleasedDrain({
+  cancel,
+  drain,
+  onCancelled,
+  retryOnCancellationFailure = true,
+}: {
+  readonly cancel: () => Promise<void>;
+  readonly drain: () => Promise<void>;
+  readonly onCancelled: () => void;
+  readonly retryOnCancellationFailure?: boolean;
+}): Promise<void> {
+  try {
+    await cancel();
+    onCancelled();
+  } catch {
+    if (retryOnCancellationFailure) {
+      await Promise.resolve();
+      await retryReleasedThreadDrain(drain, () =>
+        recoverOrCancelReleasedDrain({
+          cancel,
+          drain,
+          onCancelled,
+          retryOnCancellationFailure: false,
+        })
       );
     }
-    closeRuntimeInput(item.runtimeInput, message);
-    item.run.emit({ message, type: "turn-error" });
-    item.run.close();
   }
 }
 

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -66,10 +66,9 @@ export async function drainAgentThreadInputQueue(
         inputQueue: context.inputQueue,
         model: context.model,
         onBlocked: (released) => {
-          released.then(
-            () => drainAgentThreadInputQueue(context),
-            () => undefined
-          );
+          released
+            .then(() => drainAgentThreadInputQueue(context))
+            .catch(() => undefined);
         },
         release: () => {
           turn.to({ tag: "none" });

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -2,6 +2,7 @@ import { deferred } from "../../internal/deferred";
 import type { AgentThreadContext } from "./agent-thread-context";
 import { assertThreadMachineInvariants } from "./agent-thread-machines";
 import { runThreadInputDrainLoop } from "./thread-drain";
+import { withThreadDrainOwnership } from "./thread-drain-coordinator";
 
 export async function drainAgentThreadInputQueue(
   context: AgentThreadContext
@@ -23,38 +24,47 @@ export async function drainAgentThreadInputQueue(
     restartRequested: false,
   });
 
-  const loop = runThreadInputDrainLoop({
-    activate: ({ abort, run, runtimeInput, turnId }) => {
-      turn.to({ tag: "active", abort, run, runtimeInput, turnId });
-    },
-    continueDraining: () => {
-      if (terminal.state.tag !== "open") {
-        return false;
+  const loop = withThreadDrainOwnership(
+    context.execution.executionHost,
+    context.threadKey,
+    async ({ contended }) => {
+      if (contended) {
+        await context.state.refresh();
       }
-      const state = drain.state;
-      return !(state.tag === "draining" && state.restartRequested);
-    },
-    deactivateRun: () => {
-      const state = turn.state;
-      if (state.tag === "active") {
-        turn.to({
-          tag: "finishing",
-          abort: state.abort,
-          run: state.run,
-          turnId: state.turnId,
-        });
-      }
-    },
-    events: context.events,
-    execution: context.execution,
-    inputQueue: context.inputQueue,
-    model: context.model,
-    release: () => {
-      turn.to({ tag: "none" });
-    },
-    state: context.state,
-    threadKey: context.threadKey,
-  });
+      return await runThreadInputDrainLoop({
+        activate: ({ abort, run, runtimeInput, turnId }) => {
+          turn.to({ tag: "active", abort, run, runtimeInput, turnId });
+        },
+        continueDraining: () => {
+          if (terminal.state.tag !== "open") {
+            return false;
+          }
+          const state = drain.state;
+          return !(state.tag === "draining" && state.restartRequested);
+        },
+        deactivateRun: () => {
+          const state = turn.state;
+          if (state.tag === "active") {
+            turn.to({
+              tag: "finishing",
+              abort: state.abort,
+              run: state.run,
+              turnId: state.turnId,
+            });
+          }
+        },
+        events: context.events,
+        execution: context.execution,
+        inputQueue: context.inputQueue,
+        model: context.model,
+        release: () => {
+          turn.to({ tag: "none" });
+        },
+        state: context.state,
+        threadKey: context.threadKey,
+      });
+    }
+  );
   loop.then(loopSettled.resolve, loopSettled.reject);
 
   try {

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -1,6 +1,7 @@
 import { deferred } from "../../internal/deferred";
 import type { AgentThreadContext } from "./agent-thread-context";
 import { assertThreadMachineInvariants } from "./agent-thread-machines";
+import { recoverThreadDurableInputClaims } from "./durable-queue-claims";
 import { runThreadInputDrainLoop } from "./thread-drain";
 import { withThreadDrainOwnership } from "./thread-drain-coordinator";
 
@@ -27,8 +28,15 @@ export async function drainAgentThreadInputQueue(
   const loop = withThreadDrainOwnership(
     context.execution.executionHost,
     context.threadKey,
-    async ({ contended }) => {
-      if (contended) {
+    context,
+    async ({ refreshRequired }) => {
+      await recoverThreadDurableInputClaims({
+        allowOwned: true,
+        executionHost: context.execution.executionHost,
+        state: context.durableInputRecovery,
+        threadKey: context.threadKey,
+      });
+      if (refreshRequired) {
         await context.state.refresh();
       }
       return await runThreadInputDrainLoop({

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -1,4 +1,6 @@
 import { deferred } from "../../internal/deferred";
+import { closeRuntimeInput } from "../input/runtime-input";
+import { unregisterLiveThreadInput } from "../runtime/live-input-ownership";
 import type { AgentThreadContext } from "./agent-thread-context";
 import { assertThreadMachineInvariants } from "./agent-thread-machines";
 import { recoverThreadDurableInputClaims } from "./durable-queue-claims";
@@ -67,7 +69,7 @@ export async function drainAgentThreadInputQueue(
         model: context.model,
         onBlocked: (released) => {
           released
-            .then(() => drainAgentThreadInputQueue(context))
+            .then(() => restartReleasedThreadDrain(context))
             .catch(() => undefined);
         },
         release: () => {
@@ -95,4 +97,58 @@ export async function drainAgentThreadInputQueue(
       await drainAgentThreadInputQueue(context);
     }
   }
+}
+
+const RELEASED_DRAIN_RETRY_LIMIT = 3;
+
+async function restartReleasedThreadDrain(
+  context: AgentThreadContext
+): Promise<void> {
+  await retryReleasedThreadDrain(
+    () => drainAgentThreadInputQueue(context),
+    (failure) => settleInputsAfterRestartFailure(context, failure)
+  );
+}
+
+/** @internal exported for retry/observability regression tests. */
+export async function retryReleasedThreadDrain(
+  drain: () => Promise<void>,
+  onPermanentFailure: (failure: unknown) => void,
+  retryLimit = RELEASED_DRAIN_RETRY_LIMIT
+): Promise<void> {
+  let failure: unknown;
+  for (let attempt = 0; attempt < retryLimit; attempt += 1) {
+    try {
+      await drain();
+      return;
+    } catch (error) {
+      failure = error;
+      await Promise.resolve();
+    }
+  }
+  onPermanentFailure(failure);
+}
+
+function settleInputsAfterRestartFailure(
+  context: AgentThreadContext,
+  failure: unknown
+): void {
+  const message = `Thread drain restart failed after ${RELEASED_DRAIN_RETRY_LIMIT} attempts: ${errorMessage(failure)}`;
+  for (const item of context.inputQueue.splice(0)) {
+    if (item.durableMessageId) {
+      unregisterLiveThreadInput(
+        context.execution.executionHost,
+        context.threadKey,
+        item.durableMessageId,
+        item.durableOwner
+      );
+    }
+    closeRuntimeInput(item.runtimeInput, message);
+    item.run.emit({ message, type: "turn-error" });
+    item.run.close();
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -65,6 +65,12 @@ export async function drainAgentThreadInputQueue(
         execution: context.execution,
         inputQueue: context.inputQueue,
         model: context.model,
+        onBlocked: (released) => {
+          released.then(
+            () => drainAgentThreadInputQueue(context),
+            () => undefined
+          );
+        },
         release: () => {
           turn.to({ tag: "none" });
         },

--- a/packages/runtime/src/thread/handle/agent-thread-kill.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-kill.ts
@@ -26,29 +26,33 @@ export function killAgentThread(context: AgentThreadContext): Promise<void> {
   context.pendingOverlays.length = 0;
   context.pendingRuntimeInputs.length = 0;
   turnAbort(context.turn)?.abort();
-  const immediateClose = closeKilledRuntimeInputs({
-    activeRuntimeInput: activeTurnRuntimeInput(context.turn),
-    executionHost: context.execution.executionHost,
-    inputQueue: context.inputQueue,
-    message: killedError.message,
-    runToClose: turnRunToClose(context.turn),
-    threadKey: context.threadKey,
-  });
-  const admissionClose = context.inputAdmissionQueue.then(() =>
-    closeKilledRuntimeInputs({
+  const close = async (): Promise<void> => {
+    await closeKilledRuntimeInputs({
+      activeRuntimeInput: activeTurnRuntimeInput(context.turn),
+      executionHost: context.execution.executionHost,
+      inputQueue: context.inputQueue,
+      message: killedError.message,
+      runToClose: turnRunToClose(context.turn),
+      threadKey: context.threadKey,
+    });
+    await context.inputAdmissionQueue;
+    await closeKilledRuntimeInputs({
       activeRuntimeInput: undefined,
       executionHost: context.execution.executionHost,
       inputQueue: context.inputQueue,
       message: killedError.message,
       runToClose: undefined,
       threadKey: context.threadKey,
-    })
-  );
-  Promise.all([immediateClose, admissionClose]).then(
+    });
+  };
+  close().then(
     () => settled.resolve(),
     (error: unknown) => {
-      context.terminal.toIf("killed", { tag: "open" });
-      settled.reject(error);
+      try {
+        context.terminal.toIf("killed", { tag: "open" });
+      } finally {
+        settled.reject(error);
+      }
     }
   );
   return killPromise;

--- a/packages/runtime/src/thread/handle/agent-thread-kill.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-kill.ts
@@ -7,7 +7,6 @@ import {
   turnAbort,
   turnRunToClose,
 } from "./agent-thread-machines";
-import { withThreadDrainOwnership } from "./thread-drain-coordinator";
 
 export function killAgentThread(context: AgentThreadContext): Promise<void> {
   const current = context.terminal.state;
@@ -28,30 +27,23 @@ export function killAgentThread(context: AgentThreadContext): Promise<void> {
   context.pendingRuntimeInputs.length = 0;
   turnAbort(context.turn)?.abort();
   const close = async (): Promise<void> => {
-    await withThreadDrainOwnership(
-      context.execution.executionHost,
-      context.threadKey,
-      context,
-      async () => {
-        await closeKilledRuntimeInputs({
-          activeRuntimeInput: activeTurnRuntimeInput(context.turn),
-          executionHost: context.execution.executionHost,
-          inputQueue: context.inputQueue,
-          message: killedError.message,
-          runToClose: turnRunToClose(context.turn),
-          threadKey: context.threadKey,
-        });
-        await context.inputAdmissionQueue;
-        await closeKilledRuntimeInputs({
-          activeRuntimeInput: undefined,
-          executionHost: context.execution.executionHost,
-          inputQueue: context.inputQueue,
-          message: killedError.message,
-          runToClose: undefined,
-          threadKey: context.threadKey,
-        });
-      }
-    );
+    await closeKilledRuntimeInputs({
+      activeRuntimeInput: activeTurnRuntimeInput(context.turn),
+      executionHost: context.execution.executionHost,
+      inputQueue: context.inputQueue,
+      message: killedError.message,
+      runToClose: turnRunToClose(context.turn),
+      threadKey: context.threadKey,
+    });
+    await context.inputAdmissionQueue;
+    await closeKilledRuntimeInputs({
+      activeRuntimeInput: undefined,
+      executionHost: context.execution.executionHost,
+      inputQueue: context.inputQueue,
+      message: killedError.message,
+      runToClose: undefined,
+      threadKey: context.threadKey,
+    });
   };
   close().then(
     () => settled.resolve(),

--- a/packages/runtime/src/thread/handle/agent-thread-kill.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-kill.ts
@@ -27,23 +27,42 @@ export function killAgentThread(context: AgentThreadContext): Promise<void> {
   context.pendingRuntimeInputs.length = 0;
   turnAbort(context.turn)?.abort();
   const close = async (): Promise<void> => {
-    await closeKilledRuntimeInputs({
-      activeRuntimeInput: activeTurnRuntimeInput(context.turn),
-      executionHost: context.execution.executionHost,
-      inputQueue: context.inputQueue,
-      message: killedError.message,
-      runToClose: turnRunToClose(context.turn),
-      threadKey: context.threadKey,
-    });
-    await context.inputAdmissionQueue;
-    await closeKilledRuntimeInputs({
-      activeRuntimeInput: undefined,
-      executionHost: context.execution.executionHost,
-      inputQueue: context.inputQueue,
-      message: killedError.message,
-      runToClose: undefined,
-      threadKey: context.threadKey,
-    });
+    const errors: unknown[] = [];
+    try {
+      await closeKilledRuntimeInputs({
+        activeRuntimeInput: activeTurnRuntimeInput(context.turn),
+        executionHost: context.execution.executionHost,
+        inputQueue: context.inputQueue,
+        message: killedError.message,
+        runToClose: turnRunToClose(context.turn),
+        threadKey: context.threadKey,
+      });
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await context.inputAdmissionQueue;
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await closeKilledRuntimeInputs({
+        activeRuntimeInput: undefined,
+        executionHost: context.execution.executionHost,
+        inputQueue: context.inputQueue,
+        message: killedError.message,
+        runToClose: undefined,
+        threadKey: context.threadKey,
+      });
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "Thread teardown failed.");
+    }
   };
   close().then(
     () => settled.resolve(),

--- a/packages/runtime/src/thread/handle/agent-thread-kill.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-kill.ts
@@ -7,6 +7,7 @@ import {
   turnAbort,
   turnRunToClose,
 } from "./agent-thread-machines";
+import { withThreadDrainOwnership } from "./thread-drain-coordinator";
 
 export function killAgentThread(context: AgentThreadContext): Promise<void> {
   const current = context.terminal.state;
@@ -27,23 +28,30 @@ export function killAgentThread(context: AgentThreadContext): Promise<void> {
   context.pendingRuntimeInputs.length = 0;
   turnAbort(context.turn)?.abort();
   const close = async (): Promise<void> => {
-    await closeKilledRuntimeInputs({
-      activeRuntimeInput: activeTurnRuntimeInput(context.turn),
-      executionHost: context.execution.executionHost,
-      inputQueue: context.inputQueue,
-      message: killedError.message,
-      runToClose: turnRunToClose(context.turn),
-      threadKey: context.threadKey,
-    });
-    await context.inputAdmissionQueue;
-    await closeKilledRuntimeInputs({
-      activeRuntimeInput: undefined,
-      executionHost: context.execution.executionHost,
-      inputQueue: context.inputQueue,
-      message: killedError.message,
-      runToClose: undefined,
-      threadKey: context.threadKey,
-    });
+    await withThreadDrainOwnership(
+      context.execution.executionHost,
+      context.threadKey,
+      context,
+      async () => {
+        await closeKilledRuntimeInputs({
+          activeRuntimeInput: activeTurnRuntimeInput(context.turn),
+          executionHost: context.execution.executionHost,
+          inputQueue: context.inputQueue,
+          message: killedError.message,
+          runToClose: turnRunToClose(context.turn),
+          threadKey: context.threadKey,
+        });
+        await context.inputAdmissionQueue;
+        await closeKilledRuntimeInputs({
+          activeRuntimeInput: undefined,
+          executionHost: context.execution.executionHost,
+          inputQueue: context.inputQueue,
+          message: killedError.message,
+          runToClose: undefined,
+          threadKey: context.threadKey,
+        });
+      }
+    );
   };
   close().then(
     () => settled.resolve(),

--- a/packages/runtime/src/thread/handle/agent-thread-kill.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-kill.ts
@@ -46,7 +46,10 @@ export function killAgentThread(context: AgentThreadContext): Promise<void> {
   );
   Promise.all([immediateClose, admissionClose]).then(
     () => settled.resolve(),
-    settled.reject
+    (error: unknown) => {
+      context.terminal.toIf("killed", { tag: "open" });
+      settled.reject(error);
+    }
   );
   return killPromise;
 }

--- a/packages/runtime/src/thread/handle/agent-thread-machines.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-machines.ts
@@ -68,7 +68,7 @@ export function createThreadTerminalMachine(): Fsm<ThreadTerminalState> {
     name: "thread-terminal",
     transitions: {
       open: ["killed"],
-      killed: ["deleting"],
+      killed: ["deleting", "open"],
       deleting: ["killed", "deleted"],
       deleted: [],
     },

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -220,7 +220,6 @@ export class AgentThread {
       pendingOverlays: this.#context.pendingOverlays,
       pendingRuntimeInputs: this.#context.pendingRuntimeInputs,
       run,
-      source: kind,
       threadKey: this.#context.threadKey,
     });
     this.#assertOpen();

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -138,29 +138,35 @@ export class AgentThread {
       return current.deletePromise;
     }
 
-    const killPromise = this.kill();
+    const killPromise =
+      current.tag === "killed" ? current.killPromise : this.kill();
     const settled = deferred();
     const deletePromise = settled.promise;
-    // Transition before wiring the continuation so the machine state never
-    // depends on microtask scheduling.
-    terminal.to({ tag: "deleting", deletePromise, killPromise });
-    killPromise
-      .then(() => this.#deleteThread())
-      .then(
-        () => {
-          terminal.toIf("deleting", {
-            tag: "deleted",
-            deletePromise,
-            killPromise,
-          });
-          settled.resolve();
-        },
-        (error: unknown) => {
-          // Roll back to `killed` so the delete can be retried.
-          terminal.toIf("deleting", { tag: "killed", killPromise });
-          settled.reject(error);
-        }
-      );
+    const remove = async (): Promise<void> => {
+      await killPromise;
+      const afterKill = terminal.state;
+      if (afterKill.tag === "deleting" || afterKill.tag === "deleted") {
+        return await afterKill.deletePromise;
+      }
+      if (afterKill.tag !== "killed") {
+        throw new Error("Thread kill did not reach a terminal state.");
+      }
+      terminal.to({ tag: "deleting", deletePromise, killPromise });
+      try {
+        await this.#deleteThread();
+        terminal.toIf("deleting", {
+          tag: "deleted",
+          deletePromise,
+          killPromise,
+        });
+      } catch (error) {
+        // The durable delete can be retried without repeating the successful
+        // kill teardown.
+        terminal.toIf("deleting", { tag: "killed", killPromise });
+        throw error;
+      }
+    };
+    remove().then(settled.resolve, settled.reject);
     return deletePromise;
   }
 

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -44,15 +44,12 @@ export class AgentThread {
   }
 
   async send(input: AgentInput): Promise<AgentTurn> {
-    this.#assertOpen();
+    return await this.#queueTurnInput(input, "send");
+  }
 
-    const run = new BufferedAgentTurn();
-    const loaded = this.#ensureStarted();
-    await this.#enqueueInputAdmission(async () => {
-      await loaded;
-      await this.#admitSend(input, run);
-    });
-    return run;
+  /** Queue a durable user turn that starts only after the active turn ends. */
+  async followUp(input: AgentInput): Promise<AgentTurn> {
+    return await this.#queueTurnInput(input, "follow-up");
   }
 
   overlay(input: AgentInput): this {
@@ -180,7 +177,26 @@ export class AgentThread {
     return killAgentThread(this.#context);
   }
 
-  async #admitSend(input: AgentInput, run: BufferedAgentTurn): Promise<void> {
+  async #queueTurnInput(
+    input: AgentInput,
+    kind: "follow-up" | "send"
+  ): Promise<AgentTurn> {
+    this.#assertOpen();
+
+    const run = new BufferedAgentTurn();
+    const loaded = this.#ensureStarted();
+    await this.#enqueueInputAdmission(async () => {
+      await loaded;
+      await this.#admitSend(input, run, kind);
+    });
+    return run;
+  }
+
+  async #admitSend(
+    input: AgentInput,
+    run: BufferedAgentTurn,
+    kind: "follow-up" | "send"
+  ): Promise<void> {
     this.#assertOpen();
 
     await this.#recoverDurableInputClaims();
@@ -200,9 +216,11 @@ export class AgentThread {
       attachmentStore: this.#context.model.attachmentStore,
       input,
       inputQueue: this.#context.inputQueue,
+      kind,
       pendingOverlays: this.#context.pendingOverlays,
       pendingRuntimeInputs: this.#context.pendingRuntimeInputs,
       run,
+      source: kind,
       threadKey: this.#context.threadKey,
     });
     this.#assertOpen();

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -10,6 +10,10 @@ import type { ThreadExecutionOptions } from "../runtime/execution";
 import type { NotifyOptions } from "../runtime/notification";
 import { queueThreadNotification } from "../runtime/notification";
 import { readThreadEvents } from "../runtime/thread-event-replay";
+import {
+  reserveThreadInputAdmission,
+  type ThreadInputAdmissionReservation,
+} from "../runtime/thread-input-admission-coordinator";
 import { threadKilledError } from "../state/thread-errors";
 import type {
   ThreadCompactionInput,
@@ -184,10 +188,22 @@ export class AgentThread {
     this.#assertOpen();
 
     const run = new BufferedAgentTurn();
+    const executionHost = this.#context.execution.executionHost;
+    const reservation = executionHost
+      ? reserveThreadInputAdmission(executionHost, this.#context.threadKey)
+      : undefined;
     const loaded = this.#ensureStarted();
     await this.#enqueueInputAdmission(async () => {
-      await loaded;
-      await this.#admitSend(input, run, kind);
+      const admit = async (): Promise<void> => {
+        await loaded;
+        await this.#admitSend(
+          input,
+          run,
+          kind,
+          async (operation) => await operation()
+        );
+      };
+      await (reservation ? reservation(admit) : admit());
     });
     return run;
   }
@@ -195,7 +211,8 @@ export class AgentThread {
   async #admitSend(
     input: AgentInput,
     run: BufferedAgentTurn,
-    kind: "follow-up" | "send"
+    kind: "follow-up" | "send",
+    reservation?: ThreadInputAdmissionReservation
   ): Promise<void> {
     this.#assertOpen();
 
@@ -219,6 +236,7 @@ export class AgentThread {
       kind,
       pendingOverlays: this.#context.pendingOverlays,
       pendingRuntimeInputs: this.#context.pendingRuntimeInputs,
+      reservation,
       run,
       threadKey: this.#context.threadKey,
     });

--- a/packages/runtime/src/thread/handle/durable-inputs.test.ts
+++ b/packages/runtime/src/thread/handle/durable-inputs.test.ts
@@ -7,6 +7,7 @@ import type {
   HostStoreTransaction,
   ThreadInputBoundary,
   ThreadInputInbox,
+  ThreadInputKind,
 } from "../../execution";
 import { createInMemoryHost } from "../../platform/memory";
 import {
@@ -258,7 +259,7 @@ function transactionWithInputTrace(
 function claimTrace(
   boundary: ThreadInputBoundary,
   messageId: string | undefined,
-  kind: "send" | "steer" | undefined
+  kind: ThreadInputKind | undefined
 ): string {
   const target = messageId ? "targeted" : "any";
   return `claim:${boundary}:${target}:${kind ?? "none"}`;

--- a/packages/runtime/src/thread/handle/durable-inputs.test.ts
+++ b/packages/runtime/src/thread/handle/durable-inputs.test.ts
@@ -49,7 +49,7 @@ describe("AgentThread durable inputs", () => {
     expect(nonEmptyClaims(trace)).toEqual([
       "recover",
       "admit:send:none",
-      "claim:turn-idle:targeted:send",
+      "claim:turn-idle:any:send",
       "promote:send",
       "ack:send",
     ]);
@@ -88,7 +88,7 @@ describe("AgentThread durable inputs", () => {
     expect(nonEmptyClaims(trace)).toEqual([
       "recover",
       "admit:send:none",
-      "claim:turn-idle:targeted:send",
+      "claim:turn-idle:any:send",
       "promote:send",
       "ack:send",
       "admit:steer:step-start",
@@ -98,12 +98,12 @@ describe("AgentThread durable inputs", () => {
     ]);
   });
 
-  it("does not let recovered pending sends steal a newly admitted send turn", async () => {
+  it("runs an older recovered follow-up before a newly admitted send", async () => {
     const base = createInMemoryHost();
     await base.store.inputs.admit({
       admittedAtMs: 1,
       input: userText("old"),
-      kind: "send",
+      kind: "follow-up",
       messageId: "old-message",
       threadKey: "durable-recovery",
     });
@@ -130,7 +130,12 @@ describe("AgentThread durable inputs", () => {
     );
 
     expect(events[0]).toEqual(sentUserText("new"));
-    expect(seenHistory[0]).toEqual([userTextToModelMessage(userText("new"))]);
+    expect(seenHistory[0]).toEqual([userTextToModelMessage(userText("old"))]);
+    expect(seenHistory[1]).toEqual([
+      userTextToModelMessage(userText("old")),
+      assistantMessage("DONE 1"),
+      userTextToModelMessage(userText("new")),
+    ]);
     await expect(base.store.inputs.releaseClaim(oldClaim)).resolves.toBeNull();
     await expect(
       base.store.inputs.claimNext("durable-recovery", "turn-idle")
@@ -160,12 +165,12 @@ describe("AgentThread durable inputs", () => {
     );
 
     expect(events[0]).toEqual(sentUserText("new"));
-    expect(seenHistory[0]).toEqual([userTextToModelMessage(userText("new"))]);
+    expect(seenHistory[0]).toEqual([userTextToModelMessage(userText("old"))]);
     await vi.waitFor(() => expect(seenHistory).toHaveLength(2));
     expect(seenHistory[1]).toEqual([
-      userTextToModelMessage(userText("new")),
-      assistantMessage("DONE 1"),
       userTextToModelMessage(userText("old")),
+      assistantMessage("DONE 1"),
+      userTextToModelMessage(userText("new")),
     ]);
     await expect(
       host.store.inputs.claimNext("durable-pending-orphan", "turn-idle")

--- a/packages/runtime/src/thread/handle/durable-queue-claims.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-claims.ts
@@ -9,6 +9,7 @@ import { BufferedAgentTurn } from "../protocol/turn";
 import {
   claimDurableThreadInput,
   recoverDurableThreadInputs,
+  releaseDurableThreadInputClaim,
 } from "../runtime/durable-input-claims";
 import {
   cancelThreadExecutionRun,
@@ -138,15 +139,13 @@ export async function prepareQueuedDurableInput({
     return { item, kind: "prepared" };
   }
 
-  const oldestFirst = item.durableInputKind === "follow-up";
   const claimed = await claimDurableThreadInput({
     boundary: "turn-idle",
     executionHost,
-    messageId: oldestFirst ? undefined : item.durableMessageId,
     threadKey,
   });
   if (claimed.kind === "claimed" && claimed.record) {
-    if (oldestFirst && claimed.record.messageId !== item.durableMessageId) {
+    if (claimed.record.messageId !== item.durableMessageId) {
       return {
         item: await queuedInputFromClaim(claimed.record, executionHost),
         kind: "preceding",
@@ -174,12 +173,18 @@ async function queuedInputFromClaim(
     threadKey: record.threadKey,
     turnId: record.messageId,
   });
-  const precreated = await precreateThreadExecutionRun({
-    executionHost,
-    kind: "user-turn",
-    runId,
-    threadKey: record.threadKey,
-  });
+  let precreated: Awaited<ReturnType<typeof precreateThreadExecutionRun>>;
+  try {
+    precreated = await precreateThreadExecutionRun({
+      executionHost,
+      kind: "user-turn",
+      runId,
+      threadKey: record.threadKey,
+    });
+  } catch (error) {
+    await releaseDurableThreadInputClaim({ executionHost, record });
+    throw error;
+  }
   return {
     acceptedEvent: record.input,
     awaitBoundaries: false,

--- a/packages/runtime/src/thread/handle/durable-queue-claims.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-claims.ts
@@ -14,10 +14,35 @@ import {
   cancelThreadExecutionRun,
   precreateThreadExecutionRun,
 } from "../runtime/execution";
-import {
-  isThreadDrainOwned,
-  withThreadDrainOwnership,
-} from "./thread-drain-coordinator";
+import { isThreadDrainOwned } from "./thread-drain-coordinator";
+
+const sharedRecoveries = new WeakMap<object, Map<string, Promise<void>>>();
+
+async function recoverAfterLiveDrain(
+  executionHost: AgentHost,
+  threadKey: string
+): Promise<void> {
+  let byThread = sharedRecoveries.get(executionHost.store);
+  if (!byThread) {
+    byThread = new Map();
+    sharedRecoveries.set(executionHost.store, byThread);
+  }
+  const existing = byThread.get(threadKey);
+  if (existing) {
+    return await existing;
+  }
+  const recovery = (async () => {
+    await recoverDurableThreadInputs({ executionHost, threadKey });
+  })();
+  byThread.set(threadKey, recovery);
+  try {
+    await recovery;
+  } finally {
+    if (byThread.get(threadKey) === recovery) {
+      byThread.delete(threadKey);
+    }
+  }
+}
 
 /**
  * One-shot recovery of orphaned durable input claims:
@@ -42,10 +67,12 @@ export class DurableInputRecoveryState {
 }
 
 export async function recoverThreadDurableInputClaims({
+  allowOwned = false,
   executionHost,
   state,
   threadKey,
 }: {
+  readonly allowOwned?: boolean;
   readonly executionHost: AgentHost | undefined;
   readonly state: DurableInputRecoveryState;
   readonly threadKey: string;
@@ -53,15 +80,18 @@ export async function recoverThreadDurableInputClaims({
   if (state.machine.state.tag !== "pending") {
     return;
   }
+  if (
+    executionHost &&
+    !allowOwned &&
+    isThreadDrainOwned(executionHost, threadKey)
+  ) {
+    return;
+  }
 
   state.machine.to({ tag: "recovering" });
   try {
     if (executionHost) {
-      if (!isThreadDrainOwned(executionHost, threadKey)) {
-        await withThreadDrainOwnership(executionHost, threadKey, async () => {
-          await recoverDurableThreadInputs({ executionHost, threadKey });
-        });
-      }
+      await recoverAfterLiveDrain(executionHost, threadKey);
     } else {
       await recoverDurableThreadInputs({ executionHost, threadKey });
     }

--- a/packages/runtime/src/thread/handle/durable-queue-claims.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-claims.ts
@@ -18,6 +18,7 @@ import {
 } from "../runtime/execution";
 import {
   isLiveThreadInputOwnedByOther,
+  liveThreadInputOwnedByOther,
   unregisterLiveThreadInput,
 } from "../runtime/live-input-ownership";
 import { inputMetaForQueuedKind } from "./durable-queue-send";
@@ -142,7 +143,7 @@ export async function claimOrphanDurableThreadInput({
 
 export type QueuedDurableInputPreparation =
   | { readonly kind: "prepared"; readonly item: QueuedInput }
-  | { readonly kind: "blocked" }
+  | { readonly kind: "blocked"; readonly released: Promise<void> }
   | { readonly kind: "preceding"; readonly item: QueuedInput }
   | { readonly kind: "unavailable" };
 
@@ -166,19 +167,18 @@ export async function prepareQueuedDurableInput({
   });
   if (claimed.kind === "claimed" && claimed.record) {
     if (claimed.record.messageId !== item.durableMessageId) {
-      if (
-        isLiveThreadInputOwnedByOther(
-          executionHost,
-          threadKey,
-          claimed.record.messageId,
-          item.durableOwner
-        )
-      ) {
+      const released = liveThreadInputOwnedByOther(
+        executionHost,
+        threadKey,
+        claimed.record.messageId,
+        item.durableOwner
+      );
+      if (released) {
         await releaseDurableThreadInputClaim({
           executionHost,
           record: claimed.record,
         });
-        return { kind: "blocked" };
+        return { kind: "blocked", released };
       }
       return {
         item: await queuedInputFromClaim(claimed.record, executionHost),
@@ -189,7 +189,8 @@ export async function prepareQueuedDurableInput({
       unregisterLiveThreadInput(
         executionHost,
         threadKey,
-        item.durableMessageId
+        item.durableMessageId,
+        item.durableOwner
       );
     }
     return {
@@ -199,7 +200,12 @@ export async function prepareQueuedDurableInput({
   }
 
   if (item.durableMessageId) {
-    unregisterLiveThreadInput(executionHost, threadKey, item.durableMessageId);
+    unregisterLiveThreadInput(
+      executionHost,
+      threadKey,
+      item.durableMessageId,
+      item.durableOwner
+    );
   }
   await cancelThreadExecutionRun({
     executionHost,

--- a/packages/runtime/src/thread/handle/durable-queue-claims.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-claims.ts
@@ -14,6 +14,10 @@ import {
   cancelThreadExecutionRun,
   precreateThreadExecutionRun,
 } from "../runtime/execution";
+import {
+  isThreadDrainOwned,
+  withThreadDrainOwnership,
+} from "./thread-drain-coordinator";
 
 /**
  * One-shot recovery of orphaned durable input claims:
@@ -52,10 +56,15 @@ export async function recoverThreadDurableInputClaims({
 
   state.machine.to({ tag: "recovering" });
   try {
-    await recoverDurableThreadInputs({
-      executionHost,
-      threadKey,
-    });
+    if (executionHost) {
+      if (!isThreadDrainOwned(executionHost, threadKey)) {
+        await withThreadDrainOwnership(executionHost, threadKey, async () => {
+          await recoverDurableThreadInputs({ executionHost, threadKey });
+        });
+      }
+    } else {
+      await recoverDurableThreadInputs({ executionHost, threadKey });
+    }
     state.machine.to({ tag: "recovered" });
   } catch (error) {
     state.machine.to({ tag: "pending" });
@@ -78,30 +87,13 @@ export async function claimOrphanDurableThreadInput({
   if (claimed.kind === "unavailable" || !claimed.record) {
     return;
   }
-
-  const runId = createThreadExecutionRunId({
-    threadKey: claimed.record.threadKey,
-    turnId: claimed.record.messageId,
-  });
-  const precreated = await precreateThreadExecutionRun({
-    executionHost,
-    kind: "user-turn",
-    runId,
-    threadKey,
-  });
-  return {
-    acceptedEvent: claimed.record.input,
-    awaitBoundaries: false,
-    durableInputClaim: claimed.record,
-    ...(precreated
-      ? { executionRun: { kind: precreated.kind, runId: precreated.runId } }
-      : {}),
-    initialEvents: [],
-    preUserRuntimeInputs: [],
-    run: new BufferedAgentTurn(precreated?.runId),
-    runtimeInput: createRuntimeInputState([]),
-  };
+  return await queuedInputFromClaim(claimed.record, executionHost);
 }
+
+export type QueuedDurableInputPreparation =
+  | { readonly kind: "prepared"; readonly item: QueuedInput }
+  | { readonly kind: "preceding"; readonly item: QueuedInput }
+  | { readonly kind: "unavailable" };
 
 export async function prepareQueuedDurableInput({
   executionHost,
@@ -111,19 +103,29 @@ export async function prepareQueuedDurableInput({
   readonly executionHost: AgentHost | undefined;
   readonly item: QueuedInput;
   readonly threadKey: string;
-}): Promise<QueuedInput | undefined> {
+}): Promise<QueuedDurableInputPreparation> {
   if (!item.durableInput) {
-    return item;
+    return { item, kind: "prepared" };
   }
 
+  const oldestFirst = item.durableInputKind === "follow-up";
   const claimed = await claimDurableThreadInput({
     boundary: "turn-idle",
     executionHost,
-    messageId: item.durableMessageId,
+    messageId: oldestFirst ? undefined : item.durableMessageId,
     threadKey,
   });
   if (claimed.kind === "claimed" && claimed.record) {
-    return { ...item, durableInputClaim: claimed.record };
+    if (oldestFirst && claimed.record.messageId !== item.durableMessageId) {
+      return {
+        item: await queuedInputFromClaim(claimed.record, executionHost),
+        kind: "preceding",
+      };
+    }
+    return {
+      item: { ...item, durableInputClaim: claimed.record },
+      kind: "prepared",
+    };
   }
 
   await cancelThreadExecutionRun({
@@ -131,5 +133,34 @@ export async function prepareQueuedDurableInput({
     executionRun: item.executionRun,
   });
   item.run.close();
-  return;
+  return { kind: "unavailable" };
+}
+
+async function queuedInputFromClaim(
+  record: import("../../execution/host/types").ClaimedThreadInput,
+  executionHost: AgentHost | undefined
+): Promise<QueuedInput> {
+  const runId = createThreadExecutionRunId({
+    threadKey: record.threadKey,
+    turnId: record.messageId,
+  });
+  const precreated = await precreateThreadExecutionRun({
+    executionHost,
+    kind: "user-turn",
+    runId,
+    threadKey: record.threadKey,
+  });
+  return {
+    acceptedEvent: record.input,
+    awaitBoundaries: false,
+    durableInputClaim: record,
+    durableInputKind: record.kind === "follow-up" ? "follow-up" : "send",
+    ...(precreated
+      ? { executionRun: { kind: precreated.kind, runId: precreated.runId } }
+      : {}),
+    initialEvents: [],
+    preUserRuntimeInputs: [],
+    run: new BufferedAgentTurn(precreated?.runId),
+    runtimeInput: createRuntimeInputState([]),
+  };
 }

--- a/packages/runtime/src/thread/handle/durable-queue-claims.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-claims.ts
@@ -16,6 +16,10 @@ import {
   cancelThreadExecutionRun,
   precreateThreadExecutionRun,
 } from "../runtime/execution";
+import {
+  isLiveThreadInputOwnedByOther,
+  unregisterLiveThreadInput,
+} from "../runtime/live-input-ownership";
 import { inputMetaForQueuedKind } from "./durable-queue-send";
 import { isThreadDrainOwned } from "./thread-drain-coordinator";
 
@@ -120,11 +124,25 @@ export async function claimOrphanDurableThreadInput({
   if (claimed.kind === "unavailable" || !claimed.record) {
     return;
   }
+  if (
+    isLiveThreadInputOwnedByOther(
+      executionHost,
+      threadKey,
+      claimed.record.messageId
+    )
+  ) {
+    await releaseDurableThreadInputClaim({
+      executionHost,
+      record: claimed.record,
+    });
+    return;
+  }
   return await queuedInputFromClaim(claimed.record, executionHost);
 }
 
 export type QueuedDurableInputPreparation =
   | { readonly kind: "prepared"; readonly item: QueuedInput }
+  | { readonly kind: "blocked" }
   | { readonly kind: "preceding"; readonly item: QueuedInput }
   | { readonly kind: "unavailable" };
 
@@ -148,10 +166,31 @@ export async function prepareQueuedDurableInput({
   });
   if (claimed.kind === "claimed" && claimed.record) {
     if (claimed.record.messageId !== item.durableMessageId) {
+      if (
+        isLiveThreadInputOwnedByOther(
+          executionHost,
+          threadKey,
+          claimed.record.messageId,
+          item.durableOwner
+        )
+      ) {
+        await releaseDurableThreadInputClaim({
+          executionHost,
+          record: claimed.record,
+        });
+        return { kind: "blocked" };
+      }
       return {
         item: await queuedInputFromClaim(claimed.record, executionHost),
         kind: "preceding",
       };
+    }
+    if (item.durableMessageId) {
+      unregisterLiveThreadInput(
+        executionHost,
+        threadKey,
+        item.durableMessageId
+      );
     }
     return {
       item: { ...item, durableInputClaim: claimed.record },
@@ -159,6 +198,9 @@ export async function prepareQueuedDurableInput({
     };
   }
 
+  if (item.durableMessageId) {
+    unregisterLiveThreadInput(executionHost, threadKey, item.durableMessageId);
+  }
   await cancelThreadExecutionRun({
     executionHost,
     executionRun: item.executionRun,

--- a/packages/runtime/src/thread/handle/durable-queue-claims.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-claims.ts
@@ -1,6 +1,7 @@
 import { createThreadExecutionRunId } from "../../execution/host/thread-execution-run-id";
 import type { AgentHost } from "../../execution/host/types";
 import { Fsm } from "../../fsm";
+import { attachInputMeta } from "../input/input-meta";
 import {
   createRuntimeInputState,
   type QueuedInput,
@@ -15,6 +16,7 @@ import {
   cancelThreadExecutionRun,
   precreateThreadExecutionRun,
 } from "../runtime/execution";
+import { inputMetaForQueuedKind } from "./durable-queue-send";
 import { isThreadDrainOwned } from "./thread-drain-coordinator";
 
 const sharedRecoveries = new WeakMap<object, Map<string, Promise<void>>>();
@@ -185,8 +187,15 @@ async function queuedInputFromClaim(
     await releaseDurableThreadInputClaim({ executionHost, record });
     throw error;
   }
+  if (record.kind === "steer") {
+    await releaseDurableThreadInputClaim({ executionHost, record });
+    throw new Error("A steering input cannot be claimed at turn-idle.");
+  }
   return {
-    acceptedEvent: record.input,
+    acceptedEvent: attachInputMeta(
+      record.input,
+      inputMetaForQueuedKind(record.kind)
+    ),
     awaitBoundaries: false,
     durableInputClaim: record,
     durableInputKind: record.kind === "follow-up" ? "follow-up" : "send",

--- a/packages/runtime/src/thread/handle/durable-queue-send.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-send.ts
@@ -161,6 +161,7 @@ export async function createQueuedSendInput({
       acceptedEvent: processed,
       awaitBoundaries,
       durableInput: admission.kind === "admitted",
+      durableInputKind: kind,
       ...(admission.kind === "admitted"
         ? { durableMessageId: admission.receipt.record.messageId }
         : {}),

--- a/packages/runtime/src/thread/handle/durable-queue-send.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-send.ts
@@ -8,6 +8,7 @@ import {
 } from "../input/attachments";
 import type { AgentInput } from "../input/input";
 import { attachInputMeta, userInputFromEvent } from "../input/input-meta";
+import type { InputEventMeta } from "../input/input-meta-types";
 import { normalizeAgentInput } from "../input/input-normalization";
 import {
   createRuntimeInputState,
@@ -102,10 +103,7 @@ export async function createQueuedSendInput({
   const normalized = normalizeAgentInput(input);
   const acceptedInput =
     normalized.meta === undefined
-      ? attachInputMeta(normalized, {
-          source: kind,
-          ...(kind === "follow-up" ? { streaming: "follow-up" } : {}),
-        })
+      ? attachInputMeta(normalized, inputMetaForQueuedKind(kind))
       : normalized;
   const stagedRefs: RuntimeAttachmentReference[] = [];
   let keepStagedAttachments = false;
@@ -180,4 +178,14 @@ export async function createQueuedSendInput({
       await cleanupStagedRuntimeAttachments(attachmentStore, stagedRefs);
     }
   }
+}
+
+/** @internal exported for the durable-kind/meta invariant test. */
+export function inputMetaForQueuedKind(
+  kind: Exclude<ThreadInputKind, "steer">
+): InputEventMeta {
+  return {
+    source: kind,
+    ...(kind === "follow-up" ? { streaming: "follow-up" } : {}),
+  };
 }

--- a/packages/runtime/src/thread/handle/durable-queue-send.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-send.ts
@@ -18,8 +18,10 @@ import {
 import type { AgentEvent } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
 import { admitDurableThreadInput } from "../runtime/durable-input-admission";
+import { registerLiveThreadInput } from "../runtime/live-input-ownership";
 import { startThreadQueueDrain } from "../runtime/notification";
 import type { ThreadEventDispatcher } from "../runtime/thread-event-dispatcher";
+import type { ThreadInputAdmissionReservation } from "../runtime/thread-input-admission-coordinator";
 
 export async function admitThreadSendInput({
   awaitBoundaries,
@@ -32,6 +34,7 @@ export async function admitThreadSendInput({
   kind = "send",
   pendingOverlays,
   pendingRuntimeInputs,
+  reservation,
   run,
   threadKey,
 }: {
@@ -45,6 +48,7 @@ export async function admitThreadSendInput({
   readonly kind?: Exclude<ThreadInputKind, "steer">;
   readonly pendingOverlays: QueuedRuntimeInput[];
   readonly pendingRuntimeInputs: QueuedRuntimeInput[];
+  readonly reservation?: ThreadInputAdmissionReservation;
   readonly run: BufferedAgentTurn;
   readonly threadKey: string;
 }): Promise<void> {
@@ -57,6 +61,7 @@ export async function admitThreadSendInput({
     kind,
     pendingOverlays,
     pendingRuntimeInputs,
+    reservation,
     run,
     threadKey,
   });
@@ -86,6 +91,7 @@ export async function createQueuedSendInput({
   kind = "send",
   pendingOverlays,
   pendingRuntimeInputs,
+  reservation,
   run,
   threadKey,
 }: {
@@ -97,6 +103,7 @@ export async function createQueuedSendInput({
   readonly kind?: Exclude<ThreadInputKind, "steer">;
   readonly pendingOverlays: QueuedRuntimeInput[];
   readonly pendingRuntimeInputs: QueuedRuntimeInput[];
+  readonly reservation?: ThreadInputAdmissionReservation;
   readonly run: BufferedAgentTurn;
   readonly threadKey: string;
 }): Promise<QueuedSendInputResult> {
@@ -133,6 +140,7 @@ export async function createQueuedSendInput({
       input: queuedInput,
       kind,
       precreateExecutionRun: true,
+      reservation,
       threadKey,
     });
     let executionRun: QueuedInput["executionRun"];
@@ -154,6 +162,7 @@ export async function createQueuedSendInput({
       awaitBoundaries,
       durableInput: admission.kind === "admitted",
       durableInputKind: kind,
+      durableOwner: run,
       ...(admission.kind === "admitted"
         ? { durableMessageId: admission.receipt.record.messageId }
         : {}),
@@ -171,6 +180,14 @@ export async function createQueuedSendInput({
       stagedRefs,
       [queuedInput, processed]
     );
+    if (admission.kind === "admitted") {
+      registerLiveThreadInput(
+        executionHost,
+        threadKey,
+        admission.receipt.record.messageId,
+        run
+      );
+    }
     keepStagedAttachments = true;
     return { kind: "queued", item, processed };
   } finally {

--- a/packages/runtime/src/thread/handle/durable-queue-send.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-send.ts
@@ -18,7 +18,10 @@ import {
 import type { AgentEvent } from "../protocol/events";
 import type { BufferedAgentTurn } from "../protocol/turn";
 import { admitDurableThreadInput } from "../runtime/durable-input-admission";
-import { registerLiveThreadInput } from "../runtime/live-input-ownership";
+import {
+  registerLiveThreadInput,
+  unregisterLiveThreadInput,
+} from "../runtime/live-input-ownership";
 import { startThreadQueueDrain } from "../runtime/notification";
 import type { ThreadEventDispatcher } from "../runtime/thread-event-dispatcher";
 import type { ThreadInputAdmissionReservation } from "../runtime/thread-input-admission-coordinator";
@@ -114,6 +117,7 @@ export async function createQueuedSendInput({
       : normalized;
   const stagedRefs: RuntimeAttachmentReference[] = [];
   let keepStagedAttachments = false;
+  let registeredMessageId: string | undefined;
   try {
     const stagedAcceptedInput = await stageUserInputAttachments(
       acceptedInput,
@@ -135,14 +139,25 @@ export async function createQueuedSendInput({
       attachmentStore,
       { stagedRefs, trustRuntimeAttachmentRefs: true }
     );
+    const messageId = crypto.randomUUID();
+    registerLiveThreadInput(executionHost, threadKey, messageId, run);
+    registeredMessageId = messageId;
     const admission = await admitDurableThreadInput({
       executionHost,
       input: queuedInput,
       kind,
+      messageId,
       precreateExecutionRun: true,
       reservation,
       threadKey,
     });
+    if (
+      admission.kind === "unavailable" ||
+      (admission.kind === "admitted" && admission.receipt.duplicate)
+    ) {
+      unregisterLiveThreadInput(executionHost, threadKey, messageId, run);
+      registeredMessageId = undefined;
+    }
     let executionRun: QueuedInput["executionRun"];
     if (admission.kind === "admitted") {
       if (admission.receipt.duplicate) {
@@ -180,18 +195,18 @@ export async function createQueuedSendInput({
       stagedRefs,
       [queuedInput, processed]
     );
-    if (admission.kind === "admitted") {
-      registerLiveThreadInput(
-        executionHost,
-        threadKey,
-        admission.receipt.record.messageId,
-        run
-      );
-    }
     keepStagedAttachments = true;
     return { kind: "queued", item, processed };
   } finally {
     if (!keepStagedAttachments) {
+      if (registeredMessageId) {
+        unregisterLiveThreadInput(
+          executionHost,
+          threadKey,
+          registeredMessageId,
+          run
+        );
+      }
       await cleanupStagedRuntimeAttachments(attachmentStore, stagedRefs);
     }
   }

--- a/packages/runtime/src/thread/handle/durable-queue-send.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-send.ts
@@ -1,4 +1,4 @@
-import type { AgentHost } from "../../execution/host/types";
+import type { AgentHost, ThreadInputKind } from "../../execution/host/types";
 import {
   cleanupStagedRuntimeAttachments,
   cleanupUnreferencedStagedRuntimeAttachments,
@@ -8,6 +8,7 @@ import {
 } from "../input/attachments";
 import type { AgentInput } from "../input/input";
 import { attachInputMeta, userInputFromEvent } from "../input/input-meta";
+import type { InputSource } from "../input/input-meta-types";
 import { normalizeAgentInput } from "../input/input-normalization";
 import {
   createRuntimeInputState,
@@ -28,9 +29,11 @@ export async function admitThreadSendInput({
   executionHost,
   input,
   inputQueue,
+  kind = "send",
   pendingOverlays,
   pendingRuntimeInputs,
   run,
+  source = "send",
   threadKey,
 }: {
   readonly awaitBoundaries: boolean;
@@ -40,9 +43,11 @@ export async function admitThreadSendInput({
   readonly executionHost: AgentHost | undefined;
   readonly input: AgentInput;
   readonly inputQueue: QueuedInput[];
+  readonly kind?: Exclude<ThreadInputKind, "steer">;
   readonly pendingOverlays: QueuedRuntimeInput[];
   readonly pendingRuntimeInputs: QueuedRuntimeInput[];
   readonly run: BufferedAgentTurn;
+  readonly source?: Extract<InputSource, "follow-up" | "send">;
   readonly threadKey: string;
 }): Promise<void> {
   const queued = await createQueuedSendInput({
@@ -51,9 +56,11 @@ export async function admitThreadSendInput({
     events,
     executionHost,
     input,
+    kind,
     pendingOverlays,
     pendingRuntimeInputs,
     run,
+    source,
     threadKey,
   });
   if (queued.kind === "handled") {
@@ -79,9 +86,11 @@ export async function createQueuedSendInput({
   events,
   executionHost,
   input,
+  kind = "send",
   pendingOverlays,
   pendingRuntimeInputs,
   run,
+  source = "send",
   threadKey,
 }: {
   readonly awaitBoundaries: boolean;
@@ -89,15 +98,20 @@ export async function createQueuedSendInput({
   readonly events: ThreadEventDispatcher;
   readonly executionHost: AgentHost | undefined;
   readonly input: AgentInput;
+  readonly kind?: Exclude<ThreadInputKind, "steer">;
   readonly pendingOverlays: QueuedRuntimeInput[];
   readonly pendingRuntimeInputs: QueuedRuntimeInput[];
   readonly run: BufferedAgentTurn;
+  readonly source?: Extract<InputSource, "follow-up" | "send">;
   readonly threadKey: string;
 }): Promise<QueuedSendInputResult> {
   const normalized = normalizeAgentInput(input);
   const acceptedInput =
     normalized.meta === undefined
-      ? attachInputMeta(normalized, { source: "send" })
+      ? attachInputMeta(normalized, {
+          source,
+          ...(source === "follow-up" ? { streaming: "follow-up" } : {}),
+        })
       : normalized;
   const stagedRefs: RuntimeAttachmentReference[] = [];
   let keepStagedAttachments = false;
@@ -125,7 +139,7 @@ export async function createQueuedSendInput({
     const admission = await admitDurableThreadInput({
       executionHost,
       input: queuedInput,
-      kind: "send",
+      kind,
       precreateExecutionRun: true,
       threadKey,
     });

--- a/packages/runtime/src/thread/handle/durable-queue-send.ts
+++ b/packages/runtime/src/thread/handle/durable-queue-send.ts
@@ -8,7 +8,6 @@ import {
 } from "../input/attachments";
 import type { AgentInput } from "../input/input";
 import { attachInputMeta, userInputFromEvent } from "../input/input-meta";
-import type { InputSource } from "../input/input-meta-types";
 import { normalizeAgentInput } from "../input/input-normalization";
 import {
   createRuntimeInputState,
@@ -33,7 +32,6 @@ export async function admitThreadSendInput({
   pendingOverlays,
   pendingRuntimeInputs,
   run,
-  source = "send",
   threadKey,
 }: {
   readonly awaitBoundaries: boolean;
@@ -47,7 +45,6 @@ export async function admitThreadSendInput({
   readonly pendingOverlays: QueuedRuntimeInput[];
   readonly pendingRuntimeInputs: QueuedRuntimeInput[];
   readonly run: BufferedAgentTurn;
-  readonly source?: Extract<InputSource, "follow-up" | "send">;
   readonly threadKey: string;
 }): Promise<void> {
   const queued = await createQueuedSendInput({
@@ -60,7 +57,6 @@ export async function admitThreadSendInput({
     pendingOverlays,
     pendingRuntimeInputs,
     run,
-    source,
     threadKey,
   });
   if (queued.kind === "handled") {
@@ -90,7 +86,6 @@ export async function createQueuedSendInput({
   pendingOverlays,
   pendingRuntimeInputs,
   run,
-  source = "send",
   threadKey,
 }: {
   readonly awaitBoundaries: boolean;
@@ -102,15 +97,14 @@ export async function createQueuedSendInput({
   readonly pendingOverlays: QueuedRuntimeInput[];
   readonly pendingRuntimeInputs: QueuedRuntimeInput[];
   readonly run: BufferedAgentTurn;
-  readonly source?: Extract<InputSource, "follow-up" | "send">;
   readonly threadKey: string;
 }): Promise<QueuedSendInputResult> {
   const normalized = normalizeAgentInput(input);
   const acceptedInput =
     normalized.meta === undefined
       ? attachInputMeta(normalized, {
-          source,
-          ...(source === "follow-up" ? { streaming: "follow-up" } : {}),
+          source: kind,
+          ...(kind === "follow-up" ? { streaming: "follow-up" } : {}),
         })
       : normalized;
   const stagedRefs: RuntimeAttachmentReference[] = [];

--- a/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
@@ -45,7 +45,9 @@ describe.each(hostFactories)(
       let active = 0;
       let calls = 0;
       let maxActive = 0;
-      const model = createCallbackModel(async () => {
+      const modelOrder: string[] = [];
+      const model = createCallbackModel(async ({ history }) => {
+        modelOrder.push(JSON.stringify(history));
         calls += 1;
         active += 1;
         maxActive = Math.max(maxActive, active);
@@ -67,6 +69,10 @@ describe.each(hostFactories)(
 
       expect(calls).toBe(2);
       expect(maxActive).toBe(1);
+      expect(modelOrder).toHaveLength(2);
+      expect(modelOrder[0]).toContain("first");
+      expect(modelOrder[0]).not.toContain("second");
+      expect(modelOrder[1]).toContain("second");
       expect(firstEvents.at(-1)?.type).toBe("turn-end");
       expect(secondEvents.at(-1)?.type).toBe("turn-end");
     });

--- a/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
@@ -73,6 +73,14 @@ describe.each(hostFactories)(
       expect(modelOrder[0]).toContain("first");
       expect(modelOrder[0]).not.toContain("second");
       expect(modelOrder[1]).toContain("second");
+      expect(firstEvents[0]).toMatchObject({
+        text: "first",
+        type: "user-input",
+      });
+      expect(secondEvents[0]).toMatchObject({
+        text: "second",
+        type: "user-input",
+      });
       expect(firstEvents.at(-1)?.type).toBe("turn-end");
       expect(secondEvents.at(-1)?.type).toBe("turn-end");
     });

--- a/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "../../agent/core/agent";
+import type { AgentHost } from "../../execution";
+import {
+  createCloudflareStorageHost,
+  InMemoryCloudflareDurableObjectStorage,
+} from "../../platform/cloudflare/host/durable-object-host";
+import { FileExecutionStore } from "../../platform/file/storage/file-execution-store";
+import { tempDir } from "../../platform/file/storage/file-execution-store-test-support";
+import { createInMemoryHost } from "../../platform/memory";
+import {
+  assistantMessage,
+  createCallbackModel,
+} from "../../testing/test-fixtures";
+import { collect } from "./test-support";
+
+const hostFactories: readonly [string, () => AgentHost | Promise<AgentHost>][] =
+  [
+    ["memory", () => createInMemoryHost()],
+    [
+      "file",
+      async () => {
+        const fallback = createInMemoryHost();
+        return {
+          ...fallback,
+          store: new FileExecutionStore(await tempDir()),
+        };
+      },
+    ],
+    [
+      "Cloudflare",
+      () =>
+        createCloudflareStorageHost({
+          prefix: `follow-up-concurrency-${crypto.randomUUID()}`,
+          storage: new InMemoryCloudflareDurableObjectStorage(),
+        }),
+    ],
+  ];
+
+describe.each(hostFactories)(
+  "%s host follow-up ownership",
+  (_name, hostFactory) => {
+    it("serializes model turns across Agent handles sharing a thread", async () => {
+      const host = await hostFactory();
+      let active = 0;
+      let calls = 0;
+      let maxActive = 0;
+      const model = createCallbackModel(async () => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        active -= 1;
+        return [assistantMessage(`DONE ${calls}`)];
+      });
+      const firstAgent = new Agent({ host, model });
+      const secondAgent = new Agent({ host, model });
+
+      const [first, second] = await Promise.all([
+        firstAgent.thread("shared-follow-up").followUp("first"),
+        secondAgent.thread("shared-follow-up").followUp("second"),
+      ]);
+      const [firstEvents, secondEvents] = await Promise.all([
+        collect(first),
+        collect(second),
+      ]);
+
+      expect(calls).toBe(2);
+      expect(maxActive).toBe(1);
+      expect(firstEvents.at(-1)?.type).toBe("turn-end");
+      expect(secondEvents.at(-1)?.type).toBe("turn-end");
+    });
+  }
+);

--- a/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
@@ -70,5 +70,22 @@ describe.each(hostFactories)(
       expect(firstEvents.at(-1)?.type).toBe("turn-end");
       expect(secondEvents.at(-1)?.type).toBe("turn-end");
     });
+
+    it("refreshes a stale handle after another handle owns the thread", async () => {
+      const host = await hostFactory();
+      const model = createCallbackModel(() => [assistantMessage("DONE")]);
+      const agentA = new Agent({ host, model });
+      const agentB = new Agent({ host, model });
+      const threadA = agentA.thread("alternating-follow-up");
+      const threadB = agentB.thread("alternating-follow-up");
+
+      const b1 = await collect(await threadB.followUp("B1"));
+      const a1 = await collect(await threadA.followUp("A1"));
+      const b2 = await collect(await threadB.followUp("B2"));
+
+      expect(b1.at(-1)?.type).toBe("turn-end");
+      expect(a1.at(-1)?.type).toBe("turn-end");
+      expect(b2.at(-1)?.type).toBe("turn-end");
+    });
   }
 );

--- a/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up-concurrency.test.ts
@@ -58,10 +58,12 @@ describe.each(hostFactories)(
       const firstAgent = new Agent({ host, model });
       const secondAgent = new Agent({ host, model });
 
-      const [first, second] = await Promise.all([
-        firstAgent.thread("shared-follow-up").followUp("first"),
-        secondAgent.thread("shared-follow-up").followUp("second"),
-      ]);
+      const first = await firstAgent
+        .thread("shared-follow-up")
+        .followUp("first");
+      const second = await secondAgent
+        .thread("shared-follow-up")
+        .followUp("second");
       const [firstEvents, secondEvents] = await Promise.all([
         collect(first),
         collect(second),
@@ -101,5 +103,44 @@ describe.each(hostFactories)(
       expect(a1.at(-1)?.type).toBe("turn-end");
       expect(b2.at(-1)?.type).toBe("turn-end");
     });
+
+    it.each([
+      ["send", "send"],
+      ["send", "followUp"],
+    ] as const)(
+      "keeps concurrent %s/%s records attached to their caller turns",
+      async (firstMethod, secondMethod) => {
+        const host = await hostFactory();
+        const modelOrder: string[] = [];
+        const model = createCallbackModel(async ({ history }) => {
+          modelOrder.push(JSON.stringify(history));
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return [assistantMessage("DONE")];
+        });
+        const firstThread = new Agent({ host, model }).thread(
+          `caller-turn-${firstMethod}-${secondMethod}`
+        );
+        const secondThread = new Agent({ host, model }).thread(
+          `caller-turn-${firstMethod}-${secondMethod}`
+        );
+
+        const [firstTurn, secondTurn] = await Promise.all([
+          firstThread[firstMethod]("first"),
+          secondThread[secondMethod]("second"),
+        ]);
+        const [firstEvents, secondEvents] = await Promise.all([
+          collect(firstTurn),
+          collect(secondTurn),
+        ]);
+
+        expect(modelOrder).toHaveLength(2);
+        expect(modelOrder.join("\n")).toContain("first");
+        expect(modelOrder.join("\n")).toContain("second");
+        expect(firstEvents[0]).toMatchObject({ text: "first" });
+        expect(firstEvents.at(-1)?.type).toBe("turn-end");
+        expect(secondEvents[0]).toMatchObject({ text: "second" });
+        expect(secondEvents.at(-1)?.type).toBe("turn-end");
+      }
+    );
   }
 );

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -2,6 +2,7 @@ import type { ModelMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import { Agent } from "../../agent/core/agent";
 import { createInMemoryHost } from "../../platform/memory";
+import { MemoryThreadStore } from "../../platform/memory/storage/memory-thread-store";
 import {
   assistantMessage,
   createCallbackModel,
@@ -10,6 +11,7 @@ import {
 } from "../../testing/test-fixtures";
 import type { AgentEvent } from "../protocol/events";
 import { userTextToModelMessage } from "../protocol/mapping";
+import { AgentThread } from "./agent-thread";
 import { inputMetaForQueuedKind } from "./durable-queue-send";
 import { collect } from "./test-support";
 
@@ -233,5 +235,60 @@ describe("AgentThread follow-up queue", () => {
       messageId: "orphan-precreate-failure",
       status: "claiming",
     });
+  });
+
+  it("does not hang and can be retried after durable kill cancellation fails", async () => {
+    const base = createInMemoryHost();
+    let failTransactions = false;
+    const store = new Proxy(base.store, {
+      get(target, property) {
+        if (property === "transaction" && failTransactions) {
+          return (): Promise<never> =>
+            Promise.reject(new Error("kill transaction failed"));
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const enteredModel = createDeferred();
+    const holdModel = createDeferred();
+    const host = { ...base, store };
+    const thread = new AgentThread(
+      {
+        model: createCallbackModel(async () => {
+          enteredModel.resolve();
+          await holdModel.promise;
+          return [assistantMessage("DONE")];
+        }),
+      },
+      { key: "retry-kill", store: new MemoryThreadStore() },
+      { executionHost: host }
+    );
+    const activeEvents = collect(await thread.send("active"));
+    await enteredModel.promise;
+    const queued = await thread.followUp("queued");
+
+    failTransactions = true;
+    await expect(
+      Promise.race([
+        thread.kill(),
+        new Promise<never>((_resolve, reject) =>
+          setTimeout(() => reject(new Error("kill timed out")), 1000)
+        ),
+      ])
+    ).rejects.toThrow("kill transaction failed");
+
+    failTransactions = false;
+    await expect(
+      Promise.race([
+        thread.kill(),
+        new Promise<never>((_resolve, reject) =>
+          setTimeout(() => reject(new Error("retry timed out")), 1000)
+        ),
+      ])
+    ).resolves.toBeUndefined();
+    holdModel.resolve();
+    await activeEvents;
+    expect((await collect(queued)).at(-1)?.type).toBe("turn-error");
   });
 });

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -269,9 +269,11 @@ describe("AgentThread follow-up queue", () => {
     const queued = await thread.followUp("queued");
 
     failTransactions = true;
+    const firstKill = thread.kill();
+    holdModel.resolve();
     await expect(
       Promise.race([
-        thread.kill(),
+        firstKill,
         new Promise<never>((_resolve, reject) =>
           setTimeout(() => reject(new Error("kill timed out")), 1000)
         ),
@@ -324,9 +326,11 @@ describe("AgentThread follow-up queue", () => {
     const queued = await thread.followUp("queued");
 
     failTransactions = true;
+    const firstDelete = thread.delete();
+    holdModel.resolve();
     await expect(
       Promise.race([
-        thread.delete(),
+        firstDelete,
         new Promise<never>((_resolve, reject) =>
           setTimeout(() => reject(new Error("delete timed out")), 1000)
         ),

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -136,11 +136,13 @@ describe("AgentThread follow-up queue", () => {
     await vi.waitFor(() => expect(seenHistory).toHaveLength(2));
 
     expect(seenHistory[0]).toEqual([
+      userTextToModelMessage(userText("orphaned follow-up")),
+    ]);
+    expect(seenHistory[1]).toEqual([
+      userTextToModelMessage(userText("orphaned follow-up")),
+      assistantMessage("DONE 1"),
       userTextToModelMessage(userText("new follow-up")),
     ]);
-    expect(seenHistory[1]).toContainEqual(
-      userTextToModelMessage(userText("orphaned follow-up"))
-    );
     await expect(
       host.store.inputs.claimNext("follow-up-recovery", "turn-idle")
     ).resolves.toBeNull();

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -203,4 +203,35 @@ describe("AgentThread follow-up queue", () => {
       host.store.inputs.claimNext("recovery-during-active", "turn-idle")
     ).resolves.toBeNull();
   });
+
+  it("releases an orphan claim when turn precreation fails", async () => {
+    const host = createInMemoryHost();
+    await host.store.inputs.admit({
+      input: userText("orphan"),
+      kind: "follow-up",
+      messageId: "orphan-precreate-failure",
+      threadKey: "precreate-failure",
+    });
+    const turns = host.store.turns as {
+      create: typeof host.store.turns.create;
+    };
+    turns.create = () => Promise.reject(new Error("turn create failed"));
+    const thread = new Agent({
+      host,
+      model: createCallbackModel(() => [assistantMessage("DONE")]),
+    }).thread("precreate-failure");
+
+    const events = await collect(await thread.send("new"));
+
+    expect(events.at(-1)).toMatchObject({
+      message: "turn create failed",
+      type: "turn-error",
+    });
+    await expect(
+      host.store.inputs.claimNext("precreate-failure", "turn-idle")
+    ).resolves.toMatchObject({
+      messageId: "orphan-precreate-failure",
+      status: "claiming",
+    });
+  });
 });

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -5,6 +5,7 @@ import { createInMemoryHost } from "../../platform/memory";
 import {
   assistantMessage,
   createCallbackModel,
+  createDeferred,
   userText,
 } from "../../testing/test-fixtures";
 import type { AgentEvent } from "../protocol/events";
@@ -145,6 +146,52 @@ describe("AgentThread follow-up queue", () => {
     ]);
     await expect(
       host.store.inputs.claimNext("follow-up-recovery", "turn-idle")
+    ).resolves.toBeNull();
+  });
+
+  it("waits for a live owner before recovering an orphan claim", async () => {
+    const host = createInMemoryHost();
+    const activeStarted = createDeferred();
+    const releaseActive = createDeferred();
+    let calls = 0;
+    const model = createCallbackModel(async () => {
+      calls += 1;
+      if (calls === 1) {
+        activeStarted.resolve();
+        await releaseActive.promise;
+      }
+      return [assistantMessage(`DONE ${calls}`)];
+    });
+    const activeThread = new Agent({ host, model }).thread(
+      "recovery-during-active"
+    );
+    const recoveringThread = new Agent({ host, model }).thread(
+      "recovery-during-active"
+    );
+    const activeTurn = await activeThread.followUp("active");
+    const activeEvents = collect(activeTurn);
+    await activeStarted.promise;
+
+    await host.store.inputs.admit({
+      input: userText("orphan"),
+      kind: "follow-up",
+      messageId: "orphan-during-active",
+      threadKey: "recovery-during-active",
+    });
+    const orphanClaim = await host.store.inputs.claimNext(
+      "recovery-during-active",
+      "turn-idle"
+    );
+    expect(orphanClaim?.status).toBe("claiming");
+
+    const recoveringTurn = await recoveringThread.followUp("after orphan");
+
+    releaseActive.resolve();
+    await activeEvents;
+    await collect(recoveringTurn);
+    await vi.waitFor(() => expect(calls).toBe(3));
+    await expect(
+      host.store.inputs.claimNext("recovery-during-active", "turn-idle")
     ).resolves.toBeNull();
   });
 });

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -291,4 +291,59 @@ describe("AgentThread follow-up queue", () => {
     await activeEvents;
     expect((await collect(queued)).at(-1)?.type).toBe("turn-error");
   });
+
+  it("retries delete after durable kill cancellation fails", async () => {
+    const base = createInMemoryHost();
+    let failTransactions = false;
+    const store = new Proxy(base.store, {
+      get(target, property) {
+        if (property === "transaction" && failTransactions) {
+          return (): Promise<never> =>
+            Promise.reject(new Error("delete transaction failed"));
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const enteredModel = createDeferred();
+    const holdModel = createDeferred();
+    const host = { ...base, store };
+    const thread = new AgentThread(
+      {
+        model: createCallbackModel(async () => {
+          enteredModel.resolve();
+          await holdModel.promise;
+          return [assistantMessage("DONE")];
+        }),
+      },
+      { key: "retry-delete", store: new MemoryThreadStore() },
+      { executionHost: host }
+    );
+    const activeEvents = collect(await thread.send("active"));
+    await enteredModel.promise;
+    const queued = await thread.followUp("queued");
+
+    failTransactions = true;
+    await expect(
+      Promise.race([
+        thread.delete(),
+        new Promise<never>((_resolve, reject) =>
+          setTimeout(() => reject(new Error("delete timed out")), 1000)
+        ),
+      ])
+    ).rejects.toThrow("delete transaction failed");
+
+    failTransactions = false;
+    await expect(
+      Promise.race([
+        thread.delete(),
+        new Promise<never>((_resolve, reject) =>
+          setTimeout(() => reject(new Error("delete retry timed out")), 1000)
+        ),
+      ])
+    ).resolves.toBeUndefined();
+    holdModel.resolve();
+    await activeEvents;
+    expect((await collect(queued)).at(-1)?.type).toBe("turn-error");
+  });
 });

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -10,9 +10,18 @@ import {
 } from "../../testing/test-fixtures";
 import type { AgentEvent } from "../protocol/events";
 import { userTextToModelMessage } from "../protocol/mapping";
+import { inputMetaForQueuedKind } from "./durable-queue-send";
 import { collect } from "./test-support";
 
 describe("AgentThread follow-up queue", () => {
+  it("derives event metadata from the durable inbox kind", () => {
+    expect(inputMetaForQueuedKind("send")).toEqual({ source: "send" });
+    expect(inputMetaForQueuedKind("follow-up")).toEqual({
+      source: "follow-up",
+      streaming: "follow-up",
+    });
+  });
+
   it("delivers active follow-ups as FIFO one-at-a-time turns, not steering input", async () => {
     const host = createInMemoryHost();
     const seenHistory: ModelMessage[][] = [];

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -15,6 +15,23 @@ import { AgentThread } from "./agent-thread";
 import { inputMetaForQueuedKind } from "./durable-queue-send";
 import { collect } from "./test-support";
 
+async function withTimeout<T>(
+  promise: Promise<T>,
+  message: string
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), 1000);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 describe("AgentThread follow-up queue", () => {
   it("derives event metadata from the durable inbox kind", () => {
     expect(inputMetaForQueuedKind("send")).toEqual({ source: "send" });
@@ -243,6 +260,7 @@ describe("AgentThread follow-up queue", () => {
     const store = new Proxy(base.store, {
       get(target, property) {
         if (property === "transaction" && failTransactions) {
+          failTransactions = false;
           return (): Promise<never> =>
             Promise.reject(new Error("kill transaction failed"));
         }
@@ -271,23 +289,13 @@ describe("AgentThread follow-up queue", () => {
     failTransactions = true;
     const firstKill = thread.kill();
     holdModel.resolve();
-    await expect(
-      Promise.race([
-        firstKill,
-        new Promise<never>((_resolve, reject) =>
-          setTimeout(() => reject(new Error("kill timed out")), 1000)
-        ),
-      ])
-    ).rejects.toThrow("kill transaction failed");
+    await expect(withTimeout(firstKill, "kill timed out")).rejects.toThrow(
+      "kill transaction failed"
+    );
 
     failTransactions = false;
     await expect(
-      Promise.race([
-        thread.kill(),
-        new Promise<never>((_resolve, reject) =>
-          setTimeout(() => reject(new Error("retry timed out")), 1000)
-        ),
-      ])
+      withTimeout(thread.kill(), "retry timed out")
     ).resolves.toBeUndefined();
     holdModel.resolve();
     await activeEvents;
@@ -300,6 +308,7 @@ describe("AgentThread follow-up queue", () => {
     const store = new Proxy(base.store, {
       get(target, property) {
         if (property === "transaction" && failTransactions) {
+          failTransactions = false;
           return (): Promise<never> =>
             Promise.reject(new Error("delete transaction failed"));
         }
@@ -328,23 +337,13 @@ describe("AgentThread follow-up queue", () => {
     failTransactions = true;
     const firstDelete = thread.delete();
     holdModel.resolve();
-    await expect(
-      Promise.race([
-        firstDelete,
-        new Promise<never>((_resolve, reject) =>
-          setTimeout(() => reject(new Error("delete timed out")), 1000)
-        ),
-      ])
-    ).rejects.toThrow("delete transaction failed");
+    await expect(withTimeout(firstDelete, "delete timed out")).rejects.toThrow(
+      "delete transaction failed"
+    );
 
     failTransactions = false;
     await expect(
-      Promise.race([
-        thread.delete(),
-        new Promise<never>((_resolve, reject) =>
-          setTimeout(() => reject(new Error("delete retry timed out")), 1000)
-        ),
-      ])
+      withTimeout(thread.delete(), "delete retry timed out")
     ).resolves.toBeUndefined();
     holdModel.resolve();
     await activeEvents;

--- a/packages/runtime/src/thread/handle/follow-up.test.ts
+++ b/packages/runtime/src/thread/handle/follow-up.test.ts
@@ -1,0 +1,148 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { Agent } from "../../agent/core/agent";
+import { createInMemoryHost } from "../../platform/memory";
+import {
+  assistantMessage,
+  createCallbackModel,
+  userText,
+} from "../../testing/test-fixtures";
+import type { AgentEvent } from "../protocol/events";
+import { userTextToModelMessage } from "../protocol/mapping";
+import { collect } from "./test-support";
+
+describe("AgentThread follow-up queue", () => {
+  it("delivers active follow-ups as FIFO one-at-a-time turns, not steering input", async () => {
+    const host = createInMemoryHost();
+    const seenHistory: ModelMessage[][] = [];
+    const agent = new Agent({
+      host,
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        return [assistantMessage(`DONE ${seenHistory.length}`)];
+      }),
+    });
+    const thread = agent.thread("follow-up-fifo");
+    const first = await thread.send("initial");
+    let followUps: readonly Awaited<ReturnType<typeof thread.followUp>>[] = [];
+    const firstEvents: AgentEvent[] = [];
+
+    for await (const event of first.events()) {
+      firstEvents.push(event);
+      if (event.type === "step-start" && followUps.length === 0) {
+        followUps = await Promise.all([
+          thread.followUp("first follow-up"),
+          thread.followUp("second follow-up"),
+        ]);
+      }
+    }
+    const followUpEvents = await Promise.all(followUps.map(collect));
+
+    expect(firstEvents.some((event) => event.type === "runtime-input")).toBe(
+      false
+    );
+    expect(followUpEvents.map((events) => events[0])).toEqual([
+      {
+        meta: { source: "follow-up", streaming: "follow-up" },
+        text: "first follow-up",
+        type: "user-input",
+      },
+      {
+        meta: { source: "follow-up", streaming: "follow-up" },
+        text: "second follow-up",
+        type: "user-input",
+      },
+    ]);
+    expect(seenHistory).toEqual([
+      [userTextToModelMessage(userText("initial"))],
+      [
+        userTextToModelMessage(userText("initial")),
+        assistantMessage("DONE 1"),
+        userTextToModelMessage(userText("first follow-up")),
+      ],
+      [
+        userTextToModelMessage(userText("initial")),
+        assistantMessage("DONE 1"),
+        userTextToModelMessage(userText("first follow-up")),
+        assistantMessage("DONE 2"),
+        userTextToModelMessage(userText("second follow-up")),
+      ],
+    ]);
+    await expect(
+      host.store.inputs.claimNext("follow-up-fifo", "turn-idle")
+    ).resolves.toBeNull();
+  });
+
+  it("keeps a queued follow-up after the active turn is aborted", async () => {
+    const seenHistory: ModelMessage[][] = [];
+    const thread = new Agent({
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        return [assistantMessage("DONE")];
+      }),
+    }).thread("follow-up-abort");
+    const active = await thread.send("abort me");
+    let followUp: Awaited<ReturnType<typeof thread.followUp>> | undefined;
+    const activeEvents: AgentEvent[] = [];
+
+    for await (const event of active.events()) {
+      activeEvents.push(event);
+      if (event.type === "step-start" && !followUp) {
+        followUp = await thread.followUp("survives abort");
+        thread.interrupt();
+      }
+    }
+    if (!followUp) {
+      throw new Error("Expected follow-up admission.");
+    }
+    const followUpEvents = await collect(followUp);
+
+    expect(activeEvents.at(-1)?.type).toBe("turn-abort");
+    expect(followUpEvents[0]).toMatchObject({
+      meta: { source: "follow-up", streaming: "follow-up" },
+      text: "survives abort",
+      type: "user-input",
+    });
+    expect(seenHistory.at(-1)).toContainEqual(
+      userTextToModelMessage(userText("survives abort"))
+    );
+  });
+
+  it("recovers an orphaned follow-up claim and drains it after new work", async () => {
+    const host = createInMemoryHost();
+    await host.store.inputs.admit({
+      admittedAtMs: 1,
+      input: userText("orphaned follow-up"),
+      kind: "follow-up",
+      messageId: "orphaned-message",
+      threadKey: "follow-up-recovery",
+    });
+    const claim = await host.store.inputs.claimNext(
+      "follow-up-recovery",
+      "turn-idle"
+    );
+    expect(claim).not.toBeNull();
+
+    const seenHistory: ModelMessage[][] = [];
+    const thread = new Agent({
+      host,
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        return [assistantMessage(`DONE ${seenHistory.length}`)];
+      }),
+    }).thread("follow-up-recovery");
+
+    await collect(await thread.followUp("new follow-up"));
+    await vi.waitFor(() => expect(seenHistory).toHaveLength(2));
+
+    expect(seenHistory[0]).toEqual([
+      userTextToModelMessage(userText("new follow-up")),
+    ]);
+    expect(seenHistory[1]).toContainEqual(
+      userTextToModelMessage(userText("orphaned follow-up"))
+    );
+    await expect(
+      host.store.inputs.claimNext("follow-up-recovery", "turn-idle")
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/runtime/src/thread/handle/thread-drain-coordinator.test.ts
+++ b/packages/runtime/src/thread/handle/thread-drain-coordinator.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInMemoryHost } from "../../platform/memory";
+import { retryReleasedThreadDrain } from "./agent-thread-drain";
+import { withThreadDrainOwnership } from "./thread-drain-coordinator";
+
+describe("thread drain ownership refresh tracking", () => {
+  it("keeps refresh required when a new owner's operation fails", async () => {
+    const host = createInMemoryHost();
+    const firstOwner = {};
+    const secondOwner = {};
+    const observed: boolean[] = [];
+    await withThreadDrainOwnership(
+      host,
+      "refresh-retry",
+      firstOwner,
+      async ({ refreshRequired }) => {
+        await Promise.resolve();
+        observed.push(refreshRequired);
+      }
+    );
+    await expect(
+      withThreadDrainOwnership(
+        host,
+        "refresh-retry",
+        secondOwner,
+        async ({ refreshRequired }) => {
+          await Promise.resolve();
+          observed.push(refreshRequired);
+          throw new Error("refresh failed");
+        }
+      )
+    ).rejects.toThrow("refresh failed");
+    await withThreadDrainOwnership(
+      host,
+      "refresh-retry",
+      secondOwner,
+      async ({ refreshRequired }) => {
+        await Promise.resolve();
+        observed.push(refreshRequired);
+      }
+    );
+    await withThreadDrainOwnership(
+      host,
+      "refresh-retry",
+      secondOwner,
+      async ({ refreshRequired }) => {
+        await Promise.resolve();
+        observed.push(refreshRequired);
+      }
+    );
+
+    expect(observed).toEqual([false, true, true, false]);
+  });
+
+  it("preserves refresh-required state through all permanent restart retries", async () => {
+    const host = createInMemoryHost();
+    await withThreadDrainOwnership(
+      host,
+      "permanent",
+      {},
+      async () => undefined
+    );
+    const owner = {};
+    const refreshValues: boolean[] = [];
+    const permanentFailure = vi.fn();
+
+    await retryReleasedThreadDrain(
+      () =>
+        withThreadDrainOwnership(
+          host,
+          "permanent",
+          owner,
+          async ({ refreshRequired }) => {
+            await Promise.resolve();
+            refreshValues.push(refreshRequired);
+            throw new Error("refresh permanently failed");
+          }
+        ),
+      permanentFailure
+    );
+
+    expect(refreshValues).toEqual([true, true, true]);
+    expect(permanentFailure).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/runtime/src/thread/handle/thread-drain-coordinator.ts
+++ b/packages/runtime/src/thread/handle/thread-drain-coordinator.ts
@@ -1,0 +1,62 @@
+import type { AgentHost } from "../../execution/host/types";
+import { deferred } from "../../internal/deferred";
+
+interface DrainLock {
+  readonly settled: Promise<void>;
+}
+
+const hostDrainLocks = new WeakMap<object, Map<string, DrainLock>>();
+
+export function isThreadDrainOwned(
+  executionHost: AgentHost,
+  threadKey: string
+): boolean {
+  return hostDrainLocks.get(executionHost.store)?.has(threadKey) ?? false;
+}
+
+/**
+ * Serializes drain loops that share a host/store object and thread key.
+ * Durable inbox records remain the source of truth; this coordinator prevents
+ * two live handles in the same host isolate from claiming successive records
+ * while either model turn is still running.
+ */
+export async function withThreadDrainOwnership<T>(
+  executionHost: AgentHost | undefined,
+  threadKey: string,
+  operation: (ownership: { readonly contended: boolean }) => Promise<T>
+): Promise<T> {
+  if (!executionHost) {
+    return await operation({ contended: false });
+  }
+
+  const identity = executionHost.store;
+  let locks = hostDrainLocks.get(identity);
+  if (!locks) {
+    locks = new Map();
+    hostDrainLocks.set(identity, locks);
+  }
+
+  let contended = false;
+  for (;;) {
+    const active = locks.get(threadKey);
+    if (!active) {
+      break;
+    }
+    contended = true;
+    await active.settled;
+  }
+
+  const released = deferred();
+  const lock = { settled: released.promise } satisfies DrainLock;
+  // There is no await between observing the empty slot and installing it, so
+  // JavaScript's run-to-completion semantics make acquisition atomic.
+  locks.set(threadKey, lock);
+  try {
+    return await operation({ contended });
+  } finally {
+    if (locks.get(threadKey) === lock) {
+      locks.delete(threadKey);
+    }
+    released.resolve();
+  }
+}

--- a/packages/runtime/src/thread/handle/thread-drain-coordinator.ts
+++ b/packages/runtime/src/thread/handle/thread-drain-coordinator.ts
@@ -74,12 +74,17 @@ export async function withThreadDrainOwnership<T>(
   state.active = lock;
   const refreshRequired =
     state.lastOwner !== undefined && state.lastOwner !== owner;
+  let completed = false;
   try {
-    return await operation({ refreshRequired });
+    const result = await operation({ refreshRequired });
+    completed = true;
+    return result;
   } finally {
     if (state.active === lock) {
       state.active = undefined;
-      state.lastOwner = owner;
+      if (completed) {
+        state.lastOwner = owner;
+      }
     }
     released.resolve();
   }

--- a/packages/runtime/src/thread/handle/thread-drain-coordinator.ts
+++ b/packages/runtime/src/thread/handle/thread-drain-coordinator.ts
@@ -2,16 +2,33 @@ import type { AgentHost } from "../../execution/host/types";
 import { deferred } from "../../internal/deferred";
 
 interface DrainLock {
+  readonly owner: object;
   readonly settled: Promise<void>;
 }
 
-const hostDrainLocks = new WeakMap<object, Map<string, DrainLock>>();
+interface ThreadDrainOwnershipState {
+  active?: DrainLock;
+  lastOwner?: object;
+}
+
+export interface ThreadDrainOwnership {
+  /** Another owner completed work since this owner last held the thread. */
+  readonly refreshRequired: boolean;
+}
+
+const hostDrainStates = new WeakMap<
+  object,
+  Map<string, ThreadDrainOwnershipState>
+>();
 
 export function isThreadDrainOwned(
   executionHost: AgentHost,
   threadKey: string
 ): boolean {
-  return hostDrainLocks.get(executionHost.store)?.has(threadKey) ?? false;
+  return (
+    hostDrainStates.get(executionHost.store)?.get(threadKey)?.active !==
+    undefined
+  );
 }
 
 /**
@@ -23,39 +40,46 @@ export function isThreadDrainOwned(
 export async function withThreadDrainOwnership<T>(
   executionHost: AgentHost | undefined,
   threadKey: string,
-  operation: (ownership: { readonly contended: boolean }) => Promise<T>
+  owner: object,
+  operation: (ownership: ThreadDrainOwnership) => Promise<T>
 ): Promise<T> {
   if (!executionHost) {
-    return await operation({ contended: false });
+    return await operation({ refreshRequired: false });
   }
 
   const identity = executionHost.store;
-  let locks = hostDrainLocks.get(identity);
-  if (!locks) {
-    locks = new Map();
-    hostDrainLocks.set(identity, locks);
+  let threads = hostDrainStates.get(identity);
+  if (!threads) {
+    threads = new Map();
+    hostDrainStates.set(identity, threads);
+  }
+  let state = threads.get(threadKey);
+  if (!state) {
+    state = {};
+    threads.set(threadKey, state);
   }
 
-  let contended = false;
   for (;;) {
-    const active = locks.get(threadKey);
+    const active = state.active;
     if (!active) {
       break;
     }
-    contended = true;
     await active.settled;
   }
 
   const released = deferred();
-  const lock = { settled: released.promise } satisfies DrainLock;
+  const lock = { owner, settled: released.promise } satisfies DrainLock;
   // There is no await between observing the empty slot and installing it, so
   // JavaScript's run-to-completion semantics make acquisition atomic.
-  locks.set(threadKey, lock);
+  state.active = lock;
+  const refreshRequired =
+    state.lastOwner !== undefined && state.lastOwner !== owner;
   try {
-    return await operation({ contended });
+    return await operation({ refreshRequired });
   } finally {
-    if (locks.get(threadKey) === lock) {
-      locks.delete(threadKey);
+    if (state.active === lock) {
+      state.active = undefined;
+      state.lastOwner = owner;
     }
     released.resolve();
   }

--- a/packages/runtime/src/thread/handle/thread-drain.ts
+++ b/packages/runtime/src/thread/handle/thread-drain.ts
@@ -51,6 +51,9 @@ export async function runThreadInputDrainLoop({
         item: queuedInput,
         threadKey,
       });
+      if (preparation.kind === "blocked") {
+        break;
+      }
       if (preparation.kind === "unavailable") {
         inputQueue.shift();
         continue;

--- a/packages/runtime/src/thread/handle/thread-drain.ts
+++ b/packages/runtime/src/thread/handle/thread-drain.ts
@@ -25,6 +25,7 @@ export interface ThreadInputDrainLoopOptions {
   readonly execution: ThreadExecutionOptions;
   readonly inputQueue: QueuedInput[];
   readonly model: ModelGenerationOptions;
+  readonly onBlocked?: (released: Promise<void>) => void;
   readonly release: () => void;
   readonly state: ThreadState;
   readonly threadKey: string;
@@ -38,6 +39,7 @@ export async function runThreadInputDrainLoop({
   execution,
   inputQueue,
   model,
+  onBlocked,
   release,
   state,
   threadKey,
@@ -52,6 +54,7 @@ export async function runThreadInputDrainLoop({
         threadKey,
       });
       if (preparation.kind === "blocked") {
+        onBlocked?.(preparation.released);
         break;
       }
       if (preparation.kind === "unavailable") {

--- a/packages/runtime/src/thread/handle/thread-drain.ts
+++ b/packages/runtime/src/thread/handle/thread-drain.ts
@@ -44,18 +44,28 @@ export async function runThreadInputDrainLoop({
 }: ThreadInputDrainLoopOptions): Promise<void> {
   let claimOrphanDurableInput = true;
   while (continueDraining()) {
-    const queuedInput = inputQueue.shift();
+    const queuedInput = inputQueue[0];
     if (queuedInput) {
-      const item = await prepareQueuedDurableInput({
+      const preparation = await prepareQueuedDurableInput({
         executionHost: execution.executionHost,
         item: queuedInput,
         threadKey,
       });
-      if (!item) {
+      if (preparation.kind === "unavailable") {
+        inputQueue.shift();
         continue;
       }
+      if (preparation.kind === "prepared") {
+        inputQueue.shift();
+      }
 
-      await processInput(item);
+      await processInput(preparation.item);
+      if (
+        preparation.kind === "prepared" &&
+        queuedInput.durableInputKind === "follow-up"
+      ) {
+        claimOrphanDurableInput = false;
+      }
       continue;
     }
 

--- a/packages/runtime/src/thread/input/input-meta-types.ts
+++ b/packages/runtime/src/thread/input/input-meta-types.ts
@@ -1,4 +1,10 @@
-export type InputSource = "delegate" | "notify" | "overlay" | "send" | "steer";
+export type InputSource =
+  | "delegate"
+  | "follow-up"
+  | "notify"
+  | "overlay"
+  | "send"
+  | "steer";
 
 export interface InputEventMeta {
   readonly delegateToolName?: string;

--- a/packages/runtime/src/thread/input/runtime-input.ts
+++ b/packages/runtime/src/thread/input/runtime-input.ts
@@ -36,6 +36,7 @@ export interface QueuedInput {
   readonly durableInputClaim?: ClaimedThreadInput;
   readonly durableInputKind?: "follow-up" | "send";
   readonly durableMessageId?: string;
+  readonly durableOwner?: object;
   readonly executionRun?: QueuedThreadExecutionRun;
   readonly initialEvents: AgentEvent[];
   readonly input?: UserInput;

--- a/packages/runtime/src/thread/input/runtime-input.ts
+++ b/packages/runtime/src/thread/input/runtime-input.ts
@@ -34,6 +34,7 @@ export interface QueuedInput {
   readonly awaitBoundaries?: boolean;
   readonly durableInput?: boolean;
   readonly durableInputClaim?: ClaimedThreadInput;
+  readonly durableInputKind?: "follow-up" | "send";
   readonly durableMessageId?: string;
   readonly executionRun?: QueuedThreadExecutionRun;
   readonly initialEvents: AgentEvent[];

--- a/packages/runtime/src/thread/runtime/durable-input-admission.ts
+++ b/packages/runtime/src/thread/runtime/durable-input-admission.ts
@@ -9,6 +9,7 @@ import type {
 import { ThreadInputInboxUnavailableError } from "../../execution/host/unsupported-thread-input-inbox";
 import type { UserInput } from "../input/input";
 import { precreateThreadExecutionRun } from "./execution";
+import { withThreadInputAdmission } from "./thread-input-admission-coordinator";
 
 export type DurableInputAdmission =
   | {
@@ -37,42 +38,44 @@ export async function admitDurableThreadInput({
     return { kind: "unavailable" };
   }
 
-  try {
-    const messageId = crypto.randomUUID();
-    if (precreateExecutionRun) {
-      return await executionHost.store.transaction(async (transaction) => {
-        const receipt = await transaction.inputs.admit({
-          input,
-          kind,
-          messageId,
-          placement,
-          threadKey,
+  return await withThreadInputAdmission(executionHost, threadKey, async () => {
+    try {
+      const messageId = crypto.randomUUID();
+      if (precreateExecutionRun) {
+        return await executionHost.store.transaction(async (transaction) => {
+          const receipt = await transaction.inputs.admit({
+            input,
+            kind,
+            messageId,
+            placement,
+            threadKey,
+          });
+          if (receipt.duplicate) {
+            return { kind: "admitted", receipt };
+          }
+          const executionRun = await precreateThreadExecutionRun({
+            kind: "user-turn",
+            runId: createThreadExecutionRunId({ threadKey, turnId: messageId }),
+            threadKey,
+            turnStore: transaction.turns,
+          });
+          return { executionRun, kind: "admitted", receipt };
         });
-        if (receipt.duplicate) {
-          return { kind: "admitted", receipt };
-        }
-        const executionRun = await precreateThreadExecutionRun({
-          kind: "user-turn",
-          runId: createThreadExecutionRunId({ threadKey, turnId: messageId }),
-          threadKey,
-          turnStore: transaction.turns,
-        });
-        return { executionRun, kind: "admitted", receipt };
-      });
-    }
+      }
 
-    const receipt = await executionHost.store.inputs.admit({
-      input,
-      kind,
-      messageId,
-      placement,
-      threadKey,
-    });
-    return { kind: "admitted", receipt };
-  } catch (error) {
-    if (error instanceof ThreadInputInboxUnavailableError) {
-      return { kind: "unavailable" };
+      const receipt = await executionHost.store.inputs.admit({
+        input,
+        kind,
+        messageId,
+        placement,
+        threadKey,
+      });
+      return { kind: "admitted", receipt };
+    } catch (error) {
+      if (error instanceof ThreadInputInboxUnavailableError) {
+        return { kind: "unavailable" };
+      }
+      throw error;
     }
-    throw error;
-  }
+  });
 }

--- a/packages/runtime/src/thread/runtime/durable-input-admission.ts
+++ b/packages/runtime/src/thread/runtime/durable-input-admission.ts
@@ -26,6 +26,7 @@ export async function admitDurableThreadInput({
   executionHost,
   input,
   kind,
+  messageId = crypto.randomUUID(),
   placement,
   precreateExecutionRun = false,
   reservation,
@@ -34,6 +35,7 @@ export async function admitDurableThreadInput({
   readonly executionHost: AgentHost | undefined;
   readonly input: UserInput;
   readonly kind: ThreadInputKind;
+  readonly messageId?: string;
   readonly placement?: ThreadInputPlacement;
   readonly precreateExecutionRun?: boolean;
   readonly reservation?: ThreadInputAdmissionReservation;
@@ -45,7 +47,6 @@ export async function admitDurableThreadInput({
 
   const operation = async (): Promise<DurableInputAdmission> => {
     try {
-      const messageId = crypto.randomUUID();
       if (precreateExecutionRun) {
         return await executionHost.store.transaction(async (transaction) => {
           const receipt = await transaction.inputs.admit({

--- a/packages/runtime/src/thread/runtime/durable-input-admission.ts
+++ b/packages/runtime/src/thread/runtime/durable-input-admission.ts
@@ -9,7 +9,10 @@ import type {
 import { ThreadInputInboxUnavailableError } from "../../execution/host/unsupported-thread-input-inbox";
 import type { UserInput } from "../input/input";
 import { precreateThreadExecutionRun } from "./execution";
-import { withThreadInputAdmission } from "./thread-input-admission-coordinator";
+import {
+  type ThreadInputAdmissionReservation,
+  withThreadInputAdmission,
+} from "./thread-input-admission-coordinator";
 
 export type DurableInputAdmission =
   | {
@@ -25,6 +28,7 @@ export async function admitDurableThreadInput({
   kind,
   placement,
   precreateExecutionRun = false,
+  reservation,
   threadKey,
 }: {
   readonly executionHost: AgentHost | undefined;
@@ -32,13 +36,14 @@ export async function admitDurableThreadInput({
   readonly kind: ThreadInputKind;
   readonly placement?: ThreadInputPlacement;
   readonly precreateExecutionRun?: boolean;
+  readonly reservation?: ThreadInputAdmissionReservation;
   readonly threadKey: string;
 }): Promise<DurableInputAdmission> {
   if (!executionHost) {
     return { kind: "unavailable" };
   }
 
-  return await withThreadInputAdmission(executionHost, threadKey, async () => {
+  const operation = async (): Promise<DurableInputAdmission> => {
     try {
       const messageId = crypto.randomUUID();
       if (precreateExecutionRun) {
@@ -77,5 +82,10 @@ export async function admitDurableThreadInput({
       }
       throw error;
     }
-  });
+  };
+  return await (
+    reservation ??
+    ((reservedOperation) =>
+      withThreadInputAdmission(executionHost, threadKey, reservedOperation))
+  )(operation);
 }

--- a/packages/runtime/src/thread/runtime/durable-input-cancellation.ts
+++ b/packages/runtime/src/thread/runtime/durable-input-cancellation.ts
@@ -50,7 +50,12 @@ export async function cancelQueuedDurableThreadInputs({
     }
   });
   for (const item of durableItems) {
-    unregisterLiveThreadInput(executionHost, threadKey, item.durableMessageId);
+    unregisterLiveThreadInput(
+      executionHost,
+      threadKey,
+      item.durableMessageId,
+      item.durableOwner
+    );
   }
 }
 

--- a/packages/runtime/src/thread/runtime/durable-input-cancellation.ts
+++ b/packages/runtime/src/thread/runtime/durable-input-cancellation.ts
@@ -1,6 +1,7 @@
 import type { AgentHost, TurnRecord } from "../../execution/host/types";
 import type { QueuedInput } from "../input/runtime-input";
 import { DurableThreadInputClaimError } from "./durable-input-acknowledgement";
+import { unregisterLiveThreadInput } from "./live-input-ownership";
 
 export async function cancelQueuedDurableThreadInputs({
   executionHost,
@@ -48,6 +49,9 @@ export async function cancelQueuedDurableThreadInputs({
       }
     }
   });
+  for (const item of durableItems) {
+    unregisterLiveThreadInput(executionHost, threadKey, item.durableMessageId);
+  }
 }
 
 function isTerminalTurnStatus(status: TurnRecord["status"]): boolean {

--- a/packages/runtime/src/thread/runtime/durable-input-cancellation.ts
+++ b/packages/runtime/src/thread/runtime/durable-input-cancellation.ts
@@ -3,6 +3,15 @@ import type { QueuedInput } from "../input/runtime-input";
 import { DurableThreadInputClaimError } from "./durable-input-acknowledgement";
 import { unregisterLiveThreadInput } from "./live-input-ownership";
 
+export class DurableThreadInputCancellationError extends Error {
+  constructor(messageId: string, threadKey: string) {
+    super(
+      `Could not claim queued input ${messageId} for cancellation on ${threadKey}.`
+    );
+    this.name = "DurableThreadInputCancellationError";
+  }
+}
+
 export async function cancelQueuedDurableThreadInputs({
   executionHost,
   items,
@@ -28,7 +37,10 @@ export async function cancelQueuedDurableThreadInputs({
         { messageId: item.durableMessageId }
       );
       if (!claimed) {
-        continue;
+        throw new DurableThreadInputCancellationError(
+          item.durableMessageId,
+          threadKey
+        );
       }
       const promoted = await transaction.inputs.markPromoted(claimed);
       if (!promoted) {

--- a/packages/runtime/src/thread/runtime/kill.ts
+++ b/packages/runtime/src/thread/runtime/kill.ts
@@ -25,30 +25,30 @@ export async function closeKilledRuntimeInputs({
   runToClose,
   threadKey,
 }: CloseKilledRuntimeInputsOptions): Promise<void> {
-  closeRuntimeInput(activeRuntimeInput, message);
-  runToClose?.emit({ type: "turn-error", message });
-  runToClose?.close();
-
-  const queuedItems: QueuedInput[] = [];
-  while (inputQueue.length > 0) {
-    const item = inputQueue.shift();
-    closeRuntimeInput(item?.runtimeInput, message);
-    item?.run.emit({ type: "turn-error", message });
-    item?.run.close();
-    if (item) {
-      queuedItems.push(item);
-    }
-  }
-
+  const queuedItems = [...inputQueue];
   const nonDurableRuns = queuedItems.filter(
     (item) => item.durableMessageId === undefined
   );
+
+  // Durable cancellation must succeed before local callers are terminalized:
+  // on failure kill remains retryable and live ownership continues protecting
+  // the records from orphan recovery.
+  await cancelQueuedDurableThreadInputs({
+    executionHost,
+    items: queuedItems,
+    threadKey,
+  });
+
+  closeRuntimeInput(activeRuntimeInput, message);
+  runToClose?.emit({ type: "turn-error", message });
+  runToClose?.close();
+  for (const item of inputQueue.splice(0)) {
+    closeRuntimeInput(item.runtimeInput, message);
+    item.run.emit({ type: "turn-error", message });
+    item.run.close();
+  }
+
   await Promise.all([
-    cancelQueuedDurableThreadInputs({
-      executionHost,
-      items: queuedItems,
-      threadKey,
-    }),
     cancelThreadExecutionRun({
       executionHost,
       runId: runToClose?.runId,

--- a/packages/runtime/src/thread/runtime/kill.ts
+++ b/packages/runtime/src/thread/runtime/kill.ts
@@ -25,23 +25,24 @@ export async function closeKilledRuntimeInputs({
   runToClose,
   threadKey,
 }: CloseKilledRuntimeInputsOptions): Promise<void> {
+  closeRuntimeInput(activeRuntimeInput, message);
+  runToClose?.emit({ type: "turn-error", message });
+  runToClose?.close();
+
   const queuedItems = [...inputQueue];
   const nonDurableRuns = queuedItems.filter(
     (item) => item.durableMessageId === undefined
   );
 
-  // Durable cancellation must succeed before local callers are terminalized:
-  // on failure kill remains retryable and live ownership continues protecting
-  // the records from orphan recovery.
+  // Durable cancellation must succeed before queued callers are terminalized.
+  // Active callers close promptly on abort, while queued ownership remains
+  // protective and retryable if cancellation fails.
   await cancelQueuedDurableThreadInputs({
     executionHost,
     items: queuedItems,
     threadKey,
   });
 
-  closeRuntimeInput(activeRuntimeInput, message);
-  runToClose?.emit({ type: "turn-error", message });
-  runToClose?.close();
   for (const item of inputQueue.splice(0)) {
     closeRuntimeInput(item.runtimeInput, message);
     item.run.emit({ type: "turn-error", message });

--- a/packages/runtime/src/thread/runtime/live-input-ownership.test.ts
+++ b/packages/runtime/src/thread/runtime/live-input-ownership.test.ts
@@ -142,5 +142,8 @@ describe("live durable input ownership", () => {
     expect(
       isLiveThreadInputOwnedByOther(host, "claim-race", messageId, other)
     ).toBe(false);
+    await expect(
+      host.store.inputs.claimNext("claim-race", "turn-idle", { messageId })
+    ).resolves.toBeNull();
   });
 });

--- a/packages/runtime/src/thread/runtime/live-input-ownership.test.ts
+++ b/packages/runtime/src/thread/runtime/live-input-ownership.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { AgentHost } from "../../execution";
+import { createInMemoryHost } from "../../platform/memory";
+import { userText } from "../../testing/test-fixtures";
+import {
+  createRuntimeInputState,
+  type QueuedInput,
+} from "../input/runtime-input";
+import { BufferedAgentTurn } from "../protocol/turn";
+import { cancelQueuedDurableThreadInputs } from "./durable-input-cancellation";
+import {
+  isLiveThreadInputOwnedByOther,
+  registerLiveThreadInput,
+} from "./live-input-ownership";
+
+describe("live durable input ownership", () => {
+  it("releases ownership when durable kill cancellation fails", async () => {
+    const base = createInMemoryHost();
+    let failTransaction = true;
+    const store = new Proxy(base.store, {
+      get(target, property) {
+        if (property === "transaction" && failTransaction) {
+          failTransaction = false;
+          return (): Promise<never> =>
+            Promise.reject(new Error("transaction failed"));
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const host: AgentHost = { ...base, store };
+    const owner = {};
+    const other = {};
+    const messageId = crypto.randomUUID();
+    await base.store.inputs.admit({
+      input: userText("queued"),
+      kind: "send",
+      messageId,
+      threadKey: "kill-failure",
+    });
+    registerLiveThreadInput(host, "kill-failure", messageId, owner);
+    const item: QueuedInput = {
+      acceptedEvent: userText("queued"),
+      awaitBoundaries: false,
+      durableInput: true,
+      durableMessageId: messageId,
+      durableOwner: owner,
+      initialEvents: [],
+      preUserRuntimeInputs: [],
+      run: new BufferedAgentTurn(),
+      runtimeInput: createRuntimeInputState([]),
+    };
+
+    await expect(
+      cancelQueuedDurableThreadInputs({
+        executionHost: host,
+        items: [item],
+        threadKey: "kill-failure",
+      })
+    ).rejects.toThrow("transaction failed");
+    expect(
+      isLiveThreadInputOwnedByOther(host, "kill-failure", messageId, other)
+    ).toBe(true);
+
+    await cancelQueuedDurableThreadInputs({
+      executionHost: host,
+      items: [item],
+      threadKey: "kill-failure",
+    });
+    expect(
+      isLiveThreadInputOwnedByOther(host, "kill-failure", messageId, other)
+    ).toBe(false);
+  });
+});

--- a/packages/runtime/src/thread/runtime/live-input-ownership.test.ts
+++ b/packages/runtime/src/thread/runtime/live-input-ownership.test.ts
@@ -90,4 +90,57 @@ describe("live durable input ownership", () => {
       isLiveThreadInputOwnedByOther(host, "kill-failure", messageId, other)
     ).toBe(false);
   });
+
+  it("retains ownership while another claimant holds the durable record", async () => {
+    const host = createInMemoryHost();
+    const owner = {};
+    const other = {};
+    const messageId = crypto.randomUUID();
+    await host.store.inputs.admit({
+      input: userText("queued"),
+      kind: "send",
+      messageId,
+      threadKey: "claim-race",
+    });
+    registerLiveThreadInput(host, "claim-race", messageId, owner);
+    const held = await host.store.inputs.claimNext("claim-race", "turn-idle", {
+      messageId,
+    });
+    expect(held).not.toBeNull();
+    const item: QueuedInput = {
+      acceptedEvent: userText("queued"),
+      awaitBoundaries: false,
+      durableInput: true,
+      durableMessageId: messageId,
+      durableOwner: owner,
+      initialEvents: [],
+      preUserRuntimeInputs: [],
+      run: new BufferedAgentTurn(),
+      runtimeInput: createRuntimeInputState([]),
+    };
+
+    await expect(
+      cancelQueuedDurableThreadInputs({
+        executionHost: host,
+        items: [item],
+        threadKey: "claim-race",
+      })
+    ).rejects.toThrow("Could not claim queued input");
+    expect(
+      isLiveThreadInputOwnedByOther(host, "claim-race", messageId, other)
+    ).toBe(true);
+
+    if (!held) {
+      throw new Error("expected held claim");
+    }
+    await host.store.inputs.releaseClaim(held);
+    await cancelQueuedDurableThreadInputs({
+      executionHost: host,
+      items: [item],
+      threadKey: "claim-race",
+    });
+    expect(
+      isLiveThreadInputOwnedByOther(host, "claim-race", messageId, other)
+    ).toBe(false);
+  });
 });

--- a/packages/runtime/src/thread/runtime/live-input-ownership.test.ts
+++ b/packages/runtime/src/thread/runtime/live-input-ownership.test.ts
@@ -10,10 +10,29 @@ import { BufferedAgentTurn } from "../protocol/turn";
 import { cancelQueuedDurableThreadInputs } from "./durable-input-cancellation";
 import {
   isLiveThreadInputOwnedByOther,
+  liveThreadInputOwnedByOther,
   registerLiveThreadInput,
 } from "./live-input-ownership";
 
 describe("live durable input ownership", () => {
+  it("releases waiters when a message owner is replaced", async () => {
+    const host = createInMemoryHost();
+    const first = {};
+    const second = {};
+    registerLiveThreadInput(host, "replace", "message", first);
+    const released = liveThreadInputOwnedByOther(
+      host,
+      "replace",
+      "message",
+      second
+    );
+    registerLiveThreadInput(host, "replace", "message", second);
+    await expect(released).resolves.toBeUndefined();
+    expect(
+      isLiveThreadInputOwnedByOther(host, "replace", "message", first)
+    ).toBe(true);
+  });
+
   it("releases ownership when durable kill cancellation fails", async () => {
     const base = createInMemoryHost();
     let failTransaction = true;

--- a/packages/runtime/src/thread/runtime/live-input-ownership.ts
+++ b/packages/runtime/src/thread/runtime/live-input-ownership.ts
@@ -1,6 +1,14 @@
 import type { AgentHost } from "../../execution/host/types";
+import { deferred } from "../../internal/deferred";
 
-const liveInputs = new WeakMap<object, Map<string, Map<string, object>>>();
+interface LiveInputOwner {
+  readonly owner: object;
+  readonly released: ReturnType<typeof deferred<void>>;
+}
+const liveInputs = new WeakMap<
+  object,
+  Map<string, Map<string, LiveInputOwner>>
+>();
 
 export function registerLiveThreadInput(
   executionHost: AgentHost | undefined,
@@ -21,7 +29,25 @@ export function registerLiveThreadInput(
     messages = new Map();
     threads.set(threadKey, messages);
   }
-  messages.set(messageId, owner);
+  messages.set(messageId, { owner, released: deferred<void>() });
+}
+
+export function liveThreadInputOwnedByOther(
+  executionHost: AgentHost | undefined,
+  threadKey: string,
+  messageId: string,
+  owner?: object
+): Promise<void> | undefined {
+  if (!executionHost) {
+    return;
+  }
+  const registered = liveInputs
+    .get(executionHost.store)
+    ?.get(threadKey)
+    ?.get(messageId);
+  return registered && registered.owner !== owner
+    ? registered.released.promise
+    : undefined;
 }
 
 export function isLiveThreadInputOwnedByOther(
@@ -30,27 +56,29 @@ export function isLiveThreadInputOwnedByOther(
   messageId: string,
   owner?: object
 ): boolean {
-  if (!executionHost) {
-    return false;
-  }
-  const registered = liveInputs
-    .get(executionHost.store)
-    ?.get(threadKey)
-    ?.get(messageId);
-  return registered !== undefined && registered !== owner;
+  return (
+    liveThreadInputOwnedByOther(executionHost, threadKey, messageId, owner) !==
+    undefined
+  );
 }
 
 export function unregisterLiveThreadInput(
   executionHost: AgentHost | undefined,
   threadKey: string,
-  messageId: string
+  messageId: string,
+  owner?: object
 ): void {
   if (!executionHost) {
     return;
   }
   const threads = liveInputs.get(executionHost.store);
   const messages = threads?.get(threadKey);
+  const registered = messages?.get(messageId);
+  if (!registered || (owner !== undefined && registered.owner !== owner)) {
+    return;
+  }
   messages?.delete(messageId);
+  registered.released.resolve(undefined);
   if (messages?.size === 0) {
     threads?.delete(threadKey);
   }

--- a/packages/runtime/src/thread/runtime/live-input-ownership.ts
+++ b/packages/runtime/src/thread/runtime/live-input-ownership.ts
@@ -29,6 +29,8 @@ export function registerLiveThreadInput(
     messages = new Map();
     threads.set(threadKey, messages);
   }
+  const previous = messages.get(messageId);
+  previous?.released.resolve(undefined);
   messages.set(messageId, { owner, released: deferred<void>() });
 }
 

--- a/packages/runtime/src/thread/runtime/live-input-ownership.ts
+++ b/packages/runtime/src/thread/runtime/live-input-ownership.ts
@@ -1,0 +1,57 @@
+import type { AgentHost } from "../../execution/host/types";
+
+const liveInputs = new WeakMap<object, Map<string, Map<string, object>>>();
+
+export function registerLiveThreadInput(
+  executionHost: AgentHost | undefined,
+  threadKey: string,
+  messageId: string,
+  owner: object
+): void {
+  if (!executionHost) {
+    return;
+  }
+  let threads = liveInputs.get(executionHost.store);
+  if (!threads) {
+    threads = new Map();
+    liveInputs.set(executionHost.store, threads);
+  }
+  let messages = threads.get(threadKey);
+  if (!messages) {
+    messages = new Map();
+    threads.set(threadKey, messages);
+  }
+  messages.set(messageId, owner);
+}
+
+export function isLiveThreadInputOwnedByOther(
+  executionHost: AgentHost | undefined,
+  threadKey: string,
+  messageId: string,
+  owner?: object
+): boolean {
+  if (!executionHost) {
+    return false;
+  }
+  const registered = liveInputs
+    .get(executionHost.store)
+    ?.get(threadKey)
+    ?.get(messageId);
+  return registered !== undefined && registered !== owner;
+}
+
+export function unregisterLiveThreadInput(
+  executionHost: AgentHost | undefined,
+  threadKey: string,
+  messageId: string
+): void {
+  if (!executionHost) {
+    return;
+  }
+  const threads = liveInputs.get(executionHost.store);
+  const messages = threads?.get(threadKey);
+  messages?.delete(messageId);
+  if (messages?.size === 0) {
+    threads?.delete(threadKey);
+  }
+}

--- a/packages/runtime/src/thread/runtime/thread-input-admission-coordinator.ts
+++ b/packages/runtime/src/thread/runtime/thread-input-admission-coordinator.ts
@@ -3,11 +3,15 @@ import { deferred } from "../../internal/deferred";
 
 const hostAdmissionTails = new WeakMap<object, Map<string, Promise<void>>>();
 
-export async function withThreadInputAdmission<T>(
-  executionHost: AgentHost,
-  threadKey: string,
+export type ThreadInputAdmissionReservation = <T>(
   operation: () => Promise<T>
-): Promise<T> {
+) => Promise<T>;
+
+/** Reserve FIFO admission position synchronously, before asynchronous loading. */
+export function reserveThreadInputAdmission(
+  executionHost: AgentHost,
+  threadKey: string
+): ThreadInputAdmissionReservation {
   let byThread = hostAdmissionTails.get(executionHost.store);
   if (!byThread) {
     byThread = new Map();
@@ -17,13 +21,23 @@ export async function withThreadInputAdmission<T>(
   const released = deferred();
   const tail = previous.then(() => released.promise);
   byThread.set(threadKey, tail);
-  await previous;
-  try {
-    return await operation();
-  } finally {
-    released.resolve();
-    if (byThread.get(threadKey) === tail) {
-      byThread.delete(threadKey);
+  return async <T>(operation: () => Promise<T>): Promise<T> => {
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      released.resolve();
+      if (byThread.get(threadKey) === tail) {
+        byThread.delete(threadKey);
+      }
     }
-  }
+  };
+}
+
+export async function withThreadInputAdmission<T>(
+  executionHost: AgentHost,
+  threadKey: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  return await reserveThreadInputAdmission(executionHost, threadKey)(operation);
 }

--- a/packages/runtime/src/thread/runtime/thread-input-admission-coordinator.ts
+++ b/packages/runtime/src/thread/runtime/thread-input-admission-coordinator.ts
@@ -1,0 +1,29 @@
+import type { AgentHost } from "../../execution/host/types";
+import { deferred } from "../../internal/deferred";
+
+const hostAdmissionTails = new WeakMap<object, Map<string, Promise<void>>>();
+
+export async function withThreadInputAdmission<T>(
+  executionHost: AgentHost,
+  threadKey: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  let byThread = hostAdmissionTails.get(executionHost.store);
+  if (!byThread) {
+    byThread = new Map();
+    hostAdmissionTails.set(executionHost.store, byThread);
+  }
+  const previous = byThread.get(threadKey) ?? Promise.resolve();
+  const released = deferred();
+  const tail = previous.then(() => released.promise);
+  byThread.set(threadKey, tail);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    released.resolve();
+    if (byThread.get(threadKey) === tail) {
+      byThread.delete(threadKey);
+    }
+  }
+}

--- a/packages/runtime/src/thread/state/thread-state-delete.test.ts
+++ b/packages/runtime/src/thread/state/thread-state-delete.test.ts
@@ -102,6 +102,25 @@ describe("ThreadState deletion", () => {
     expect(store.commits).toHaveLength(commitsBefore);
   });
 
+  it("does not let a refresh resurrect a deleted snapshot", async () => {
+    const store = new BaseSpyStore();
+    const seed = new ThreadState({ key: "race-refresh", store });
+    seed.appendUserInput(userText("persisted"));
+    await seed.commit();
+
+    const state = new ThreadState({ key: "race-refresh", store });
+    await state.ensureLoaded();
+    const loadGate = createDeferred<void>();
+    store.loadGate = loadGate.promise;
+    const refresh = state.refresh();
+    const deletion = state.delete();
+    loadGate.resolve();
+    await Promise.all([refresh, deletion]);
+
+    expect(state.modelSnapshot()).toEqual([]);
+    expect(loadStored(store, "race-refresh")).toBeNull();
+  });
+
   it("does not resurrect a thread when delete wins a commit race", async () => {
     const store = new DelayedCommitStore();
     const state = new ThreadState({ key: "race", store });

--- a/packages/runtime/src/thread/state/thread-state.ts
+++ b/packages/runtime/src/thread/state/thread-state.ts
@@ -147,6 +147,12 @@ export class ThreadState {
     return await load.promise;
   }
 
+  async refresh(): Promise<void> {
+    await this.ensureLoaded();
+    const applySnapshot = await this.#loadStoredSnapshot();
+    applySnapshot();
+  }
+
   modelSnapshot(): ModelMessage[] {
     return this.#history.modelSnapshot();
   }

--- a/packages/runtime/src/thread/state/thread-state.ts
+++ b/packages/runtime/src/thread/state/thread-state.ts
@@ -149,8 +149,13 @@ export class ThreadState {
 
   async refresh(): Promise<void> {
     await this.ensureLoaded();
+    if (this.#machine.in("deleting", "deleted")) {
+      return;
+    }
     const applySnapshot = await this.#loadStoredSnapshot();
-    applySnapshot();
+    if (!this.#machine.in("deleting", "deleted")) {
+      applySnapshot();
+    }
   }
 
   modelSnapshot(): ModelMessage[] {


### PR DESCRIPTION
## Summary
- add `agent.followUp()` and `thread.followUp()` as explicit durable follow-up turn APIs
- persist follow-ups as a distinct inbox kind and expose distinct `follow-up` input/instrumentation metadata
- guarantee admitted-sequence FIFO one-at-a-time turns across active-turn aborts and durable claim recovery
- serialize live drain loops for Agent handles sharing the same host store object + thread key, with memory/file/Cloudflare adapter conformance coverage
- document follow-up versus send/steer behavior and add a runtime patch Tegami entry

## Exact delivery semantics
Each accepted call owns one `AgentTurn`, run ID, durable inbox record, model invocation, and terminal event. Follow-ups are claimed in durable `admittedSeq` order, so recovered older work runs before a newly admitted follow-up. Within one runtime isolate, a host-store/thread-key drain coordinator holds ownership through the complete model turn; contending handles wait and refresh their thread snapshot before running. This is validated with two Agent instances sharing one memory, file, or Cloudflare host store (`maxActive === 1`).

This PR does not expose an `all` batching mode because combining independently accepted calls into one model invocation would conflict with the runtime's one-call/one-turn contract.

## Tests
- `pnpm --filter @minpeter/pss-runtime test` (144 files, 866 passed, 3 skipped)
- `pnpm --filter @minpeter/pss-runtime typecheck`
- `pnpm --filter @minpeter/pss-runtime lint`
- `pnpm --filter @minpeter/pss-runtime build`
- `pnpm exec vitest run scripts/runtime-docs.test.mjs`
