### PR TITLE
chore(runtime): advance exact optional strictness

### DIFF
--- a/.tegami/2026-08-13-runtime-strictness.md
+++ b/.tegami/2026-08-13-runtime-strictness.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## TypeScript strictness
+
+Enforce `exactOptionalPropertyTypes` for the runtime OpenTelemetry subsystem and preserve absent optional OpenTelemetry fields instead of materializing `undefined`.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -5,5 +5,5 @@ Design RFCs for `pss-runtime` live here as numbered, versioned documents. An RFC
 | # | Title | Status | Source issue |
 |---|-------|--------|---------------|
 | 0002 | App-Owned Session RPC and Streaming Transport | Implemented | [#172](https://github.com/minpeter/pss-runtime/issues/172) |
-| 0003 | Plugin System Improvements — Closing Gaps vs Pi Harness Extensions | Proposed | [#213](https://github.com/minpeter/pss-runtime/issues/213) |
+| 0003 | Plugin System Improvements — Closing Gaps vs Pi Harness Extensions | Accepted | [#213](https://github.com/minpeter/pss-runtime/issues/213) |
 | 0004 | Public API vNext | Proposed | Repository RFC |

--- a/docs/runtime-typescript-strictness.md
+++ b/docs/runtime-typescript-strictness.md
@@ -12,9 +12,15 @@ Both checks are part of `pnpm --filter @minpeter/pss-runtime typecheck`. Indexed
 access fixes must narrow or validate possibly missing values; do not use
 non-null assertions or type assertions to silence diagnostics.
 
+`tsconfig.exact-optional.json` additionally enforces
+`exactOptionalPropertyTypes` for migrated production subsystems. It currently
+covers the `src/otel` entry graph, including its shared LLM and turn-protocol
+dependencies; every migrated leaf must remain in this committed check as the
+scope expands.
+
 ## Suppression inventory
 
-As of 2026-08-06, production runtime source has **zero TypeScript diagnostic
+As of 2026-08-13, production runtime source has **zero TypeScript diagnostic
 suppressions** (`@ts-ignore`, `@ts-expect-error`, or `@ts-nocheck`) for either
 strictness option. This migration adds none. The production configuration has
 only these test-source exclusions:
@@ -37,21 +43,23 @@ pnpm --filter @minpeter/pss-runtime exec tsc \
   -p tsconfig.production.json --noEmit --exactOptionalPropertyTypes
 ```
 
-The 2026-08-06 baseline is **165 diagnostics in 75 files**:
+After migrating the `otel` entry graph, the 2026-08-13 baseline is **157
+diagnostics in 75 files**:
 
 | Diagnostic | Count | Main meaning |
 | --- | ---: | --- |
-| TS2379 | 109 | An explicit `undefined` is passed to an optional property |
-| TS2375 | 31 | An object literal materializes an optional property as `undefined` |
-| TS2322 | 15 | Assignment does not distinguish absent from `undefined` |
-| TS2412 | 6 | Optional class/object property is assigned `undefined` |
-| TS2345 | 2 | Argument optionality mismatch |
+| TS2379 | 111 | An explicit `undefined` is passed to an optional property |
+| TS2375 | 26 | An object literal materializes an optional property as `undefined` |
+| TS2322 | 10 | Assignment does not distinguish absent from `undefined` |
+| TS2412 | 7 | Optional class/object property is assigned `undefined` |
 | TS1360 | 1 | `satisfies` exposes an optionality mismatch |
 | TS2420 | 1 | Implementation and interface optionality differ |
+| TS2430 | 1 | Interface extension optionality differs |
 
-Subsystem distribution: thread 64, platform 53, llm 15, agent 12, evals 12,
-execution 5, otel 2, and testing 2. Refresh this inventory in the same PR that
-changes the baseline.
+Subsystem distribution: thread 59, platform 58, agent 13, evals 12, llm 7,
+execution 6, testing 2, and otel 0. Refresh this inventory in the same PR that
+changes the baseline. `otel` is guarded at zero by
+`tsconfig.exact-optional.json`.
 
 ## Staged plan
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -106,7 +106,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.production.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.exact-optional.json --noEmit",
     "test": "vitest run",
     "test:storage-stress": "vitest run src/platform/cloudflare/storage/execution/store-stress.test.ts src/platform/cloudflare/storage/execution/store-oversized-payload.test.ts",
     "test:storage-stress:extreme": "PSS_RUNTIME_STORAGE_STRESS_PROFILE=extreme vitest run src/platform/cloudflare/storage/execution/store-stress.test.ts",

--- a/packages/runtime/src/llm/context-gate.ts
+++ b/packages/runtime/src/llm/context-gate.ts
@@ -102,10 +102,10 @@ export function enforceContextGate({
   const maxInputTokens = contextGate.maxInputTokens();
   const estimatedTokens = estimatePromptTokens(
     {
-      instructions,
+      ...(instructions === undefined ? {} : { instructions }),
       messages,
-      toolChoice,
-      tools: promptTools,
+      ...(toolChoice === undefined ? {} : { toolChoice }),
+      ...(promptTools === undefined ? {} : { tools: promptTools }),
     },
     contextGate.estimateTokens
   );
@@ -207,7 +207,6 @@ export async function materializeModelPromptTools(
         typeof tool.description === "function"
           ? tool.description({
               context: undefined,
-              experimental_sandbox: undefined,
             })
           : tool.description;
       const schema = asSchema(tool.inputSchema);

--- a/packages/runtime/src/llm/context-tokens.ts
+++ b/packages/runtime/src/llm/context-tokens.ts
@@ -180,9 +180,9 @@ export interface ContextTokenView {
 export class ContextTokenMeter {
   readonly #registry: ContextTokenCalibrationRegistry;
   readonly #calibration: boolean;
-  #attempt?: Attempt;
-  #scope?: string;
-  #maxInputTokens?: number;
+  #attempt: Attempt | undefined;
+  #scope: string | undefined;
+  #maxInputTokens: number | undefined;
 
   constructor(
     registry: ContextTokenCalibrationRegistry,
@@ -225,7 +225,12 @@ export class ContextTokenMeter {
     measurement: ModelPromptMeasurement;
     scope?: string;
   }): ContextUsageSnapshot {
-    this.#attempt = { ...input, outputUnits: 0 };
+    this.#attempt = {
+      attemptId: input.attemptId,
+      fixedFingerprint: input.fixedFingerprint,
+      measurement: input.measurement,
+      outputUnits: 0,
+    };
     this.#scope = input.scope;
     this.#maxInputTokens = input.maxInputTokens;
     return this.snapshot();
@@ -420,7 +425,10 @@ function reportedUsageTokens(usage: ModelUsage): {
   ) {
     output = usage.totalTokens - input;
   }
-  return { input, output };
+  return {
+    ...(input === undefined ? {} : { input }),
+    ...(output === undefined ? {} : { output }),
+  };
 }
 
 function roundedUnitCosts(units: readonly number[], scale: number): number[] {

--- a/packages/runtime/src/otel/trace-state.ts
+++ b/packages/runtime/src/otel/trace-state.ts
@@ -210,11 +210,14 @@ function startSpan(
   name: string,
   attributes: TraceAgentTurnEventAttributes
 ): TraceAgentTurnSpan {
+  const cleanedAttributes = cleanAttributes({
+    ...state.options.spanAttributes,
+    ...attributes,
+  });
   return state.options.tracer.startSpan(name, {
-    attributes: cleanAttributes({
-      ...state.options.spanAttributes,
-      ...attributes,
-    }),
+    ...(cleanedAttributes === undefined
+      ? {}
+      : { attributes: cleanedAttributes }),
   });
 }
 

--- a/packages/runtime/src/otel/types.ts
+++ b/packages/runtime/src/otel/types.ts
@@ -82,7 +82,9 @@ function resolveOptions(
   options: TraceAgentTurnOptions
 ): ResolvedTraceAgentTurnOptions {
   return {
-    eventAttributes: options.eventAttributes,
+    ...(options.eventAttributes === undefined
+      ? {}
+      : { eventAttributes: options.eventAttributes }),
     eventName: options.eventName ?? DEFAULT_EVENT_NAME,
     spanAttributes: {
       "pss.runtime.component": RUNTIME_COMPONENT,

--- a/packages/runtime/src/thread/protocol/turn.ts
+++ b/packages/runtime/src/thread/protocol/turn.ts
@@ -3,7 +3,7 @@ import type { AgentEvent } from "./events";
 
 export interface AgentTurn {
   events(): AsyncIterable<AgentEvent>;
-  readonly runId?: string;
+  readonly runId?: string | undefined;
 }
 
 interface QueuedEvent {
@@ -206,11 +206,17 @@ export class BufferedAgentTurn implements AgentTurn {
     resolve: (value: IteratorResult<AgentEvent>) => void,
     { ack, event }: QueuedEvent
   ): void {
-    this.#consumer.to({ tag: "delivering", ack });
+    this.#consumer.to({
+      ...(ack === undefined ? {} : { ack }),
+      tag: "delivering",
+    });
     queueMicrotask(() => {
       const current = this.#consumer.state;
       if (current.tag === "delivering") {
-        this.#consumer.to({ tag: "delivered", ack: current.ack });
+        this.#consumer.to({
+          ...(current.ack === undefined ? {} : { ack: current.ack }),
+          tag: "delivered",
+        });
       }
     });
     resolve({ done: false, value: event });

--- a/packages/runtime/tsconfig.exact-optional.json
+++ b/packages/runtime/tsconfig.exact-optional.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.production.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["src/otel/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a committed `exactOptionalPropertyTypes` typecheck for the runtime OpenTelemetry entry graph and wire it into the runtime typecheck contract
- preserve absent optional fields across OpenTelemetry, context-token, context-gate, and turn-protocol dependencies; reduce the production migration baseline from the previously documented 165 diagnostics to 157 current diagnostics
- align the RFC 0003 index status with its Accepted body and implemented runtime/coding-agent extension boundary
- add the required patch Tegami entry

## Verification
All commands ran with Node v24.19.0 and pnpm 11.9.0.

- `pnpm lint` (passes; existing oversized `experimental/cache-stable-tools/latest-freerouter.json` warning remains)
- `pnpm typecheck`
- `pnpm test`
- `pnpm check:compatibility`
- `pnpm check:tegami-notes`
- focused runtime tests: 51 passed across OpenTelemetry, context tokens, context gate, and turn protocol
- exact-optional inventory command confirms 157 diagnostics in 75 files outside the migrated zero-diagnostic entry graph

## Notes
- The root package has no `check` script, so `pnpm check` reports `Command "check" not found`; the repository-defined check scripts above were run instead.
- This intentionally leaves the remaining `exactOptionalPropertyTypes` migration for later tranches (platform/thread, agent/evals/execution/testing, and remaining LLM code).
- No Dependabot PRs or shared infrastructure were changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces exact optional strictness for the runtime OpenTelemetry entry graph and preserves absent optional fields instead of materializing undefined. Previously we passed undefined to optionals; now we omit those properties, reducing the migration baseline to 157 diagnostics and preventing undefined from leaking into spans, token accounting, context gating, and turn protocol state.

- Adds `packages/runtime/tsconfig.exact-optional.json` and runs it from `pnpm typecheck` for `src/otel/**`; keep this check green as the scope expands.
- Omits optional properties when absent across `src/otel` (span attributes), LLM context gate/token accounting (estimation args and usage reports), and thread turn protocol consumer state (`ack`); adjusts types to reflect `string | undefined` explicitly where relevant.
- Required action: Do not set optional properties to `undefined`. Omit them. If you detect presence with the `in` operator, update code to tolerate truly absent fields.
- Updates strictness docs (new baseline and subsystem distribution), marks RFC 0003 as Accepted, and adds the Tegami patch note.

<sup>Written for commit 322afde89910407c9e7c3e204a9e977a22103157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

