### PR TITLE
Add explicit compact and session TUI commands

### DIFF
--- a/.tegami/2026-08-06-session-tui-parity.md
+++ b/.tegami/2026-08-06-session-tui-parity.md
@@ -2,6 +2,8 @@
 packages:
   npm:@minpeter/pss-coding-agent:
     type: patch
+  npm:@minpeter/pss-runtime:
+    type: patch
 ---
 
-Add explicit `/compact` and Pi-compatible `/session` commands to the interactive TUI, with durable context compaction and documented session UX.
+Add explicit `/compact` and Pi-compatible `/session` commands to the interactive TUI, with runtime-owned durable context compaction and documented session UX.

--- a/.tegami/2026-08-06-session-tui-parity.md
+++ b/.tegami/2026-08-06-session-tui-parity.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+Add explicit `/compact` and Pi-compatible `/session` commands to the interactive TUI, with durable context compaction and documented session UX.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -327,9 +327,9 @@ Metadata (names, fork parentage, the active session) lives in a sidecar
 `sessions.json` next to the thread files:
 
 - `/new [name]` — start a new empty session
-- `/resume` — interactive picker (switch, rename, or delete a session;
-  deleting the live session is blocked — switch away first);
-  `/resume <key|name>` switches directly (with completions)
+- `/session` (also `/resume`) — interactive picker (switch, rename, or delete
+  a session; deleting the live session is blocked — switch away first);
+  `/session <key|name>` switches directly (with completions)
 - `/name <name>` — name the current session (also `pss --name <name>` at
   startup)
 - `/fork` — pick a branch point: the latest state or *before an earlier
@@ -338,8 +338,11 @@ Metadata (names, fork parentage, the active session) lives in a sidecar
   state under that name. Applied thread migrations carry over so they
   never re-run on the fork, and the parent thread key is recorded
 - `/clear` — wipe the current session in place (legacy behavior)
+- `/compact` — summarize the current durable conversation and replace its
+  model-facing context with the smaller continuation handoff; full history
+  remains available for replay and inspection
 
-Session recency updates on every completed turn, so the `/resume` picker
+Session recency updates on every completed turn, so the `/session` picker
 sorts by actual use.
 
 Extensions observe the lifecycle through host bus events

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -327,8 +327,9 @@ Metadata (names, fork parentage, the active session) lives in a sidecar
 `sessions.json` next to the thread files:
 
 - `/new [name]` — start a new empty session
-- `/session` — show the current session key, name, timestamps, parent, and
-  per-role message counts
+- `/session` — show the current session key, name, timestamps, parent, reconciled
+  per-role message counts, and tool call/result activity. Durable token-usage
+  totals are reported as unavailable because they are not retained
 - `/resume` — interactive picker (switch, rename, or delete a session;
   deleting the live session is blocked — switch away first);
   `/resume <key|name>` switches directly (with completions)

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -327,9 +327,11 @@ Metadata (names, fork parentage, the active session) lives in a sidecar
 `sessions.json` next to the thread files:
 
 - `/new [name]` — start a new empty session
-- `/session` (also `/resume`) — interactive picker (switch, rename, or delete
-  a session; deleting the live session is blocked — switch away first);
-  `/session <key|name>` switches directly (with completions)
+- `/session` — show the current session key, name, timestamps, parent, and
+  per-role message counts
+- `/resume` — interactive picker (switch, rename, or delete a session;
+  deleting the live session is blocked — switch away first);
+  `/resume <key|name>` switches directly (with completions)
 - `/name <name>` — name the current session (also `pss --name <name>` at
   startup)
 - `/fork` — pick a branch point: the latest state or *before an earlier
@@ -338,11 +340,13 @@ Metadata (names, fork parentage, the active session) lives in a sidecar
   state under that name. Applied thread migrations carry over so they
   never re-run on the fork, and the parent thread key is recorded
 - `/clear` — wipe the current session in place (legacy behavior)
-- `/compact` — summarize the current durable conversation and replace its
-  model-facing context with the smaller continuation handoff; full history
-  remains available for replay and inspection
+- `/compact [custom instructions]` — summarize the current durable conversation
+  through the runtime's compaction pipeline and replace its model-facing
+  context with the smaller continuation handoff; full history remains available
+  for replay and inspection. Compaction is idle-only and reports an explicit
+  error if requested while a turn is active
 
-Session recency updates on every completed turn, so the `/session` picker
+Session recency updates on every completed turn, so the `/resume` picker
 sorts by actual use.
 
 Extensions observe the lifecycle through host bus events

--- a/apps/coding-agent/src/extensions/capability-host.test.ts
+++ b/apps/coding-agent/src/extensions/capability-host.test.ts
@@ -614,27 +614,58 @@ describe("coding-agent extension capabilities", () => {
     });
   });
 
-  it("rejects extension commands that shadow built-ins", async () => {
-    const creation = createCodingAgentExtensionHost([
-      {
-        configure(registry) {
-          registry.commands.register({
-            description: "Override clear",
-            execute: () => ({ success: true }),
-            name: "clear",
-          });
+  it.each(["clear", "compact", "Compact", "session", "Session"])(
+    "rejects extension commands that shadow built-in %s",
+    async (name) => {
+      const creation = createCodingAgentExtensionHost([
+        {
+          configure(registry) {
+            registry.commands.register({
+              description: `Override ${name}`,
+              execute: () => ({ success: true }),
+              name,
+            });
+          },
+          id: "builtin-shadow-provider",
         },
-        id: "builtin-shadow-provider",
-      },
-    ]).then(async (host) => {
-      await host.dispose();
-      return host;
-    });
+      ]).then(async (host) => {
+        await host.dispose();
+        return host;
+      });
 
-    await expect(creation).rejects.toMatchObject({
-      cause: {
-        message: 'Reserved coding agent command name or alias "clear"',
-      },
-    });
-  });
+      await expect(creation).rejects.toMatchObject({
+        cause: {
+          message: `Reserved coding agent command name or alias "${name}"`,
+        },
+      });
+    }
+  );
+
+  it.each(["Compact", "Session"])(
+    "rejects case-insensitive built-in alias collisions for %s",
+    async (alias) => {
+      const creation = createCodingAgentExtensionHost([
+        {
+          configure(registry) {
+            registry.commands.register({
+              aliases: [alias],
+              description: "Alias collision",
+              execute: () => ({ success: true }),
+              name: "safe-command",
+            });
+          },
+          id: "builtin-alias-shadow-provider",
+        },
+      ]).then(async (host) => {
+        await host.dispose();
+        return host;
+      });
+
+      await expect(creation).rejects.toMatchObject({
+        cause: {
+          message: `Reserved coding agent command name or alias "${alias}"`,
+        },
+      });
+    }
+  );
 });

--- a/apps/coding-agent/src/extensions/capability-host.test.ts
+++ b/apps/coding-agent/src/extensions/capability-host.test.ts
@@ -614,34 +614,39 @@ describe("coding-agent extension capabilities", () => {
     });
   });
 
-  it.each(["clear", "compact", "Compact", "session", "Session"])(
-    "rejects extension commands that shadow built-in %s",
-    async (name) => {
-      const creation = createCodingAgentExtensionHost([
-        {
-          configure(registry) {
-            registry.commands.register({
-              description: `Override ${name}`,
-              execute: () => ({ success: true }),
-              name,
-            });
-          },
-          id: "builtin-shadow-provider",
+  it.each([
+    "clear",
+    "compact",
+    "Compact",
+    "models",
+    "Models",
+    "session",
+    "Session",
+  ])("rejects extension commands that shadow built-in %s", async (name) => {
+    const creation = createCodingAgentExtensionHost([
+      {
+        configure(registry) {
+          registry.commands.register({
+            description: `Override ${name}`,
+            execute: () => ({ success: true }),
+            name,
+          });
         },
-      ]).then(async (host) => {
-        await host.dispose();
-        return host;
-      });
+        id: "builtin-shadow-provider",
+      },
+    ]).then(async (host) => {
+      await host.dispose();
+      return host;
+    });
 
-      await expect(creation).rejects.toMatchObject({
-        cause: {
-          message: `Reserved coding agent command name or alias "${name}"`,
-        },
-      });
-    }
-  );
+    await expect(creation).rejects.toMatchObject({
+      cause: {
+        message: `Reserved coding agent command name or alias "${name}"`,
+      },
+    });
+  });
 
-  it.each(["Compact", "Session"])(
+  it.each(["Compact", "Models", "Session"])(
     "rejects case-insensitive built-in alias collisions for %s",
     async (alias) => {
       const creation = createCodingAgentExtensionHost([

--- a/apps/coding-agent/src/extensions/name-validation.ts
+++ b/apps/coding-agent/src/extensions/name-validation.ts
@@ -8,6 +8,7 @@ const RESERVED_COMMAND_NAMES = new Set([
   "fork",
   "help",
   "model",
+  "models",
   "name",
   "new",
   "reload",

--- a/apps/coding-agent/src/extensions/name-validation.ts
+++ b/apps/coding-agent/src/extensions/name-validation.ts
@@ -4,6 +4,7 @@ const COMMAND_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 const TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 const RESERVED_COMMAND_NAMES = new Set([
   "clear",
+  "compact",
   "fork",
   "help",
   "model",
@@ -11,6 +12,7 @@ const RESERVED_COMMAND_NAMES = new Set([
   "new",
   "reload",
   "resume",
+  "session",
 ]);
 const UNSAFE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -34,7 +34,7 @@ import {
   type TuiCommandAction,
   type TuiCommandResult,
 } from "./command";
-import { buildTuiCommandSet } from "./command-set";
+import { buildTuiCommandSet, resolveTuiCommand } from "./command-set";
 import { ctrlCPressDecision } from "./ctrl-c";
 import { createTuiErrorPresentation } from "./error-presentation";
 import { createExtensionUi } from "./extension-ui";
@@ -1161,10 +1161,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return null;
     }
 
-    const normalizedName = parsed.name.toLowerCase();
-    const resolvedName =
-      commandSet.commandAliasLookup.get(normalizedName) ?? normalizedName;
-    const command = commandSet.commandLookup.get(resolvedName);
+    const command = resolveTuiCommand(commandSet, parsed.name);
     if (!command) {
       return null;
     }
@@ -1598,13 +1595,12 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     if (steeringTurn !== undefined) {
       if (trimmed.length > 0) {
         const parsed = parseCommand(trimmed);
-        const resolvedCommand =
+        const activeCommand =
           parsed === null
             ? undefined
-            : (commandSet.commandAliasLookup.get(parsed.name.toLowerCase()) ??
-              parsed.name.toLowerCase());
+            : resolveTuiCommand(commandSet, parsed.name);
         const operation =
-          resolvedCommand === "compact"
+          activeCommand?.allowDuringActiveTurn === true
             ? (async () => {
                 editor.disableSubmit = true;
                 editor.setText("");

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -1597,15 +1597,33 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     const steeringTurn = session.activeTurn;
     if (steeringTurn !== undefined) {
       if (trimmed.length > 0) {
-        processSteeringInput(trimmed, steeringTurn.run).catch(
-          (error: unknown) => {
-            clearStatus();
-            const errorMessage =
-              error instanceof Error ? error.message : String(error);
-            addSystemMessage(chatContainer, `Error: ${errorMessage}`);
-            tui.requestRender();
-          }
-        );
+        const parsed = parseCommand(trimmed);
+        const resolvedCommand =
+          parsed === null
+            ? undefined
+            : (commandSet.commandAliasLookup.get(parsed.name.toLowerCase()) ??
+              parsed.name.toLowerCase());
+        const operation =
+          resolvedCommand === "compact"
+            ? (async () => {
+                editor.disableSubmit = true;
+                editor.setText("");
+                try {
+                  await processCommandInput(trimmed);
+                } finally {
+                  editor.disableSubmit = false;
+                  tui.setFocus(composerLayer);
+                  tui.requestRender();
+                }
+              })()
+            : processSteeringInput(trimmed, steeringTurn.run);
+        operation.catch((error: unknown) => {
+          clearStatus();
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          addSystemMessage(chatContainer, `Error: ${errorMessage}`);
+          tui.requestRender();
+        });
       }
       return;
     }

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -53,6 +53,7 @@ import { emitUpdateNotice } from "../update/notifier";
 import { type AgentTUIConfig, createAgentTUI } from "./agent";
 import type { TuiCommand } from "./command";
 import { createReloadCommand } from "./command-set";
+import { compactCurrentThread, createCompactCommand } from "./compact-command";
 import { parseDirectStartArguments } from "./direct-start";
 import { createModelCommand } from "./model-command";
 import {
@@ -262,6 +263,28 @@ export async function startTui(
     // opaque, so the selector is not offered then.
     const activeModelSession = modelSession;
     const builtInCommands = [
+      createCompactCommand({
+        compact: async () => {
+          const history = await sessionManager.loadSessionHistory(
+            currentSession.key
+          );
+          const clearCompactingStatus = extensionUi?.status(
+            "Compacting session context..."
+          );
+          try {
+            const result = await compactCurrentThread({
+              commit: (input) => thread.compact(input),
+              history,
+              instructions: currentInstructions(),
+              model,
+            });
+            resetUsageTotals();
+            return result;
+          } finally {
+            clearCompactingStatus?.();
+          }
+        },
+      }),
       // Session commands close over helpers defined below; the wrappers
       // defer evaluation to call time.
       ...createSessionCommands({

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -269,13 +269,13 @@ export async function startTui(
             "Compacting session context..."
           );
           try {
-            const compacted = await thread.compact(
+            const result = await thread.compact(
               instructions === undefined ? {} : { instructions }
             );
-            if (compacted) {
+            if (result.status === "compacted") {
               resetUsageTotals();
             }
-            return compacted;
+            return result;
           } finally {
             clearCompactingStatus?.();
           }

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -53,7 +53,7 @@ import { emitUpdateNotice } from "../update/notifier";
 import { type AgentTUIConfig, createAgentTUI } from "./agent";
 import type { TuiCommand } from "./command";
 import { createReloadCommand } from "./command-set";
-import { compactCurrentThread, createCompactCommand } from "./compact-command";
+import { createCompactCommand } from "./compact-command";
 import { parseDirectStartArguments } from "./direct-start";
 import { createModelCommand } from "./model-command";
 import {
@@ -264,22 +264,18 @@ export async function startTui(
     const activeModelSession = modelSession;
     const builtInCommands = [
       createCompactCommand({
-        compact: async () => {
-          const history = await sessionManager.loadSessionHistory(
-            currentSession.key
-          );
+        compact: async (instructions) => {
           const clearCompactingStatus = extensionUi?.status(
             "Compacting session context..."
           );
           try {
-            const result = await compactCurrentThread({
-              commit: (input) => thread.compact(input),
-              history,
-              instructions: currentInstructions(),
-              model,
-            });
-            resetUsageTotals();
-            return result;
+            const compacted = await thread.compact(
+              instructions === undefined ? {} : { instructions }
+            );
+            if (compacted) {
+              resetUsageTotals();
+            }
+            return compacted;
           } finally {
             clearCompactingStatus?.();
           }

--- a/apps/coding-agent/src/tui/command-set.test.ts
+++ b/apps/coding-agent/src/tui/command-set.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TuiCommand } from "./command";
-import { buildTuiCommandSet } from "./command-set";
+import { buildTuiCommandSet, resolveTuiCommand } from "./command-set";
 
 describe("buildTuiCommandSet", () => {
   it("keeps only the provided commands without injecting /help", () => {
@@ -57,5 +57,29 @@ describe("buildTuiCommandSet", () => {
     expect(commandSet.commandLookup.get("clear")?.description).toBe(
       "Start a new session"
     );
+  });
+
+  it("derives active-turn eligibility from resolved command metadata", () => {
+    const commandSet = buildTuiCommandSet([
+      {
+        aliases: ["shrink"],
+        allowDuringActiveTurn: true,
+        description: "Compact context",
+        execute: () => ({ success: true }),
+        name: "compact",
+      },
+      {
+        description: "Rename",
+        execute: () => ({ success: true }),
+        name: "name",
+      },
+    ]);
+
+    expect(resolveTuiCommand(commandSet, "SHRINK")?.allowDuringActiveTurn).toBe(
+      true
+    );
+    expect(
+      resolveTuiCommand(commandSet, "name")?.allowDuringActiveTurn
+    ).not.toBe(true);
   });
 });

--- a/apps/coding-agent/src/tui/command-set.ts
+++ b/apps/coding-agent/src/tui/command-set.ts
@@ -46,3 +46,13 @@ export const createReloadCommand = (): TuiCommand => ({
     success: true,
   }),
 });
+
+export function resolveTuiCommand(
+  commandSet: TuiCommandSet,
+  name: string
+): TuiCommand | undefined {
+  const normalizedName = name.toLowerCase();
+  const resolvedName =
+    commandSet.commandAliasLookup.get(normalizedName) ?? normalizedName;
+  return commandSet.commandLookup.get(resolvedName);
+}

--- a/apps/coding-agent/src/tui/command.ts
+++ b/apps/coding-agent/src/tui/command.ts
@@ -33,6 +33,8 @@ export interface TuiCommandContext {
 
 export interface TuiCommand {
   aliases?: readonly string[];
+  /** Permit this command to run instead of becoming steering input mid-turn. */
+  allowDuringActiveTurn?: boolean;
   /** Static completion values for simple commands. */
   argumentSuggestions?: readonly string[];
   description: string;

--- a/apps/coding-agent/src/tui/compact-command.test.ts
+++ b/apps/coding-agent/src/tui/compact-command.test.ts
@@ -1,76 +1,50 @@
-import type { AgentOptions } from "@minpeter/pss-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { compactCurrentThread, createCompactCommand } from "./compact-command";
+import { createCompactCommand } from "./compact-command";
 
 describe("/compact", () => {
-  it("compacts the current thread and reports the affected history", async () => {
-    const compact = vi.fn(() => Promise.resolve({ compactedMessages: 12 }));
+  it("runs runtime-owned compaction", async () => {
+    const compact = vi.fn(() => Promise.resolve(true));
 
     await expect(
       createCompactCommand({ compact }).execute({ args: [] })
     ).resolves.toEqual({
-      message: "Compacted 12 conversation messages.",
+      message: "Session context compacted.",
       success: true,
     });
-    expect(compact).toHaveBeenCalledOnce();
+    expect(compact).toHaveBeenCalledWith(undefined);
   });
 
-  it("turns runtime failures into a command result", async () => {
-    const compact = vi.fn(() => Promise.reject(new Error("history is empty")));
+  it("passes custom summary instructions", async () => {
+    const compact = vi.fn(() => Promise.resolve(true));
+
+    await createCompactCommand({ compact }).execute({
+      args: ["focus", "on", "decisions"],
+    });
+
+    expect(compact).toHaveBeenCalledWith("focus on decisions");
+  });
+
+  it("reports empty history without treating it as an error", async () => {
+    const compact = vi.fn(() => Promise.resolve(false));
 
     await expect(
       createCompactCommand({ compact }).execute({ args: [] })
     ).resolves.toEqual({
-      message: "Compaction failed: history is empty",
+      message: "Nothing to compact in the current session.",
+      success: true,
+    });
+  });
+
+  it("makes active-turn rejection explicit", async () => {
+    const compact = vi.fn(() =>
+      Promise.reject(new Error("Cannot compact while a turn is active."))
+    );
+
+    await expect(
+      createCompactCommand({ compact }).execute({ args: [] })
+    ).resolves.toEqual({
+      message: "Compaction failed: Cannot compact while a turn is active.",
       success: false,
     });
-  });
-});
-
-describe("compactCurrentThread", () => {
-  it("summarizes the full durable history before committing the prefix", async () => {
-    const history = [
-      { content: "question", role: "user" as const },
-      { content: "answer", role: "assistant" as const },
-    ];
-    const summarize = vi.fn(() => Promise.resolve("continuation handoff"));
-    const commit = vi.fn(() => Promise.resolve());
-    const model = {} as AgentOptions["model"];
-
-    await expect(
-      compactCurrentThread({
-        commit,
-        history,
-        instructions: "coding rules",
-        model,
-        summarize,
-      })
-    ).resolves.toEqual({ compactedMessages: 2 });
-    expect(summarize).toHaveBeenCalledWith({
-      history,
-      model: { instructions: "coding rules", model },
-    });
-    expect(commit).toHaveBeenCalledWith({
-      endSeqExclusive: 2,
-      startSeq: 0,
-      summary: "continuation handoff",
-    });
-  });
-
-  it("rejects empty sessions without spending a model call", async () => {
-    const summarize = vi.fn(() => Promise.resolve("unused"));
-    const commit = vi.fn(() => Promise.resolve());
-
-    await expect(
-      compactCurrentThread({
-        commit,
-        history: [],
-        instructions: "coding rules",
-        model: {} as AgentOptions["model"],
-        summarize,
-      })
-    ).rejects.toThrow("no conversation history");
-    expect(summarize).not.toHaveBeenCalled();
-    expect(commit).not.toHaveBeenCalled();
   });
 });

--- a/apps/coding-agent/src/tui/compact-command.test.ts
+++ b/apps/coding-agent/src/tui/compact-command.test.ts
@@ -4,7 +4,9 @@ import { createCompactCommand } from "./compact-command";
 
 describe("/compact", () => {
   it("runs runtime-owned compaction", async () => {
-    const compact = vi.fn(() => Promise.resolve(true));
+    const compact = vi.fn(() =>
+      Promise.resolve({ status: "compacted" as const })
+    );
 
     await expect(
       createCompactCommand({ compact }).execute({ args: [] })
@@ -16,7 +18,9 @@ describe("/compact", () => {
   });
 
   it("passes custom summary instructions", async () => {
-    const compact = vi.fn(() => Promise.resolve(true));
+    const compact = vi.fn(() =>
+      Promise.resolve({ status: "compacted" as const })
+    );
 
     await createCompactCommand({ compact }).execute({
       args: ["focus", "on", "decisions"],
@@ -26,13 +30,27 @@ describe("/compact", () => {
   });
 
   it("reports empty history without treating it as an error", async () => {
-    const compact = vi.fn(() => Promise.resolve(false));
+    const compact = vi.fn(() => Promise.resolve({ status: "empty" as const }));
 
     await expect(
       createCompactCommand({ compact }).execute({ args: [] })
     ).resolves.toEqual({
       message: "Nothing to compact in the current session.",
       success: true,
+    });
+  });
+
+  it("distinguishes hook/freshness skips from empty history", async () => {
+    const compact = vi.fn(() =>
+      Promise.resolve({ status: "skipped" as const })
+    );
+
+    await expect(
+      createCompactCommand({ compact }).execute({ args: [] })
+    ).resolves.toEqual({
+      message:
+        "Compaction was skipped because a hook rejected it or the session changed.",
+      success: false,
     });
   });
 

--- a/apps/coding-agent/src/tui/compact-command.test.ts
+++ b/apps/coding-agent/src/tui/compact-command.test.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import { createCompactCommand } from "./compact-command";
 
@@ -46,5 +47,30 @@ describe("/compact", () => {
       message: "Compaction failed: Cannot compact while a turn is active.",
       success: false,
     });
+  });
+
+  it("normalizes provider failures without exposing raw provider details", async () => {
+    const compact = vi.fn(() =>
+      Promise.reject(
+        new APICallError({
+          isRetryable: false,
+          message: "provider leaked secret-token",
+          requestBodyValues: { apiKey: "request-secret" },
+          statusCode: 429,
+          url: "https://provider.example?token=url-secret",
+        })
+      )
+    );
+
+    const result = await createCompactCommand({ compact }).execute({
+      args: [],
+    });
+
+    expect(result).toEqual({
+      message:
+        "Compaction failed: The provider rate limit was reached. Wait before retrying or check your provider quota.",
+      success: false,
+    });
+    expect(JSON.stringify(result)).not.toContain("secret");
   });
 });

--- a/apps/coding-agent/src/tui/compact-command.test.ts
+++ b/apps/coding-agent/src/tui/compact-command.test.ts
@@ -1,0 +1,76 @@
+import type { AgentOptions } from "@minpeter/pss-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { compactCurrentThread, createCompactCommand } from "./compact-command";
+
+describe("/compact", () => {
+  it("compacts the current thread and reports the affected history", async () => {
+    const compact = vi.fn(() => Promise.resolve({ compactedMessages: 12 }));
+
+    await expect(
+      createCompactCommand({ compact }).execute({ args: [] })
+    ).resolves.toEqual({
+      message: "Compacted 12 conversation messages.",
+      success: true,
+    });
+    expect(compact).toHaveBeenCalledOnce();
+  });
+
+  it("turns runtime failures into a command result", async () => {
+    const compact = vi.fn(() => Promise.reject(new Error("history is empty")));
+
+    await expect(
+      createCompactCommand({ compact }).execute({ args: [] })
+    ).resolves.toEqual({
+      message: "Compaction failed: history is empty",
+      success: false,
+    });
+  });
+});
+
+describe("compactCurrentThread", () => {
+  it("summarizes the full durable history before committing the prefix", async () => {
+    const history = [
+      { content: "question", role: "user" as const },
+      { content: "answer", role: "assistant" as const },
+    ];
+    const summarize = vi.fn(() => Promise.resolve("continuation handoff"));
+    const commit = vi.fn(() => Promise.resolve());
+    const model = {} as AgentOptions["model"];
+
+    await expect(
+      compactCurrentThread({
+        commit,
+        history,
+        instructions: "coding rules",
+        model,
+        summarize,
+      })
+    ).resolves.toEqual({ compactedMessages: 2 });
+    expect(summarize).toHaveBeenCalledWith({
+      history,
+      model: { instructions: "coding rules", model },
+    });
+    expect(commit).toHaveBeenCalledWith({
+      endSeqExclusive: 2,
+      startSeq: 0,
+      summary: "continuation handoff",
+    });
+  });
+
+  it("rejects empty sessions without spending a model call", async () => {
+    const summarize = vi.fn(() => Promise.resolve("unused"));
+    const commit = vi.fn(() => Promise.resolve());
+
+    await expect(
+      compactCurrentThread({
+        commit,
+        history: [],
+        instructions: "coding rules",
+        model: {} as AgentOptions["model"],
+        summarize,
+      })
+    ).rejects.toThrow("no conversation history");
+    expect(summarize).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/coding-agent/src/tui/compact-command.ts
+++ b/apps/coding-agent/src/tui/compact-command.ts
@@ -1,10 +1,13 @@
-import { normalizeTurnError } from "@minpeter/pss-runtime";
+import {
+  type ManualThreadCompactionResult,
+  normalizeTurnError,
+} from "@minpeter/pss-runtime";
 import type { TuiCommand, TuiCommandResult } from "./command";
 import { createTuiErrorPresentation } from "./error-presentation";
 
 export interface CompactCommandContext {
   /** Run runtime-owned compaction for the current durable thread. */
-  compact(instructions?: string): Promise<boolean>;
+  compact(instructions?: string): Promise<ManualThreadCompactionResult>;
 }
 
 /** Explicit context compaction, matching the interactive Pi `/compact` UX. */
@@ -12,16 +15,24 @@ export function createCompactCommand(
   context: CompactCommandContext
 ): TuiCommand {
   return {
+    allowDuringActiveTurn: true,
     description: "Compact session context: /compact [custom instructions]",
     execute: async (input): Promise<TuiCommandResult> => {
       try {
         const instructions = input.args.join(" ").trim() || undefined;
-        const compacted = await context.compact(instructions);
-        return compacted
-          ? { message: "Session context compacted.", success: true }
-          : {
+        const result = await context.compact(instructions);
+        if (result.status === "compacted") {
+          return { message: "Session context compacted.", success: true };
+        }
+        return result.status === "empty"
+          ? {
               message: "Nothing to compact in the current session.",
               success: true,
+            }
+          : {
+              message:
+                "Compaction was skipped because a hook rejected it or the session changed.",
+              success: false,
             };
       } catch (error) {
         const normalized = normalizeTurnError(error);

--- a/apps/coding-agent/src/tui/compact-command.ts
+++ b/apps/coding-agent/src/tui/compact-command.ts
@@ -1,51 +1,8 @@
-import {
-  type AgentOptions,
-  summarizeCompactionRange,
-  type ThreadCompactionInput,
-} from "@minpeter/pss-runtime";
-import type { ModelMessage } from "ai";
 import type { TuiCommand, TuiCommandResult } from "./command";
 
 export interface CompactCommandContext {
-  /** Summarize and compact the current durable thread. */
-  compact(): Promise<{ compactedMessages: number }>;
-}
-
-interface CompactCurrentThreadOptions {
-  readonly commit: (input: ThreadCompactionInput) => Promise<void>;
-  readonly history: readonly ModelMessage[];
-  readonly instructions: string;
-  readonly model: AgentOptions["model"];
-  readonly summarize?: (options: {
-    readonly history: readonly ModelMessage[];
-    readonly model: {
-      readonly instructions: string;
-      readonly model: AgentOptions["model"];
-    };
-  }) => Promise<string>;
-}
-
-/** Generate a continuation handoff and atomically install it as context. */
-export async function compactCurrentThread({
-  commit,
-  history,
-  instructions,
-  model,
-  summarize = summarizeCompactionRange,
-}: CompactCurrentThreadOptions): Promise<{ compactedMessages: number }> {
-  if (history.length === 0) {
-    throw new Error("the current session has no conversation history");
-  }
-  const summary = await summarize({
-    history,
-    model: { instructions, model },
-  });
-  await commit({
-    endSeqExclusive: history.length,
-    startSeq: 0,
-    summary,
-  });
-  return { compactedMessages: history.length };
+  /** Run runtime-owned compaction for the current durable thread. */
+  compact(instructions?: string): Promise<boolean>;
 }
 
 /** Explicit context compaction, matching the interactive Pi `/compact` UX. */
@@ -53,14 +10,17 @@ export function createCompactCommand(
   context: CompactCommandContext
 ): TuiCommand {
   return {
-    description: "Compact the current session context",
-    execute: async (): Promise<TuiCommandResult> => {
+    description: "Compact session context: /compact [custom instructions]",
+    execute: async (input): Promise<TuiCommandResult> => {
       try {
-        const { compactedMessages } = await context.compact();
-        return {
-          message: `Compacted ${compactedMessages} conversation messages.`,
-          success: true,
-        };
+        const instructions = input.args.join(" ").trim() || undefined;
+        const compacted = await context.compact(instructions);
+        return compacted
+          ? { message: "Session context compacted.", success: true }
+          : {
+              message: "Nothing to compact in the current session.",
+              success: true,
+            };
       } catch (error) {
         return {
           message: `Compaction failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/apps/coding-agent/src/tui/compact-command.ts
+++ b/apps/coding-agent/src/tui/compact-command.ts
@@ -1,4 +1,6 @@
+import { normalizeTurnError } from "@minpeter/pss-runtime";
 import type { TuiCommand, TuiCommandResult } from "./command";
+import { createTuiErrorPresentation } from "./error-presentation";
 
 export interface CompactCommandContext {
   /** Run runtime-owned compaction for the current durable thread. */
@@ -22,8 +24,16 @@ export function createCompactCommand(
               success: true,
             };
       } catch (error) {
+        const normalized = normalizeTurnError(error);
+        const presentation = createTuiErrorPresentation(
+          normalized.message ?? error,
+          normalized.error
+        );
         return {
-          message: `Compaction failed: ${error instanceof Error ? error.message : String(error)}`,
+          message: [
+            `Compaction failed: ${presentation.message}`,
+            ...(presentation.hint === undefined ? [] : [presentation.hint]),
+          ].join(" "),
           success: false,
         };
       }

--- a/apps/coding-agent/src/tui/compact-command.ts
+++ b/apps/coding-agent/src/tui/compact-command.ts
@@ -1,0 +1,73 @@
+import {
+  type AgentOptions,
+  summarizeCompactionRange,
+  type ThreadCompactionInput,
+} from "@minpeter/pss-runtime";
+import type { ModelMessage } from "ai";
+import type { TuiCommand, TuiCommandResult } from "./command";
+
+export interface CompactCommandContext {
+  /** Summarize and compact the current durable thread. */
+  compact(): Promise<{ compactedMessages: number }>;
+}
+
+interface CompactCurrentThreadOptions {
+  readonly commit: (input: ThreadCompactionInput) => Promise<void>;
+  readonly history: readonly ModelMessage[];
+  readonly instructions: string;
+  readonly model: AgentOptions["model"];
+  readonly summarize?: (options: {
+    readonly history: readonly ModelMessage[];
+    readonly model: {
+      readonly instructions: string;
+      readonly model: AgentOptions["model"];
+    };
+  }) => Promise<string>;
+}
+
+/** Generate a continuation handoff and atomically install it as context. */
+export async function compactCurrentThread({
+  commit,
+  history,
+  instructions,
+  model,
+  summarize = summarizeCompactionRange,
+}: CompactCurrentThreadOptions): Promise<{ compactedMessages: number }> {
+  if (history.length === 0) {
+    throw new Error("the current session has no conversation history");
+  }
+  const summary = await summarize({
+    history,
+    model: { instructions, model },
+  });
+  await commit({
+    endSeqExclusive: history.length,
+    startSeq: 0,
+    summary,
+  });
+  return { compactedMessages: history.length };
+}
+
+/** Explicit context compaction, matching the interactive Pi `/compact` UX. */
+export function createCompactCommand(
+  context: CompactCommandContext
+): TuiCommand {
+  return {
+    description: "Compact the current session context",
+    execute: async (): Promise<TuiCommandResult> => {
+      try {
+        const { compactedMessages } = await context.compact();
+        return {
+          message: `Compacted ${compactedMessages} conversation messages.`,
+          success: true,
+        };
+      } catch (error) {
+        return {
+          message: `Compaction failed: ${error instanceof Error ? error.message : String(error)}`,
+          success: false,
+        };
+      }
+    },
+    name: "compact",
+  };
+}

--- a/apps/coding-agent/src/tui/session-commands.test.ts
+++ b/apps/coding-agent/src/tui/session-commands.test.ts
@@ -175,9 +175,43 @@ describe("/session", () => {
   it("shows current session metadata and message statistics", async () => {
     const { context, manager } = createContext();
     (manager.loadSessionHistory as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { content: "system context", role: "system" },
       { content: "question", role: "user" },
-      { content: "answer", role: "assistant" },
-      { content: [], role: "tool" },
+      {
+        content: [
+          { text: "checking", type: "text" },
+          {
+            input: {},
+            toolCallId: "call-1",
+            toolName: "read",
+            type: "tool-call",
+          },
+          {
+            input: {},
+            toolCallId: "call-2",
+            toolName: "grep",
+            type: "tool-call",
+          },
+        ],
+        role: "assistant",
+      },
+      {
+        content: [
+          {
+            output: { type: "text", value: "one" },
+            toolCallId: "call-1",
+            toolName: "read",
+            type: "tool-result",
+          },
+          {
+            output: { type: "text", value: "two" },
+            toolCallId: "call-2",
+            toolName: "grep",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
     ]);
 
     const result = await command(context, "session").execute({ args: [] });
@@ -185,8 +219,12 @@ describe("/session", () => {
     expect(result).toMatchObject({ success: true });
     expect(result.message).toContain("Key: cwd:/work");
     expect(result.message).toContain(
-      "Messages: 3 (1 user, 1 assistant, 1 tool)"
+      "Messages: 4 total (1 user, 1 assistant, 1 tool, 1 other)"
     );
+    expect(result.message).toContain(
+      "Tool activity: 2 calls, 2 results across 1 tool messages"
+    );
+    expect(result.message).toContain("Durable token usage: unavailable");
   });
 
   it("rejects arguments instead of switching sessions", async () => {

--- a/apps/coding-agent/src/tui/session-commands.test.ts
+++ b/apps/coding-agent/src/tui/session-commands.test.ts
@@ -171,13 +171,34 @@ describe("/new", () => {
   });
 });
 
-describe("/resume", () => {
-  it("exposes /session as the canonical Pi-compatible command", () => {
-    const { context } = createContext();
-    expect(command(context, "session").name).toBe("session");
-    expect(command(context, "session").aliases).toContain("resume");
+describe("/session", () => {
+  it("shows current session metadata and message statistics", async () => {
+    const { context, manager } = createContext();
+    (manager.loadSessionHistory as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { content: "question", role: "user" },
+      { content: "answer", role: "assistant" },
+      { content: [], role: "tool" },
+    ]);
+
+    const result = await command(context, "session").execute({ args: [] });
+
+    expect(result).toMatchObject({ success: true });
+    expect(result.message).toContain("Key: cwd:/work");
+    expect(result.message).toContain(
+      "Messages: 3 (1 user, 1 assistant, 1 tool)"
+    );
   });
 
+  it("rejects arguments instead of switching sessions", async () => {
+    const { context, manager } = createContext();
+    await expect(
+      command(context, "session").execute({ args: ["other"] })
+    ).resolves.toEqual({ message: "Usage: /session", success: false });
+    expect(manager.switchToSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("/resume", () => {
   it("opens the inline session selector without arguments", async () => {
     const { context } = createContext();
     const result = await command(context, "resume").execute({ args: [] });

--- a/apps/coding-agent/src/tui/session-commands.test.ts
+++ b/apps/coding-agent/src/tui/session-commands.test.ts
@@ -227,6 +227,18 @@ describe("/session", () => {
     expect(result.message).toContain("Durable token usage: unavailable");
   });
 
+  it("reloads the index entry so completed-turn recency is current", async () => {
+    const { context, manager } = createContext();
+    (manager.getSession as ReturnType<typeof vi.fn>).mockResolvedValue(
+      entry("cwd:/work", { updatedAt: "2026-01-01T00:05:00.000Z" })
+    );
+
+    const result = await command(context, "session").execute({ args: [] });
+
+    expect(manager.getSession).toHaveBeenCalledWith("cwd:/work");
+    expect(result.message).toContain("Updated: 2026-01-01T00:05:00.000Z");
+  });
+
   it("rejects arguments instead of switching sessions", async () => {
     const { context, manager } = createContext();
     await expect(

--- a/apps/coding-agent/src/tui/session-commands.test.ts
+++ b/apps/coding-agent/src/tui/session-commands.test.ts
@@ -124,7 +124,8 @@ function createContext(overrides?: Partial<SessionCommandContext>): {
 
 function command(context: SessionCommandContext, name: string) {
   const found = createSessionCommands(context).find(
-    (candidate) => candidate.name === name
+    (candidate) =>
+      candidate.name === name || candidate.aliases?.includes(name) === true
   );
   if (found === undefined) {
     throw new Error(`missing command ${name}`);
@@ -171,6 +172,12 @@ describe("/new", () => {
 });
 
 describe("/resume", () => {
+  it("exposes /session as the canonical Pi-compatible command", () => {
+    const { context } = createContext();
+    expect(command(context, "session").name).toBe("session");
+    expect(command(context, "session").aliases).toContain("resume");
+  });
+
   it("opens the inline session selector without arguments", async () => {
     const { context } = createContext();
     const result = await command(context, "resume").execute({ args: [] });

--- a/apps/coding-agent/src/tui/session-commands.ts
+++ b/apps/coding-agent/src/tui/session-commands.ts
@@ -146,7 +146,7 @@ function createResumeCommand(context: SessionCommandContext): TuiCommand {
 
 function createSessionInfoCommand(context: SessionCommandContext): TuiCommand {
   return {
-    description: "Show current session information and message statistics",
+    description: "Show current session metadata and retained message activity",
     execute: (input) =>
       runSessionCommand(async () => {
         if (input.args.length > 0) {
@@ -308,13 +308,31 @@ function formatCurrentSessionInfo(
 ): string {
   const count = (role: ModelMessage["role"]): number =>
     history.filter((message) => message.role === role).length;
+  const userMessages = count("user");
+  const assistantMessages = count("assistant");
+  const toolMessages = count("tool");
+  const otherMessages =
+    history.length - userMessages - assistantMessages - toolMessages;
+  const assistantToolCalls = history
+    .filter((message) => message.role === "assistant")
+    .flatMap((message) =>
+      Array.isArray(message.content)
+        ? message.content.filter((part) => part.type === "tool-call")
+        : []
+    ).length;
+  const toolResults = history
+    .filter((message) => message.role === "tool")
+    .flatMap((message) => message.content)
+    .filter((part) => part.type === "tool-result").length;
   return [
     `Session: ${session.name ?? "untitled"}`,
     `Key: ${session.key}`,
     ...(session.parentKey === undefined
       ? []
       : [`Parent: ${session.parentKey}`]),
-    `Messages: ${history.length} (${count("user")} user, ${count("assistant")} assistant, ${count("tool")} tool)`,
+    `Messages: ${history.length} total (${userMessages} user, ${assistantMessages} assistant, ${toolMessages} tool, ${otherMessages} other)`,
+    `Tool activity: ${assistantToolCalls} calls, ${toolResults} results across ${toolMessages} tool messages`,
+    "Durable token usage: unavailable (usage totals are not retained)",
     `Created: ${session.createdAt}`,
     `Updated: ${session.updatedAt}`,
   ].join("\n");

--- a/apps/coding-agent/src/tui/session-commands.ts
+++ b/apps/coding-agent/src/tui/session-commands.ts
@@ -1,3 +1,4 @@
+import type { ModelMessage } from "ai";
 import type { CodingAgentExtensionUi } from "../extensions/types";
 import {
   sessionDisplayKey,
@@ -53,6 +54,7 @@ export function createSessionCommands(
 ): TuiCommand[] {
   return [
     createNewCommand(context),
+    createSessionInfoCommand(context),
     createResumeCommand(context),
     createForkCommand(context),
     createNameCommand(context),
@@ -84,9 +86,8 @@ function createNewCommand(context: SessionCommandContext): TuiCommand {
 
 function createResumeCommand(context: SessionCommandContext): TuiCommand {
   return {
-    aliases: ["resume"],
     description:
-      "Resume, rename, or delete a session: /session [key|name] (also /resume; no argument opens the picker)",
+      "Resume, rename, or delete a session: /resume [key|name] (no argument opens the picker)",
     execute: (input) =>
       runSessionCommand(async () => {
         if (input.args.length === 0) {
@@ -139,6 +140,25 @@ function createResumeCommand(context: SessionCommandContext): TuiCommand {
       }
       return completions;
     },
+    name: "resume",
+  };
+}
+
+function createSessionInfoCommand(context: SessionCommandContext): TuiCommand {
+  return {
+    description: "Show current session information and message statistics",
+    execute: (input) =>
+      runSessionCommand(async () => {
+        if (input.args.length > 0) {
+          return { message: "Usage: /session", success: false };
+        }
+        const session = context.currentSession();
+        const history = await context.manager.loadSessionHistory(session.key);
+        return {
+          message: formatCurrentSessionInfo(session, history),
+          success: true,
+        };
+      }),
     name: "session",
   };
 }
@@ -280,4 +300,22 @@ async function runSessionCommand(
 function optionalName(args: readonly string[]): string | undefined {
   const name = args.join(" ").trim();
   return name.length === 0 ? undefined : name;
+}
+
+function formatCurrentSessionInfo(
+  session: SessionIndexEntry,
+  history: readonly ModelMessage[]
+): string {
+  const count = (role: ModelMessage["role"]): number =>
+    history.filter((message) => message.role === role).length;
+  return [
+    `Session: ${session.name ?? "untitled"}`,
+    `Key: ${session.key}`,
+    ...(session.parentKey === undefined
+      ? []
+      : [`Parent: ${session.parentKey}`]),
+    `Messages: ${history.length} (${count("user")} user, ${count("assistant")} assistant, ${count("tool")} tool)`,
+    `Created: ${session.createdAt}`,
+    `Updated: ${session.updatedAt}`,
+  ].join("\n");
 }

--- a/apps/coding-agent/src/tui/session-commands.ts
+++ b/apps/coding-agent/src/tui/session-commands.ts
@@ -152,7 +152,9 @@ function createSessionInfoCommand(context: SessionCommandContext): TuiCommand {
         if (input.args.length > 0) {
           return { message: "Usage: /session", success: false };
         }
-        const session = context.currentSession();
+        const current = context.currentSession();
+        const session =
+          (await context.manager.getSession(current.key)) ?? current;
         const history = await context.manager.loadSessionHistory(session.key);
         return {
           message: formatCurrentSessionInfo(session, history),

--- a/apps/coding-agent/src/tui/session-commands.ts
+++ b/apps/coding-agent/src/tui/session-commands.ts
@@ -84,8 +84,9 @@ function createNewCommand(context: SessionCommandContext): TuiCommand {
 
 function createResumeCommand(context: SessionCommandContext): TuiCommand {
   return {
+    aliases: ["resume"],
     description:
-      "Resume, rename, or delete a session: /resume [key|name] (no argument opens the picker)",
+      "Resume, rename, or delete a session: /session [key|name] (also /resume; no argument opens the picker)",
     execute: (input) =>
       runSessionCommand(async () => {
         if (input.args.length === 0) {
@@ -138,7 +139,7 @@ function createResumeCommand(context: SessionCommandContext): TuiCommand {
       }
       return completions;
     },
-    name: "resume",
+    name: "session",
   };
 }
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1184,6 +1184,20 @@ const agent = await createAgent({
 });
 ```
 
+Force runtime-owned compaction on an idle thread with `thread.compact()`. The
+manual path shares automatic compaction's attachment hydration, model-context
+transforms, prior-summary handling, hooks, single-flight, and freshness checks.
+Optional instructions replace the default continuation-handoff prompt:
+
+```ts
+const thread = agent.thread("default");
+await thread.compact({ instructions: "Prioritize unresolved decisions." });
+```
+
+Manual compaction returns `false` for empty history and rejects while a turn is
+active. Passing an explicit `ThreadCompactionInput` remains available for hosts
+that already produced a validated summary.
+
 The context gate estimates the prompt immediately before `generateText`. With
 `onOverflow: "error"`, the turn fails before the provider is called. With
 `onOverflow: "compact"` (the default), the runtime runs blocking compaction and

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1187,16 +1187,19 @@ const agent = await createAgent({
 Force runtime-owned compaction on an idle thread with `thread.compact()`. The
 manual path shares automatic compaction's attachment hydration, model-context
 transforms, prior-summary handling, hooks, single-flight, and freshness checks.
-Optional instructions replace the default continuation-handoff prompt:
+Optional instructions append an `Additional focus` section while preserving the
+default continuation-handoff safety rules and required sections:
 
 ```ts
 const thread = agent.thread("default");
 await thread.compact({ instructions: "Prioritize unresolved decisions." });
 ```
 
-Manual compaction returns `false` for empty history and rejects while a turn is
-active. Passing an explicit `ThreadCompactionInput` remains available for hosts
-that already produced a validated summary.
+Manual compaction returns a `compacted`, `empty`, or `skipped` status and rejects
+while a turn is active. `skipped` distinguishes a hook cancellation or freshness
+race from empty history. Passing an explicit `ThreadCompactionInput` remains
+available for hosts that already produced a validated summary and returns the
+hook dispatcher's boolean commit decision.
 
 The context gate estimates the prompt immediately before `generateText`. With
 `onOverflow: "error"`, the turn fails before the provider is called. With

--- a/packages/runtime/src/agent/core/thread-entry.ts
+++ b/packages/runtime/src/agent/core/thread-entry.ts
@@ -4,7 +4,10 @@ import type {
 } from "../../execution/host/types";
 import type { AgentInput, UserInput } from "../../thread/input/input";
 import type { AgentTurn } from "../../thread/protocol/turn";
-import type { CompactionSummaryOptions } from "../../thread/runtime/auto-compaction-types";
+import type {
+  CompactionSummaryOptions,
+  ManualThreadCompactionResult,
+} from "../../thread/runtime/auto-compaction-types";
 import type { NotifyOptions } from "../../thread/runtime/notification";
 import type { ThreadCompactionInput } from "../../thread/state/thread-state";
 import { namespacePart } from "../identity/namespace";
@@ -22,9 +25,10 @@ export interface ThreadAddress {
 export type ThreadKey = string | ThreadAddress;
 
 export interface ThreadHandle {
+  compact(input: ThreadCompactionInput): Promise<boolean>;
   compact(
-    input?: CompactionSummaryOptions | ThreadCompactionInput
-  ): Promise<boolean>;
+    options?: CompactionSummaryOptions
+  ): Promise<ManualThreadCompactionResult>;
   delete(): Promise<void>;
   dispose(): Promise<void>;
   events(options?: ThreadEventReadOptions): AsyncIterable<StoredThreadEvent>;

--- a/packages/runtime/src/agent/core/thread-entry.ts
+++ b/packages/runtime/src/agent/core/thread-entry.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../execution/host/types";
 import type { AgentInput, UserInput } from "../../thread/input/input";
 import type { AgentTurn } from "../../thread/protocol/turn";
+import type { CompactionSummaryOptions } from "../../thread/runtime/auto-compaction-types";
 import type { NotifyOptions } from "../../thread/runtime/notification";
 import type { ThreadCompactionInput } from "../../thread/state/thread-state";
 import { namespacePart } from "../identity/namespace";
@@ -21,7 +22,9 @@ export interface ThreadAddress {
 export type ThreadKey = string | ThreadAddress;
 
 export interface ThreadHandle {
-  compact(input: ThreadCompactionInput): Promise<void>;
+  compact(
+    input?: CompactionSummaryOptions | ThreadCompactionInput
+  ): Promise<boolean>;
   delete(): Promise<void>;
   dispose(): Promise<void>;
   events(options?: ThreadEventReadOptions): AsyncIterable<StoredThreadEvent>;

--- a/packages/runtime/src/agent/core/thread-handle-factory.ts
+++ b/packages/runtime/src/agent/core/thread-handle-factory.ts
@@ -26,7 +26,7 @@ export function createThreadPublicHandle({
   ): AgentTurn => applyAgentInstrumentations(turn, instrumentations, context);
 
   const publicHandle: ThreadHandle = {
-    compact: (input) => thread.compact(input),
+    compact: thread.compact.bind(thread),
     delete: async () => {
       evict(key);
       await thread.delete();

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -25,6 +25,7 @@ import type {
   AgentInstrumentationOperation,
   AgentOptions,
   CompactionContextMessage,
+  CompactionSummaryOptions,
   HostAttachmentStore,
   ModelToolCacheFingerprintMetadata,
   PrepareModelStep,
@@ -201,9 +202,9 @@ describe("runtime public exports", () => {
       summary: "Earlier turns established the durable context.",
     } satisfies CompactionContextMessage;
 
-    expectTypeOf<
-      Parameters<ThreadHandle["compact"]>[0]
-    >().toEqualTypeOf<ThreadCompactionInput>();
+    expectTypeOf<Parameters<ThreadHandle["compact"]>[0]>().toEqualTypeOf<
+      CompactionSummaryOptions | ThreadCompactionInput | undefined
+    >();
     expectTypeOf<
       Parameters<
         NonNullable<AgentHooks["transformModelContext"]>

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -203,7 +203,7 @@ describe("runtime public exports", () => {
     } satisfies CompactionContextMessage;
 
     expectTypeOf<Parameters<ThreadHandle["compact"]>[0]>().toEqualTypeOf<
-      CompactionSummaryOptions | ThreadCompactionInput | undefined
+      CompactionSummaryOptions | undefined
     >();
     expectTypeOf<
       Parameters<

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -179,6 +179,7 @@ export type {
   AgentCompactionContext,
   AgentCompactionReason,
   CompactionSummaryOptions,
+  ManualThreadCompactionResult,
 } from "./thread/runtime/auto-compaction-types";
 export {
   type SpeculativeCompactionOptions,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -185,6 +185,10 @@ export {
   speculativeCompaction,
 } from "./thread/runtime/speculative-compaction";
 export { ThreadEventReplayUnsupportedError } from "./thread/runtime/thread-event-replay";
+export {
+  type NormalizedTurnError,
+  normalizeTurnError,
+} from "./thread/runtime/turn-error-metadata";
 export type {
   CompactionContextMessage,
   ThreadContextMessage,

--- a/packages/runtime/src/thread/handle/agent-thread-context.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-context.ts
@@ -26,7 +26,9 @@ export interface AgentThreadContext {
   readonly drain: Fsm<ThreadDrainState>;
   readonly durableInputRecovery: DurableInputRecoveryState;
   readonly events: ThreadEventDispatcher;
-  readonly execution: ThreadExecutionOptions;
+  readonly execution: ThreadExecutionOptions & {
+    readonly hookRuntime: AgentHookRuntime;
+  };
   /** Serializes input admission; concurrency control, not a state. */
   inputAdmissionQueue: Promise<void>;
   readonly inputQueue: QueuedInput[];

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -40,6 +40,7 @@ import {
 import { recoverThreadDurableInputClaims } from "./durable-queue-claims";
 import { admitThreadSendInput } from "./durable-queue-send";
 import { addDurableSteeringInput } from "./durable-steering";
+import { withThreadDrainOwnership } from "./thread-drain-coordinator";
 import { createOverlayRuntimeInput } from "./thread-overlay";
 
 export class AgentThread {
@@ -118,13 +119,13 @@ export class AgentThread {
   compact(
     options?: CompactionSummaryOptions
   ): Promise<ManualThreadCompactionResult>;
-  compact(
+  async compact(
     input?: CompactionSummaryOptions | ThreadCompactionInput
   ): Promise<boolean | ManualThreadCompactionResult> {
     this.#assertOpen();
 
     if (input !== undefined && "summary" in input) {
-      return this.#compactExplicitSummary(input);
+      return await this.#compactExplicitSummary(input);
     }
 
     const executionHost = this.#context.execution.executionHost;
@@ -134,35 +135,45 @@ export class AgentThread {
     return this.#enqueueInputAdmission(async () => {
       const compact = async (): Promise<ManualThreadCompactionResult> => {
         await this.#ensureStarted();
-        await this.#recoverDurableInputClaims();
-        this.#assertOpen();
-        if (this.#context.turn.state.tag !== "none") {
-          throw new Error("Cannot compact while a turn is active.");
-        }
-        if (this.#context.state.modelSnapshot().length === 0) {
-          return { status: "empty" };
-        }
-        const transforms = createTurnModelTransforms({
-          hookRuntime: this.#context.execution.hookRuntime,
-          state: this.#context.state,
-          threadKey: this.#context.threadKey,
-        });
-        const compacted = await compactThreadManually({
-          compact: (compactionInput, guard) =>
-            this.#context.events.compact(
-              this.#context.state,
-              compactionInput,
-              guard
-            ),
-          latestContextTransform: transforms.latestContextTransform,
-          model: this.#context.model,
-          signal: new AbortController().signal,
-          state: this.#context.state,
-          summaryOptions: input,
-          threadKey: this.#context.threadKey,
-          transformModelContext: transforms.transformModelContext,
-        });
-        return { status: compacted ? "compacted" : "skipped" };
+        return await withThreadDrainOwnership(
+          executionHost,
+          this.#context.threadKey,
+          this.#context,
+          async ({ refreshRequired }) => {
+            await this.#recoverDurableInputClaims();
+            if (refreshRequired) {
+              await this.#context.state.refresh();
+            }
+            this.#assertOpen();
+            if (this.#context.turn.state.tag !== "none") {
+              throw new Error("Cannot compact while a turn is active.");
+            }
+            if (this.#context.state.modelSnapshot().length === 0) {
+              return { status: "empty" };
+            }
+            const transforms = createTurnModelTransforms({
+              hookRuntime: this.#context.execution.hookRuntime,
+              state: this.#context.state,
+              threadKey: this.#context.threadKey,
+            });
+            const compacted = await compactThreadManually({
+              compact: (compactionInput, guard) =>
+                this.#context.events.compact(
+                  this.#context.state,
+                  compactionInput,
+                  guard
+                ),
+              latestContextTransform: transforms.latestContextTransform,
+              model: this.#context.model,
+              signal: new AbortController().signal,
+              state: this.#context.state,
+              summaryOptions: input,
+              threadKey: this.#context.threadKey,
+              transformModelContext: transforms.transformModelContext,
+            });
+            return { status: compacted ? "compacted" : "skipped" };
+          }
+        );
       };
       return await (reservation ? reservation(compact) : compact());
     });

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -6,6 +6,8 @@ import { deferred } from "../../internal/deferred";
 import type { ModelGenerationOptions } from "../../llm/model-step-types";
 import type { AgentInput, UserInput } from "../input/input";
 import { type AgentTurn, BufferedAgentTurn } from "../protocol/turn";
+import { compactThreadManually } from "../runtime/auto-compaction-runner";
+import type { CompactionSummaryOptions } from "../runtime/auto-compaction-types";
 import type { ThreadExecutionOptions } from "../runtime/execution";
 import type { NotifyOptions } from "../runtime/notification";
 import { queueThreadNotification } from "../runtime/notification";
@@ -14,6 +16,7 @@ import {
   reserveThreadInputAdmission,
   type ThreadInputAdmissionReservation,
 } from "../runtime/thread-input-admission-coordinator";
+import { createTurnModelTransforms } from "../runtime/turn-model-transforms";
 import { threadKilledError } from "../state/thread-errors";
 import type {
   ThreadCompactionInput,
@@ -108,7 +111,9 @@ export class AgentThread {
     return run;
   }
 
-  async compact(input: ThreadCompactionInput): Promise<void> {
+  async compact(
+    input?: CompactionSummaryOptions | ThreadCompactionInput
+  ): Promise<boolean> {
     this.#assertOpen();
 
     await this.#ensureStarted();
@@ -116,7 +121,36 @@ export class AgentThread {
 
     this.#assertOpen();
 
-    await this.#context.events.compact(this.#context.state, input);
+    if (input !== undefined && "summary" in input) {
+      await this.#context.events.compact(this.#context.state, input);
+      return true;
+    }
+    return await this.#enqueueInputAdmission(async () => {
+      this.#assertOpen();
+      if (this.#context.turn.state.tag !== "none") {
+        throw new Error("Cannot compact while a turn is active.");
+      }
+      const transforms = createTurnModelTransforms({
+        hookRuntime: this.#context.execution.hookRuntime,
+        state: this.#context.state,
+        threadKey: this.#context.threadKey,
+      });
+      return await compactThreadManually({
+        compact: (compactionInput, guard) =>
+          this.#context.events.compact(
+            this.#context.state,
+            compactionInput,
+            guard
+          ),
+        latestContextTransform: transforms.latestContextTransform,
+        model: this.#context.model,
+        signal: new AbortController().signal,
+        state: this.#context.state,
+        summaryOptions: input,
+        threadKey: this.#context.threadKey,
+        transformModelContext: transforms.transformModelContext,
+      });
+    });
   }
 
   events(options?: ThreadEventReadOptions): AsyncIterable<StoredThreadEvent> {

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -118,49 +118,63 @@ export class AgentThread {
   compact(
     options?: CompactionSummaryOptions
   ): Promise<ManualThreadCompactionResult>;
-  async compact(
+  compact(
     input?: CompactionSummaryOptions | ThreadCompactionInput
   ): Promise<boolean | ManualThreadCompactionResult> {
     this.#assertOpen();
 
+    if (input !== undefined && "summary" in input) {
+      return this.#compactExplicitSummary(input);
+    }
+
+    const executionHost = this.#context.execution.executionHost;
+    const reservation = executionHost
+      ? reserveThreadInputAdmission(executionHost, this.#context.threadKey)
+      : undefined;
+    return this.#enqueueInputAdmission(async () => {
+      const compact = async (): Promise<ManualThreadCompactionResult> => {
+        await this.#ensureStarted();
+        await this.#recoverDurableInputClaims();
+        this.#assertOpen();
+        if (this.#context.turn.state.tag !== "none") {
+          throw new Error("Cannot compact while a turn is active.");
+        }
+        if (this.#context.state.modelSnapshot().length === 0) {
+          return { status: "empty" };
+        }
+        const transforms = createTurnModelTransforms({
+          hookRuntime: this.#context.execution.hookRuntime,
+          state: this.#context.state,
+          threadKey: this.#context.threadKey,
+        });
+        const compacted = await compactThreadManually({
+          compact: (compactionInput, guard) =>
+            this.#context.events.compact(
+              this.#context.state,
+              compactionInput,
+              guard
+            ),
+          latestContextTransform: transforms.latestContextTransform,
+          model: this.#context.model,
+          signal: new AbortController().signal,
+          state: this.#context.state,
+          summaryOptions: input,
+          threadKey: this.#context.threadKey,
+          transformModelContext: transforms.transformModelContext,
+        });
+        return { status: compacted ? "compacted" : "skipped" };
+      };
+      return await (reservation ? reservation(compact) : compact());
+    });
+  }
+
+  async #compactExplicitSummary(
+    input: ThreadCompactionInput
+  ): Promise<boolean> {
     await this.#ensureStarted();
     await this.#recoverDurableInputClaims();
-
     this.#assertOpen();
-
-    if (input !== undefined && "summary" in input) {
-      return await this.#context.events.compact(this.#context.state, input);
-    }
-    return await this.#enqueueInputAdmission(async () => {
-      this.#assertOpen();
-      if (this.#context.turn.state.tag !== "none") {
-        throw new Error("Cannot compact while a turn is active.");
-      }
-      if (this.#context.state.modelSnapshot().length === 0) {
-        return { status: "empty" };
-      }
-      const transforms = createTurnModelTransforms({
-        hookRuntime: this.#context.execution.hookRuntime,
-        state: this.#context.state,
-        threadKey: this.#context.threadKey,
-      });
-      const compacted = await compactThreadManually({
-        compact: (compactionInput, guard) =>
-          this.#context.events.compact(
-            this.#context.state,
-            compactionInput,
-            guard
-          ),
-        latestContextTransform: transforms.latestContextTransform,
-        model: this.#context.model,
-        signal: new AbortController().signal,
-        state: this.#context.state,
-        summaryOptions: input,
-        threadKey: this.#context.threadKey,
-        transformModelContext: transforms.transformModelContext,
-      });
-      return { status: compacted ? "compacted" : "skipped" };
-    });
+    return await this.#context.events.compact(this.#context.state, input);
   }
 
   events(options?: ThreadEventReadOptions): AsyncIterable<StoredThreadEvent> {

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -7,7 +7,10 @@ import type { ModelGenerationOptions } from "../../llm/model-step-types";
 import type { AgentInput, UserInput } from "../input/input";
 import { type AgentTurn, BufferedAgentTurn } from "../protocol/turn";
 import { compactThreadManually } from "../runtime/auto-compaction-runner";
-import type { CompactionSummaryOptions } from "../runtime/auto-compaction-types";
+import type {
+  CompactionSummaryOptions,
+  ManualThreadCompactionResult,
+} from "../runtime/auto-compaction-types";
 import type { ThreadExecutionOptions } from "../runtime/execution";
 import type { NotifyOptions } from "../runtime/notification";
 import { queueThreadNotification } from "../runtime/notification";
@@ -111,9 +114,13 @@ export class AgentThread {
     return run;
   }
 
+  compact(input: ThreadCompactionInput): Promise<boolean>;
+  compact(
+    options?: CompactionSummaryOptions
+  ): Promise<ManualThreadCompactionResult>;
   async compact(
     input?: CompactionSummaryOptions | ThreadCompactionInput
-  ): Promise<boolean> {
+  ): Promise<boolean | ManualThreadCompactionResult> {
     this.#assertOpen();
 
     await this.#ensureStarted();
@@ -122,20 +129,22 @@ export class AgentThread {
     this.#assertOpen();
 
     if (input !== undefined && "summary" in input) {
-      await this.#context.events.compact(this.#context.state, input);
-      return true;
+      return await this.#context.events.compact(this.#context.state, input);
     }
     return await this.#enqueueInputAdmission(async () => {
       this.#assertOpen();
       if (this.#context.turn.state.tag !== "none") {
         throw new Error("Cannot compact while a turn is active.");
       }
+      if (this.#context.state.modelSnapshot().length === 0) {
+        return { status: "empty" };
+      }
       const transforms = createTurnModelTransforms({
         hookRuntime: this.#context.execution.hookRuntime,
         state: this.#context.state,
         threadKey: this.#context.threadKey,
       });
-      return await compactThreadManually({
+      const compacted = await compactThreadManually({
         compact: (compactionInput, guard) =>
           this.#context.events.compact(
             this.#context.state,
@@ -150,6 +159,7 @@ export class AgentThread {
         threadKey: this.#context.threadKey,
         transformModelContext: transforms.transformModelContext,
       });
+      return { status: compacted ? "compacted" : "skipped" };
     });
   }
 

--- a/packages/runtime/src/thread/handle/agent-thread.ts
+++ b/packages/runtime/src/thread/handle/agent-thread.ts
@@ -127,6 +127,9 @@ export class AgentThread {
     if (input !== undefined && "summary" in input) {
       return await this.#compactExplicitSummary(input);
     }
+    if (this.#context.turn.state.tag !== "none") {
+      throw new Error("Cannot compact while a turn is active.");
+    }
 
     const executionHost = this.#context.execution.executionHost;
     const reservation = executionHost

--- a/packages/runtime/src/thread/handle/persistence-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-compaction.test.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage } from "ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Agent } from "../../agent/core/agent";
 import { hostWithThreads } from "../../testing/host-with-threads";
 import {
@@ -63,5 +63,98 @@ describe("Agent thread persistence compaction", () => {
       ],
       schemaVersion: 2,
     });
+  });
+
+  it("manually compacts through prior summaries, custom instructions, and context hooks", async () => {
+    const store = new SpyStore();
+    const seenHistory: ModelMessage[][] = [];
+    const transformModelContext = vi.fn(() => ({
+      action: "continue" as const,
+    }));
+    const agent = new Agent({
+      hooks: { transformModelContext },
+      host: hostWithThreads(store),
+      model: createCallbackModel(({ history }) => {
+        seenHistory.push([...history]);
+        const isSummary = history.some(
+          (message) =>
+            message.role === "system" &&
+            typeof message.content === "string" &&
+            message.content.includes("Focus on architectural decisions")
+        );
+        return Promise.resolve([
+          assistantMessage(isSummary ? "combined handoff" : "DONE"),
+        ]);
+      }),
+    });
+    const thread = agent.thread("manual-compact");
+
+    await collect(await thread.send("old"));
+    await thread.compact({
+      endSeqExclusive: 2,
+      startSeq: 0,
+      summary: "prior handoff",
+    });
+    await collect(await thread.send("newer"));
+
+    await expect(
+      thread.compact({ instructions: "Focus on architectural decisions" })
+    ).resolves.toBe(true);
+
+    const summaryCall = seenHistory.at(-1) ?? [];
+    expect(summaryCall).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining("prior handoff"),
+          role: "user",
+        }),
+      ])
+    );
+    expect(transformModelContext).toHaveBeenCalledTimes(3);
+    expect(store.threads.get("manual-compact")?.state).toMatchObject({
+      compactions: [
+        expect.anything(),
+        expect.objectContaining({
+          endSeqExclusive: 4,
+          summary: { content: "combined handoff", role: "system" },
+        }),
+      ],
+    });
+  });
+
+  it("reports no-op manual compaction for an empty thread", async () => {
+    const agent = new Agent({
+      model: createCallbackModel(() =>
+        Promise.resolve([assistantMessage("unused")])
+      ),
+    });
+
+    await expect(agent.thread("empty").compact()).resolves.toBe(false);
+  });
+
+  it("rejects manual compaction while a turn is active", async () => {
+    let releaseModel: (() => void) | undefined;
+    const modelGate = new Promise<void>((resolve) => {
+      releaseModel = resolve;
+    });
+    let modelStarted = false;
+    const agent = new Agent({
+      model: createCallbackModel(async () => {
+        modelStarted = true;
+        await modelGate;
+        return [assistantMessage("DONE")];
+      }),
+    });
+    const thread = agent.thread("busy");
+    const turn = await thread.send("work");
+    const collecting = collect(turn);
+    await vi.waitFor(() => expect(modelStarted).toBe(true));
+
+    await expect(thread.compact()).rejects.toThrow(
+      "Cannot compact while a turn is active."
+    );
+
+    releaseModel?.();
+    await collecting;
   });
 });

--- a/packages/runtime/src/thread/handle/persistence-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-compaction.test.ts
@@ -143,35 +143,68 @@ describe("Agent thread persistence compaction", () => {
     });
   });
 
-  it("waits for an active drain before manual compaction", async () => {
+  it("rejects same-handle manual compaction while a turn is active", async () => {
     let releaseModel: (() => void) | undefined;
     const modelGate = new Promise<void>((resolve) => {
       releaseModel = resolve;
     });
-    let modelCalls = 0;
+    let modelStarted = false;
     const agent = new Agent({
       model: createCallbackModel(async () => {
-        modelCalls += 1;
-        if (modelCalls === 1) {
-          await modelGate;
-          return [assistantMessage("DONE")];
-        }
-        return [assistantMessage("SUMMARY")];
+        modelStarted = true;
+        await modelGate;
+        return [assistantMessage("DONE")];
       }),
     });
     const thread = agent.thread("busy");
-    const turn = await thread.send("work ".repeat(200));
+    const turn = await thread.send("work");
     const collecting = collect(turn);
-    await vi.waitFor(() => expect(modelCalls).toBe(1));
+    await vi.waitFor(() => expect(modelStarted).toBe(true));
 
-    const compacting = thread.compact();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(modelCalls).toBe(1);
+    await expect(thread.compact()).rejects.toThrow(
+      "Cannot compact while a turn is active."
+    );
+
     releaseModel?.();
+    await collecting;
+  });
+
+  it("waits for another handle's active drain before compaction", async () => {
+    const store = new SpyStore();
+    const host = hostWithThreads(store);
+    let releaseOwner: (() => void) | undefined;
+    const ownerGate = new Promise<void>((resolve) => {
+      releaseOwner = resolve;
+    });
+    let ownerStarted = false;
+    let compactionCalls = 0;
+    const ownerThread = new Agent({
+      host,
+      model: createCallbackModel(async () => {
+        ownerStarted = true;
+        await ownerGate;
+        return [assistantMessage("OWNER DONE")];
+      }),
+    }).thread("cross-handle-busy");
+    const compactingThread = new Agent({
+      host,
+      model: createCallbackModel(() => {
+        compactionCalls += 1;
+        return [assistantMessage("SUMMARY")];
+      }),
+    }).thread("cross-handle-busy");
+    const turn = await ownerThread.send("work ".repeat(200));
+    const collecting = collect(turn);
+    await vi.waitFor(() => expect(ownerStarted).toBe(true));
+
+    const compacting = compactingThread.compact();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(compactionCalls).toBe(0);
+    releaseOwner?.();
     await collecting;
 
     await expect(compacting).resolves.toEqual({ status: "compacted" });
-    expect(modelCalls).toBe(2);
+    expect(compactionCalls).toBe(1);
   });
 
   it("returns false when beforeCompaction cancels an explicit input", async () => {

--- a/packages/runtime/src/thread/handle/persistence-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-compaction.test.ts
@@ -189,4 +189,78 @@ describe("Agent thread persistence compaction", () => {
       })
     ).resolves.toBe(false);
   });
+
+  it("keeps same-handle compact-before-followUp admission FIFO", async () => {
+    const order: string[] = [];
+    const model = createCallbackModel(async ({ history }) => {
+      const isSummary = history[0]?.role === "system";
+      order.push(isSummary ? "compact" : "turn");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return [assistantMessage(isSummary ? "SUMMARY" : "DONE")];
+    });
+    const thread = new Agent({ model }).thread("same-handle-compact-fifo");
+    await collect(await thread.send("old ".repeat(200)));
+    order.length = 0;
+
+    const compactPromise = thread.compact();
+    const followUpPromise = thread.followUp("after compact");
+    const [compaction, followUp] = await Promise.all([
+      compactPromise,
+      followUpPromise,
+    ]);
+    await collect(followUp);
+
+    expect(compaction).toEqual({ status: "compacted" });
+    expect(order).toEqual(["compact", "turn"]);
+  });
+
+  it("serializes compact-before-followUp across Agents sharing a store", async () => {
+    const store = new SpyStore();
+    const host = hostWithThreads(store);
+    const seedAgent = new Agent({
+      host,
+      model: createCallbackModel(() => [assistantMessage("SEED")]),
+    });
+    await collect(
+      await seedAgent.thread("shared-compact-fifo").send("old ".repeat(200))
+    );
+
+    let active = 0;
+    let maxActive = 0;
+    const order: string[] = [];
+    const model = createCallbackModel(async ({ history }) => {
+      const isSummary = history[0]?.role === "system";
+      order.push(isSummary ? "compact" : "turn");
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      active -= 1;
+      return [assistantMessage(isSummary ? "SHARED SUMMARY" : "DONE")];
+    });
+    const compactThread = new Agent({ host, model }).thread(
+      "shared-compact-fifo"
+    );
+    const followUpThread = new Agent({ host, model }).thread(
+      "shared-compact-fifo"
+    );
+
+    const compactPromise = compactThread.compact();
+    const followUpPromise = followUpThread.followUp("after shared compact");
+    const [compaction, followUp] = await Promise.all([
+      compactPromise,
+      followUpPromise,
+    ]);
+    await collect(followUp);
+
+    expect(compaction).toEqual({ status: "compacted" });
+    expect(order).toEqual(["compact", "turn"]);
+    expect(maxActive).toBe(1);
+    expect(store.threads.get("shared-compact-fifo")?.state).toMatchObject({
+      compactions: [
+        {
+          summary: { content: "SHARED SUMMARY", role: "system" },
+        },
+      ],
+    });
+  });
 });

--- a/packages/runtime/src/thread/handle/persistence-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-compaction.test.ts
@@ -99,9 +99,18 @@ describe("Agent thread persistence compaction", () => {
 
     await expect(
       thread.compact({ instructions: "Focus on architectural decisions" })
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ status: "compacted" });
 
     const summaryCall = seenHistory.at(-1) ?? [];
+    expect(summaryCall[0]).toMatchObject({
+      content: expect.stringContaining("## Objective"),
+      role: "system",
+    });
+    expect(summaryCall[0]).toMatchObject({
+      content: expect.stringContaining(
+        "## Additional focus\nFocus on architectural decisions"
+      ),
+    });
     expect(summaryCall).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -129,7 +138,9 @@ describe("Agent thread persistence compaction", () => {
       ),
     });
 
-    await expect(agent.thread("empty").compact()).resolves.toBe(false);
+    await expect(agent.thread("empty").compact()).resolves.toEqual({
+      status: "empty",
+    });
   });
 
   it("rejects manual compaction while a turn is active", async () => {
@@ -156,5 +167,26 @@ describe("Agent thread persistence compaction", () => {
 
     releaseModel?.();
     await collecting;
+  });
+
+  it("returns false when beforeCompaction cancels an explicit input", async () => {
+    const agent = new Agent({
+      hooks: {
+        beforeCompaction: () => ({ action: "cancel", reason: "policy" }),
+      },
+      model: createCallbackModel(() =>
+        Promise.resolve([assistantMessage("DONE")])
+      ),
+    });
+    const thread = agent.thread("cancel-explicit");
+    await collect(await thread.send("history"));
+
+    await expect(
+      thread.compact({
+        endSeqExclusive: 2,
+        startSeq: 0,
+        summary: "blocked",
+      })
+    ).resolves.toBe(false);
   });
 });

--- a/packages/runtime/src/thread/handle/persistence-compaction.test.ts
+++ b/packages/runtime/src/thread/handle/persistence-compaction.test.ts
@@ -143,30 +143,35 @@ describe("Agent thread persistence compaction", () => {
     });
   });
 
-  it("rejects manual compaction while a turn is active", async () => {
+  it("waits for an active drain before manual compaction", async () => {
     let releaseModel: (() => void) | undefined;
     const modelGate = new Promise<void>((resolve) => {
       releaseModel = resolve;
     });
-    let modelStarted = false;
+    let modelCalls = 0;
     const agent = new Agent({
       model: createCallbackModel(async () => {
-        modelStarted = true;
-        await modelGate;
-        return [assistantMessage("DONE")];
+        modelCalls += 1;
+        if (modelCalls === 1) {
+          await modelGate;
+          return [assistantMessage("DONE")];
+        }
+        return [assistantMessage("SUMMARY")];
       }),
     });
     const thread = agent.thread("busy");
-    const turn = await thread.send("work");
+    const turn = await thread.send("work ".repeat(200));
     const collecting = collect(turn);
-    await vi.waitFor(() => expect(modelStarted).toBe(true));
+    await vi.waitFor(() => expect(modelCalls).toBe(1));
 
-    await expect(thread.compact()).rejects.toThrow(
-      "Cannot compact while a turn is active."
-    );
-
+    const compacting = thread.compact();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(modelCalls).toBe(1);
     releaseModel?.();
     await collecting;
+
+    await expect(compacting).resolves.toEqual({ status: "compacted" });
+    expect(modelCalls).toBe(2);
   });
 
   it("returns false when beforeCompaction cancels an explicit input", async () => {
@@ -214,47 +219,57 @@ describe("Agent thread persistence compaction", () => {
     expect(order).toEqual(["compact", "turn"]);
   });
 
-  it("serializes compact-before-followUp across Agents sharing a store", async () => {
+  it("refreshes the original owner after another Agent compacts", async () => {
     const store = new SpyStore();
     const host = hostWithThreads(store);
-    const seedAgent = new Agent({
-      host,
-      model: createCallbackModel(() => [assistantMessage("SEED")]),
-    });
-    await collect(
-      await seedAgent.thread("shared-compact-fifo").send("old ".repeat(200))
-    );
-
     let active = 0;
     let maxActive = 0;
     const order: string[] = [];
-    const model = createCallbackModel(async ({ history }) => {
-      const isSummary = history[0]?.role === "system";
-      order.push(isSummary ? "compact" : "turn");
+    const ownerHistories: ModelMessage[][] = [];
+    const ownerModel = createCallbackModel(async ({ history }) => {
+      ownerHistories.push([...history]);
+      order.push("turn");
       active += 1;
       maxActive = Math.max(maxActive, active);
       await new Promise((resolve) => setTimeout(resolve, 15));
       active -= 1;
-      return [assistantMessage(isSummary ? "SHARED SUMMARY" : "DONE")];
+      return [assistantMessage(`OWNER ${ownerHistories.length}`)];
     });
-    const compactThread = new Agent({ host, model }).thread(
+    const compactingModel = createCallbackModel(async () => {
+      order.push("compact");
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      active -= 1;
+      return [assistantMessage("SHARED SUMMARY")];
+    });
+    const ownerThread = new Agent({ host, model: ownerModel }).thread(
       "shared-compact-fifo"
     );
-    const followUpThread = new Agent({ host, model }).thread(
-      "shared-compact-fifo"
-    );
+    await collect(await ownerThread.send("old ".repeat(200)));
+    order.length = 0;
+    const compactingThread = new Agent({
+      host,
+      model: compactingModel,
+    }).thread("shared-compact-fifo");
 
-    const compactPromise = compactThread.compact();
-    const followUpPromise = followUpThread.followUp("after shared compact");
+    const compactPromise = compactingThread.compact();
+    const followUpPromise = ownerThread.followUp("after shared compact");
     const [compaction, followUp] = await Promise.all([
       compactPromise,
       followUpPromise,
     ]);
-    await collect(followUp);
+    const followUpEvents = await collect(followUp);
+    const sendEvents = await collect(await ownerThread.send("after follow-up"));
 
     expect(compaction).toEqual({ status: "compacted" });
-    expect(order).toEqual(["compact", "turn"]);
+    expect(order).toEqual(["compact", "turn", "turn"]);
     expect(maxActive).toBe(1);
+    expect(followUpEvents.at(-1)?.type).toBe("turn-end");
+    expect(sendEvents.at(-1)?.type).toBe("turn-end");
+    expect(JSON.stringify(ownerHistories[1])).toContain("SHARED SUMMARY");
+    expect(JSON.stringify(ownerHistories[1])).toContain("after shared compact");
+    expect(JSON.stringify(ownerHistories[2])).toContain("after follow-up");
     expect(store.threads.get("shared-compact-fifo")?.state).toMatchObject({
       compactions: [
         {

--- a/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
@@ -68,10 +68,36 @@ export async function compactThreadBlocking(
   return await runSingleFlight({ ...options, reason: "overflow" });
 }
 
+/** Force a compaction through the same snapshot, transform, and freshness
+ * pipeline used by automatic compaction. */
+export async function compactThreadManually(
+  options: Omit<RunOptions, "compaction" | "reason"> & {
+    readonly summaryOptions?: CompactionSummaryOptions;
+  }
+): Promise<boolean> {
+  return await runSingleFlight({
+    ...options,
+    compaction: async (context) => {
+      if (context.history.length === 0) {
+        return;
+      }
+      const range = { endSeqExclusive: context.history.length, startSeq: 0 };
+      return {
+        ...range,
+        summary: await context.summarize(range, options.summaryOptions),
+      };
+    },
+    reason: "manual",
+  });
+}
+
 function runSingleFlight(options: RunOptions): Promise<boolean> {
   const existing = activeCompactions.get(options.state);
   if (existing) {
-    if (options.reason === "overflow" && existing.reason === "completed-turn") {
+    if (
+      options.reason !== "completed-turn" &&
+      existing.reason === "completed-turn"
+    ) {
       return existing.promise
         .catch(() => false)
         .then(

--- a/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
@@ -9,6 +9,7 @@ import { hydrateRuntimeAttachments } from "../input/attachments";
 import { compactionContextForModel } from "../state/context";
 import type { ThreadState } from "../state/thread-state";
 import {
+  buildCompactionSummaryInstructions,
   summarizeCompactionRange,
   summaryHistoryForRange,
 } from "./auto-compaction-summary";
@@ -197,7 +198,13 @@ async function compactThreadOnce(options: RunOptions): Promise<boolean> {
       history: summaryHistory,
       model: { ...options.model, temperature: 0 },
       signal,
-      summaryInstructions: summaryOptions.instructions,
+      summaryInstructions:
+        summaryOptions.instructions === undefined
+          ? undefined
+          : `${buildCompactionSummaryInstructions()}
+
+## Additional focus
+${summaryOptions.instructions}`,
       toolEvidence: summaryOptions.toolEvidence,
       transformModelContext: options.transformModelContext,
     });

--- a/packages/runtime/src/thread/runtime/auto-compaction-types.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-types.ts
@@ -9,8 +9,13 @@ export type ThreadTokenEstimator = (
 
 export type AgentCompactionReason = "completed-turn" | "manual" | "overflow";
 
+export type ManualThreadCompactionResult =
+  | { readonly status: "compacted" }
+  | { readonly status: "empty" }
+  | { readonly status: "skipped" };
+
 export interface CompactionSummaryOptions {
-  /** Replaces the runtime's default continuation-handoff instructions. */
+  /** Appends an `Additional focus` section to the default handoff contract. */
   readonly instructions?: string;
   /** Controls whether raw tool-result evidence is appended after model output. */
   readonly toolEvidence?: "deterministic" | "omit";

--- a/packages/runtime/src/thread/runtime/auto-compaction-types.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-types.ts
@@ -7,7 +7,7 @@ export type ThreadTokenEstimator = (
   messages: readonly ModelMessage[]
 ) => number;
 
-export type AgentCompactionReason = "completed-turn" | "overflow";
+export type AgentCompactionReason = "completed-turn" | "manual" | "overflow";
 
 export interface CompactionSummaryOptions {
   /** Replaces the runtime's default continuation-handoff instructions. */


### PR DESCRIPTION
## Summary
- add `/session` current-session metadata with reconciled role totals, tool call/result activity, and an explicit durable-token-usage availability label while preserving `/resume` as the session picker/direct resume command
- add idle-only `/compact [custom instructions]` backed by a runtime-owned manual compaction operation and normalized safe provider-error presentation
- share automatic compaction's prior-summary context, attachment/model pipeline, context transforms, hooks, single-flight, and freshness checks; document both public runtime and TUI behavior
- reserve `compact` and `session` case-insensitively against extension command/alias collisions
- add runtime and coding-agent patch Tegami entries

## Tests
- `pnpm --filter @minpeter/pss-runtime test` (142 files, 860 passed / 3 skipped)
- `pnpm --filter @minpeter/pss-coding-agent test` (112 files, 779 tests)
- runtime + coding-agent typechecks
- repository lint (clean; pre-existing oversized experimental JSON warning only)
- `pnpm turbo run build --filter=@minpeter/pss-coding-agent...`

## Scope note
Follow-up input mode is not included in this slice. The runtime distinguishes follow-up inputs internally, but the current public TUI thread adapter has no safely feature-detectable follow-up capability or queued-turn consumption contract; changing active input semantics here would risk losing or concurrently consuming buffered turns. Existing active-turn steering remains unchanged.