### PR TITLE
fix: guard tegami entries against heading-less bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Validate Pi compatibility manifest
         run: pnpm check:compatibility
 
+      - name: Check tegami entry sections
+        run: pnpm check:tegami-notes
+
       - name: Lint
         run: pnpm lint
 

--- a/.tegami/2026-08-05-agent-host-fault-conformance.md
+++ b/.tegami/2026-08-05-agent-host-fault-conformance.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Add AgentHost fault-injection conformance coverage
+
 Add reusable AgentHost fault-injection conformance coverage for durable cursors, leases, inputs, checkpoints, and transaction crash boundaries across memory, file, and Cloudflare hosts.

--- a/.tegami/2026-08-05-harden-coding-agent-tools.md
+++ b/.tegami/2026-08-05-harden-coding-agent-tools.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Harden built-in web, extension, and shell tool handling
+
 Validate built-in web and extension tool schemas before execution, improve model-facing parameter descriptions, and report failed shell commands accurately.

--- a/.tegami/2026-08-05-release-package-gates.md
+++ b/.tegami/2026-08-05-release-package-gates.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Harden published-package release gates
+
 Validate published package metadata and packed-tarball imports in the release gate, and ship a stable `pss-eval` bin wrapper that avoids missing-bin install warnings before builds.

--- a/.tegami/2026-08-06-buffered-turn-falsy-errors.md
+++ b/.tegami/2026-08-06-buffered-turn-falsy-errors.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Preserve falsy buffered turn errors as rejections
+
 Separate successful and failed buffered turn closure so every JavaScript falsy value remains observable as an iterator rejection.

--- a/.tegami/2026-08-06-durable-follow-up-queue.md
+++ b/.tegami/2026-08-06-durable-follow-up-queue.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Add durable followUp turns with recovery
+
 Add durable `followUp` turns with recovery and distinct metadata. FIFO one-at-a-time execution applies within one process/isolate to handles sharing the exact store wrapper.

--- a/.tegami/2026-08-06-extension-authoring-api.md
+++ b/.tegami/2026-08-06-extension-authoring-api.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Make the extension factory API canonical
+
 Make the extension factory API canonical, add typed event maps and explicit renderer modes, and preserve the deprecated registry API through a legacy subpath.

--- a/.tegami/2026-08-06-harden-event-cursors.md
+++ b/.tegami/2026-08-06-harden-event-cursors.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Scope event cursors nominally and validate offsets
+
 Scope run and thread event cursors nominally and validate cursor offsets and replay limits consistently across storage backends.

--- a/.tegami/2026-08-06-jsonl-protocol.md
+++ b/.tegami/2026-08-06-jsonl-protocol.md
@@ -6,5 +6,7 @@ packages:
     type: patch
 ---
 
+## Add the versioned JSONL agent protocol
+
 Add a versioned transport-neutral JSONL RPC protocol, TypeScript client, and Node spawn transport.
 Expose coding-agent prompt, steer, abort, and state operations through a protocol-clean stdio mode.

--- a/.tegami/2026-08-06-notification-dispatch-retries.md
+++ b/.tegami/2026-08-06-notification-dispatch-retries.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Harden notification retry handling
+
 Prevent idempotent notification retries from rescheduling terminal runs and fail safely when deduplicated notification records are missing or inconsistent.

--- a/.tegami/2026-08-06-provider-registry.md
+++ b/.tegami/2026-08-06-provider-registry.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Add lazy provider descriptors with API-key selection
+
 Add lazy Anthropic, OpenAI, and OpenAI-compatible provider descriptors with API-key selection for headless and library use while preserving legacy AI environment behavior.

--- a/.tegami/2026-08-06-remove-dead-runtime-declarations.md
+++ b/.tegami/2026-08-06-remove-dead-runtime-declarations.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Remove dead runtime declarations
+
 Remove verified unused runtime declarations and internal test helpers.

--- a/.tegami/2026-08-06-session-tui-parity.md
+++ b/.tegami/2026-08-06-session-tui-parity.md
@@ -6,4 +6,6 @@ packages:
     type: patch
 ---
 
+## Add session TUI compaction parity
+
 Add explicit `/compact` and Pi-compatible `/session` commands to the interactive TUI, with runtime-owned durable context compaction and documented session UX.

--- a/.tegami/2026-08-06-sql-queue-host.md
+++ b/.tegami/2026-08-06-sql-queue-host.md
@@ -4,4 +4,6 @@ packages:
     type: patch
 ---
 
+## Add the SQL + durable queue host
+
 Add platform-neutral SQL store and leased durable-queue integration ports, worker draining, and exact-work outbox reconciliation with in-memory reference contract coverage.

--- a/.tegami/2026-08-06-tegami-pending-heading-guard.md
+++ b/.tegami/2026-08-06-tegami-pending-heading-guard.md
@@ -1,0 +1,13 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Guard tegami entries with a pending-note heading check
+
+Find and repair pending release entries that had no `##` body section, which
+made tegami skip them silently; add `pnpm check:tegami-notes` to the Validate
+workflow so a pending entry without a visible section heading fails CI before
+it can become unreleasable again.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ packages:
 
 - Target the published package whose behavior changes: `npm:@minpeter/pss-runtime` or `npm:@minpeter/pss-coding-agent`. Changes under `extensions/` target `npm:@minpeter/pss-coding-agent` because the built-in extensions ship inside its bundle.
 - Always use `type: patch` (or minor/major when asked). The `replay: exit-prerelease(...)` form is reserved for changes that must not bump a version (docs-only, CI-only); using it for a code change makes the Version Packages PR silently skip the entry.
+- Give the entry body at least one `## <Title>` section. Tegami only drafts notes whose body parses into a markdown section, so a pending entry without any heading is silently never released; `pnpm check:tegami-notes` enforces this in CI.
 - Copy the form from this template, not from an arbitrary existing entry.
 
 # Releases

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:tui": "tsx --conditions=@minpeter/pss-source apps/coding-agent/src/tui/app.ts",
     "build": "turbo run build",
     "check:compatibility": "node scripts/validate-pi-compatibility-manifest.mjs",
+    "check:tegami-notes": "node scripts/check-tegami-notes.mjs",
     "typecheck": "turbo run typecheck && tsc -p tsconfig.json --noEmit",
     "test": "turbo run test && vitest run scripts/*.test.mjs",
     "coverage": "vitest run --config vitest.coverage.config.ts --coverage",

--- a/scripts/check-tegami-notes.mjs
+++ b/scripts/check-tegami-notes.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+
+const TEGAMI_DIRECTORY = ".tegami";
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+const EXPLICIT_BUMP_RE = /^\s*type:\s*(patch|minor|major)\s*$/m;
+// Mirrors tegami's parseHeading: ATX headings only, at most 3 leading spaces.
+const HEADING_RE = /^ {0,3}#{1,6}(?:[ \t]+|$)/;
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+const LINE_SPLIT_RE = /\r\n|\r|\n/;
+
+// Tegami drafts a pending note into the Version Packages PR only when the
+// body parses into at least one markdown section, which requires one heading
+// outside fenced code (see parseMarkdownSections in tegami's publish module).
+// A note with an explicit type: bump but no heading is silently unreleasable.
+function hasVisibleSection(body) {
+  let fence;
+  for (const line of body.split(LINE_SPLIT_RE)) {
+    const fenceMarker = line.match(FENCE_RE);
+    if (fenceMarker) {
+      const marker = fenceMarker[1];
+      if (!fence) {
+        fence = marker;
+      } else if (marker[0] === fence[0] && marker.length >= fence.length) {
+        fence = undefined;
+      }
+      continue;
+    }
+    if (!fence && HEADING_RE.test(line)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function findTegamiNoteErrors(cwd = process.cwd()) {
+  const directory = join(cwd, TEGAMI_DIRECTORY);
+  const errors = [];
+  for (const file of readdirSync(directory)) {
+    if (!file.endsWith(".md")) {
+      continue;
+    }
+    const text = readFileSync(join(directory, file), "utf8");
+    const frontmatter = text.match(FRONTMATTER_RE);
+    if (!(frontmatter && EXPLICIT_BUMP_RE.test(frontmatter[1]))) {
+      // Not pending: replay-only notes never bump a version, and notes
+      // without an explicit type carry no release intent to guard.
+      continue;
+    }
+    if (!hasVisibleSection(text.slice(frontmatter[0].length))) {
+      errors.push(
+        `${TEGAMI_DIRECTORY}/${file}: pending entry has no markdown heading; tegami skips notes without a section, so this change would never be released. Add a '## <Title>' section above the body.`
+      );
+    }
+  }
+  return errors;
+}
+
+export function main() {
+  const errors = findTegamiNoteErrors();
+  if (errors.length > 0) {
+    console.error(errors.join("\n"));
+    return 1;
+  }
+  console.log("All pending tegami entries have a visible section heading");
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}

--- a/scripts/check-tegami-notes.test.mjs
+++ b/scripts/check-tegami-notes.test.mjs
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { findTegamiNoteErrors } from "./check-tegami-notes.mjs";
+
+const fixtures = [];
+
+function createFixture() {
+  const cwd = mkdtempSync(join(tmpdir(), "tegami-notes-"));
+  mkdirSync(join(cwd, ".tegami"), { recursive: true });
+  fixtures.push(cwd);
+  return cwd;
+}
+
+function writeNote(cwd, name, content) {
+  writeFileSync(join(cwd, ".tegami", name), content);
+}
+
+afterEach(() => {
+  for (const cwd of fixtures.splice(0)) {
+    rmSync(cwd, { force: true, recursive: true });
+  }
+});
+
+describe("check-tegami-notes", () => {
+  it("accepts a pending entry with a heading section", () => {
+    const cwd = createFixture();
+    writeNote(
+      cwd,
+      "2026-08-07-good.md",
+      "---\npackages:\n  npm:@example/pkg:\n    type: patch\n---\n\n## Add the thing\n\nBody text.\n"
+    );
+    expect(findTegamiNoteErrors(cwd)).toEqual([]);
+  });
+
+  it("rejects a pending entry without any heading", () => {
+    const cwd = createFixture();
+    writeNote(
+      cwd,
+      "2026-08-07-bad.md",
+      "---\npackages:\n  npm:@example/pkg:\n    type: minor\n---\n\nBody text without sections.\n"
+    );
+    const errors = findTegamiNoteErrors(cwd);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("2026-08-07-bad.md");
+    expect(errors[0]).toContain("## <Title>");
+  });
+
+  it("ignores replay-only entries that never bump a version", () => {
+    const cwd = createFixture();
+    writeNote(
+      cwd,
+      "2026-08-07-replay.md",
+      "---\npackages:\n  npm:@example/pkg:\n    replay:\n      - exit-prerelease(npm:@example/pkg)\n---\n\nDocs-only body without sections.\n"
+    );
+    expect(findTegamiNoteErrors(cwd)).toEqual([]);
+  });
+
+  it("does not count headings inside fenced code blocks, matching tegami", () => {
+    const cwd = createFixture();
+    writeNote(
+      cwd,
+      "2026-08-07-fenced.md",
+      "---\npackages:\n  npm:@example/pkg:\n    type: patch\n---\n\n```md\n## Not a section\n```\n"
+    );
+    expect(findTegamiNoteErrors(cwd)).toHaveLength(1);
+  });
+
+  it("accepts heading depths other than level two", () => {
+    const cwd = createFixture();
+    writeNote(
+      cwd,
+      "2026-08-07-deep.md",
+      "---\npackages:\n  npm:@example/pkg:\n    type: patch\n---\n\n### Deeper title\n\nBody.\n"
+    );
+    expect(findTegamiNoteErrors(cwd)).toEqual([]);
+  });
+
+  it("ignores non-markdown files like the publish lock", () => {
+    const cwd = createFixture();
+    writeFileSync(join(cwd, ".tegami", "publish-lock.yaml"), "core: {}\n");
+    expect(findTegamiNoteErrors(cwd)).toEqual([]);
+  });
+
+  it("finds no problems in the real repository notes", () => {
+    expect(findTegamiNoteErrors()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Tegami's note parser (`parseMarkdownSections`) only drafts a release entry whose body contains at least one markdown section — i.e. one ATX heading outside a fenced code block. A note with an explicit `type: patch|minor|major` frontmatter bump but **no `##` heading anywhere in the body** is silently skipped by `tegami version`: no bump, no changelog, no error. Verified empirically in #362: the regenerated Version Packages PR shipped a single runtime changelog while 13 pending patch notes sat invisible on main.

Root cause evidence: every note released so far has exactly one heading; the 13 skipped notes have zero headings and zero `replay` markers.

## Changes

- **Fix the 13 pending entries**: add a `## <Title>` section above each existing body, title derived from the note content (no body/frontmatter edits, bumps unchanged). This unblocks releases for, among others, the JSONL protocol (#360), session TUI parity & `/compact`, SQL + durable queue host, provider registry, follow-up queue, and release package gates (#361).
- **New guard**: `scripts/check-tegami-notes.mjs` mirrors tegami's exact section semantics (`/^[ ]{0,3}#{1,6}/` outside ```/`~~~` fences) and fails when a *pending* note (explicit `type:` bump) has no visible section. `replay`-only notes are exempt by design — they never bump a version.
- **CI**: wired into the Validate workflow as `pnpm check:tegami-notes` right after the Pi compatibility manifest check (pure file scan, ~ms, no dependencies).
- **Docs**: AGENTS.md gains a bullet stating the body-section requirement.
- Own tegami entry in correct form (`replay`, CI-only change).

## Verification

- `scripts/check-tegami-notes.mjs` run against pre-fix main flags exactly those 13 files; passes on this branch.
- 7 new vitest cases (accepted heading, rejected heading-less, replay exempt, fenced-code non-heading, non-`##` depth accepted, `.yaml` ignored, real repo clean) — full `scripts/` suite: 91 passed.
- `pnpm build`, `pnpm api:check`, `pnpm lint` green.
- After merge, `pnpm tegami ci` on main will regenerate the Version Packages PR showing all 13 releases (verified locally against a scratch checkout before opening).

## Notes

The `files.maxSize` warning during `pnpm lint` (`experimental/cache-stable-tools/latest-freerouter.json`) is pre-existing on main and untouched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Tegami from silently skipping pending release notes without a markdown section. Adds a fast CI guard and fixes 13 existing notes so their changelogs ship in the next release.

- **Bug Fixes**
  - Added a "## <Title>" section to 13 pending `.tegami` entries so they are drafted and released (unblocks JSONL protocol, session TUI parity, provider registry, durable follow‑up queue, SQL + queue host, release gates, and more).

- **New Features**
  - Added `scripts/check-tegami-notes.mjs` to require at least one visible ATX heading (outside fenced code) for pending notes; wired into Validate workflow as `pnpm check:tegami-notes`, with tests and a short AGENTS.md note.

<sup>Written for commit 8f287411c18b839929a94d82959d4efa8d7c8133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

