### PR TITLE
feat(runtime): continue compaction summaries past episode deadlines

### DIFF
--- a/.tegami/2026-08-26-detached-compaction-summaries.md
+++ b/.tegami/2026-08-26-detached-compaction-summaries.md
@@ -1,0 +1,16 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Detached compaction summaries outlive episode deadlines
+
+A compaction episode deadline now bounds only the caller's wait, not the
+provider work: an in-flight summary continues detached after
+`CompactionDeadlineExceededError`, installs as a fail-closed validated
+speculative candidate, and the next episode joins or promotes it without a
+second summary call. Detached calls are single-flight per thread, honour
+explicit summary signals, and carry a fixed 120s leak backstop
+(`DETACHED_SUMMARY_BACKSTOP_MS`). Slow models converge across episodes
+instead of restarting aborted summaries every episode.

--- a/packages/runtime/src/thread/runtime/auto-compaction-preparation.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-preparation.ts
@@ -13,6 +13,7 @@ import {
   summarizeCompactionRange,
   summaryHistoryForRange,
 } from "./auto-compaction-summary";
+import { resolveSummaryLifetimeSignal } from "./auto-compaction-summary-lifetime";
 import { compactionTokenAccounting } from "./auto-compaction-token-accounting";
 import type {
   AgentCompactionModelContextProvenance,
@@ -102,10 +103,13 @@ export async function prepareAutoCompaction(
     range: AutoCompactionRange,
     summaryOptions: CompactionSummaryOptions = {}
   ): Promise<string> => {
-    const signal = summaryOptions.signal
-      ? AbortSignal.any([options.signal, summaryOptions.signal])
-      : options.signal;
+    const lifetime = resolveSummaryLifetimeSignal({
+      episodeSignal: options.signal,
+      options: summaryOptions,
+    });
+    const { signal } = lifetime;
     if (signal.aborted) {
+      lifetime.release();
       const rejected = Promise.reject<string>(signal.reason);
       rejected.catch(() => undefined);
       return rejected;
@@ -129,6 +133,7 @@ ${summaryOptions.instructions}`,
         transformModelContext: options.transformModelContext,
       });
     });
+    running.then(lifetime.release, lifetime.release);
     running.catch(() => undefined);
     return running;
   };

--- a/packages/runtime/src/thread/runtime/auto-compaction-summary-lifetime.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-summary-lifetime.ts
@@ -1,0 +1,45 @@
+import {
+  type CompactionSummaryOptions,
+  DETACHED_SUMMARY_BACKSTOP_MS,
+} from "./auto-compaction-types";
+
+export interface SummaryLifetimeSignal {
+  readonly release: () => void;
+  readonly signal: AbortSignal;
+}
+
+/**
+ * Resolves the provider-call signal for a summary. Episode-lifetime calls bind
+ * the episode (deadline-armed) signal. Detached calls exclude it so the
+ * provider work survives the caller's wait bound, and are contained only by an
+ * explicit caller signal plus a fixed leak backstop.
+ */
+export function resolveSummaryLifetimeSignal({
+  episodeSignal,
+  options,
+}: {
+  readonly episodeSignal: AbortSignal;
+  readonly options: CompactionSummaryOptions;
+}): SummaryLifetimeSignal {
+  if (options.lifetime !== "detached") {
+    return {
+      release: () => undefined,
+      signal: options.signal
+        ? AbortSignal.any([episodeSignal, options.signal])
+        : episodeSignal,
+    };
+  }
+  const backstop = new AbortController();
+  const timer = setTimeout(() => {
+    backstop.abort(
+      new Error("Detached compaction summary exceeded the safety backstop.")
+    );
+  }, DETACHED_SUMMARY_BACKSTOP_MS);
+  timer.unref();
+  return {
+    release: () => clearTimeout(timer),
+    signal: options.signal
+      ? AbortSignal.any([options.signal, backstop.signal])
+      : backstop.signal,
+  };
+}

--- a/packages/runtime/src/thread/runtime/auto-compaction-types.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-types.ts
@@ -23,6 +23,13 @@ export type ManualThreadCompactionResult =
 export interface CompactionSummaryOptions {
   /** Appends an `Additional focus` section to the default handoff contract. */
   readonly instructions?: string;
+  /**
+   * "episode" (default) binds the provider call to the episode deadline.
+   * "detached" keeps the provider call running past the episode deadline;
+   * the caller owns landing its result. The episode wait stays bounded either
+   * way.
+   */
+  readonly lifetime?: "detached" | "episode";
   /** Cancels manual compaction and its active provider request. */
   readonly signal?: AbortSignal;
   /** Controls whether raw tool-result evidence is appended after model output. */
@@ -83,6 +90,12 @@ export interface AgentCompaction {
 
 /** Episode bound used when a policy omits `deadlineMs`. */
 export const DEFAULT_COMPACTION_DEADLINE_MS = 15_000;
+
+/**
+ * Leak containment for detached summary calls: a runaway provider stream is
+ * aborted after this long. This is a backstop, not a behavioral timeout.
+ */
+export const DETACHED_SUMMARY_BACKSTOP_MS = 120_000;
 
 /** Largest delay accepted by JavaScript timer implementations. */
 export const MAX_COMPACTION_DEADLINE_MS = 2_147_483_647;

--- a/packages/runtime/src/thread/runtime/speculative-compaction-abort-installation.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-abort-installation.test.ts
@@ -5,7 +5,7 @@ import { speculativeCompaction } from "./speculative-compaction";
 import { context, message } from "./speculative-compaction-test-support";
 
 describe("speculativeCompaction", () => {
-  it("throws after an aborted summary resolves without installing its candidate", async () => {
+  it("throws after an aborted summary resolves while its candidate still installs", async () => {
     const controller = new AbortController();
     let resolveSummary: (summary: string) => void = () => {
       throw new TypeError("summary promise was not initialized");
@@ -43,8 +43,8 @@ describe("speculativeCompaction", () => {
       context([...preparedHistory, message("tail")], summarize)
     );
 
-    expect(promoted?.summary).toBe("fresh summary");
-    expect(summarize).toHaveBeenCalledTimes(2);
+    expect(promoted?.summary).toBe("late summary");
+    expect(summarize).toHaveBeenCalledTimes(1);
   });
 
   it.each(["transformed", "unknown"] as const)(

--- a/packages/runtime/src/thread/runtime/speculative-compaction-abort-rollback.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-abort-rollback.test.ts
@@ -4,7 +4,7 @@ import { speculativeCompaction } from "./speculative-compaction";
 import { context, message } from "./speculative-compaction-test-support";
 
 describe("speculativeCompaction", () => {
-  it("removes an initial candidate when its preparation episode later aborts", async () => {
+  it("keeps a completed preparation candidate when its episode later aborts", async () => {
     const controller = new AbortController();
     const summarize = vi
       .fn<AgentCompactionContext["summarize"]>()
@@ -31,11 +31,11 @@ describe("speculativeCompaction", () => {
       })
     );
 
-    expect(retried?.summary).toBe("fresh retry");
-    expect(summarize).toHaveBeenCalledTimes(2);
+    expect(retried?.summary).toBe("aborted prepared");
+    expect(summarize).toHaveBeenCalledTimes(1);
   });
 
-  it("restores the prior candidate when an installed replacement episode aborts", async () => {
+  it("keeps a completed replacement candidate when its episode aborts", async () => {
     const replacementController = new AbortController();
     const summarize = vi
       .fn<AgentCompactionContext["summarize"]>()
@@ -64,11 +64,11 @@ describe("speculativeCompaction", () => {
       context([...widened, message("8")], summarize, { reason: "overflow" })
     );
 
-    expect(promoted?.summary).toBe("prepared");
+    expect(promoted?.summary).toBe("aborted replacement");
     expect(summarize).toHaveBeenCalledTimes(2);
   });
 
-  it("does not restore an aborted predecessor when its replacement aborts", async () => {
+  it("promotes a completed replacement candidate after both episodes abort", async () => {
     const preparedController = new AbortController();
     const replacementController = new AbortController();
     const summarize = vi
@@ -102,11 +102,11 @@ describe("speculativeCompaction", () => {
       context([...widened, message("8")], summarize, { reason: "overflow" })
     );
 
-    expect(promoted?.summary).toBe("fresh overflow");
-    expect(summarize).toHaveBeenCalledTimes(3);
+    expect(promoted?.summary).toBe("candidate B");
+    expect(summarize).toHaveBeenCalledTimes(2);
   });
 
-  it("preserves an existing candidate when promotion fallback is aborted", async () => {
+  it("installs a completed promotion fallback after its episode aborts", async () => {
     const controller = new AbortController();
     let resolveFallback: (summary: string) => void = () => {
       throw new TypeError("fallback promise was not initialized");
@@ -146,7 +146,7 @@ describe("speculativeCompaction", () => {
       context(promotedHistory, summarize, { reason: "overflow" })
     );
 
-    expect(promoted?.summary).toBe("prepared");
+    expect(promoted?.summary).toBe("late fallback");
     expect(summarize).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/runtime/src/thread/runtime/speculative-compaction-candidate-reuse.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-candidate-reuse.test.ts
@@ -32,7 +32,7 @@ describe("speculativeCompaction", () => {
     expect(summarizeB).toHaveBeenCalledTimes(1);
   });
 
-  it("re-summarizes a broader range when an old candidate reaches overflow", async () => {
+  it("reuses a promote-installed candidate when its tail still fits the budget", async () => {
     const summarize = vi
       .fn<AgentCompactionContext["summarize"]>()
       .mockResolvedValueOnce("prepared")
@@ -62,9 +62,8 @@ describe("speculativeCompaction", () => {
       context(overflowHistory, summarize, { reason: "overflow" })
     );
 
-    expect(promoted?.summary).toBe("overflow");
-    expect(promoted?.endSeqExclusive).toBeGreaterThan(2);
-    expect(summarize).toHaveBeenCalledTimes(2);
+    expect(promoted?.summary).toBe("prepared");
+    expect(summarize).toHaveBeenCalledTimes(1);
   });
 
   it("reuses a widened candidate when its full uncovered tail still fits", async () => {

--- a/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
@@ -10,29 +10,22 @@ import {
   latestPrefixCompaction,
   selectAutoCompactionRange,
 } from "./auto-compaction-range";
-import { NORMAL_COMPACTION_SETTLEMENT } from "./auto-compaction-settlement";
 import type {
   AgentCompactionContext,
   AutoCompactionRange,
   ThreadTokenEstimator,
 } from "./auto-compaction-types";
+import {
+  type DetachedSummaryJob,
+  DetachedSummaryJobs,
+} from "./speculative-compaction-detached";
 
-interface Candidate {
+export interface SpeculativeCandidate {
   readonly compactions: readonly ThreadCompactionRecord[];
   readonly hydratedPrefix: readonly ModelMessage[];
   readonly input: ThreadCompactionInput;
   readonly prefix: readonly ModelMessage[];
   readonly replacementConsumed: boolean;
-}
-
-type CandidateLifecycle =
-  | { readonly tag: "aborted" }
-  | { readonly tag: "live" };
-
-interface CandidateInstallation {
-  readonly candidate: Candidate;
-  lifecycle: CandidateLifecycle;
-  readonly previous: CandidateInstallation | undefined;
 }
 
 interface CandidateStoreOptions {
@@ -41,9 +34,17 @@ interface CandidateStoreOptions {
   readonly retain: number;
 }
 
+/**
+ * Candidates are installed by detached summary jobs, never synchronously by an
+ * episode, so a deadline that bounds the caller's wait cannot destroy finished
+ * provider work. Freshness is enforced at consumption by #getFresh and #fits;
+ * there is deliberately no abort-rollback listener because detached installs
+ * happen after the originating episode settled.
+ */
 export class SpeculativeCompactionCandidates {
-  readonly #candidates = new WeakMap<object, CandidateInstallation>();
+  readonly #candidates = new WeakMap<object, SpeculativeCandidate>();
   readonly #estimate: ThreadTokenEstimator;
+  readonly #jobs = new DetachedSummaryJobs();
   readonly #max: number;
   readonly #retain: number;
 
@@ -59,47 +60,34 @@ export class SpeculativeCompactionCandidates {
     }
     const expectedCurrent = this.#candidates.get(context.threadIdentity);
     const expectedInstallation = this.#getFresh(context);
-    if (expectedInstallation?.candidate.replacementConsumed) {
+    if (expectedInstallation?.replacementConsumed) {
       return;
     }
     const range = this.#selectRange(context);
     if (
       range === undefined ||
       (expectedInstallation !== undefined &&
-        !isCompatibleExpansion(expectedInstallation.candidate, range))
+        !isCompatibleExpansion(expectedInstallation, range))
     ) {
       return;
     }
-
-    const summary = await context.summarize(range);
-    context.signal.throwIfAborted();
-    if (!summary.trim()) {
-      return;
-    }
-    if (this.#candidates.get(context.threadIdentity) !== expectedCurrent) {
-      return;
-    }
-    const next = {
-      compactions: structuredClone(context.compactions),
-      hydratedPrefix: structuredClone(
-        context.estimatedHistory.slice(0, range.endSeqExclusive)
-      ),
-      input: { ...range, summary },
-      prefix: structuredClone(context.history.slice(0, range.endSeqExclusive)),
-      replacementConsumed: expectedInstallation !== undefined,
-    };
-    this.#installCandidate(
+    await this.#jobs.startOrJoin(
       context,
-      expectedCurrent,
-      expectedInstallation,
-      next
-    );
+      range,
+      this.#installDetached(
+        context,
+        range,
+        expectedCurrent,
+        expectedInstallation !== undefined
+      )
+    ).promise;
+    context.signal.throwIfAborted();
   }
 
   async promote(
     context: AgentCompactionContext
   ): Promise<ThreadCompactionInput | undefined> {
-    const candidate = this.#getFresh(context)?.candidate;
+    const candidate = this.#getFresh(context);
     const range = this.#selectRange(context);
     if (candidate !== undefined && this.#fits(candidate, context)) {
       context.signal.throwIfAborted();
@@ -108,58 +96,73 @@ export class SpeculativeCompactionCandidates {
     if (range === undefined) {
       return;
     }
-    const summary = await context.summarize(range);
+    const expectedCurrent = this.#candidates.get(context.threadIdentity);
+    const job = this.#jobs.startOrJoin(
+      context,
+      range,
+      this.#installDetached(context, range, expectedCurrent)
+    );
+    const summary = await job.promise;
     context.signal.throwIfAborted();
     if (!summary.trim()) {
       return;
     }
-    return { ...range, summary };
-  }
-
-  #installCandidate(
-    context: AgentCompactionContext,
-    expectedCurrent: CandidateInstallation | undefined,
-    previous: CandidateInstallation | undefined,
-    next: Candidate
-  ): void {
-    const installation: CandidateInstallation = {
-      candidate: next,
-      lifecycle: { tag: "live" },
-      previous,
-    };
-    const restore = (): void => {
-      if (context.signal.reason === NORMAL_COMPACTION_SETTLEMENT) {
-        return;
-      }
-      installation.lifecycle = { tag: "aborted" };
-      if (this.#candidates.get(context.threadIdentity) !== installation) {
-        return;
-      }
-      let restored = installation.previous;
-      while (restored?.lifecycle.tag === "aborted") {
-        restored = restored.previous;
-      }
-      if (restored) {
-        this.#candidates.set(context.threadIdentity, restored);
-        return;
-      }
-      this.#candidates.delete(context.threadIdentity);
-    };
-    context.signal.addEventListener("abort", restore, { once: true });
-    try {
-      context.signal.throwIfAborted();
-      if (this.#candidates.get(context.threadIdentity) !== expectedCurrent) {
-        context.signal.removeEventListener("abort", restore);
-        return;
-      }
-      this.#candidates.set(context.threadIdentity, installation);
-    } catch (error) {
-      context.signal.removeEventListener("abort", restore);
-      throw error;
+    if (this.#jobMatchesContext(job, range)) {
+      return { ...range, summary };
     }
+    const installed = this.#getFresh(context);
+    if (installed !== undefined && this.#fits(installed, context)) {
+      return { ...installed.input };
+    }
+    return;
   }
 
-  #fits(candidate: Candidate, context: AgentCompactionContext): boolean {
+  /**
+   * A joined job is only returned directly when its range matches; snapshot
+   * freshness was already enforced when the join happened, and installed
+   * results are re-validated fail-closed by #getFresh/#fits at use.
+   */
+  #jobMatchesContext(
+    job: DetachedSummaryJob,
+    range: AutoCompactionRange
+  ): boolean {
+    return (
+      job.range.startSeq === range.startSeq &&
+      job.range.endSeqExclusive === range.endSeqExclusive
+    );
+  }
+
+  #installDetached(
+    context: AgentCompactionContext,
+    range: AutoCompactionRange,
+    expectedCurrent: SpeculativeCandidate | undefined,
+    replacedFresh: boolean = expectedCurrent !== undefined
+  ): (summary: string) => void {
+    const compactions = structuredClone(context.compactions);
+    const hydratedPrefix = structuredClone(
+      context.estimatedHistory.slice(0, range.endSeqExclusive)
+    );
+    const prefix = structuredClone(
+      context.history.slice(0, range.endSeqExclusive)
+    );
+    return (summary) => {
+      if (this.#candidates.get(context.threadIdentity) !== expectedCurrent) {
+        return;
+      }
+      this.#candidates.set(context.threadIdentity, {
+        compactions,
+        hydratedPrefix,
+        input: { ...range, summary },
+        prefix,
+        replacementConsumed: replacedFresh,
+      });
+    };
+  }
+
+  #fits(
+    candidate: SpeculativeCandidate,
+    context: AgentCompactionContext
+  ): boolean {
     if (context.modelContextProvenance !== "standard") {
       return false;
     }
@@ -202,13 +205,9 @@ export class SpeculativeCompactionCandidates {
     return context.instructionsTokens + historyTokens <= this.#max;
   }
 
-  #getFresh(
-    context: AgentCompactionContext
-  ): CandidateInstallation | undefined {
-    const installation = this.#candidates.get(context.threadIdentity);
-    const candidate = installation?.candidate;
+  #getFresh(context: AgentCompactionContext): SpeculativeCandidate | undefined {
+    const candidate = this.#candidates.get(context.threadIdentity);
     if (
-      installation?.lifecycle.tag === "live" &&
       candidate !== undefined &&
       equalSnapshot(
         candidate.prefix,
@@ -220,11 +219,10 @@ export class SpeculativeCompactionCandidates {
       ) &&
       equalSnapshot(candidate.compactions, context.compactions)
     ) {
-      return installation;
+      return candidate;
     }
     return;
   }
-
   #selectRange(
     context: AgentCompactionContext
   ): AutoCompactionRange | undefined {
@@ -243,7 +241,7 @@ export class SpeculativeCompactionCandidates {
 }
 
 function isCompatibleExpansion(
-  candidate: Candidate,
+  candidate: SpeculativeCandidate,
   range: AutoCompactionRange
 ): boolean {
   return (

--- a/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
@@ -107,7 +107,7 @@ export class SpeculativeCompactionCandidates {
     if (!summary.trim()) {
       return;
     }
-    if (this.#jobMatchesContext(job, range)) {
+    if (this.#jobMatchesContext(job, context, range)) {
       return { ...range, summary };
     }
     const installed = this.#getFresh(context);
@@ -124,11 +124,21 @@ export class SpeculativeCompactionCandidates {
    */
   #jobMatchesContext(
     job: DetachedSummaryJob,
+    context: AgentCompactionContext,
     range: AutoCompactionRange
   ): boolean {
     return (
       job.range.startSeq === range.startSeq &&
-      job.range.endSeqExclusive === range.endSeqExclusive
+      job.range.endSeqExclusive === range.endSeqExclusive &&
+      equalSnapshot(job.compactions, context.compactions) &&
+      equalSnapshot(
+        job.prefix,
+        context.history.slice(0, range.endSeqExclusive)
+      ) &&
+      equalSnapshot(
+        job.hydratedPrefix,
+        context.estimatedHistory.slice(0, range.endSeqExclusive)
+      )
     );
   }
 

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached-cancellation.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached-cancellation.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ModelContextTokenEstimateInput } from "../../llm/context-gate";
+import {
+  assistantMessage,
+  createCallbackModel,
+  createDeferred,
+} from "../../testing/test-fixtures";
+import { compactThreadBlocking } from "./auto-compaction-runner";
+import type { AgentCompaction } from "./auto-compaction-types";
+import { DETACHED_SUMMARY_BACKSTOP_MS } from "./auto-compaction-types";
+import {
+  DEADLINE_MS,
+  hangingSummaryProvider,
+  stateWithHistory,
+} from "./speculative-compaction-detached-test-support";
+
+function detachedPolicy(
+  summaryOptions: { readonly signal?: AbortSignal } = {}
+): AgentCompaction {
+  return Object.assign(
+    async (context: Parameters<AgentCompaction>[0]) => {
+      const summary = await context.summarize(
+        { endSeqExclusive: 2, startSeq: 0 },
+        { lifetime: "detached", ...summaryOptions }
+      );
+      return { endSeqExclusive: 2, startSeq: 0, summary };
+    },
+    {
+      deadlineMs: () => DEADLINE_MS,
+      estimateTokens: ({ messages }: ModelContextTokenEstimateInput) =>
+        messages.length * 10,
+    }
+  ) satisfies AgentCompaction;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("detached summary cancellation", () => {
+  it("cancels detached provider work through an explicit summary signal", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000));
+    const state = await stateWithHistory("detached-explicit-cancel");
+    const { model, provider } = hangingSummaryProvider();
+    const explicit = new AbortController();
+
+    const first = compactThreadBlocking({
+      compaction: detachedPolicy({ signal: explicit.signal }),
+      model,
+      state,
+      threadKey: "detached-explicit-cancel",
+    });
+    const settled = expect(first).rejects.toMatchObject({
+      name: "CompactionDeadlineExceededError",
+    });
+    await provider.started.promise;
+
+    explicit.abort(new TypeError("operator cancelled"));
+    expect(provider.signal?.aborted).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS + 1);
+    await settled;
+    expect(provider.called).toBe(1);
+    expect(state.compactionSnapshot()).toEqual([]);
+  });
+
+  it("aborts a runaway detached summary at the safety backstop", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000));
+    const state = await stateWithHistory("detached-backstop");
+    const { model, provider } = hangingSummaryProvider();
+
+    const first = compactThreadBlocking({
+      compaction: detachedPolicy(),
+      model,
+      state,
+      threadKey: "detached-backstop",
+    });
+    const settled = expect(first).rejects.toMatchObject({
+      name: "CompactionDeadlineExceededError",
+    });
+    await provider.started.promise;
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS + 1);
+    await settled;
+    expect(provider.signal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(DETACHED_SUMMARY_BACKSTOP_MS);
+    expect(provider.signal?.aborted).toBe(true);
+  });
+
+  it("contains a detached provider rejection landing after the episode settled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000));
+    const state = await stateWithHistory("detached-late-rejection");
+    const started = createDeferred();
+    let rejectSummary: (reason: unknown) => void = () => {
+      throw new TypeError("provider failure was not armed");
+    };
+    const gate = new Promise<never>((_resolve, reject) => {
+      rejectSummary = reject;
+    });
+    const provider = {
+      called: 0,
+      signal: undefined as AbortSignal | undefined,
+    };
+    const model = {
+      model: createCallbackModel(async ({ signal }) => {
+        provider.called += 1;
+        provider.signal = signal;
+        started.resolve();
+        await gate;
+        return [assistantMessage("unreachable")];
+      }),
+    };
+
+    const first = compactThreadBlocking({
+      compaction: detachedPolicy(),
+      model,
+      state,
+      threadKey: "detached-late-rejection",
+    });
+    const settled = expect(first).rejects.toMatchObject({
+      name: "CompactionDeadlineExceededError",
+    });
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS + 1);
+    await settled;
+
+    const lateRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown): void => {
+      lateRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      rejectSummary(new Error("late provider failure"));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(lateRejections).toEqual([]);
+      expect(provider.called).toBe(1);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+});

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached-cancellation.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached-cancellation.test.ts
@@ -100,9 +100,12 @@ describe("detached summary cancellation", () => {
     const gate = new Promise<never>((_resolve, reject) => {
       rejectSummary = reject;
     });
-    const provider = {
+    const provider: {
+      called: number;
+      signal: AbortSignal | undefined;
+    } = {
       called: 0,
-      signal: undefined as AbortSignal | undefined,
+      signal: undefined,
     };
     const model = {
       model: createCallbackModel(async ({ signal }) => {

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached-test-support.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached-test-support.ts
@@ -1,0 +1,76 @@
+import type { ModelMessage } from "ai";
+import { MemoryThreadStore } from "../../platform/memory";
+import {
+  assistantMessage,
+  createCallbackModel,
+  createDeferred,
+} from "../../testing/test-fixtures";
+import { ThreadState } from "../state/thread-state";
+import type { AgentCompaction } from "./auto-compaction-types";
+import { speculativeCompaction } from "./speculative-compaction";
+
+export const DEADLINE_MS = 15_000;
+
+export interface HangingProvider {
+  called: number;
+  readonly firstGate: ReturnType<typeof createDeferred>;
+  signal: AbortSignal | undefined;
+  readonly started: ReturnType<typeof createDeferred>;
+}
+
+/** The first provider call hangs until firstGate resolves; later calls return. */
+export function hangingSummaryProvider(): {
+  readonly model: { readonly model: ReturnType<typeof createCallbackModel> };
+  readonly provider: HangingProvider;
+} {
+  const provider: HangingProvider = {
+    called: 0,
+    firstGate: createDeferred(),
+    signal: undefined,
+    started: createDeferred(),
+  };
+  return {
+    model: {
+      model: createCallbackModel(async ({ signal }) => {
+        provider.called += 1;
+        provider.signal = signal;
+        provider.started.resolve();
+        if (provider.called === 1) {
+          await provider.firstGate.promise;
+        }
+        return [assistantMessage(`detached summary ${provider.called}`)];
+      }),
+    },
+    provider,
+  };
+}
+
+export function policy(): AgentCompaction {
+  return speculativeCompaction({
+    estimateTokens: (messages) => messages.length * 10,
+    maxInputTokens: 100,
+    prepareRatio: 0.5,
+    promoteRatio: 0.7,
+    retainRatio: 0.2,
+  });
+}
+
+export async function stateWithHistory(key: string): Promise<ThreadState> {
+  const state = new ThreadState({
+    key,
+    store: new MemoryThreadStore(),
+  });
+  await state.ensureLoaded();
+  const history: readonly ModelMessage[] = [
+    { content: "1", role: "user" },
+    assistantMessage("2"),
+    { content: "3", role: "user" },
+    assistantMessage("4"),
+    { content: "5", role: "user" },
+    assistantMessage("6"),
+  ];
+  for (const message of history) {
+    state.history.appendModelMessage(message);
+  }
+  return state;
+}

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached.test.ts
@@ -3,12 +3,14 @@ import {
   compactThreadBlocking,
   compactThreadManually,
 } from "./auto-compaction-runner";
+import type { AgentCompactionContext } from "./auto-compaction-types";
 import {
   DEADLINE_MS,
   hangingSummaryProvider,
   policy,
   stateWithHistory,
 } from "./speculative-compaction-detached-test-support";
+import { context, message } from "./speculative-compaction-test-support";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -118,5 +120,73 @@ describe("speculativeCompaction detached summaries", () => {
     expect(records).toHaveLength(2);
     expect(JSON.stringify(records[0])).toContain("manual");
     expect(JSON.stringify(records[1])).toContain("detached summary 2");
+  });
+  it("lets only the current detached job install after a drifted job replaces it", async () => {
+    const firstHistory = Array.from({ length: 6 }, (_, index) =>
+      message(`A-${index}`, index % 2 === 0 ? "user" : "assistant")
+    );
+    const secondHistory = Array.from({ length: 6 }, (_, index) =>
+      message(`B-${index}`, index % 2 === 0 ? "user" : "assistant")
+    );
+    let resolveFirst: (summary: string) => void = () => {
+      throw new TypeError("first summary promise was not initialized");
+    };
+    let resolveSecond: (summary: string) => void = () => {
+      throw new TypeError("second summary promise was not initialized");
+    };
+    const first = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = new Promise<string>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const summarize = vi
+      .fn<AgentCompactionContext["summarize"]>()
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second)
+      .mockResolvedValueOnce("unexpected fresh summary");
+    const compaction = policy();
+
+    const pendingFirst = compaction(context(firstHistory, summarize));
+    const pendingSecond = compaction(context(secondHistory, summarize));
+    expect(summarize).toHaveBeenCalledTimes(2);
+
+    resolveFirst("candidate A");
+    await pendingFirst;
+    resolveSecond("candidate B");
+    await pendingSecond;
+    const promoted = await compaction(
+      context([...secondHistory, message("tail")], summarize, {
+        reason: "overflow",
+      })
+    );
+
+    expect(promoted?.summary).toBe("candidate B");
+    expect(summarize).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses a direct detached result when its source snapshot drifts", async () => {
+    const history = Array.from({ length: 6 }, (_, index) =>
+      message(String(index), index % 2 === 0 ? "user" : "assistant")
+    );
+    let resolveSummary: (summary: string) => void = () => {
+      throw new TypeError("summary promise was not initialized");
+    };
+    const summary = new Promise<string>((resolve) => {
+      resolveSummary = resolve;
+    });
+    const summarize = vi
+      .fn<AgentCompactionContext["summarize"]>()
+      .mockReturnValue(summary);
+    const compaction = policy();
+    const pending = compaction(
+      context(history, summarize, { reason: "overflow" })
+    );
+    expect(summarize).toHaveBeenCalledTimes(1);
+
+    history[0] = message("changed");
+    resolveSummary("stale summary");
+
+    await expect(Promise.resolve(pending)).resolves.toBeUndefined();
   });
 });

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  compactThreadBlocking,
+  compactThreadManually,
+} from "./auto-compaction-runner";
+import {
+  DEADLINE_MS,
+  hangingSummaryProvider,
+  policy,
+  stateWithHistory,
+} from "./speculative-compaction-detached-test-support";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("speculativeCompaction detached summaries", () => {
+  it("keeps an in-flight summary running past the deadline and commits it on the next episode", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000));
+    const state = await stateWithHistory("detached-deadline-convergence");
+    const { model, provider } = hangingSummaryProvider();
+    const options = {
+      compaction: policy(),
+      model,
+      state,
+      threadKey: "detached-deadline-convergence",
+    };
+
+    const first = compactThreadBlocking(options);
+    const firstSettled = expect(first).rejects.toMatchObject({
+      deadlineMs: DEADLINE_MS,
+      name: "CompactionDeadlineExceededError",
+      reason: "overflow",
+    });
+    await provider.started.promise;
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS + 1);
+    await firstSettled;
+
+    expect(provider.called).toBe(1);
+    expect(provider.signal?.aborted).toBe(false);
+
+    provider.firstGate.resolve();
+    const second = await compactThreadBlocking(options);
+
+    expect(second).toBe(true);
+    expect(provider.called).toBe(1);
+    expect(state.compactionSnapshot()).toHaveLength(1);
+    expect(JSON.stringify(state.compactionSnapshot())).toContain(
+      "detached summary 1"
+    );
+  });
+
+  it("joins a second blocking episode to the same detached summary call", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000));
+    const state = await stateWithHistory("detached-single-flight");
+    const { model, provider } = hangingSummaryProvider();
+    const options = {
+      compaction: policy(),
+      model,
+      state,
+      threadKey: "detached-single-flight",
+    };
+
+    const first = compactThreadBlocking(options);
+    const firstSettled = expect(first).rejects.toMatchObject({
+      name: "CompactionDeadlineExceededError",
+    });
+    await provider.started.promise;
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS + 1);
+    await firstSettled;
+
+    const second = compactThreadBlocking(options);
+    provider.firstGate.resolve();
+
+    await expect(second).resolves.toBe(true);
+    expect(provider.called).toBe(1);
+    expect(state.compactionSnapshot()).toHaveLength(1);
+  });
+
+  it("refuses a detached result that went stale before its next use", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000));
+    const state = await stateWithHistory("detached-stale");
+    const { model, provider } = hangingSummaryProvider();
+    const options = {
+      compaction: policy(),
+      model,
+      state,
+      threadKey: "detached-stale",
+    };
+
+    const first = compactThreadBlocking(options);
+    const firstSettled = expect(first).rejects.toMatchObject({
+      name: "CompactionDeadlineExceededError",
+    });
+    await provider.started.promise;
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS + 1);
+    await firstSettled;
+    expect(provider.called).toBe(1);
+
+    const manual = await compactThreadManually({
+      explicitInput: { endSeqExclusive: 2, startSeq: 0, summary: "manual" },
+      model,
+      state,
+      threadKey: "detached-stale",
+    });
+    expect(manual).toBe(true);
+    expect(state.compactionSnapshot()).toHaveLength(1);
+
+    provider.firstGate.resolve();
+    const second = await compactThreadBlocking(options);
+
+    expect(second).toBe(true);
+    expect(provider.called).toBe(2);
+    const records = state.compactionSnapshot();
+    expect(records).toHaveLength(2);
+    expect(JSON.stringify(records[0])).toContain("manual");
+    expect(JSON.stringify(records[1])).toContain("detached summary 2");
+  });
+});

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
@@ -12,6 +12,7 @@ export interface DetachedSummaryJob {
   readonly prefix: readonly ModelMessage[];
   readonly promise: Promise<string>;
   readonly range: AutoCompactionRange;
+  readonly token: Readonly<object>;
 }
 
 /**
@@ -32,10 +33,12 @@ export class DetachedSummaryJobs {
     if (existing !== undefined && matchesContext(existing, context)) {
       return existing;
     }
+    const token = Object.freeze({});
     const promise = context
       .summarize(range, { lifetime: "detached" })
       .then((summary) => {
-        if (summary.trim()) {
+        const current = this.#jobs.get(context.threadIdentity);
+        if (summary.trim() && current?.token === token) {
           install(summary);
         }
         return summary;
@@ -46,6 +49,7 @@ export class DetachedSummaryJobs {
       prefix: context.history.slice(0, range.endSeqExclusive),
       promise,
       range,
+      token,
     };
     this.#jobs.set(context.threadIdentity, job);
     const release = (): void => {

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
@@ -1,0 +1,81 @@
+import type { ModelMessage } from "ai";
+import type { ThreadCompactionRecord } from "../state/snapshot";
+import { equalSnapshot } from "../state/snapshot-equal";
+import type {
+  AgentCompactionContext,
+  AutoCompactionRange,
+} from "./auto-compaction-types";
+
+export interface DetachedSummaryJob {
+  readonly compactions: readonly ThreadCompactionRecord[];
+  readonly hydratedPrefix: readonly ModelMessage[];
+  readonly prefix: readonly ModelMessage[];
+  readonly promise: Promise<string>;
+  readonly range: AutoCompactionRange;
+}
+
+/**
+ * Process-local, single-flight registry for summary provider calls that
+ * outlive their originating compaction episode. The episode deadline bounds
+ * the caller's wait, never the detached work; a second episode joins the
+ * in-flight call instead of starting another.
+ */
+export class DetachedSummaryJobs {
+  readonly #jobs = new WeakMap<object, DetachedSummaryJob>();
+
+  startOrJoin(
+    context: AgentCompactionContext,
+    range: AutoCompactionRange,
+    install: (summary: string) => void
+  ): DetachedSummaryJob {
+    const existing = this.#jobs.get(context.threadIdentity);
+    if (existing !== undefined && matchesContext(existing, context)) {
+      return existing;
+    }
+    const promise = context
+      .summarize(range, { lifetime: "detached" })
+      .then((summary) => {
+        if (summary.trim()) {
+          install(summary);
+        }
+        return summary;
+      });
+    const job: DetachedSummaryJob = {
+      compactions: context.compactions,
+      hydratedPrefix: context.estimatedHistory.slice(0, range.endSeqExclusive),
+      prefix: context.history.slice(0, range.endSeqExclusive),
+      promise,
+      range,
+    };
+    this.#jobs.set(context.threadIdentity, job);
+    const release = (): void => {
+      if (this.#jobs.get(context.threadIdentity) === job) {
+        this.#jobs.delete(context.threadIdentity);
+      }
+    };
+    promise.then(release, release);
+    return job;
+  }
+}
+
+/**
+ * Single-flight means one in-flight call per context snapshot. A job captured
+ * before the thread drifted is not a duplicate of the work this context needs,
+ * so it neither joins nor blocks a fresh call.
+ */
+function matchesContext(
+  job: DetachedSummaryJob,
+  context: AgentCompactionContext
+): boolean {
+  return (
+    equalSnapshot(job.compactions, context.compactions) &&
+    equalSnapshot(
+      job.prefix,
+      context.history.slice(0, job.range.endSeqExclusive)
+    ) &&
+    equalSnapshot(
+      job.hydratedPrefix,
+      context.estimatedHistory.slice(0, job.range.endSeqExclusive)
+    )
+  );
+}

--- a/packages/runtime/src/thread/runtime/speculative-compaction-replacement.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-replacement.test.ts
@@ -65,7 +65,7 @@ describe("speculativeCompaction", () => {
     expect(summarize).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps an old candidate eligible until an expanded replacement installs", async () => {
+  it("keeps a completed replacement after its episode aborts", async () => {
     const controller = new AbortController();
     let resolveAbortedSummary: (summary: string) => void = () => {
       throw new TypeError("aborted summary promise was not initialized");
@@ -76,10 +76,7 @@ describe("speculativeCompaction", () => {
     const summarize = vi
       .fn<AgentCompactionContext["summarize"]>()
       .mockResolvedValueOnce("prepared")
-      .mockReturnValueOnce(abortedSummary)
-      .mockRejectedValueOnce(new TypeError("provider failed"))
-      .mockResolvedValueOnce("   ")
-      .mockResolvedValueOnce("replacement");
+      .mockReturnValueOnce(abortedSummary);
     const compaction = speculativeCompaction({
       estimateTokens: (messages) => messages.length * 10,
       maxInputTokens: 100,
@@ -102,10 +99,6 @@ describe("speculativeCompaction", () => {
     await expect(Promise.resolve(abortedReplacement)).rejects.toMatchObject({
       name: "AbortError",
     });
-    await expect(
-      Promise.resolve(compaction(context(widened, summarize)))
-    ).rejects.toThrow("provider failed");
-    await compaction(context(widened, summarize));
     await compaction(context(widened, summarize));
     const promoted = await compaction(
       context([...widened, message("8")], summarize)
@@ -114,9 +107,9 @@ describe("speculativeCompaction", () => {
     expect(promoted).toEqual({
       endSeqExclusive: 6,
       startSeq: 0,
-      summary: "replacement",
+      summary: "aborted replacement",
     });
-    expect(summarize).toHaveBeenCalledTimes(5);
+    expect(summarize).toHaveBeenCalledTimes(2);
   });
 
   it("promotes one successful bounded replacement without a third summary", async () => {


### PR DESCRIPTION
Stacks on #384.

## What changes

The episode deadline (`DEFAULT_COMPACTION_DEADLINE_MS = 15_000`, unchanged) now bounds only the caller-visible **wait**, never the provider **work**. When a deadline expires mid-summary:

- the provider call continues **detached** instead of being aborted;
- its completed result installs as a speculative candidate, validated fail-closed at use (`#getFresh` prefix/compactions equality + `#fits` budget, unchanged);
- the next episode **joins** the in-flight call (single-flight per thread, gated on context snapshot match) or promotes the installed candidate — zero wasted provider calls.

Measured motivation (2026-08-26 live sweep on PR #384 head): slow model `stealth/ox-alpha` timed out 60-80% of episode-internal summary paths at 15s and restarted the same summary every episode; prepared candidates hit 10/10 at ~3ms.

## Deliberate invariant shift

Candidate installs no longer carry an abort-rollback listener: installs happen inside the detached job chain, by definition after the originating episode settled. Freshness enforcement moved fully to consumption time (existing `#getFresh`/`#fits`), which already refuses drifted snapshots. The abort-rollback/replacement test suites were rewritten to pin the new contract.

## Safety

- Explicit `summaryOptions.signal` still cancels detached work immediately.
- A fixed 120s leak backstop (`DETACHED_SUMMARY_BACKSTOP_MS`, `setTimeout`+`unref`) bounds runaway calls; it is containment, not behavior.
- Late detached rejections are contained (no `unhandledRejection`); listener cleanup verified.
- `CompactionSummaryOptions.lifetime` defaults to `"episode"` — byte-identical behavior for every existing caller, including manual compaction.

## Evidence

- RED→GREEN: new `speculative-compaction-detached(.test).ts` / `-cancellation.test.ts` (deadline expiry no longer aborts the provider call; single-flight join; backstop; stale refusal; late-rejection containment).
- Full runtime suite 214 files / 1340 passed; root `turbo run test && vitest` green; lint/typecheck/build green; public API snapshot unchanged.
- Tegami entry included (runtime patch).