### PR TITLE
docs: clarify runtime guarantees and harden release gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,15 +54,6 @@ jobs:
       - name: Verify release artifacts
         run: pnpm verify:release
 
-      - name: Verify coding-agent dependency resolution
-        run: |
-          pack_dir="$RUNNER_TEMP/coding-agent-pack"
-          install_dir="$RUNNER_TEMP/coding-agent-install"
-          mkdir -p "$pack_dir" "$install_dir"
-          pnpm --filter @minpeter/pss-runtime pack --pack-destination "$pack_dir"
-          pnpm --filter @minpeter/pss-coding-agent pack --pack-destination "$pack_dir"
-          npm install --package-lock-only --ignore-scripts --prefix "$install_dir" "$pack_dir"/*.tgz
-
       - name: Version or publish packages
         run: pnpm tegami ci
         env:

--- a/.tegami/2026-08-05-release-package-gates.md
+++ b/.tegami/2026-08-05-release-package-gates.md
@@ -1,0 +1,7 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+Validate published package metadata and packed-tarball imports in the release gate, and ship a stable `pss-eval` bin wrapper that avoids missing-bin install warnings before builds.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -594,10 +594,8 @@ otherwise from `process.env`. An injected `client` replaces the OpenSearch
 client entirely.
 
 ```ts
-import {
-  createCodingAgentTools,
-  resolveStartTuiTools,
-} from "@minpeter/pss-coding-agent";
+import { createCodingAgentTools } from "@minpeter/pss-coding-agent";
+import { resolveStartTuiTools } from "@minpeter/pss-coding-agent/tools";
 
 const tools = createCodingAgentTools({ webToolsAvailability: "required" });
 

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -340,7 +340,7 @@ Metadata (names, fork parentage, the active session) lives in a sidecar
   compaction records that fit it); `/fork <name>` forks at the latest
   state under that name. Applied thread migrations carry over so they
   never re-run on the fork, and the parent thread key is recorded
-- `/clear` — wipe the current session in place (legacy behavior)
+- `/clear [name]` — alias for `/new [name]`; starts a new empty session and preserves the previous session for `/resume`
 - `/compact [custom instructions]` — summarize the current durable conversation
   through the runtime's compaction pipeline and replace its model-facing
   context with the smaller continuation handoff; full history remains available
@@ -594,6 +594,11 @@ otherwise from `process.env`. An injected `client` replaces the OpenSearch
 client entirely.
 
 ```ts
+import {
+  createCodingAgentTools,
+  resolveStartTuiTools,
+} from "@minpeter/pss-coding-agent";
+
 const tools = createCodingAgentTools({ webToolsAvailability: "required" });
 
 // Custom entrypoint around the TUI defaults:

--- a/apps/worker-agent/README.md
+++ b/apps/worker-agent/README.md
@@ -16,7 +16,7 @@ pnpm -F "@minpeter/pss-worker-agent" ship   # deploy
 
 After local `dev`, run `ship` again to restore the prod webhook.
 
-## Session transport (RFC 0002 phase 1)
+## Session transport (RFC 0002)
 
 The initial remote submit-turn RPC is the existing authenticated tRPC mutation:
 
@@ -27,20 +27,20 @@ Authorization: Bearer <WORKER_AGENT_TUI_TOKEN>
 
 Development accepts requests without a token; production requires the configured bearer token. `createRemoteTuiDeliveryClient()` is the supported client for this compatibility surface. It waits for the existing tool-only delivery result, so its response is a delivery result rather than an admission receipt.
 
-RFC 0002 names the generalized transport fields as follows:
+The compatibility RPC differs from the implemented generalized transport:
 
 | RFC shape | Initial `tui.turn` shape | Notes |
 | --- | --- | --- |
 | `SubmitTurnRequest.channel` | `input.channel` | Currently restricted to `{ kind: "tui", id }`. |
 | `SubmitTurnRequest.text` | `input.text` | Trimmed and rejected when empty. |
 | `SubmitTurnRequest.sessionScopeKey` | `input.sessionScopeKey` | Optional and trimmed before forwarding. |
-| `SubmitTurnRequest.idempotencyKey` | Not present | Added by the generalized session admission surface in a later phase. |
+| `SubmitTurnRequest.idempotencyKey` | Not present | Available on `session.submitTurn`. |
 | `SubmitTurnResponse.accepted` | `output.delivered` | Not equivalent: `delivered` reports tool delivery after the run. |
-| `SubmitTurnResponse.runId` | Not present | Added by the generalized durable-admission surface. |
+| `SubmitTurnResponse.runId` | Not present | Returned by `session.submitTurn`. |
 | `SubmitTurnResponse.threadKey` | Implicit (`default` inside the channel DO) | Runtime naming remains `threadKey`; transport naming remains `session`. |
-| `SubmitTurnResponse.eventCursor` | Not present | Clients use durable replay cursors when replay is available. |
+| `SubmitTurnResponse.eventCursor` | Not present | Clients use durable replay cursors through `session.replayEvents`. |
 
-The current route is intentionally retained while the `session` transport is added. Telegram continues to use its webhook delivery path.
+The route is intentionally retained for compatibility alongside the `session` transport. Telegram continues to use its webhook delivery path.
 
 ## Session submit and replay
 

--- a/docs/rfc/0002-app-owned-session-rpc.md
+++ b/docs/rfc/0002-app-owned-session-rpc.md
@@ -2,7 +2,7 @@
 source_issue: 172
 source_url: https://github.com/minpeter/pss-runtime/issues/172
 original_created_at: 2026-07-07
-status: Proposed
+status: Implemented
 ---
 
 > Moved from GitHub issue #172 into the repo on 2026-07-19; the issue is closed and this file is the canonical copy.
@@ -11,7 +11,7 @@ status: Proposed
 
 | Field | Value |
 |-------|-------|
-| **Status** | Proposed |
+| **Status** | Implemented |
 | **Authors** | @minpeter |
 | **Created** | 2026-07-07 |
 | **Target packages** | `apps/worker-agent`, optionally examples/docs in `@minpeter/pss-runtime` |
@@ -34,22 +34,21 @@ The key design split:
 
 ## Current State
 
-`apps/worker-agent` already has a narrow remote TUI RPC path:
+`apps/worker-agent` implements the app-owned transport while keeping transport
+concerns out of runtime core:
 
-- Worker entrypoint routes `/trpc` to `handleTuiRpcRequest`.
-- `tui.turn` is a tRPC mutation.
-- `dispatchTuiTurn()` forwards to the target Agent Durable Object `/turn` endpoint.
-- Remote clients use `createRemoteTuiDeliveryClient()` with an HTTP link.
+- `session.submitTurn` durably admits an input and returns `runId` and
+  `threadKey`; an optional idempotency key makes admission retry-safe.
+- `session.replayEvents` reads committed `StoredThreadEvent` records after an
+  exclusive cursor from `ThreadHandle.events()`.
+- `GET /session/events` replays the same durable records and then follows newly
+  committed events over SSE; the remote client reconnects with its last cursor.
+- Auth, `ChannelAddress` routing, and `sessionScopeKey` remain worker-owned.
+- The older `tui.turn` delivery-result RPC remains as a compatibility surface.
 
-This proves the app-owned RPC direction, but the current surface is turn-submission-oriented and not a general session transport:
-
-- No standard session creation/open shape.
-- No durable event replay endpoint.
-- No live SSE stream surface.
-- No shared cursor contract across TUI/webhook/browser clients.
-- No explicit relationship to RFC 0001's future `thread.events({ after })` API.
-
----
+Polling `session.replayEvents` is the portable baseline. SSE is optional and
+never the only recovery path. See `apps/worker-agent/README.md` for request and
+reconnect details.
 
 ## Goals
 
@@ -158,27 +157,26 @@ worker-agent transport
 
 ---
 
-## Implementation Plan
+## Implementation Status
 
-| Phase | Work | Gate |
-|-------|------|------|
-| 1 | Document current `/trpc/tui.turn` as the initial submit-turn RPC | existing TUI remote tests |
-| 2 | Add transport-level event cursor types shared by client/server | typecheck + contract tests |
-| 3 | Add replay-events RPC backed by RFC 0001 thread event replay | reconnect test with cursor |
-| 4 | Add SSE endpoint as an optional live stream over durable replay | reconnect + dropped-connection tests |
-| 5 | Unify TUI/browser client around submit + replay + stream model | worker-agent remote eval |
+| Phase | Result | Gate |
+|-------|--------|------|
+| 1 | Existing `/trpc/tui.turn` retained and documented as compatibility RPC | remote TUI tests |
+| 2 | Shared request, response, channel, and cursor schemas | session contract tests |
+| 3 | `session.submitTurn` and `session.replayEvents` backed by durable admission/replay | idempotency and cursor replay tests |
+| 4 | Optional `/session/events` SSE replay/follow endpoint | reconnect and dropped-response tests |
+| 5 | Remote session client exposes submit, polling replay, and SSE helpers | remote client tests |
 
----
+## Resolved Decisions
 
-## Open Questions
-
-1. Should the generalized RPC keep tRPC, or expose plain JSON endpoints for easier non-TypeScript clients?
-2. Should SSE be required, or should cursor replay polling be the baseline and SSE optional?
-3. Should submit-turn return immediately after durable admission, or wait for tool-only delivery like current TUI behavior?
-4. Should Telegram use the same replay surface internally, or remain webhook-delivery-only?
-5. What is the public naming: `session`, `thread`, `channel`, or `conversation`?
-
----
+1. tRPC is the typed submit/replay baseline; SSE is a separate HTTP endpoint.
+2. Cursor polling is required as the deployment-neutral recovery path; SSE is
+   optional.
+3. `session.submitTurn` returns after durable admission. The legacy `tui.turn`
+   continues to wait for its delivery result.
+4. Telegram remains webhook-delivery-owned rather than consuming session replay.
+5. Runtime naming remains `thread`; the app transport uses `session` and maps a
+   `ChannelAddress` to its Durable Object.
 
 ## References
 

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -4,6 +4,6 @@ Design RFCs for `pss-runtime` live here as numbered, versioned documents. An RFC
 
 | # | Title | Status | Source issue |
 |---|-------|--------|---------------|
-| 0002 | App-Owned Session RPC and Streaming Transport | Proposed | [#172](https://github.com/minpeter/pss-runtime/issues/172) |
+| 0002 | App-Owned Session RPC and Streaming Transport | Implemented | [#172](https://github.com/minpeter/pss-runtime/issues/172) |
 | 0003 | Plugin System Improvements — Closing Gaps vs Pi Harness Extensions | Proposed | [#213](https://github.com/minpeter/pss-runtime/issues/213) |
 | 0004 | Public API vNext | Proposed | Repository RFC |

--- a/docs/rfc/session-lifecycle.md
+++ b/docs/rfc/session-lifecycle.md
@@ -5,8 +5,8 @@ Status: implemented (initial cut) — tracks issue #258.
 ## Motivation
 
 The coding agent originally pinned one durable thread per working directory
-(`cwd:<path>`), with `/clear` as the only lifecycle operation (delete and
-recreate the same key). Multiple parallel sessions, resuming older work,
+(`cwd:<path>`), with a destructive `/clear` operation that deleted and
+recreated the same key. Multiple parallel sessions, resuming older work,
 naming, and branching all require explicit session management, and
 extensions need lifecycle visibility so their state does not silently
 outlive the thread it belongs to.
@@ -94,9 +94,11 @@ narrow and explicit:
   records that fit inside it. Either way `appliedMigrations` carries over,
   so #256 migrations never re-run on the fork. `/fork <name>` forks at the
   latest state under that name.
-- `/clear` keeps its legacy meaning (wipe the current session in place) and
-  emits `host:session-start` with reason `clear`. Its `new` alias moved to
-  the dedicated `/new` command.
+- `/clear [name]` is a compatibility alias for `/new [name]`: it creates and
+  switches to a new session without deleting the previous one. Both spellings
+  emit the normal `new` lifecycle reason; `clear` remains in the reason type so
+  older extension hosts can decode persisted/third-party events, but the built-in
+  command no longer emits it.
 - `new`, `resume`, `name`, `fork` (plus the previously reserved names) are
   reserved: extensions cannot register them.
 

--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
     "lint": "ultracite check .",
     "format": "ultracite fix .",
     "tegami": "node scripts/tegami.mts",
-    "verify:release": "node scripts/verify-release-artifacts.mjs",
+    "verify:release": "node scripts/verify-release-artifacts.mjs && pnpm verify:package-apis",
     "api:check": "node scripts/runtime-public-api.mjs check",
     "api:update": "pnpm --filter @minpeter/pss-runtime build && node scripts/runtime-public-api.mjs update",
     "boundaries": "node scripts/prepare-boundaries.mjs && turbo boundaries",
     "repo:packages": "turbo query ls --output json",
     "repo:affected": "turbo query affected",
-    "audit": "corepack pnpm audit --audit-level moderate"
+    "audit": "corepack pnpm audit --audit-level moderate",
+    "verify:package-apis": "publint packages/runtime && publint apps/coding-agent && node scripts/packed-consumer-smoke.mjs"
   },
   "devDependencies": {
     "@ai-sdk/openai-compatible": "3.0.20",
@@ -59,6 +60,7 @@
     "ajv": "8.20.0",
     "dotenv": "^17.4.2",
     "eslint": "10.7.0",
+    "publint": "^0.3.23",
     "react": "19.2.8",
     "tegami": "1.2.7",
     "tsx": "^4.23.1",

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -7,6 +7,24 @@
 Minimal, platform-agnostic agent runtime with keyed threads, synchronized
 `turn.events()`, and opaque persistence contracts.
 
+## Guarantees and boundaries
+
+- **Provider boundary:** `model` accepts concrete AI SDK language-model objects
+  for the versions represented by the exported `LanguageModel` type (currently
+  v2, v3, and v4). PSS normalizes its own event protocol, but provider model
+  availability, token accounting, streaming quality, and retry behavior remain
+  provider/SDK concerns. `observedRetryable` is evidence, not a retry promise.
+- **Durability boundary:** durability comes from the selected `AgentHost`.
+  Omitting `host` uses an in-memory host and does not survive process loss. File
+  and Cloudflare hosts persist committed snapshots, execution records, and
+  replay events according to their adapter contracts; ephemeral stream deltas
+  and work outside the host transaction are not durable. Applications must use
+  stable `namespace` and thread keys to reopen the same state.
+- **API boundary:** supported imports are exactly the subpaths in the package
+  `exports` map. Files under `dist/`, opaque stored snapshots, and adapter
+  implementation details are not public APIs. `turn.events()` is the live
+  driver; `thread.events()` is committed replay, not a second live stream.
+
 ## Core DX
 
 ```ts

--- a/packages/runtime/bin/pss-eval.js
+++ b/packages/runtime/bin/pss-eval.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { runCli } from "../dist/evals/cli.js";
+
+const exitCode = await runCli(process.argv.slice(2));
+process.exit(exitCode);

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -87,10 +87,11 @@
     }
   },
   "bin": {
-    "pss-eval": "./dist/evals/cli-bin.js"
+    "pss-eval": "./bin/pss-eval.js"
   },
   "files": [
     "dist",
+    "bin",
     "README.md",
     "LICENSE.md"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       eslint:
         specifier: 10.7.0
         version: 10.7.0(jiti@2.7.0)
+      publint:
+        specifier: ^0.3.23
+        version: 0.3.23
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -173,7 +176,7 @@ importers:
         version: link:../../extensions/web
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        version: 0.22.14(publint@0.3.23)(tsx@4.23.1)(typescript@7.0.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -549,7 +552,7 @@ importers:
         version: 1.62.0
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        version: 0.22.14(publint@0.3.23)(tsx@4.23.1)(typescript@7.0.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -565,7 +568,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        version: 0.22.14(publint@0.3.23)(tsx@4.23.1)(typescript@7.0.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -587,7 +590,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        version: 0.22.14(publint@0.3.23)(tsx@4.23.1)(typescript@7.0.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -627,7 +630,7 @@ importers:
         version: 0.20.1(@babel/core@8.0.1)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0-beta.5)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0-beta.5)(ai@7.0.51(zod@4.4.3))(chat@4.36.0(ai@7.0.51(zod@4.4.3))(zod@4.4.3))(react@19.2.8)(rolldown@1.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(zod@4.4.3)
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
+        version: 0.22.14(publint@0.3.23)(tsx@4.23.1)(typescript@7.0.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -1646,6 +1649,10 @@ packages:
 
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@publint/pack@0.1.6':
+    resolution: {integrity: sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA==}
+    engines: {node: '>=18'}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -3853,6 +3860,10 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3960,6 +3971,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   parse-json@4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
@@ -4071,6 +4085,11 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  publint@0.3.23:
+    resolution: {integrity: sha512-5MQipUPcB7MWw84zLUkHrg/H/UBtk3LL+A0GngTTBSsiNJLQurMUaSIRG3edlOrRz4UFe0AOKK9TZdIWviV+jQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -4181,6 +4200,10 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -5810,6 +5833,10 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.2': {}
+
+  '@publint/pack@0.1.6':
+    dependencies:
+      tinyexec: 1.2.4
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -8022,6 +8049,8 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   nan@2.28.0:
@@ -8133,6 +8162,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.8.0: {}
+
   parse-json@4.0.0:
     dependencies:
       error-ex: 1.3.4
@@ -8231,6 +8262,13 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  publint@0.3.23:
+    dependencies:
+      '@publint/pack': 0.1.6
+      package-manager-detector: 1.8.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   pump@3.0.4:
     dependencies:
@@ -8402,6 +8440,10 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-array-concat@1.1.4:
     dependencies:
@@ -8784,7 +8826,7 @@ snapshots:
     dependencies:
       typescript: 7.0.2
 
-  tsdown@0.22.14(tsx@4.23.1)(typescript@7.0.2):
+  tsdown@0.22.14(publint@0.3.23)(tsx@4.23.1)(typescript@7.0.2):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -8802,6 +8844,7 @@ snapshots:
       unconfig-core: 7.5.0
       verkit: 0.3.0
     optionalDependencies:
+      publint: 0.3.23
       tsx: 4.23.1
       typescript: 7.0.2
     transitivePeerDependencies:

--- a/scripts/packed-consumer-smoke.mjs
+++ b/scripts/packed-consumer-smoke.mjs
@@ -47,8 +47,22 @@ for (const [name, value] of Object.entries({
   );
 
   run(process.execPath, ["consumer.mjs"], temporary);
-  run(join(temporary, "node_modules/.bin/pss-eval"), ["--help"], temporary);
-  run(join(temporary, "node_modules/.bin/pss"), ["--help"], temporary);
+  run(
+    process.execPath,
+    [
+      join(temporary, "node_modules/@minpeter/pss-runtime/bin/pss-eval.js"),
+      "--help",
+    ],
+    temporary
+  );
+  run(
+    process.execPath,
+    [
+      join(temporary, "node_modules/@minpeter/pss-coding-agent/bin/pss.js"),
+      "--help",
+    ],
+    temporary
+  );
   console.log("Packed-tarball consumer smoke passed");
 } finally {
   await rm(temporary, { force: true, recursive: true });

--- a/scripts/packed-consumer-smoke.mjs
+++ b/scripts/packed-consumer-smoke.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const PACKAGE_SCOPE_PREFIX = /^@/u;
+const root = resolve(import.meta.dirname, "..");
+const temporary = await mkdtemp(join(tmpdir(), "pss-packed-consumer-"));
+
+try {
+  const tarballs = [pack("packages/runtime"), pack("apps/coding-agent")];
+  run(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--no-package-lock",
+      ...tarballs,
+    ],
+    temporary
+  );
+
+  await writeFile(
+    join(temporary, "consumer.mjs"),
+    `import { createAgent } from "@minpeter/pss-runtime";
+import { createInMemoryHost } from "@minpeter/pss-runtime/platform/memory";
+import { createCodingAgent, createCodingAgentTools } from "@minpeter/pss-coding-agent";
+import { createWorkspaceTools } from "@minpeter/pss-coding-agent/workspace-tools";
+
+for (const [name, value] of Object.entries({
+  createAgent,
+  createCodingAgent,
+  createCodingAgentTools,
+  createInMemoryHost,
+  createWorkspaceTools,
+})) {
+  if (typeof value !== "function") throw new TypeError(name + " is not callable");
+}
+`,
+    "utf8"
+  );
+
+  run(process.execPath, ["consumer.mjs"], temporary);
+  run(join(temporary, "node_modules/.bin/pss-eval"), ["--help"], temporary);
+  run(join(temporary, "node_modules/.bin/pss"), ["--help"], temporary);
+  console.log("Packed-tarball consumer smoke passed");
+} finally {
+  await rm(temporary, { force: true, recursive: true });
+}
+
+function pack(packageDirectory) {
+  const destination = temporary;
+  run(
+    "pnpm",
+    ["pack", "--pack-destination", destination],
+    resolve(root, packageDirectory)
+  );
+  const packageJson = JSON.parse(
+    readFileSync(resolve(root, packageDirectory, "package.json"), "utf8")
+  );
+  const fileName = `${packageJson.name.replace(PACKAGE_SCOPE_PREFIX, "").replaceAll("/", "-")}-${packageJson.version}.tgz`;
+  return join(destination, fileName);
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed\n${result.stdout}${result.stderr}`
+    );
+  }
+}

--- a/scripts/packed-consumer-smoke.mjs
+++ b/scripts/packed-consumer-smoke.mjs
@@ -29,6 +29,7 @@ try {
     `import { createAgent } from "@minpeter/pss-runtime";
 import { createInMemoryHost } from "@minpeter/pss-runtime/platform/memory";
 import { createCodingAgent, createCodingAgentTools } from "@minpeter/pss-coding-agent";
+import { resolveStartTuiTools } from "@minpeter/pss-coding-agent/tools";
 import { createWorkspaceTools } from "@minpeter/pss-coding-agent/workspace-tools";
 
 for (const [name, value] of Object.entries({
@@ -37,6 +38,7 @@ for (const [name, value] of Object.entries({
   createCodingAgentTools,
   createInMemoryHost,
   createWorkspaceTools,
+  resolveStartTuiTools,
 })) {
   if (typeof value !== "function") throw new TypeError(name + " is not callable");
 }

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -26,11 +26,14 @@ describe("release workflow", () => {
     expect(ciWorkflow).toContain('node: ["24", "26"]');
     expect(ciWorkflow).toContain("cancel-in-progress: true");
     expect(workflow).toContain("pnpm tegami ci");
-    expect(workflow).toContain("pnpm --filter @minpeter/pss-runtime pack");
-    expect(workflow).toContain("pnpm --filter @minpeter/pss-coding-agent pack");
-    expect(workflow).toContain(
-      "npm install --package-lock-only --ignore-scripts"
+    expect(workflow).toContain("pnpm verify:release");
+    expect(packageJson.scripts["verify:release"]).toContain(
+      "pnpm verify:package-apis"
     );
+    expect(packageJson.scripts["verify:package-apis"]).toContain(
+      "node scripts/packed-consumer-smoke.mjs"
+    );
+    expect(workflow).not.toContain("Verify coding-agent dependency resolution");
     expect(workflow).not.toContain("NPM_CONFIG_PROVENANCE");
     expect(workflow).not.toContain("changesets/action");
   });

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -90,14 +90,18 @@ export function cleanupFixtures() {
 }
 
 function packageMetadata(packageName) {
-  return packageName === "coding-agent"
-    ? {
-        bin: {
-          pss: "./bin/pss.js",
-          "pss-coding-agent": "./bin/pss.js",
-        },
-      }
-    : {};
+  if (packageName === "runtime") {
+    return { bin: { "pss-eval": "./bin/pss-eval.js" } };
+  }
+  if (packageName === "coding-agent") {
+    return {
+      bin: {
+        pss: "./bin/pss.js",
+        "pss-coding-agent": "./bin/pss.js",
+      },
+    };
+  }
+  return {};
 }
 
 function fixturePackageRoot(cwd, packageName) {
@@ -118,6 +122,12 @@ function writePackageDeclarationFixtures(cwd, packageName, packageRoot) {
   writeFileSync(join(packageRoot, "dist", "index.d.ts"), declaration);
 
   if (packageName === "runtime") {
+    mkdirSync(join(packageRoot, "bin"), { recursive: true });
+    writeFileSync(
+      join(packageRoot, "bin", "pss-eval.js"),
+      "#!/usr/bin/env node\nimport '../dist/evals/cli.js';\n",
+      { mode: 0o755 }
+    );
     writeRuntimeDeclarationFixtures(cwd, packageName);
     return;
   }

--- a/scripts/verify-release-artifacts/package-checks.mjs
+++ b/scripts/verify-release-artifacts/package-checks.mjs
@@ -14,6 +14,9 @@ import {
 } from "./shared.mjs";
 
 const REQUIRED_PACKAGE_BINS = {
+  runtime: {
+    "pss-eval": "./bin/pss-eval.js",
+  },
   "coding-agent": {
     pss: "./bin/pss.js",
     "pss-coding-agent": "./bin/pss.js",


### PR DESCRIPTION
## Summary

- correct `/clear` documentation to match its current `/new` alias behavior, complete the web-tool snippet imports, and mark RFC 0002's submit/replay/SSE transport as implemented
- document the runtime's provider, durability, and public API boundaries
- strengthen `verify:release` with publint and an isolated consumer that installs packed runtime/coding-agent tarballs, imports public subpaths, and executes both CLI help paths
- move `pss-eval` to a stable published bin wrapper so workspace installs no longer warn about a pre-build `dist` bin target

## Validation

- `pnpm lint` (passes; existing oversized `experimental/cache-stable-tools/latest-freerouter.json` warning)
- `pnpm typecheck`
- `pnpm build`
- `pnpm verify:release`
- `pnpm exec vitest run scripts/verify-release-artifacts-package.test.mjs scripts/runtime-docs.test.mjs scripts/release-workflow.test.mjs` (19 passed)

## Notes

`@arethetypeswrong/cli` was evaluated but is not compatible with this repository's TypeScript 7 toolchain: its core currently crashes while reading `ts.ScriptTarget.Latest`. It is therefore not added as a flaky/nonfunctional gate; publint plus the real packed-consumer install exercises the applicable package surface today.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified runtime guarantees and marked RFC 0002 as implemented. Hardened release gates with `publint`, a packed-tarball consumer smoke test wired into `pnpm verify:release`, and a stable `pss-eval` bin to remove pre-build warnings.

- **New Features**
  - Release verification: `pnpm verify:release` now chains `publint` for `packages/runtime` and `apps/coding-agent`, then runs `scripts/packed-consumer-smoke.mjs` to install packed tarballs, import public subpaths (`@minpeter/pss-runtime/platform/memory`, `@minpeter/pss-coding-agent/tools`, `@minpeter/pss-coding-agent/workspace-tools`), and execute `pss-eval --help` and `pss --help`. CI uses this single step and removes the ad‑hoc pack/install.
  - Stable CLI: `@minpeter/pss-runtime` exposes `pss-eval` via `bin/pss-eval.js` to avoid missing-bin warnings before builds.

- **Docs**
  - Runtime README adds provider, durability, and API boundary guarantees.
  - RFC 0002 set to Implemented with `session.submitTurn`, `session.replayEvents`, and optional `/session/events` SSE; polling replay is the baseline.
  - Worker-agent README clarifies the compatibility `tui.turn` vs the `session` transport; both remain supported.
  - `/clear [name]` documented as an alias for `/new [name]`; previous session is preserved for `/resume`, and the built-in command no longer emits a `clear` reason.
  - Examples import `resolveStartTuiTools` from `@minpeter/pss-coding-agent/tools`.

<sup>Written for commit fcf166f210898173dea031515c1559e32cc6922a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

