### PR TITLE
test(runtime): bound Vitest worker fan-out

### DIFF
--- a/.tegami/2026-08-26-runtime-test-workers.md
+++ b/.tegami/2026-08-26-runtime-test-workers.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Bound runtime test workers
+
+Limit runtime Vitest concurrency so cold imports remain within their test
+deadlines when the full workspace test suite fans out across packages.

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    maxWorkers: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- cap runtime Vitest at four workers to prevent root-suite cold-import starvation
- add a non-versioning Tegami entry for the test-infrastructure change

## Validation
- `pnpm check:tegami-notes`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (after the repository-required build prime; 18/18 tasks)
- `pnpm --filter @minpeter/pss-runtime exec vitest run --maxWorkers=4` (214 files, 1,342 passed, 4 skipped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps runtime Vitest at four workers so cold imports keep meeting their deadlines when the full workspace test suite fans out. Vitest previously used default concurrency, which could starve the runtime package's cold-import tests.

- Adds a non-versioning Tegami note recording the test-infrastructure change.

<sup>Written for commit 56c1b508d8e510a12a5deef5b93d79827ebcf764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

