### PR TITLE
feat(runtime): promote compaction to budget-owning policy objects

### DIFF
--- a/.tegami/2026-08-07-compaction-budget-policy.md
+++ b/.tegami/2026-08-07-compaction-budget-policy.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Turn compaction into budget-owning policy objects
+
+`createAgent` accepts a compaction policy object carrying the context budget it compacts toward; the model-step context gate calls the policy's `maxInputTokens()` before every model request, so custom compaction and the gate can no longer drift apart. `speculativeCompaction` returns such a policy, and `contextGateForCompaction`/`estimatorForCompaction`/`DEFAULT_AGENT_MAX_INPUT_TOKENS` are removed: a bare `AgentCompaction` function now runs with the local gate off (provider-overflow-reactive compaction only) instead of a silent 128K fallback budget. A policy without `compact` is a budget-only source; pair it with `onOverflow: "error"` to fail over-budget turns without rewriting history.

--- a/apps/coding-agent/src/thread-config.test.ts
+++ b/apps/coding-agent/src/thread-config.test.ts
@@ -82,6 +82,9 @@ describe("resolveCodingAgentThreadConfig", () => {
         "/repo/demo",
         "/home/me"
       ).compaction
-    ).toBeTypeOf("function");
+    ).toMatchObject({
+      compact: expect.any(Function),
+      maxInputTokens: expect.any(Function),
+    });
   });
 });

--- a/apps/worker-agent/src/agent/agent.test.ts
+++ b/apps/worker-agent/src/agent/agent.test.ts
@@ -8,8 +8,11 @@ import {
 } from "./agent";
 
 describe("worker-agent compaction", () => {
-  it("uses a callable strategy", () => {
-    expect(WORKER_AGENT_COMPACTION).toBeTypeOf("function");
+  it("uses a budget-owning policy strategy", () => {
+    expect(WORKER_AGENT_COMPACTION).toMatchObject({
+      compact: expect.any(Function),
+      maxInputTokens: expect.any(Function),
+    });
   });
 });
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1202,6 +1202,40 @@ const agent = await createAgent({
 });
 ```
 
+`compaction` accepts either a policy object or a bare compaction function. A
+policy owns the context budget it compacts toward:
+
+```ts
+const agent = await createAgent({
+  compaction: {
+    compact: async (context) => {
+      if (context.reason !== "overflow") {
+        return;
+      }
+      const range = {
+        endSeqExclusive: context.history.length - 2,
+        startSeq: 0,
+      };
+      return { ...range, summary: await context.summarize(range) };
+    },
+    // The gate calls this before every model request; return the active
+    // model's window here.
+    maxInputTokens: () => 200_000,
+    onOverflow: "compact",
+  },
+  model,
+});
+```
+
+The runtime passes the policy straight to the context gate, so the budget and
+the compaction thresholds can never drift apart. `estimateTokens` overrides the
+prompt estimator for both the gate and the compaction context; `bufferTokens`
+reserves headroom inside the budget. A policy without `compact` is a
+budget-only source: pair it with `onOverflow: "error"` to fail over-budget
+turns without rewriting history. A bare `AgentCompaction` function carries no
+budget, so the local gate stays off and compaction reacts to provider-thrown
+context-window errors only.
+
 Force runtime-owned compaction on an idle thread with `thread.compact()`. The
 manual path shares automatic compaction's attachment hydration, model-context
 transforms, prior-summary handling, hooks, single-flight, and freshness checks.
@@ -1219,10 +1253,11 @@ race from empty history. Passing an explicit `ThreadCompactionInput` remains
 available for hosts that already produced a validated summary and returns the
 hook dispatcher's boolean commit decision.
 
-The context gate estimates the prompt immediately before `generateText`. With
-`onOverflow: "error"`, the turn fails before the provider is called. With
-`onOverflow: "compact"` (the default), the runtime runs blocking compaction and
-retries once. Provider-thrown context-window errors still use the same blocking
+The context gate estimates the prompt immediately before `generateText`, calling
+the policy's `maxInputTokens()` on every request. With `onOverflow: "error"`,
+the turn fails before the provider is called. With `onOverflow: "compact"` (the
+default), the runtime runs blocking compaction and retries once.
+Provider-thrown context-window errors still use the same blocking
 compaction fallback.
 
 Hosts that need durable runs pass `host:` into `createAgent()`. The execution subpath

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -8,6 +8,7 @@
       "type AgentCompactionContext",
       "type AgentCompactionDecision",
       "type AgentCompactionEvent",
+      "type AgentCompactionPolicy",
       "type AgentCompactionReason",
       "type AgentEvent",
       "type AgentEventListener",
@@ -37,6 +38,7 @@
       "type CommittedThreadMigrations",
       "type CompactionContextMessage",
       "type CompactionSummaryOptions",
+      "type ContextBudgetSource",
       "type ContextTokenOptions",
       "type ContextTokenProfile",
       "type ContextUsageSnapshot",
@@ -119,7 +121,6 @@
       "value COMPACTION_SUMMARY_CONTRACT",
       "value CompactionSummaryNotSmallerError",
       "value ContextBudgetExceededError",
-      "value DEFAULT_AGENT_MAX_INPUT_TOKENS",
       "value DEFAULT_MAX_IMAGE_ATTACHMENT_BYTES",
       "value IMAGE_PREPARE_LOG_MESSAGE",
       "value MAX_IMAGE_DECODED_PIXELS",
@@ -534,7 +535,10 @@
       "value encodeJsonl",
       "value servePssProtocol"
     ],
-    "./protocol/node": ["type SpawnPssClientOptions", "value spawnPssClient"],
+    "./protocol/node": [
+      "type SpawnPssClientOptions",
+      "value spawnPssClient"
+    ],
     "./testing": [
       "value agentEvent",
       "value agentEventStream",

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -535,10 +535,7 @@
       "value encodeJsonl",
       "value servePssProtocol"
     ],
-    "./protocol/node": [
-      "type SpawnPssClientOptions",
-      "value spawnPssClient"
-    ],
+    "./protocol/node": ["type SpawnPssClientOptions", "value spawnPssClient"],
     "./testing": [
       "value agentEvent",
       "value agentEventStream",

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -7,8 +7,10 @@ import { createInMemoryHost } from "../../platform/memory";
 import { AgentThread } from "../../thread/handle/agent-thread";
 import type { AgentInput } from "../../thread/input/input";
 import type { AgentTurn } from "../../thread/protocol/turn";
-import type { AgentCompaction } from "../../thread/runtime/auto-compaction-types";
-import { contextGateForCompaction } from "../../thread/runtime/speculative-compaction";
+import type {
+  AgentCompaction,
+  AgentCompactionPolicy,
+} from "../../thread/runtime/auto-compaction-types";
 import {
   normalizeThreadStateMigrations,
   type ThreadStateMigration,
@@ -29,7 +31,6 @@ import {
   type AgentOptions,
   assertAgentOptions,
   type CreateAgentOptions,
-  DEFAULT_AGENT_MAX_INPUT_TOKENS,
 } from "./options";
 import {
   type AgentThreadEntry,
@@ -71,7 +72,7 @@ export class Agent {
   readonly #hookRuntime: AgentHookRuntime;
   readonly #notificationOverlays?: AgentOptions["notificationOverlays"];
   readonly #threadMigrations: readonly ThreadStateMigration[];
-  readonly #compaction?: AgentCompaction;
+  readonly #compaction?: AgentCompaction | AgentCompactionPolicy;
   readonly host: AgentHost;
   readonly namespace?: string;
   constructor(options: AgentConstructorOptions) {
@@ -101,12 +102,10 @@ export class Agent {
         providedHost?.attachmentStore ??
         options.attachmentStore ??
         this.#host.attachmentStore,
-      contextGate: options.compaction
-        ? (contextGateForCompaction(options.compaction) ?? {
-            maxInputTokens: DEFAULT_AGENT_MAX_INPUT_TOKENS,
-            onOverflow: "compact",
-          })
-        : false,
+      contextGate:
+        typeof options.compaction === "function"
+          ? false
+          : (options.compaction ?? false),
       diagnostics: this.#host.diagnostics,
       instructions: options.instructions,
       model: options.model,

--- a/packages/runtime/src/agent/core/options-compaction.test.ts
+++ b/packages/runtime/src/agent/core/options-compaction.test.ts
@@ -3,12 +3,32 @@ import { createCallbackModel } from "../../testing/test-fixtures";
 import { assertAgentOptions } from "./options";
 
 describe("AgentOptions.compaction", () => {
-  it("rejects non-functions", () => {
+  it("rejects non-functions and non-policy objects", () => {
+    expect(() =>
+      assertAgentOptions({
+        compaction: 1 as never,
+        model: createCallbackModel(() => []),
+      })
+    ).toThrow(
+      "Agent: options.compaction must be a function or a compaction policy."
+    );
+  });
+
+  it("rejects a policy object without maxInputTokens", () => {
     expect(() =>
       assertAgentOptions({
         compaction: {} as never,
         model: createCallbackModel(() => []),
       })
-    ).toThrow("Agent: options.compaction must be a function.");
+    ).toThrow("Agent: options.compaction.maxInputTokens must be a function.");
+  });
+
+  it("accepts a budget-only policy object", () => {
+    expect(() =>
+      assertAgentOptions({
+        compaction: { maxInputTokens: () => 1, onOverflow: "error" },
+        model: createCallbackModel(() => []),
+      })
+    ).not.toThrow();
   });
 });

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -1,14 +1,17 @@
 import type { LanguageModel, ToolSet } from "ai";
 import type { RuntimeDiagnosticsSink } from "../../diagnostics";
 import type { AgentHost } from "../../execution/host/types";
-import type { ModelContextGateOptions } from "../../llm/context-gate";
+import type { ContextBudgetSource } from "../../llm/context-gate";
 import type { ContextTokenOptions } from "../../llm/context-tokens";
 import type { PrepareModelStep } from "../../llm/model-step-preparation";
 import type { AgentToolChoice } from "../../llm/model-step-types";
 import { assertNoUnsupportedToolApproval } from "../../llm/tool-approval";
 import type { HostAttachmentStore } from "../../thread/input/attachments";
 import type { AgentInput, UserInput } from "../../thread/input/input";
-import type { AgentCompaction } from "../../thread/runtime/auto-compaction-types";
+import type {
+  AgentCompaction,
+  AgentCompactionPolicy,
+} from "../../thread/runtime/auto-compaction-types";
 import {
   normalizeThreadStateMigrations,
   type ThreadStateMigration,
@@ -19,14 +22,10 @@ import {
   normalizeAgentInstrumentations,
 } from "./instrumentation";
 
-export const DEFAULT_AGENT_MAX_INPUT_TOKENS = 128_000;
-
-export type AgentContextGateOptions = ModelContextGateOptions;
-
 export interface AgentOptions {
   readonly alwaysActiveTools?: readonly string[];
   readonly attachmentStore?: HostAttachmentStore;
-  readonly compaction?: AgentCompaction;
+  readonly compaction?: AgentCompaction | AgentCompactionPolicy;
   readonly contextTokens?: ContextTokenOptions;
   readonly hooks?: AgentHooks;
   readonly host?: AgentHost;
@@ -56,7 +55,7 @@ export type AgentModelOptions = Pick<
   | "toolOrder"
   | "tools"
 > & {
-  readonly contextGate?: false | AgentContextGateOptions;
+  readonly contextGate?: false | ContextBudgetSource;
   readonly contextTokenMeter?: import("../../llm/context-tokens").ContextTokenMeter;
   readonly diagnostics?: RuntimeDiagnosticsSink;
 };
@@ -96,14 +95,43 @@ export function assertAgentOptions(
   ) {
     throw new TypeError("Agent: options.prepareModelStep must be a function.");
   }
-  if (
-    candidate.compaction !== undefined &&
-    typeof candidate.compaction !== "function"
-  ) {
-    throw new TypeError("Agent: options.compaction must be a function.");
+  if (candidate.compaction !== undefined) {
+    assertCompactionObject(candidate.compaction);
   }
   normalizeAgentInstrumentations(candidate.instrumentations);
   normalizeThreadStateMigrations(candidate.threadMigrations);
+}
+
+function assertCompactionObject(compaction: AgentOptions["compaction"]): void {
+  if (typeof compaction === "function") {
+    return;
+  }
+  if (compaction === null || typeof compaction !== "object") {
+    throw new TypeError(
+      "Agent: options.compaction must be a function or a compaction policy."
+    );
+  }
+  if (typeof compaction.maxInputTokens !== "function") {
+    throw new TypeError(
+      "Agent: options.compaction.maxInputTokens must be a function."
+    );
+  }
+  if (
+    compaction.compact !== undefined &&
+    typeof compaction.compact !== "function"
+  ) {
+    throw new TypeError(
+      "Agent: options.compaction.compact must be a function."
+    );
+  }
+  if (
+    compaction.estimateTokens !== undefined &&
+    typeof compaction.estimateTokens !== "function"
+  ) {
+    throw new TypeError(
+      "Agent: options.compaction.estimateTokens must be a function."
+    );
+  }
 }
 
 function assertToolNameList(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,7 +35,6 @@ export type {
   AgentTransformDecision,
   AgentTurnStartEvent,
 } from "./agent/core/hooks";
-export { DEFAULT_AGENT_MAX_INPUT_TOKENS } from "./agent/core/options";
 export { threadStoreKey } from "./agent/core/thread-entry";
 export {
   type ModelToolCacheFingerprintMetadata,
@@ -52,6 +51,7 @@ export type {
   ThreadEventReadOptions,
 } from "./execution/host/types";
 export type {
+  ContextBudgetSource,
   ModelContextTokenEstimateInput,
   ModelPromptMeasurement,
   ModelPromptMeasurementProfile,
@@ -177,6 +177,7 @@ export {
 export type {
   AgentCompaction,
   AgentCompactionContext,
+  AgentCompactionPolicy,
   AgentCompactionReason,
   CompactionSummaryOptions,
   ManualThreadCompactionResult,

--- a/packages/runtime/src/llm/attachment-hydration.test.ts
+++ b/packages/runtime/src/llm/attachment-hydration.test.ts
@@ -76,7 +76,7 @@ describe("model attachment hydration", () => {
     await runModelStep(
       {
         attachmentStore,
-        contextGate: { maxInputTokens: 200 },
+        contextGate: { maxInputTokens: () => 200 },
         model: fakeModel,
       },
       {

--- a/packages/runtime/src/llm/context-gate.test.ts
+++ b/packages/runtime/src/llm/context-gate.test.ts
@@ -129,7 +129,7 @@ describe("model prompt measurement", () => {
     ];
 
     enforceContextGate({
-      contextGate: { estimateTokens, maxInputTokens: 2 },
+      contextGate: { estimateTokens, maxInputTokens: () => 2 },
       instructions: "instruction",
       messages,
     });

--- a/packages/runtime/src/llm/context-gate.ts
+++ b/packages/runtime/src/llm/context-gate.ts
@@ -40,10 +40,16 @@ export interface ModelPromptMeasurementProfile {
   ) => ModelPromptMeasurement;
 }
 
-export interface ModelContextGateOptions {
+/**
+ * A budget source consulted before every model request. The gate calls
+ * `maxInputTokens()` (and `estimateTokens`, when provided) on each call, so
+ * hosts may back the budget with live signal such as the active model's
+ * context window.
+ */
+export interface ContextBudgetSource {
   readonly bufferTokens?: number;
   readonly estimateTokens?: (input: ModelContextTokenEstimateInput) => number;
-  readonly maxInputTokens: number;
+  readonly maxInputTokens: () => number;
   readonly onOverflow?: "compact" | "error";
 }
 
@@ -82,7 +88,7 @@ export function enforceContextGate({
   promptTools,
   toolChoice,
 }: {
-  readonly contextGate?: false | ModelContextGateOptions;
+  readonly contextGate?: false | ContextBudgetSource;
   readonly instructions?: string;
   readonly messages: readonly ModelMessage[];
   readonly promptTools?: readonly ModelPromptTool[];
@@ -93,6 +99,7 @@ export function enforceContextGate({
   }
 
   const bufferTokens = contextGate.bufferTokens ?? 0;
+  const maxInputTokens = contextGate.maxInputTokens();
   const estimatedTokens = estimatePromptTokens(
     {
       instructions,
@@ -102,21 +109,21 @@ export function enforceContextGate({
     },
     contextGate.estimateTokens
   );
-  if (estimatedTokens + bufferTokens <= contextGate.maxInputTokens) {
+  if (estimatedTokens + bufferTokens <= maxInputTokens) {
     return;
   }
 
   throw new ContextBudgetExceededError({
     bufferTokens,
     estimatedTokens,
-    maxInputTokens: contextGate.maxInputTokens,
+    maxInputTokens,
     onOverflow: contextGate.onOverflow ?? "compact",
   });
 }
 
 function estimatePromptTokens(
   input: ModelContextTokenEstimateInput,
-  estimator: ModelContextGateOptions["estimateTokens"]
+  estimator: ContextBudgetSource["estimateTokens"]
 ): number {
   if (estimator) {
     return estimator(input);

--- a/packages/runtime/src/llm/llm.test.ts
+++ b/packages/runtime/src/llm/llm.test.ts
@@ -673,7 +673,7 @@ describe("generateModelStep", () => {
           } as never,
           contextGate: {
             estimateTokens,
-            maxInputTokens: 100,
+            maxInputTokens: () => 100,
           },
           model: fakeModel,
           prepareModelStep: () => ({ activeTools: [] }),

--- a/packages/runtime/src/llm/model-step-types.ts
+++ b/packages/runtime/src/llm/model-step-types.ts
@@ -3,7 +3,7 @@ import type { RuntimeDiagnosticsSink } from "../diagnostics";
 import type { HostAttachmentStore } from "../thread/input/attachments";
 import type { ModelUsage, StreamAgentEvent } from "../thread/protocol/events";
 import type { ThreadContextMessage } from "../thread/state/context";
-import type { ModelContextGateOptions } from "./context-gate";
+import type { ContextBudgetSource } from "./context-gate";
 import type { ContextTokenMeter, ContextTokenOptions } from "./context-tokens";
 import type {
   PreparedModelToolChoice,
@@ -25,7 +25,7 @@ export interface ModelStepResult {
 export interface ModelGenerationOptions {
   alwaysActiveTools?: readonly string[];
   attachmentStore?: HostAttachmentStore;
-  contextGate?: false | ModelContextGateOptions;
+  contextGate?: false | ContextBudgetSource;
   contextTokenMeter?: ContextTokenMeter;
   contextTokens?: ContextTokenOptions;
   diagnostics?: RuntimeDiagnosticsSink;

--- a/packages/runtime/src/llm/model-step.ts
+++ b/packages/runtime/src/llm/model-step.ts
@@ -113,7 +113,7 @@ export async function generateModelStepResult({
     contextTokenMeter?.begin({
       attemptId,
       fixedFingerprint: promptMeasurement.fixedFingerprint,
-      maxInputTokens: contextGate ? contextGate.maxInputTokens : undefined,
+      maxInputTokens: contextGate ? contextGate.maxInputTokens() : undefined,
       measurement: promptMeasurement,
       scope,
     });

--- a/packages/runtime/src/thread/handle/automatic-compaction.test-support.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction.test-support.ts
@@ -2,7 +2,7 @@ import type { ModelMessage } from "ai";
 import { expect, vi } from "vitest";
 import { Agent } from "../../agent/core/agent";
 import type { AgentOptions } from "../../agent/core/options";
-import type { AgentCompaction } from "../runtime/auto-compaction-types";
+import type { AgentCompactionPolicy } from "../runtime/auto-compaction-types";
 import { speculativeCompaction } from "../runtime/speculative-compaction";
 
 export type CompactionAgentOptions = ConstructorParameters<typeof Agent>[0] & {
@@ -23,7 +23,7 @@ export const tokenCompactionPolicy = ({
 }: {
   readonly retain: number;
   readonly trigger: number;
-}): AgentCompaction => {
+}): AgentCompactionPolicy => {
   const maxInputTokens = 10_000;
   return speculativeCompaction({
     estimateTokens: tenTokensPerMessage,

--- a/packages/runtime/src/thread/handle/compaction-budget-policy.test.ts
+++ b/packages/runtime/src/thread/handle/compaction-budget-policy.test.ts
@@ -1,0 +1,103 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { hostWithThreads } from "../../testing/host-with-threads";
+import {
+  assistantMessage,
+  createCallbackModel,
+} from "../../testing/test-fixtures";
+import type { AgentCompactionReason } from "../runtime/auto-compaction-types";
+import { agentWithCompaction } from "./automatic-compaction.test-support";
+import { collect, SpyStore } from "./test-support";
+
+const oversizedUserText = "x".repeat(400);
+const beyondLegacyDefaultUserText = "y".repeat(600_000);
+const gateRejectedPattern = /context gate rejected prompt/;
+
+describe("Agent compaction budget policy", () => {
+  it("rejects an over-budget prompt through the policy methods and recovers by invoking compact with reason overflow", async () => {
+    const seenReasons: AgentCompactionReason[] = [];
+    const maxInputTokens = vi.fn(() => 64);
+    const compact = vi.fn(
+      (context: {
+        readonly history: readonly ModelMessage[];
+        readonly reason: AgentCompactionReason;
+      }) => {
+        seenReasons.push(context.reason);
+        return { endSeqExclusive: 1, startSeq: 0, summary: "S" };
+      }
+    );
+    let calls = 0;
+    const agent = agentWithCompaction({
+      compaction: { compact, maxInputTokens, onOverflow: "compact" },
+      host: hostWithThreads(new SpyStore()),
+      model: createCallbackModel(() => {
+        calls += 1;
+        return [assistantMessage("DONE")];
+      }),
+    });
+    const thread = agent.thread("policy-overflow");
+
+    const events = await collect(await thread.send(oversizedUserText));
+
+    expect(maxInputTokens.mock.calls.length).toBeGreaterThan(0);
+    expect(seenReasons).toEqual(["overflow"]);
+    expect(events).toContainEqual({ text: "DONE", type: "assistant-output" });
+    expect(calls).toBe(1);
+  });
+
+  it("does not locally gate a bare compaction function against any default budget", async () => {
+    const seenReasons: AgentCompactionReason[] = [];
+    let calls = 0;
+    const histories: ModelMessage[][] = [];
+    const agent = agentWithCompaction({
+      compaction: (context: { readonly reason: AgentCompactionReason }) => {
+        seenReasons.push(context.reason);
+        return;
+      },
+      host: hostWithThreads(new SpyStore()),
+      model: createCallbackModel(({ history }) => {
+        calls += 1;
+        histories.push([...history]);
+        return [assistantMessage("DONE")];
+      }),
+    });
+    const thread = agent.thread("bare-function-no-gate");
+
+    const events = await collect(
+      await thread.send(beyondLegacyDefaultUserText)
+    );
+
+    expect(events).toContainEqual({ text: "DONE", type: "assistant-output" });
+    expect(calls).toBe(1);
+    expect(seenReasons).not.toContain("overflow");
+    expect(
+      histories[0]?.some((message) =>
+        JSON.stringify(message).includes(beyondLegacyDefaultUserText)
+      )
+    ).toBe(true);
+  });
+
+  it("propagates ContextBudgetExceededError when the budget source selects error mode without a compact method", async () => {
+    let calls = 0;
+    const agent = agentWithCompaction({
+      compaction: { maxInputTokens: () => 64, onOverflow: "error" },
+      host: hostWithThreads(new SpyStore()),
+      model: createCallbackModel(() => {
+        calls += 1;
+        return [assistantMessage("DONE")];
+      }),
+    });
+    const thread = agent.thread("policy-error-mode");
+
+    const events = await collect(await thread.send(oversizedUserText));
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "turn-error" &&
+          gateRejectedPattern.test(event.message)
+      )
+    ).toBe(true);
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/runtime/src/thread/handle/compaction-budget-policy.test.ts
+++ b/packages/runtime/src/thread/handle/compaction-budget-policy.test.ts
@@ -94,8 +94,7 @@ describe("Agent compaction budget policy", () => {
     expect(
       events.some(
         (event) =>
-          event.type === "turn-error" &&
-          gateRejectedPattern.test(event.message)
+          event.type === "turn-error" && gateRejectedPattern.test(event.message)
       )
     ).toBe(true);
     expect(calls).toBe(0);

--- a/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
@@ -15,6 +15,7 @@ import {
 } from "./auto-compaction-summary";
 import type {
   AgentCompaction,
+  AgentCompactionPolicy,
   AgentCompactionReason,
   AutoCompactionRange,
   CompactionSummaryOptions,
@@ -22,8 +23,11 @@ import type {
   ThreadContextTransformObserver,
   ThreadModelContextTransform,
 } from "./auto-compaction-types";
+import {
+  invokeCompaction,
+  threadEstimatorForCompaction,
+} from "./auto-compaction-types";
 import { equalSnapshot } from "./snapshot-equal";
-import { estimatorForCompaction } from "./speculative-compaction";
 
 interface ActiveCompaction {
   readonly promise: Promise<boolean>;
@@ -37,7 +41,7 @@ const pendingCompactions = new WeakMap<
 
 interface RunOptions {
   readonly compact?: ThreadCompactionHandler;
-  readonly compaction?: AgentCompaction;
+  readonly compaction?: AgentCompaction | AgentCompactionPolicy;
   readonly latestContextTransform?: ThreadContextTransformObserver;
   readonly model: ModelGenerationOptions;
   readonly reason: AgentCompactionReason;
@@ -129,7 +133,7 @@ function runSingleFlight(options: RunOptions): Promise<boolean> {
 async function compactThreadOnce(options: RunOptions): Promise<boolean> {
   const { state } = options;
   const legacyEstimate = options.compaction
-    ? estimatorForCompaction(options.compaction)
+    ? threadEstimatorForCompaction(options.compaction)
     : undefined;
   const meterView = legacyEstimate
     ? undefined
@@ -209,25 +213,28 @@ ${summaryOptions.instructions}`,
       transformModelContext: options.transformModelContext,
     });
   };
-  const input = await options.compaction?.(
-    Object.freeze({
-      compactions,
-      estimatedContextTokens,
-      estimatedHistory,
-      ...(estimatedHistoryMessageTokens
-        ? { estimatedHistoryMessageTokens }
-        : {}),
-      estimateTokens: estimate,
-      history,
-      instructionsTokens: fixedTokens,
-      modelContext: hydratedModelContext,
-      reason: options.reason,
-      signal,
-      summarize,
-      threadIdentity: state.compactionIdentity,
-      threadKey: options.threadKey,
-    })
-  );
+  const input = options.compaction
+    ? await invokeCompaction(
+        options.compaction,
+        Object.freeze({
+          compactions,
+          estimatedContextTokens,
+          estimatedHistory,
+          ...(estimatedHistoryMessageTokens
+            ? { estimatedHistoryMessageTokens }
+            : {}),
+          estimateTokens: estimate,
+          history,
+          instructionsTokens: fixedTokens,
+          modelContext: hydratedModelContext,
+          reason: options.reason,
+          signal,
+          summarize,
+          threadIdentity: state.compactionIdentity,
+          threadKey: options.threadKey,
+        })
+      )
+    : undefined;
   if (!input) {
     return false;
   }

--- a/packages/runtime/src/thread/runtime/auto-compaction-types.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-types.ts
@@ -1,4 +1,5 @@
 import type { ModelMessage } from "ai";
+import type { ContextBudgetSource } from "../../llm/context-gate";
 import type { ThreadContextMessage } from "../state/context";
 import type { ThreadCompactionRecord } from "../state/snapshot";
 import type { ThreadCompactionInput } from "../state/thread-state";
@@ -50,6 +51,46 @@ export type AgentCompaction = (
   | ThreadCompactionInput
   | undefined
   | Promise<ThreadCompactionInput | undefined>;
+
+/**
+ * A compaction strategy that owns the context budget it compacts toward. The
+ * runtime passes the policy straight to the model-step context gate, which
+ * calls `maxInputTokens()` (and `estimateTokens`, when provided) before every
+ * model request. A policy without `compact` is a budget-only source: pair it
+ * with `onOverflow: "error"` to fail over-budget turns without rewriting
+ * history.
+ */
+export interface AgentCompactionPolicy extends ContextBudgetSource {
+  readonly compact?: (
+    context: Readonly<AgentCompactionContext>
+  ) =>
+    | ThreadCompactionInput
+    | undefined
+    | Promise<ThreadCompactionInput | undefined>;
+}
+
+export function invokeCompaction(
+  compaction: AgentCompaction | AgentCompactionPolicy,
+  context: Readonly<AgentCompactionContext>
+):
+  | ThreadCompactionInput
+  | undefined
+  | Promise<ThreadCompactionInput | undefined> {
+  return typeof compaction === "function"
+    ? compaction(context)
+    : compaction.compact?.(context);
+}
+
+/** The thread-history estimator pinned by a policy, when it provides one. */
+export function threadEstimatorForCompaction(
+  compaction: AgentCompaction | AgentCompactionPolicy
+): ThreadTokenEstimator | undefined {
+  if (typeof compaction === "function" || !compaction.estimateTokens) {
+    return;
+  }
+  const estimateTokens = compaction.estimateTokens;
+  return (messages) => estimateTokens({ messages });
+}
 
 export type ThreadModelContextTransform = (
   messages: readonly ThreadContextMessage[],

--- a/packages/runtime/src/thread/runtime/execution.ts
+++ b/packages/runtime/src/thread/runtime/execution.ts
@@ -9,7 +9,10 @@ import type {
 } from "../../execution/host/types";
 import type { RuntimeToolExecutionContext } from "../../llm/tool-execution-types";
 import type { ThreadState } from "../state/thread-state";
-import type { AgentCompaction } from "./auto-compaction-types";
+import type {
+  AgentCompaction,
+  AgentCompactionPolicy,
+} from "./auto-compaction-types";
 import {
   createThreadToolExecutionContext,
   type ThreadToolCallInterceptor,
@@ -17,7 +20,7 @@ import {
 } from "./execution-checkpoints";
 
 export interface ThreadExecutionOptions {
-  readonly compaction?: AgentCompaction;
+  readonly compaction?: AgentCompaction | AgentCompactionPolicy;
   readonly executionHost?: AgentHost;
   readonly hookRuntime?: AgentHookRuntime;
 }

--- a/packages/runtime/src/thread/runtime/speculative-compaction.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction.test.ts
@@ -1,11 +1,7 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentCompactionContext } from "./auto-compaction-types";
-import {
-  contextGateForCompaction,
-  estimatorForCompaction,
-  speculativeCompaction,
-} from "./speculative-compaction";
+import { speculativeCompaction } from "./speculative-compaction";
 
 const message = (
   content: string,
@@ -44,23 +40,20 @@ describe("speculativeCompaction", () => {
     expect(() => speculativeCompaction(options)).toThrow(TypeError);
   });
 
-  it("leaves default token accounting to the runtime context meter", () => {
+  it("exposes its budget through the policy surface without an estimator", () => {
     const compaction = speculativeCompaction({ maxInputTokens: 100 });
 
-    expect(estimatorForCompaction(compaction)).toBeUndefined();
-    expect(contextGateForCompaction(compaction)).toEqual({
-      maxInputTokens: 100,
-      onOverflow: "compact",
-    });
+    expect(compaction.estimateTokens).toBeUndefined();
+    expect(compaction.maxInputTokens()).toBe(100);
+    expect(compaction.onOverflow).toBe("compact");
   });
 
   it("preserves an explicit token estimator as a complete override", () => {
     const estimateTokens = vi.fn(() => 17);
     const compaction = speculativeCompaction({ estimateTokens });
 
-    expect(estimatorForCompaction(compaction)).toBe(estimateTokens);
     expect(
-      contextGateForCompaction(compaction)?.estimateTokens?.({
+      compaction.estimateTokens?.({
         instructions: "system",
         messages: [message("user")],
       })
@@ -85,9 +78,9 @@ describe("speculativeCompaction", () => {
     );
 
     expect(
-      await compaction(context(preparedHistory, summarize))
+      await compaction.compact?.(context(preparedHistory, summarize))
     ).toBeUndefined();
-    const promoted = await compaction(
+    const promoted = await compaction.compact?.(
       context([...preparedHistory, message("tail")], summarize)
     );
 
@@ -108,8 +101,10 @@ describe("speculativeCompaction", () => {
       message(String(index), index % 2 === 0 ? "user" : "assistant")
     );
 
-    await compaction(context(history, summarize));
-    await compaction(context([...history, message("tail")], summarize));
+    await compaction.compact?.(context(history, summarize));
+    await compaction.compact?.(
+      context([...history, message("tail")], summarize)
+    );
 
     expect(summarize).toHaveBeenCalledTimes(1);
   });
@@ -129,12 +124,12 @@ describe("speculativeCompaction", () => {
     const history = Array.from({ length: 6 }, (_, index) =>
       message(String(index), index % 2 === 0 ? "user" : "assistant")
     );
-    await compaction(context(history, summarize));
+    await compaction.compact?.(context(history, summarize));
     const changed = history.map((entry, index) =>
       index === 0 ? message("changed") : entry
     );
 
-    const promoted = await compaction(
+    const promoted = await compaction.compact?.(
       context([...changed, message("tail")], summarize)
     );
 
@@ -156,9 +151,9 @@ describe("speculativeCompaction", () => {
     const history = Array.from({ length: 6 }, (_, index) =>
       message(String(index), index % 2 === 0 ? "user" : "assistant")
     );
-    await compaction(context(history, summarizeA));
+    await compaction.compact?.(context(history, summarizeA));
 
-    const promoted = await compaction(
+    const promoted = await compaction.compact?.(
       context([...history, message("tail")], summarizeB, {
         threadIdentity: identityB,
       })
@@ -184,7 +179,7 @@ describe("speculativeCompaction", () => {
     const prepared = Array.from({ length: 6 }, (_, index) =>
       message(String(index), index % 2 === 0 ? "user" : "assistant")
     );
-    await compaction(context(prepared, summarize));
+    await compaction.compact?.(context(prepared, summarize));
     const overflowHistory = [
       ...prepared,
       message("6"),
@@ -193,7 +188,7 @@ describe("speculativeCompaction", () => {
       message("9", "assistant"),
     ];
 
-    const promoted = await compaction(
+    const promoted = await compaction.compact?.(
       context(overflowHistory, summarize, { reason: "overflow" })
     );
 

--- a/packages/runtime/src/thread/runtime/speculative-compaction.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction.ts
@@ -1,9 +1,11 @@
-import type { ModelContextGateOptions } from "../../llm/context-gate";
-import { estimateModelMessagesTokens } from "../../llm/context-gate";
+import {
+  estimateModelMessagesTokens,
+  type ModelContextTokenEstimateInput,
+} from "../../llm/context-gate";
 import { selectAutoCompactionRange } from "./auto-compaction-range";
 import type {
-  AgentCompaction,
   AgentCompactionContext,
+  AgentCompactionPolicy,
   ThreadTokenEstimator,
 } from "./auto-compaction-types";
 import { equalSnapshot } from "./snapshot-equal";
@@ -26,31 +28,13 @@ interface Candidate {
   readonly prefix: readonly unknown[];
 }
 
-const contextGateMetadata = new WeakMap<
-  AgentCompaction,
-  ModelContextGateOptions
->();
-const estimatorMetadata = new WeakMap<AgentCompaction, ThreadTokenEstimator>();
-
-export function contextGateForCompaction(
-  compaction: AgentCompaction
-): ModelContextGateOptions | undefined {
-  return contextGateMetadata.get(compaction);
-}
-
-export function estimatorForCompaction(
-  compaction: AgentCompaction
-): ThreadTokenEstimator | undefined {
-  return estimatorMetadata.get(compaction);
-}
-
 /**
  * Prepare a summary at 65% of the context budget and promote it at 80% without
  * another model call. By default the newest 40% of the model context is kept.
  */
 export function speculativeCompaction(
   options: SpeculativeCompactionOptions = {}
-): AgentCompaction {
+): AgentCompactionPolicy {
   const max = options.maxInputTokens ?? 128_000;
   const prepare = options.prepareRatio ?? 0.65;
   const promote = options.promoteRatio ?? 0.8;
@@ -79,7 +63,7 @@ export function speculativeCompaction(
   const customEstimate = options.estimateTokens;
   const estimate = customEstimate ?? estimateModelMessagesTokens;
   const candidates = new WeakMap<object, Candidate>();
-  const compaction: AgentCompaction = async (context) => {
+  const compact = async (context: AgentCompactionContext) => {
     const tokens = context.estimatedContextTokens;
     const candidate = getFreshCandidate(candidates, context);
     if (tokens >= Math.floor(max * promote) || context.reason === "overflow") {
@@ -98,10 +82,14 @@ export function speculativeCompaction(
     await prepareCandidate({ candidates, context, estimate, max, retain });
     return;
   };
-  contextGateMetadata.set(compaction, {
+  return {
+    compact,
     ...(customEstimate
       ? {
-          estimateTokens: ({ instructions, messages }) =>
+          estimateTokens: ({
+            instructions,
+            messages,
+          }: ModelContextTokenEstimateInput) =>
             customEstimate(
               instructions
                 ? [{ content: instructions, role: "system" }, ...messages]
@@ -109,13 +97,9 @@ export function speculativeCompaction(
             ),
         }
       : {}),
-    maxInputTokens: max,
-    onOverflow: "compact",
-  });
-  if (customEstimate) {
-    estimatorMetadata.set(compaction, customEstimate);
-  }
-  return compaction;
+    maxInputTokens: () => max,
+    onOverflow: "compact" as const,
+  };
 }
 
 async function prepareCandidate({


### PR DESCRIPTION
## Summary

Reshapes the runtime compaction surface so the context budget can no longer decouple from the compaction strategy — the failure mode behind the production incident part of #365 (item 1). Items 2 (overflow boundary relaxation) and 3 (persistent speculative candidates) are deliberately out of scope; the issue stays open.

- `createAgent` accepts a compaction **policy object** (`AgentCompactionPolicy extends ContextBudgetSource`): `maxInputTokens()`, `estimateTokens?`, `bufferTokens?`, `onOverflow?`, `compact?`. The runtime passes it straight to the model-step context gate, which calls `maxInputTokens()\) before every model request — the budget and the compaction thresholds share one source of truth.
- `speculativeCompaction()` now returns that policy shape; the module-private metadata WeakMaps (`contextGateForCompaction`, `estimatorForCompaction`) and the silent `DEFAULT_AGENT_MAX_INPUT_TOKENS` (128K) fallback are gone, along with the export.
- A bare `AgentCompaction` function carries no budget, so the local gate stays off and compaction reacts to provider-thrown context-window errors only — no more silently assumed 128K budget on custom strategies.
- A policy without `compact` is a budget-only source; pair it with `onOverflow: "error"` to fail over-budget turns without rewriting history. This replaces the need for a separate `createAgent({ contextGate })` option: one public knob covers both.

Related: #365 (left open; no closing keyword on purpose).

## Behavior changes

- Custom bare-function compaction: the local context gate no longer assumes 128_000 input tokens; overflow handling relies on provider errors. Hosts that depended on the old implicit 128K gate should switch to a policy object with an explicit `maxInputTokens`.
- `DEFAULT_AGENT_MAX_INPUT_TOKENS` is removed from the root barrel (public-api snapshot updated).

## Verification

- New agent-level suite `thread/handle/compaction-budget-policy.test.ts` (RED-first on old code: `TypeError: options.compaction must be a function` / gate rejection):
  - policy object + over-budget prompt → gate rejects via `maxInputTokens()` → overflow compaction runs `compact` with reason `overflow` → turn completes
  - bare function + >128K prompt → no local rejection, turn completes
  - budget-only `{ onOverflow: "error" }` → `turn-error` with the gate message, model never called
- `packages/runtime`: `pnpm test` → **155 files / 1109 tests passed**; `tsc --noEmit` clean; biome clean; tsdown build green; `public-api.snapshot.json` regenerated (`+type AgentCompactionPolicy`, `+type ContextBudgetSource`, `-value DEFAULT_AGENT_MAX_INPUT_TOKENS`).
- Consumers: `apps/coding-agent` 809 tests, `apps/worker-agent` 173 tests green (only assertions pinning the old function shape needed migration).
- Full monorepo: `turbo run test` → **18/18 tasks green**; root `vitest run scripts/*.test.mjs` → **85/85** (a stale gitignored `.artifacts/nextjs-bench/results` directory that broke the boundaries test setup was removed; unrelated to this change).
- Real-surface smoke against the built package (`dist/index.js` via `node` + `MockLanguageModelV4`): policy + 400-char prompt → `{"reasons":["overflow"],"outputs":["DONE"],"gateCalls":4,"ok":true}`; smoke artifacts removed afterwards.

## Notes

- High default turbo concurrency (`--concurrency=10`) made unrelated suites flake on this box (resource timeouts); every suite passes in isolation and the 18/18 pass was taken at `--concurrency=4`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted agent compaction to budget-owning policy objects so the context budget and compaction strategy stay in sync. This removes the silent 128K fallback and prevents gate/strategy drift that caused the incident in #365 (item 1).

- **New Features**
  - `createAgent({ compaction })` now accepts a policy object (`AgentCompactionPolicy extends ContextBudgetSource`) or a function.
  - The context gate calls `maxInputTokens()` on every request; optional `estimateTokens`, `bufferTokens`, `onOverflow`, and `compact`.
  - `speculativeCompaction()` now returns a policy object.
  - Bare `AgentCompaction` functions no longer enable a local gate; they rely on provider overflow errors.
  - Public API: `+type AgentCompactionPolicy`, `+type ContextBudgetSource`; `DEFAULT_AGENT_MAX_INPUT_TOKENS` removed.

- **Migration**
  - If you relied on the implicit 128K budget, switch to a policy with `maxInputTokens`.
  - Replace `DEFAULT_AGENT_MAX_INPUT_TOKENS` with an explicit budget in a policy.
  - Stop using `contextGateForCompaction` and `estimatorForCompaction`; set `estimateTokens` on the policy or use the `speculativeCompaction()` policy.
  - If passing a `contextGate` directly, update `maxInputTokens` to be a function: `() => number`.

<sup>Written for commit 806295ef72cbf2f4cf954fc2778bc8f5e1d8331e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

