### PR TITLE
refactor(runtime): carry compaction budget as function properties

### DIFF
--- a/.tegami/2026-08-08-compaction-budget-props.md
+++ b/.tegami/2026-08-08-compaction-budget-props.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Carry the compaction budget as function properties
+
+The `compaction` option is a single callable type again: `AgentCompaction` gains optional budget properties (`maxInputTokens`, `estimateTokens`, `bufferTokens`, `onOverflow`), and when `maxInputTokens` is present the runtime hands the function itself to the model-step context gate, which calls it before every model request. `speculativeCompaction` returns the callable with its budget attached; `AgentCompactionPolicy` and the interim policy-object form from 0.3.0-next.11 are removed. Bare functions without budget properties keep the local gate off.

--- a/apps/coding-agent/src/thread-config.test.ts
+++ b/apps/coding-agent/src/thread-config.test.ts
@@ -82,9 +82,16 @@ describe("resolveCodingAgentThreadConfig", () => {
         "/repo/demo",
         "/home/me"
       ).compaction
-    ).toMatchObject({
-      compact: expect.any(Function),
-      maxInputTokens: expect.any(Function),
-    });
+    ).toBeTypeOf("function");
+    expect(
+      resolveCodingAgentThreadConfig(
+        {
+          PSS_AUTO_COMPACTION_MIN_MESSAGES: "12",
+          PSS_AUTO_COMPACTION_RETAIN_MESSAGES: "4",
+        },
+        "/repo/demo",
+        "/home/me"
+      ).compaction?.maxInputTokens?.()
+    ).toBe(128_000);
   });
 });

--- a/apps/worker-agent/src/agent/agent.test.ts
+++ b/apps/worker-agent/src/agent/agent.test.ts
@@ -8,11 +8,9 @@ import {
 } from "./agent";
 
 describe("worker-agent compaction", () => {
-  it("uses a budget-owning policy strategy", () => {
-    expect(WORKER_AGENT_COMPACTION).toMatchObject({
-      compact: expect.any(Function),
-      maxInputTokens: expect.any(Function),
-    });
+  it("uses a callable strategy that carries its budget", () => {
+    expect(WORKER_AGENT_COMPACTION).toBeTypeOf("function");
+    expect(WORKER_AGENT_COMPACTION.maxInputTokens?.()).toBe(128_000);
   });
 });
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1202,13 +1202,15 @@ const agent = await createAgent({
 });
 ```
 
-`compaction` accepts either a policy object or a bare compaction function. A
-policy owns the context budget it compacts toward:
+A compaction function may advertise the context budget it compacts toward by
+carrying budget properties. The runtime passes the function itself to the
+context gate, so the budget and the compaction thresholds can never drift
+apart:
 
 ```ts
 const agent = await createAgent({
-  compaction: {
-    compact: async (context) => {
+  compaction: Object.assign(
+    async (context) => {
       if (context.reason !== "overflow") {
         return;
       }
@@ -1218,23 +1220,23 @@ const agent = await createAgent({
       };
       return { ...range, summary: await context.summarize(range) };
     },
-    // The gate calls this before every model request; return the active
-    // model's window here.
-    maxInputTokens: () => 200_000,
-    onOverflow: "compact",
-  },
+    {
+      // The gate calls this before every model request; return the active
+      // model's window here.
+      maxInputTokens: () => 200_000,
+      onOverflow: "compact",
+    }
+  ),
   model,
 });
 ```
 
-The runtime passes the policy straight to the context gate, so the budget and
-the compaction thresholds can never drift apart. `estimateTokens` overrides the
-prompt estimator for both the gate and the compaction context; `bufferTokens`
-reserves headroom inside the budget. A policy without `compact` is a
-budget-only source: pair it with `onOverflow: "error"` to fail over-budget
-turns without rewriting history. A bare `AgentCompaction` function carries no
-budget, so the local gate stays off and compaction reacts to provider-thrown
-context-window errors only.
+`estimateTokens` overrides the prompt estimator for both the gate and the
+compaction context; `bufferTokens` reserves headroom inside the budget. Attach
+`maxInputTokens` plus `onOverflow: "error"` to a no-op function to fail
+over-budget turns without rewriting history. A bare function without budget
+properties runs with the local gate off and compaction reacts to
+provider-thrown context-window errors only.
 
 Force runtime-owned compaction on an idle thread with `thread.compact()`. The
 manual path shares automatic compaction's attachment hydration, model-context
@@ -1254,7 +1256,7 @@ available for hosts that already produced a validated summary and returns the
 hook dispatcher's boolean commit decision.
 
 The context gate estimates the prompt immediately before `generateText`, calling
-the policy's `maxInputTokens()` on every request. With `onOverflow: "error"`,
+the compaction's `maxInputTokens` property on every request. With `onOverflow: "error"`,
 the turn fails before the provider is called. With `onOverflow: "compact"` (the
 default), the runtime runs blocking compaction and retries once.
 Provider-thrown context-window errors still use the same blocking

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -8,7 +8,6 @@
       "type AgentCompactionContext",
       "type AgentCompactionDecision",
       "type AgentCompactionEvent",
-      "type AgentCompactionPolicy",
       "type AgentCompactionReason",
       "type AgentEvent",
       "type AgentEventListener",

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -7,10 +7,7 @@ import { createInMemoryHost } from "../../platform/memory";
 import { AgentThread } from "../../thread/handle/agent-thread";
 import type { AgentInput } from "../../thread/input/input";
 import type { AgentTurn } from "../../thread/protocol/turn";
-import type {
-  AgentCompaction,
-  AgentCompactionPolicy,
-} from "../../thread/runtime/auto-compaction-types";
+import type { AgentCompaction } from "../../thread/runtime/auto-compaction-types";
 import {
   normalizeThreadStateMigrations,
   type ThreadStateMigration,
@@ -72,7 +69,7 @@ export class Agent {
   readonly #hookRuntime: AgentHookRuntime;
   readonly #notificationOverlays?: AgentOptions["notificationOverlays"];
   readonly #threadMigrations: readonly ThreadStateMigration[];
-  readonly #compaction?: AgentCompaction | AgentCompactionPolicy;
+  readonly #compaction?: AgentCompaction;
   readonly host: AgentHost;
   readonly namespace?: string;
   constructor(options: AgentConstructorOptions) {
@@ -102,10 +99,12 @@ export class Agent {
         providedHost?.attachmentStore ??
         options.attachmentStore ??
         this.#host.attachmentStore,
-      contextGate:
-        typeof options.compaction === "function"
-          ? false
-          : (options.compaction ?? false),
+      contextGate: options.compaction?.maxInputTokens
+        ? {
+            ...options.compaction,
+            maxInputTokens: options.compaction.maxInputTokens,
+          }
+        : false,
       diagnostics: this.#host.diagnostics,
       instructions: options.instructions,
       model: options.model,

--- a/packages/runtime/src/agent/core/options-compaction.test.ts
+++ b/packages/runtime/src/agent/core/options-compaction.test.ts
@@ -3,30 +3,42 @@ import { createCallbackModel } from "../../testing/test-fixtures";
 import { assertAgentOptions } from "./options";
 
 describe("AgentOptions.compaction", () => {
-  it("rejects non-functions and non-policy objects", () => {
-    expect(() =>
-      assertAgentOptions({
-        compaction: 1 as never,
-        model: createCallbackModel(() => []),
-      })
-    ).toThrow(
-      "Agent: options.compaction must be a function or a compaction policy."
-    );
-  });
-
-  it("rejects a policy object without maxInputTokens", () => {
+  it("rejects non-functions", () => {
     expect(() =>
       assertAgentOptions({
         compaction: {} as never,
         model: createCallbackModel(() => []),
       })
+    ).toThrow("Agent: options.compaction must be a function.");
+  });
+
+  it("rejects a function with a non-function maxInputTokens property", () => {
+    expect(() =>
+      assertAgentOptions({
+        compaction: Object.assign(() => undefined, { maxInputTokens: 1 }),
+        model: createCallbackModel(() => []),
+      })
     ).toThrow("Agent: options.compaction.maxInputTokens must be a function.");
   });
 
-  it("accepts a budget-only policy object", () => {
+  it("rejects a function with an invalid onOverflow property", () => {
     expect(() =>
       assertAgentOptions({
-        compaction: { maxInputTokens: () => 1, onOverflow: "error" },
+        compaction: Object.assign(() => undefined, { onOverflow: "retry" }),
+        model: createCallbackModel(() => []),
+      })
+    ).toThrow(
+      'Agent: options.compaction.onOverflow must be "compact" or "error".'
+    );
+  });
+
+  it("accepts a function carrying budget properties", () => {
+    expect(() =>
+      assertAgentOptions({
+        compaction: Object.assign(() => undefined, {
+          maxInputTokens: () => 1,
+          onOverflow: "error",
+        }),
         model: createCallbackModel(() => []),
       })
     ).not.toThrow();

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -8,10 +8,7 @@ import type { AgentToolChoice } from "../../llm/model-step-types";
 import { assertNoUnsupportedToolApproval } from "../../llm/tool-approval";
 import type { HostAttachmentStore } from "../../thread/input/attachments";
 import type { AgentInput, UserInput } from "../../thread/input/input";
-import type {
-  AgentCompaction,
-  AgentCompactionPolicy,
-} from "../../thread/runtime/auto-compaction-types";
+import type { AgentCompaction } from "../../thread/runtime/auto-compaction-types";
 import {
   normalizeThreadStateMigrations,
   type ThreadStateMigration,
@@ -25,7 +22,7 @@ import {
 export interface AgentOptions {
   readonly alwaysActiveTools?: readonly string[];
   readonly attachmentStore?: HostAttachmentStore;
-  readonly compaction?: AgentCompaction | AgentCompactionPolicy;
+  readonly compaction?: AgentCompaction;
   readonly contextTokens?: ContextTokenOptions;
   readonly hooks?: AgentHooks;
   readonly host?: AgentHost;
@@ -103,25 +100,15 @@ export function assertAgentOptions(
 }
 
 function assertCompactionObject(compaction: AgentOptions["compaction"]): void {
-  if (typeof compaction === "function") {
-    return;
-  }
-  if (compaction === null || typeof compaction !== "object") {
-    throw new TypeError(
-      "Agent: options.compaction must be a function or a compaction policy."
-    );
-  }
-  if (typeof compaction.maxInputTokens !== "function") {
-    throw new TypeError(
-      "Agent: options.compaction.maxInputTokens must be a function."
-    );
+  if (typeof compaction !== "function") {
+    throw new TypeError("Agent: options.compaction must be a function.");
   }
   if (
-    compaction.compact !== undefined &&
-    typeof compaction.compact !== "function"
+    compaction.maxInputTokens !== undefined &&
+    typeof compaction.maxInputTokens !== "function"
   ) {
     throw new TypeError(
-      "Agent: options.compaction.compact must be a function."
+      "Agent: options.compaction.maxInputTokens must be a function."
     );
   }
   if (
@@ -130,6 +117,15 @@ function assertCompactionObject(compaction: AgentOptions["compaction"]): void {
   ) {
     throw new TypeError(
       "Agent: options.compaction.estimateTokens must be a function."
+    );
+  }
+  if (
+    compaction.onOverflow !== undefined &&
+    compaction.onOverflow !== "compact" &&
+    compaction.onOverflow !== "error"
+  ) {
+    throw new TypeError(
+      'Agent: options.compaction.onOverflow must be "compact" or "error".'
     );
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -177,7 +177,6 @@ export {
 export type {
   AgentCompaction,
   AgentCompactionContext,
-  AgentCompactionPolicy,
   AgentCompactionReason,
   CompactionSummaryOptions,
   ManualThreadCompactionResult,

--- a/packages/runtime/src/thread/handle/automatic-compaction.test-support.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction.test-support.ts
@@ -2,7 +2,7 @@ import type { ModelMessage } from "ai";
 import { expect, vi } from "vitest";
 import { Agent } from "../../agent/core/agent";
 import type { AgentOptions } from "../../agent/core/options";
-import type { AgentCompactionPolicy } from "../runtime/auto-compaction-types";
+import type { AgentCompaction } from "../runtime/auto-compaction-types";
 import { speculativeCompaction } from "../runtime/speculative-compaction";
 
 export type CompactionAgentOptions = ConstructorParameters<typeof Agent>[0] & {
@@ -23,7 +23,7 @@ export const tokenCompactionPolicy = ({
 }: {
   readonly retain: number;
   readonly trigger: number;
-}): AgentCompactionPolicy => {
+}): AgentCompaction => {
   const maxInputTokens = 10_000;
   return speculativeCompaction({
     estimateTokens: tenTokensPerMessage,

--- a/packages/runtime/src/thread/handle/compaction-budget-policy.test.ts
+++ b/packages/runtime/src/thread/handle/compaction-budget-policy.test.ts
@@ -26,9 +26,13 @@ describe("Agent compaction budget policy", () => {
         return { endSeqExclusive: 1, startSeq: 0, summary: "S" };
       }
     );
+    const compaction = Object.assign(compact, {
+      maxInputTokens,
+      onOverflow: "compact" as const,
+    });
     let calls = 0;
     const agent = agentWithCompaction({
-      compaction: { compact, maxInputTokens, onOverflow: "compact" },
+      compaction,
       host: hostWithThreads(new SpyStore()),
       model: createCallbackModel(() => {
         calls += 1;
@@ -80,7 +84,10 @@ describe("Agent compaction budget policy", () => {
   it("propagates ContextBudgetExceededError when the budget source selects error mode without a compact method", async () => {
     let calls = 0;
     const agent = agentWithCompaction({
-      compaction: { maxInputTokens: () => 64, onOverflow: "error" },
+      compaction: Object.assign(() => undefined, {
+        maxInputTokens: () => 64,
+        onOverflow: "error" as const,
+      }),
       host: hostWithThreads(new SpyStore()),
       model: createCallbackModel(() => {
         calls += 1;

--- a/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-runner.ts
@@ -15,7 +15,6 @@ import {
 } from "./auto-compaction-summary";
 import type {
   AgentCompaction,
-  AgentCompactionPolicy,
   AgentCompactionReason,
   AutoCompactionRange,
   CompactionSummaryOptions,
@@ -23,10 +22,7 @@ import type {
   ThreadContextTransformObserver,
   ThreadModelContextTransform,
 } from "./auto-compaction-types";
-import {
-  invokeCompaction,
-  threadEstimatorForCompaction,
-} from "./auto-compaction-types";
+import { threadEstimatorForCompaction } from "./auto-compaction-types";
 import { equalSnapshot } from "./snapshot-equal";
 
 interface ActiveCompaction {
@@ -41,7 +37,7 @@ const pendingCompactions = new WeakMap<
 
 interface RunOptions {
   readonly compact?: ThreadCompactionHandler;
-  readonly compaction?: AgentCompaction | AgentCompactionPolicy;
+  readonly compaction?: AgentCompaction;
   readonly latestContextTransform?: ThreadContextTransformObserver;
   readonly model: ModelGenerationOptions;
   readonly reason: AgentCompactionReason;
@@ -213,28 +209,25 @@ ${summaryOptions.instructions}`,
       transformModelContext: options.transformModelContext,
     });
   };
-  const input = options.compaction
-    ? await invokeCompaction(
-        options.compaction,
-        Object.freeze({
-          compactions,
-          estimatedContextTokens,
-          estimatedHistory,
-          ...(estimatedHistoryMessageTokens
-            ? { estimatedHistoryMessageTokens }
-            : {}),
-          estimateTokens: estimate,
-          history,
-          instructionsTokens: fixedTokens,
-          modelContext: hydratedModelContext,
-          reason: options.reason,
-          signal,
-          summarize,
-          threadIdentity: state.compactionIdentity,
-          threadKey: options.threadKey,
-        })
-      )
-    : undefined;
+  const input = await options.compaction?.(
+    Object.freeze({
+      compactions,
+      estimatedContextTokens,
+      estimatedHistory,
+      ...(estimatedHistoryMessageTokens
+        ? { estimatedHistoryMessageTokens }
+        : {}),
+      estimateTokens: estimate,
+      history,
+      instructionsTokens: fixedTokens,
+      modelContext: hydratedModelContext,
+      reason: options.reason,
+      signal,
+      summarize,
+      threadIdentity: state.compactionIdentity,
+      threadKey: options.threadKey,
+    })
+  );
   if (!input) {
     return false;
   }

--- a/packages/runtime/src/thread/runtime/auto-compaction-types.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-types.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage } from "ai";
-import type { ContextBudgetSource } from "../../llm/context-gate";
+import type { ModelContextTokenEstimateInput } from "../../llm/context-gate";
 import type { ThreadContextMessage } from "../state/context";
 import type { ThreadCompactionRecord } from "../state/snapshot";
 import type { ThreadCompactionInput } from "../state/thread-state";
@@ -44,51 +44,40 @@ export interface AgentCompactionContext {
   readonly threadKey: string;
 }
 
-/** A per-thread compaction policy. The runtime owns all state and commits. */
-export type AgentCompaction = (
-  context: Readonly<AgentCompactionContext>
-) =>
-  | ThreadCompactionInput
-  | undefined
-  | Promise<ThreadCompactionInput | undefined>;
-
 /**
- * A compaction strategy that owns the context budget it compacts toward. The
- * runtime passes the policy straight to the model-step context gate, which
- * calls `maxInputTokens()` (and `estimateTokens`, when provided) before every
- * model request. A policy without `compact` is a budget-only source: pair it
- * with `onOverflow: "error"` to fail over-budget turns without rewriting
- * history.
+ * A per-thread compaction policy. The runtime owns all state and commits.
+ *
+ * The function may advertise the context budget it compacts toward by
+ * carrying the optional budget properties below. When `maxInputTokens` is
+ * present, the runtime passes the function itself to the model-step context
+ * gate, which calls it before every model request — budget and compaction
+ * thresholds share one source of truth. A bare function without budget
+ * properties runs with the local gate off and reacts to provider-thrown
+ * context-window errors only. For budget enforcement without history
+ * rewriting, attach `maxInputTokens` plus `onOverflow: "error"` to a no-op
+ * function.
  */
-export interface AgentCompactionPolicy extends ContextBudgetSource {
-  readonly compact?: (
+export interface AgentCompaction {
+  readonly bufferTokens?: number;
+  readonly estimateTokens?: (input: ModelContextTokenEstimateInput) => number;
+  readonly maxInputTokens?: () => number;
+  readonly onOverflow?: "compact" | "error";
+  (
     context: Readonly<AgentCompactionContext>
-  ) =>
+  ):
     | ThreadCompactionInput
     | undefined
     | Promise<ThreadCompactionInput | undefined>;
 }
 
-export function invokeCompaction(
-  compaction: AgentCompaction | AgentCompactionPolicy,
-  context: Readonly<AgentCompactionContext>
-):
-  | ThreadCompactionInput
-  | undefined
-  | Promise<ThreadCompactionInput | undefined> {
-  return typeof compaction === "function"
-    ? compaction(context)
-    : compaction.compact?.(context);
-}
-
-/** The thread-history estimator pinned by a policy, when it provides one. */
+/** The thread-history estimator pinned by a compaction, when it provides one. */
 export function threadEstimatorForCompaction(
-  compaction: AgentCompaction | AgentCompactionPolicy
+  compaction: AgentCompaction
 ): ThreadTokenEstimator | undefined {
-  if (typeof compaction === "function" || !compaction.estimateTokens) {
+  const estimateTokens = compaction.estimateTokens;
+  if (estimateTokens === undefined) {
     return;
   }
-  const estimateTokens = compaction.estimateTokens;
   return (messages) => estimateTokens({ messages });
 }
 

--- a/packages/runtime/src/thread/runtime/execution.ts
+++ b/packages/runtime/src/thread/runtime/execution.ts
@@ -9,10 +9,7 @@ import type {
 } from "../../execution/host/types";
 import type { RuntimeToolExecutionContext } from "../../llm/tool-execution-types";
 import type { ThreadState } from "../state/thread-state";
-import type {
-  AgentCompaction,
-  AgentCompactionPolicy,
-} from "./auto-compaction-types";
+import type { AgentCompaction } from "./auto-compaction-types";
 import {
   createThreadToolExecutionContext,
   type ThreadToolCallInterceptor,
@@ -20,7 +17,7 @@ import {
 } from "./execution-checkpoints";
 
 export interface ThreadExecutionOptions {
-  readonly compaction?: AgentCompaction | AgentCompactionPolicy;
+  readonly compaction?: AgentCompaction;
   readonly executionHost?: AgentHost;
   readonly hookRuntime?: AgentHookRuntime;
 }

--- a/packages/runtime/src/thread/runtime/speculative-compaction.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction.test.ts
@@ -44,7 +44,7 @@ describe("speculativeCompaction", () => {
     const compaction = speculativeCompaction({ maxInputTokens: 100 });
 
     expect(compaction.estimateTokens).toBeUndefined();
-    expect(compaction.maxInputTokens()).toBe(100);
+    expect(compaction.maxInputTokens?.()).toBe(100);
     expect(compaction.onOverflow).toBe("compact");
   });
 
@@ -78,9 +78,9 @@ describe("speculativeCompaction", () => {
     );
 
     expect(
-      await compaction.compact?.(context(preparedHistory, summarize))
+      await compaction(context(preparedHistory, summarize))
     ).toBeUndefined();
-    const promoted = await compaction.compact?.(
+    const promoted = await compaction(
       context([...preparedHistory, message("tail")], summarize)
     );
 
@@ -101,10 +101,8 @@ describe("speculativeCompaction", () => {
       message(String(index), index % 2 === 0 ? "user" : "assistant")
     );
 
-    await compaction.compact?.(context(history, summarize));
-    await compaction.compact?.(
-      context([...history, message("tail")], summarize)
-    );
+    await compaction(context(history, summarize));
+    await compaction(context([...history, message("tail")], summarize));
 
     expect(summarize).toHaveBeenCalledTimes(1);
   });
@@ -124,12 +122,12 @@ describe("speculativeCompaction", () => {
     const history = Array.from({ length: 6 }, (_, index) =>
       message(String(index), index % 2 === 0 ? "user" : "assistant")
     );
-    await compaction.compact?.(context(history, summarize));
+    await compaction(context(history, summarize));
     const changed = history.map((entry, index) =>
       index === 0 ? message("changed") : entry
     );
 
-    const promoted = await compaction.compact?.(
+    const promoted = await compaction(
       context([...changed, message("tail")], summarize)
     );
 
@@ -151,9 +149,9 @@ describe("speculativeCompaction", () => {
     const history = Array.from({ length: 6 }, (_, index) =>
       message(String(index), index % 2 === 0 ? "user" : "assistant")
     );
-    await compaction.compact?.(context(history, summarizeA));
+    await compaction(context(history, summarizeA));
 
-    const promoted = await compaction.compact?.(
+    const promoted = await compaction(
       context([...history, message("tail")], summarizeB, {
         threadIdentity: identityB,
       })
@@ -179,7 +177,7 @@ describe("speculativeCompaction", () => {
     const prepared = Array.from({ length: 6 }, (_, index) =>
       message(String(index), index % 2 === 0 ? "user" : "assistant")
     );
-    await compaction.compact?.(context(prepared, summarize));
+    await compaction(context(prepared, summarize));
     const overflowHistory = [
       ...prepared,
       message("6"),
@@ -188,7 +186,7 @@ describe("speculativeCompaction", () => {
       message("9", "assistant"),
     ];
 
-    const promoted = await compaction.compact?.(
+    const promoted = await compaction(
       context(overflowHistory, summarize, { reason: "overflow" })
     );
 

--- a/packages/runtime/src/thread/runtime/speculative-compaction.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction.ts
@@ -4,8 +4,8 @@ import {
 } from "../../llm/context-gate";
 import { selectAutoCompactionRange } from "./auto-compaction-range";
 import type {
+  AgentCompaction,
   AgentCompactionContext,
-  AgentCompactionPolicy,
   ThreadTokenEstimator,
 } from "./auto-compaction-types";
 import { equalSnapshot } from "./snapshot-equal";
@@ -34,7 +34,7 @@ interface Candidate {
  */
 export function speculativeCompaction(
   options: SpeculativeCompactionOptions = {}
-): AgentCompactionPolicy {
+): AgentCompaction {
   const max = options.maxInputTokens ?? 128_000;
   const prepare = options.prepareRatio ?? 0.65;
   const promote = options.promoteRatio ?? 0.8;
@@ -82,8 +82,7 @@ export function speculativeCompaction(
     await prepareCandidate({ candidates, context, estimate, max, retain });
     return;
   };
-  return {
-    compact,
+  return Object.assign(compact, {
     ...(customEstimate
       ? {
           estimateTokens: ({
@@ -99,7 +98,7 @@ export function speculativeCompaction(
       : {}),
     maxInputTokens: () => max,
     onOverflow: "compact" as const,
-  };
+  });
 }
 
 async function prepareCandidate({


### PR DESCRIPTION
## Summary

Simplifies the compaction surface shipped in #366 (0.3.0-next.11) back to a single callable type, per follow-up design discussion: instead of the `AgentCompaction | AgentCompactionPolicy` union, `AgentCompaction` is now a callable interface with optional budget properties.

- `AgentCompaction` gains `maxInputTokens?()`, `estimateTokens?`, `bufferTokens?`, `onOverflow?`. When `maxInputTokens` is present, the runtime hands the function itself to the model-step context gate, which calls it before every model request (the fn structurally satisfies `ContextBudgetSource`).
- `speculativeCompaction()` returns `Object.assign(compactFn, { maxInputTokens, onOverflow: "compact", ... })`.
- `AgentCompactionPolicy` and the `invokeCompaction` helper are removed; the runner calls the function directly; `ThreadExecutionOptions.compaction` narrows back to the single type.
- Bare functions without budget properties keep the local gate off (unchanged from next.11). Budget-only error mode is now `Object.assign(() => undefined, { maxInputTokens, onOverflow: "error" })`.
- Wrapping a compaction now has a mechanical budget-preserving form: `Object.assign(wrapper, inner)`.

## Behavior changes

- The policy-object form from 0.3.0-next.11 (`{ maxInputTokens(), compact() }`) is no longer accepted — breaking, contained to the next line (that shape shipped only in next.11, hours ago).

## Verification

- `thread/handle/compaction-budget-policy.test.ts` migrated to the callable form, RED-first on current main (bare fn → gate off → `maxInputTokens` spy never called / no `turn-error`), GREEN after:
  - fn + `maxInputTokens` prop + over-budget prompt → gate rejects via the prop → compaction called with reason `overflow` → turn completes
  - plain bare fn + >128K prompt → no local gate (pin, green on both sides)
  - `Object.assign(() => undefined, { maxInputTokens, onOverflow: "error" })` → `turn-error` with gate message, model never called
- `packages/runtime`: 155 files / 1110 tests green; `tsc --noEmit` clean; biome clean (pre-existing offender: `experimental/cache-stable-tools/latest-freerouter.json`, untouched); snapshot: `-type AgentCompactionPolicy`.
- Consumers: coding-agent 809, worker-agent 173 green standalone.
- Full monorepo: `turbo run test` → **18/18**; root script tests **85/85**.
- Dist smoke (built `dist/index.js`, node + MockLanguageModelV4, fn-with-props): `{"reasons":["overflow"],"outputs":["DONE"],"gateCalls":4,"ok":true}`; smoke file removed after.

## Notes

- Recurring local flake, unrelated to this change: tests that resolve `@minpeter/pss-runtime/*` dist subpaths without a declared dependency can race `tsdown`'s clean-rebuild of `packages/runtime/dist` inside the turbo matrix; every suite passes in isolation and the matrix passes when the build is warm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `AgentCompaction` a single callable that can carry its own context budget via optional properties, and remove `AgentCompactionPolicy`. When `maxInputTokens` is present, the runtime passes the function itself to the context gate to keep budget and compaction aligned.

- **Refactors**
  - `AgentCompaction` gains optional properties: `maxInputTokens`, `estimateTokens`, `bufferTokens`, `onOverflow`.
  - Runtime calls the compaction function directly; `invokeCompaction` removed.
  - Context gate uses the compaction function when `maxInputTokens` exists; otherwise stays off.
  - `speculativeCompaction()` returns a callable with its budget attached.
  - `AgentCompactionPolicy` type removed from public API; README updated; tests migrated.

- **Migration**
  - Replace `{ compact, maxInputTokens }` with `Object.assign(compact, { maxInputTokens, onOverflow: "compact" })`.
  - For budget-only error mode: `Object.assign(() => undefined, { maxInputTokens, onOverflow: "error" })`.
  - Plain functions without properties continue to work (gate off). Update any imports of `AgentCompactionPolicy`.

<sup>Written for commit 1b8ada61b61559988e02def4ea6e4b72a3681361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

