### PR TITLE
fix(release): install task validator sandbox

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,36 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Install sandbox prerequisite
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends bubblewrap procps util-linux
+          sudo mv /usr/bin/bwrap /usr/bin/bwrap.real
+          sudo tee /usr/bin/bwrap >/dev/null <<'EOF'
+          #!/bin/bash
+          args=()
+          for argument in "$@"; do
+            if [[ "$argument" != "--unshare-net" ]]; then
+              args+=("$argument")
+            fi
+          done
+          kill_tree() {
+            local parent=$1 child
+            while read -r child; do
+              if [[ -n "$child" ]]; then
+                kill_tree "$child"
+              fi
+            done < <(pgrep -P "$parent" 2>/dev/null || true)
+            sudo kill -KILL "$parent" 2>/dev/null || true
+          }
+          sudo /usr/bin/unshare --net --fork /usr/bin/bwrap.real "${args[@]}" &
+          child=$!
+          trap 'kill_tree "$child"; exit 143' TERM INT HUP
+          wait "$child"
+          EOF
+          sudo chmod 0755 /usr/bin/bwrap
+          /usr/bin/bwrap --unshare-net --ro-bind / / --dev /dev --proc /proc -- /usr/bin/env true
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -46,6 +76,8 @@ jobs:
         run: pnpm typecheck
 
       - name: Test
+        env:
+          PSS_TASK_VALIDATOR_NETWORK_ISOLATED: "1"
         run: pnpm test
 
       - name: Build

--- a/.tegami/2026-08-27-release-sandbox.md
+++ b/.tegami/2026-08-27-release-sandbox.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Prepare the release sandbox
+
+Install the task-validator sandbox in the release workflow so its pre-publish
+test gate exercises the same isolated environment as CI.

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -25,6 +25,11 @@ describe("release workflow", () => {
     expect(ciWorkflow).toContain("node-version: ${{ matrix.node }}");
     expect(ciWorkflow).toContain('node: ["24", "26"]');
     expect(ciWorkflow).toContain("cancel-in-progress: true");
+    expect(workflow).toContain("- name: Install sandbox prerequisite");
+    expect(workflow).toContain(
+      "sudo apt-get install --yes --no-install-recommends bubblewrap procps util-linux"
+    );
+    expect(workflow).toContain('PSS_TASK_VALIDATOR_NETWORK_ISOLATED: "1"');
     expect(workflow).toContain("pnpm tegami ci");
     expect(workflow).toContain("pnpm verify:release");
     expect(packageJson.scripts["verify:release"]).toContain(


### PR DESCRIPTION
## Summary
- install the Bubblewrap task-validator sandbox in the Release workflow
- mark the release test step as running inside an isolated parent network namespace
- pin the contract with a release workflow test and CI-only Tegami entry

## Validation
- `pnpm exec vitest run scripts/release-workflow.test.mjs` (RED before workflow change, GREEN after)
- `pnpm check:tegami-notes`
- `pnpm lint`
- YAML parse and embedded `bash -n` validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs the Bubblewrap task-validator sandbox in the release workflow so the pre-publish test gate uses the same network isolation as CI, preventing npm publishing from being blocked by task-utility tests that behave differently without the sandbox.

- Adds an "Install sandbox prerequisite" step that wraps `bwrap` to strip `--unshare-net` and run in an isolated parent network namespace via `unshare --net`.
- Sets `PSS_TASK_VALIDATOR_NETWORK_ISOLATED: "1"` on the release workflow Test step.
- Pins this contract with release workflow test assertions and a CI-only `.tegami` note.

<sup>Written for commit ed38af6d1d40ab0f00a309e44b801595c2c0c052. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

