### PR TITLE
fix(runtime): isolate compaction summarize from agent instructions

### DIFF
--- a/.tegami/2026-08-18-isolate-compaction-summary-instructions.md
+++ b/.tegami/2026-08-18-isolate-compaction-summary-instructions.md
@@ -1,0 +1,12 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Isolate compaction summarize from agent instructions
+
+Stop forwarding `model.instructions` into the compaction summary model call so
+agent persona/policy prompts (including reminder silence rules) cannot suppress
+handoff summary output. The compaction contract remains the sole instruction
+source via the leading system history message.

--- a/packages/runtime/src/thread/runtime/auto-compaction-summary.test.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-summary.test.ts
@@ -76,6 +76,36 @@ describe("automatic compaction summary contract", () => {
     });
   });
 
+  it("does not inherit agent persona instructions on the summary model call", async () => {
+    let captured: MockLanguageModelV4CallOptions | undefined;
+    const model = createMockLanguageModelV4((options) => {
+      captured = options;
+      return Promise.resolve(mockLanguageModelV4Text("summary"));
+    });
+    const personaSilence =
+      "PRODUCE_ZERO_TEXT_SILENCE_MARKER: Produce zero text when investigation is empty.";
+
+    await expect(
+      summarizeCompactionRange({
+        history: [
+          { content: "reminder history. ".repeat(200), role: "user" },
+          { content: "tool result noted", role: "assistant" },
+        ],
+        model: {
+          instructions: personaSilence,
+          model,
+          temperature: 1,
+        },
+      })
+    ).resolves.toBe("summary");
+
+    const serialized = JSON.stringify(captured);
+    expect(serialized).not.toContain("PRODUCE_ZERO_TEXT_SILENCE_MARKER");
+    expect(serialized).toContain(
+      "[INTERNAL COMPACTION INSTRUCTION - NOT CONVERSATION HISTORY]"
+    );
+  });
+
   it("ends assistant-ended history with an explicit summary request", async () => {
     let captured: MockLanguageModelV4CallOptions | undefined;
     const model = createMockLanguageModelV4((options) => {

--- a/packages/runtime/src/thread/runtime/auto-compaction-summary.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-summary.ts
@@ -180,11 +180,15 @@ export async function summarizeCompactionRange({
           },
         ]
       : transformedHistoryBase;
+  // Compaction summarize is an internal control call. Do not inherit the
+  // agent persona / policy instructions (e.g. reminder silence: "produce zero
+  // text") — those can suppress the summary assistant output and leave the
+  // thread uncompacted. The handoff contract already lives on the leading
+  // system history message and is hoisted by promptForModel.
   const output = await generateModelStep({
     attachmentStore: model.attachmentStore,
     contextGate: false,
     history: transformedHistory,
-    instructions: model.instructions,
     maxOutputTokens,
     model: model.model,
     seed: model.seed,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  nanoid@^3: 3.3.18
   '@ai-sdk/provider-utils@3.0.31>undici': 6.28.0
   dockerode@4.0.12>uuid: 11.1.1
   miniflare@5.20260730.0-alpha>undici: 7.29.0
@@ -3870,8 +3871,8 @@ packages:
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4981,7 +4982,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
@@ -8056,7 +8057,7 @@ snapshots:
   nan@2.28.0:
     optional: true
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -8238,7 +8239,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ packages:
   - "extensions/*"
 autoInstallPeers: false
 overrides:
+  # postcss(via vite/vitest) still pulls nanoid 3.3.17; GHSA-2v37-7h3g-55p8 needs >=3.3.18
+  nanoid@^3: 3.3.18
   # Security-only, parent-scoped resolutions where direct updates cannot reach the vulnerable edge.
   # Keep these exact so unrelated consumers retain their declared dependency ranges.
   '@ai-sdk/provider-utils@3.0.31>undici': 6.28.0


### PR DESCRIPTION
## Summary
- Compaction summarize is an internal control call, but `summarizeCompactionRange` was still forwarding `model.instructions` into `generateModelStep`.
- Agent persona/policy prompts (notably reminder silence: produce zero text) can then suppress summary assistant output → empty summary → compaction skip / uncompacted history growth.
- Stop inheriting `model.instructions` on the summary call. The compaction handoff contract remains the instruction source via the leading system history message (hoisted by `promptForModel`). `temperature: 0` override on the runner path is unchanged.

## Why default change (no knob)
- Persona instructions do not help handoff summaries.
- Runtime already treats summarize as internal control (`[INTERNAL COMPACTION INSTRUCTION…]`, temperature override).
- Matches discussion on the Vooy latency / reminder compaction thread.

## Test plan
- [x] Mutation RED: reintroduce `instructions: model.instructions` → new unit test fails (silence marker appears in mock prompt system content)
- [x] GREEN: `pnpm --filter @minpeter/pss-runtime exec vitest run src/thread/runtime/auto-compaction-summary.test.ts` → 13/13
- [x] `auto-compaction-runner.test.ts` + `auto-compaction-summary-signal.test.ts` → 9/9
- [x] `pnpm check:tegami-notes`
- [ ] After release/pin: Bori reminder empty_summary regression on heavy hist

## Context
Bori agent-backend pin `@minpeter/pss-runtime@0.3.0-next.12`. Observed empty_summary when reminder agent instructions (silence) were inherited by summarize.