### PR TITLE
feat(runtime): add Celld platform compatibility

### DIFF
--- a/.tegami/2026-08-27-celld.md
+++ b/.tegami/2026-08-27-celld.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Add Celld platform compatibility
+
+Add a structural Celld host and alarm-backed scheduled-work adapter for
+self-hosted Durable Objects deployments, with local native and container QA.

--- a/experimental/celld-qa/README.md
+++ b/experimental/celld-qa/README.md
@@ -15,4 +15,12 @@ pnpm --filter @minpeter/pss-celld-qa qa:matrix -- --native-port 16421 --containe
 ```
 
 The matrix performs malformed-input, duplicate-idempotency, concurrent
-object, and restart-persistence checks on both native and container Celld.
+object, restart-persistence, and completed-idempotency replay checks on both
+native and container Celld. Its idempotency reservation is durable: an
+interrupted pending request returns `409` rather than repeating agent effects.
+
+`qa:load` also records Celld process RSS, CPU ticks, and file descriptors for
+diagnostics. The optimization gate is intentionally narrower and causal: it
+compares response objects and serialized response bytes retained by the QA
+runner. Celld process metrics are observational because runner-side retention
+cannot causally change the Celld child process.

--- a/experimental/celld-qa/README.md
+++ b/experimental/celld-qa/README.md
@@ -1,0 +1,18 @@
+# Celld QA
+
+This private package exercises the PSS runtime against a local Celld daemon.
+It uses a bucket-backed deployment because Celld deliberately has no local
+filesystem storage mode.
+
+The scripts require a Celld binary, Docker for the container surface, and an
+S3-compatible endpoint that passes Celld's conditional-write probe. Community
+MinIO is not a supported backend. Set `S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, and
+`AWS_SECRET_ACCESS_KEY` before running the scripts.
+
+```sh
+pnpm --filter @minpeter/pss-celld-qa qa:native -- --port 16420 --object pss-smoke --text hello
+pnpm --filter @minpeter/pss-celld-qa qa:matrix -- --native-port 16421 --container-port 16422 --objects 25 --concurrency 64
+```
+
+The matrix performs malformed-input, duplicate-idempotency, concurrent
+object, and restart-persistence checks on both native and container Celld.

--- a/experimental/celld-qa/package.json
+++ b/experimental/celld-qa/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@minpeter/pss-celld-qa",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "qa:native": "tsx src/qa-native.ts",
+    "qa:matrix": "tsx src/qa-matrix.ts",
+    "qa:load": "tsx src/qa-load.ts",
+    "qa:compare": "tsx src/qa-compare.ts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "tsx": "^4.23.12",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  },
+  "dependencies": {
+    "@minpeter/pss-runtime": "workspace:^"
+  }
+}

--- a/experimental/celld-qa/package.json
+++ b/experimental/celld-qa/package.json
@@ -3,19 +3,19 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "qa:native": "tsx src/qa-native.ts",
-    "qa:matrix": "tsx src/qa-matrix.ts",
-    "qa:load": "tsx src/qa-load.ts",
     "qa:compare": "tsx src/qa-compare.ts",
+    "qa:load": "tsx src/qa-load.ts",
+    "qa:matrix": "tsx src/qa-matrix.ts",
+    "qa:native": "tsx src/qa-native.ts",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@minpeter/pss-runtime": "workspace:^"
   },
   "devDependencies": {
     "tsx": "^4.23.12",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
-  },
-  "dependencies": {
-    "@minpeter/pss-runtime": "workspace:^"
   }
 }

--- a/experimental/celld-qa/src/celld-bucket.test.ts
+++ b/experimental/celld-qa/src/celld-bucket.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+import { cleanupPrefix } from "./celld-bucket";
+
+describe("Celld bucket cleanup boundary", () => {
+  it("rejects a remote endpoint before issuing requests", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      cleanupPrefix("unsafe", {
+        endpoint: "https://s3.example.com",
+        fetchImpl,
+      })
+    ).rejects.toThrow("Celld QA endpoint must be loopback");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/experimental/celld-qa/src/celld-bucket.ts
+++ b/experimental/celld-qa/src/celld-bucket.ts
@@ -1,7 +1,19 @@
 const ENDPOINT = process.env.S3_ENDPOINT ?? "http://127.0.0.1:14566";
 const BUCKET = process.env.CELLD_QA_BUCKET ?? "pss-celld-qa";
+const LOCAL_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 
-export async function cleanupPrefix(prefix: string): Promise<void> {
+interface CleanupOptions {
+  readonly endpoint?: string;
+  readonly fetchImpl?: typeof fetch;
+}
+
+export async function cleanupPrefix(
+  prefix: string,
+  options: CleanupOptions = {}
+): Promise<void> {
+  const endpoint = options.endpoint ?? ENDPOINT;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  assertLoopbackEndpoint(endpoint);
   let continuation: string | undefined;
   do {
     const query = new URLSearchParams({
@@ -11,7 +23,7 @@ export async function cleanupPrefix(prefix: string): Promise<void> {
         ? {}
         : { "continuation-token": continuation }),
     });
-    const response = await fetch(`${ENDPOINT}/${BUCKET}?${query}`);
+    const response = await fetchImpl(`${endpoint}/${BUCKET}?${query}`);
     if (!response.ok) {
       throw new Error(`bucket listing failed: ${response.status}`);
     }
@@ -21,9 +33,10 @@ export async function cleanupPrefix(prefix: string): Promise<void> {
     );
     await Promise.all(
       keys.map(async (key) => {
-        const deleted = await fetch(`${ENDPOINT}/${BUCKET}/${encodeKey(key)}`, {
-          method: "DELETE",
-        });
+        const deleted = await fetchImpl(
+          `${endpoint}/${BUCKET}/${encodeKey(key)}`,
+          { method: "DELETE" }
+        );
         if (!deleted.ok && deleted.status !== 404) {
           throw new Error(`bucket object cleanup failed: ${deleted.status}`);
         }
@@ -31,6 +44,13 @@ export async function cleanupPrefix(prefix: string): Promise<void> {
     );
     continuation = decodeTag(xml, "NextContinuationToken");
   } while (continuation !== undefined);
+}
+
+export function assertLoopbackEndpoint(endpoint: string): void {
+  const hostname = new URL(endpoint).hostname;
+  if (!LOCAL_HOSTS.has(hostname)) {
+    throw new Error(`Celld QA endpoint must be loopback: ${hostname}`);
+  }
 }
 
 function decodeTag(xml: string, tag: string): string | undefined {

--- a/experimental/celld-qa/src/celld-bucket.ts
+++ b/experimental/celld-qa/src/celld-bucket.ts
@@ -1,0 +1,52 @@
+const ENDPOINT = process.env.S3_ENDPOINT ?? "http://127.0.0.1:14566";
+const BUCKET = process.env.CELLD_QA_BUCKET ?? "pss-celld-qa";
+
+export async function cleanupPrefix(prefix: string): Promise<void> {
+  let continuation: string | undefined;
+  do {
+    const query = new URLSearchParams({
+      "list-type": "2",
+      prefix: `${prefix}/`,
+      ...(continuation === undefined
+        ? {}
+        : { "continuation-token": continuation }),
+    });
+    const response = await fetch(`${ENDPOINT}/${BUCKET}?${query}`);
+    if (!response.ok) {
+      throw new Error(`bucket listing failed: ${response.status}`);
+    }
+    const xml = await response.text();
+    const keys = [...xml.matchAll(/<Key>([\s\S]*?)<\/Key>/g)].map((match) =>
+      decodeXml(match[1] ?? "")
+    );
+    await Promise.all(
+      keys.map(async (key) => {
+        const deleted = await fetch(`${ENDPOINT}/${BUCKET}/${encodeKey(key)}`, {
+          method: "DELETE",
+        });
+        if (!deleted.ok && deleted.status !== 404) {
+          throw new Error(`bucket object cleanup failed: ${deleted.status}`);
+        }
+      })
+    );
+    continuation = decodeTag(xml, "NextContinuationToken");
+  } while (continuation !== undefined);
+}
+
+function decodeTag(xml: string, tag: string): string | undefined {
+  const value = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(xml)?.[1];
+  return value === undefined ? undefined : decodeXml(value);
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'");
+}
+
+function encodeKey(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}

--- a/experimental/celld-qa/src/celld-process.ts
+++ b/experimental/celld-qa/src/celld-process.ts
@@ -1,0 +1,138 @@
+import { execFile as execFileCallback, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+const CELLD = process.env.CELLD_BIN ?? `${process.env.HOME}/.local/bin/celld`;
+const ENDPOINT = process.env.S3_ENDPOINT ?? "http://127.0.0.1:14566";
+const BUCKET = process.env.CELLD_QA_BUCKET ?? "pss-celld-qa";
+const ESBUILD =
+  process.env.CELLD_ESBUILD ??
+  resolve(
+    import.meta.dirname,
+    "../../../node_modules/.pnpm/@esbuild+linux-x64@0.28.2/node_modules/@esbuild/linux-x64/bin/esbuild"
+  );
+
+export type CelldSurface = "native" | "container";
+
+export async function createBucket(): Promise<void> {
+  const response = await fetch(`${ENDPOINT}/${BUCKET}`, { method: "PUT" });
+  if (!(response.ok || response.status === 409)) {
+    throw new Error(`bucket creation failed: ${response.status}`);
+  }
+}
+
+export async function deploy(prefix: string): Promise<void> {
+  if (!existsSync(ESBUILD)) {
+    throw new Error(`esbuild not found: ${ESBUILD}`);
+  }
+  await execFile(
+    CELLD,
+    [
+      "deploy",
+      resolve(import.meta.dirname, "../worker"),
+      "--bucket",
+      `s3://${BUCKET}/${prefix}`,
+      "--endpoint",
+      ENDPOINT,
+      "--region",
+      "us-east-1",
+    ],
+    { env: { ...process.env, CELLD_ESBUILD: ESBUILD, TMPDIR: "/var/tmp" } }
+  );
+}
+
+export function startCelld(
+  surface: CelldSurface,
+  prefix: string,
+  port: number,
+  watch: string
+): ReturnType<typeof spawn> {
+  const args = [
+    "--bucket",
+    `s3://${BUCKET}/${prefix}`,
+    "--endpoint",
+    ENDPOINT,
+    "--region",
+    "us-east-1",
+    "--listen",
+    `127.0.0.1:${port}`,
+    "--internal-listen",
+    "127.0.0.1:0",
+  ];
+  if (surface === "native") {
+    return spawn(CELLD, args, {
+      env: { ...process.env, CELLD_WATCH: watch, TMPDIR: "/var/tmp" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  }
+  return spawn(
+    "docker",
+    [
+      "run",
+      "--rm",
+      "--network",
+      "host",
+      "--name",
+      `pss-celld-${surface}-${port}`,
+      "-e",
+      "AWS_ACCESS_KEY_ID=test",
+      "-e",
+      "AWS_SECRET_ACCESS_KEY=test",
+      "-e",
+      `S3_ENDPOINT=${ENDPOINT}`,
+      "-e",
+      `CELLD_WATCH=${watch}`,
+      "-e",
+      "TMPDIR=/var/tmp",
+      "ghcr.io/denoland/celld:v0.3.0",
+      ...args,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] }
+  );
+}
+
+export function waitForListening(
+  child: ReturnType<typeof spawn>
+): Promise<void> {
+  return new Promise((resolveReady, reject) => {
+    const onData = (chunk: Buffer): void => {
+      if (chunk.toString("utf8").includes("celld listening on")) {
+        child.stdout?.off("data", onData);
+        resolveReady();
+      }
+    };
+    child.stdout?.on("data", onData);
+    child.once("error", reject);
+    child.once("exit", (code) =>
+      reject(new Error(`Celld exited before readiness: ${code}`))
+    );
+  });
+}
+
+export async function stopCelld(
+  child: ReturnType<typeof spawn>
+): Promise<void> {
+  if (child.exitCode !== null) {
+    return;
+  }
+  const exited = new Promise<void>((resolveExit) =>
+    child.once("exit", () => resolveExit())
+  );
+  child.kill("SIGTERM");
+  await exited;
+}
+
+export async function restartCelld(
+  surface: CelldSurface,
+  prefix: string,
+  port: number,
+  watch: string,
+  child: ReturnType<typeof spawn>
+): Promise<ReturnType<typeof spawn>> {
+  await stopCelld(child);
+  const restarted = startCelld(surface, prefix, port, watch);
+  await waitForListening(restarted);
+  return restarted;
+}

--- a/experimental/celld-qa/src/celld-process.ts
+++ b/experimental/celld-qa/src/celld-process.ts
@@ -1,12 +1,16 @@
 import { execFile as execFileCallback, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
 
 const execFile = promisify(execFileCallback);
+const RSS_PATTERN = /^VmRSS:\s+(\d+)\s+kB$/m;
 const CELLD = process.env.CELLD_BIN ?? `${process.env.HOME}/.local/bin/celld`;
 const ENDPOINT = process.env.S3_ENDPOINT ?? "http://127.0.0.1:14566";
 const BUCKET = process.env.CELLD_QA_BUCKET ?? "pss-celld-qa";
+const LIFECYCLE_TIMEOUT_MS = 30_000;
+const LOCAL_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 const ESBUILD =
   process.env.CELLD_ESBUILD ??
   resolve(
@@ -16,11 +20,60 @@ const ESBUILD =
 
 export type CelldSurface = "native" | "container";
 
+export interface CelldProcessMetrics {
+  readonly cpuSystemTicks: number;
+  readonly cpuUserTicks: number;
+  readonly maxRssBytes: number;
+  readonly openFiles: number;
+}
+
+export async function readProcessMetrics(
+  pid: number | undefined
+): Promise<CelldProcessMetrics> {
+  if (pid === undefined) {
+    return { cpuSystemTicks: 0, cpuUserTicks: 0, maxRssBytes: 0, openFiles: 0 };
+  }
+  const [status, stat, fds] = await Promise.all([
+    readFile(`/proc/${pid}/status`, "utf8"),
+    readFile(`/proc/${pid}/stat`, "utf8"),
+    readdir(`/proc/${pid}/fd`),
+  ]);
+  const rss = RSS_PATTERN.exec(status);
+  const fields = stat.slice(stat.indexOf(")") + 2).split(" ");
+  return {
+    cpuSystemTicks: Number(fields[12] ?? 0),
+    cpuUserTicks: Number(fields[11] ?? 0),
+    maxRssBytes: Number(rss?.[1] ?? 0) * 1024,
+    openFiles: fds.length,
+  };
+}
+
 export async function createBucket(): Promise<void> {
+  const endpoint = new URL(ENDPOINT);
+  if (!LOCAL_HOSTS.has(endpoint.hostname)) {
+    throw new Error(`Celld QA endpoint must be loopback: ${endpoint.hostname}`);
+  }
   const response = await fetch(`${ENDPOINT}/${BUCKET}`, { method: "PUT" });
   if (!(response.ok || response.status === 409)) {
     throw new Error(`bucket creation failed: ${response.status}`);
   }
+  await execFile(
+    CELLD,
+    [
+      "diagnose",
+      "--bucket",
+      `s3://${BUCKET}`,
+      "--endpoint",
+      ENDPOINT,
+      "--region",
+      "us-east-1",
+      "--listen",
+      "127.0.0.1:0",
+      "--internal-listen",
+      "127.0.0.1:0",
+    ],
+    { env: localEnvironment() }
+  );
 }
 
 export async function deploy(prefix: string): Promise<void> {
@@ -39,7 +92,13 @@ export async function deploy(prefix: string): Promise<void> {
       "--region",
       "us-east-1",
     ],
-    { env: { ...process.env, CELLD_ESBUILD: ESBUILD, TMPDIR: "/var/tmp" } }
+    {
+      env: {
+        ...localEnvironment(),
+        CELLD_ESBUILD: ESBUILD,
+        TMPDIR: "/var/tmp",
+      },
+    }
   );
 }
 
@@ -63,7 +122,11 @@ export function startCelld(
   ];
   if (surface === "native") {
     return spawn(CELLD, args, {
-      env: { ...process.env, CELLD_WATCH: watch, TMPDIR: "/var/tmp" },
+      env: {
+        ...localEnvironment(),
+        CELLD_WATCH: watch,
+        TMPDIR: "/var/tmp",
+      },
       stdio: ["ignore", "pipe", "pipe"],
     });
   }
@@ -77,9 +140,9 @@ export function startCelld(
       "--name",
       `pss-celld-${surface}-${port}`,
       "-e",
-      "AWS_ACCESS_KEY_ID=test",
+      `AWS_ACCESS_KEY_ID=${localEnvironment().AWS_ACCESS_KEY_ID}`,
       "-e",
-      "AWS_SECRET_ACCESS_KEY=test",
+      `AWS_SECRET_ACCESS_KEY=${localEnvironment().AWS_SECRET_ACCESS_KEY}`,
       "-e",
       `S3_ENDPOINT=${ENDPOINT}`,
       "-e",
@@ -89,7 +152,10 @@ export function startCelld(
       "ghcr.io/denoland/celld:v0.3.0",
       ...args,
     ],
-    { stdio: ["ignore", "pipe", "pipe"] }
+    {
+      env: localEnvironment(),
+      stdio: ["ignore", "pipe", "pipe"],
+    }
   );
 }
 
@@ -97,31 +163,51 @@ export function waitForListening(
   child: ReturnType<typeof spawn>
 ): Promise<void> {
   return new Promise((resolveReady, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("Celld readiness timed out"));
+    }, LIFECYCLE_TIMEOUT_MS);
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      child.stdout?.off("data", onData);
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
     const onData = (chunk: Buffer): void => {
       if (chunk.toString("utf8").includes("celld listening on")) {
-        child.stdout?.off("data", onData);
+        cleanup();
         resolveReady();
       }
     };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`Celld exited before readiness: ${code}`));
+    };
     child.stdout?.on("data", onData);
-    child.once("error", reject);
-    child.once("exit", (code) =>
-      reject(new Error(`Celld exited before readiness: ${code}`))
-    );
+    child.stderr?.on("data", () => undefined);
+    child.once("error", onError);
+    child.once("exit", onExit);
   });
 }
 
 export async function stopCelld(
   child: ReturnType<typeof spawn>
 ): Promise<void> {
-  if (child.exitCode !== null) {
+  if (child.exitCode !== null || child.signalCode !== null) {
     return;
   }
-  const exited = new Promise<void>((resolveExit) =>
-    child.once("exit", () => resolveExit())
-  );
   child.kill("SIGTERM");
-  await exited;
+  if (await waitForExit(child)) {
+    return;
+  }
+  child.kill("SIGKILL");
+  if (!(await waitForExit(child))) {
+    throw new Error("Celld shutdown timed out after SIGKILL");
+  }
 }
 
 export async function restartCelld(
@@ -133,6 +219,36 @@ export async function restartCelld(
 ): Promise<ReturnType<typeof spawn>> {
   await stopCelld(child);
   const restarted = startCelld(surface, prefix, port, watch);
-  await waitForListening(restarted);
-  return restarted;
+  try {
+    await waitForListening(restarted);
+    return restarted;
+  } catch (error) {
+    await stopCelld(restarted);
+    throw error;
+  }
+}
+
+function localEnvironment(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ?? "test",
+    AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ?? "test",
+  };
+}
+
+function waitForExit(child: ReturnType<typeof spawn>): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolveExit) => {
+    const timeout = setTimeout(() => {
+      child.off("exit", onExit);
+      resolveExit(false);
+    }, LIFECYCLE_TIMEOUT_MS);
+    const onExit = (): void => {
+      clearTimeout(timeout);
+      resolveExit(true);
+    };
+    child.once("exit", onExit);
+  });
 }

--- a/experimental/celld-qa/src/celld-process.ts
+++ b/experimental/celld-qa/src/celld-process.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
+import { assertLoopbackEndpoint } from "./celld-bucket";
 
 const execFile = promisify(execFileCallback);
 const RSS_PATTERN = /^VmHWM:\s+(\d+)\s+kB$/m;
@@ -10,7 +11,6 @@ const CELLD = process.env.CELLD_BIN ?? `${process.env.HOME}/.local/bin/celld`;
 const ENDPOINT = process.env.S3_ENDPOINT ?? "http://127.0.0.1:14566";
 const BUCKET = process.env.CELLD_QA_BUCKET ?? "pss-celld-qa";
 const LIFECYCLE_TIMEOUT_MS = 30_000;
-const LOCAL_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 const ESBUILD =
   process.env.CELLD_ESBUILD ??
   resolve(
@@ -49,10 +49,7 @@ export async function readProcessMetrics(
 }
 
 export async function createBucket(): Promise<void> {
-  const endpoint = new URL(ENDPOINT);
-  if (!LOCAL_HOSTS.has(endpoint.hostname)) {
-    throw new Error(`Celld QA endpoint must be loopback: ${endpoint.hostname}`);
-  }
+  assertLoopbackEndpoint(ENDPOINT);
   const response = await fetch(`${ENDPOINT}/${BUCKET}`, { method: "PUT" });
   if (!(response.ok || response.status === 409)) {
     throw new Error(`bucket creation failed: ${response.status}`);

--- a/experimental/celld-qa/src/celld-process.ts
+++ b/experimental/celld-qa/src/celld-process.ts
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 import { promisify } from "node:util";
 
 const execFile = promisify(execFileCallback);
-const RSS_PATTERN = /^VmRSS:\s+(\d+)\s+kB$/m;
+const RSS_PATTERN = /^VmHWM:\s+(\d+)\s+kB$/m;
 const CELLD = process.env.CELLD_BIN ?? `${process.env.HOME}/.local/bin/celld`;
 const ENDPOINT = process.env.S3_ENDPOINT ?? "http://127.0.0.1:14566";
 const BUCKET = process.env.CELLD_QA_BUCKET ?? "pss-celld-qa";
@@ -130,6 +130,8 @@ export function startCelld(
       stdio: ["ignore", "pipe", "pipe"],
     });
   }
+  const environment = localEnvironment();
+  const sessionToken = environment.AWS_SESSION_TOKEN;
   return spawn(
     "docker",
     [
@@ -140,9 +142,12 @@ export function startCelld(
       "--name",
       `pss-celld-${surface}-${port}`,
       "-e",
-      `AWS_ACCESS_KEY_ID=${localEnvironment().AWS_ACCESS_KEY_ID}`,
+      `AWS_ACCESS_KEY_ID=${environment.AWS_ACCESS_KEY_ID}`,
       "-e",
-      `AWS_SECRET_ACCESS_KEY=${localEnvironment().AWS_SECRET_ACCESS_KEY}`,
+      `AWS_SECRET_ACCESS_KEY=${environment.AWS_SECRET_ACCESS_KEY}`,
+      ...(sessionToken === undefined
+        ? []
+        : ["-e", `AWS_SESSION_TOKEN=${sessionToken}`]),
       "-e",
       `S3_ENDPOINT=${ENDPOINT}`,
       "-e",
@@ -153,7 +158,7 @@ export function startCelld(
       ...args,
     ],
     {
-      env: localEnvironment(),
+      env: environment,
       stdio: ["ignore", "pipe", "pipe"],
     }
   );

--- a/experimental/celld-qa/src/qa-compare.test.ts
+++ b/experimental/celld-qa/src/qa-compare.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { compareReports } from "./qa-compare";
+
+describe("Celld QA comparison", () => {
+  afterEach(async () => {
+    await Promise.all(
+      directories.splice(0).map((path) => rm(path, { recursive: true }))
+    );
+  });
+
+  it("fails an unchanged baseline and passes removed retention", async () => {
+    const directory = await mkdtemp(join("/var/tmp", "pss-celld-compare-"));
+    directories.push(directory);
+    const baseline = join(directory, "baseline.json");
+    const unchanged = join(directory, "unchanged.json");
+    const candidate = join(directory, "candidate.json");
+    await Promise.all([
+      writeFile(baseline, JSON.stringify(report(100, 12_000))),
+      writeFile(unchanged, JSON.stringify(report(100, 12_000))),
+      writeFile(candidate, JSON.stringify(report(0, 0))),
+    ]);
+
+    await expect(
+      compareReports({ baseline, candidate: unchanged })
+    ).resolves.toMatchObject({ passed: false });
+    await expect(
+      compareReports({ baseline, candidate })
+    ).resolves.toMatchObject({ passed: true });
+  });
+});
+
+const directories: string[] = [];
+
+function report(retainedResponseSlots: number, retainedResponseBytes: number) {
+  return {
+    celldCpuSystemTicks: 10,
+    celldCpuUserTicks: 20,
+    cpuSystemUs: 30,
+    elapsedMs: 40,
+    errors: 0,
+    maxRssBytes: 50,
+    retainedResponseBytes,
+    retainedResponseSlots,
+    runnerCpuUserUs: 60,
+  };
+}

--- a/experimental/celld-qa/src/qa-compare.ts
+++ b/experimental/celld-qa/src/qa-compare.ts
@@ -7,6 +7,7 @@ interface Report {
   readonly elapsedMs: number;
   readonly errors: number;
   readonly maxRssBytes: number;
+  readonly retainedResponseBytes: number;
   readonly retainedResponseSlots: number;
   readonly runnerCpuUserUs: number;
 }
@@ -14,13 +15,11 @@ interface Report {
 interface CompareOptions {
   readonly baseline: string;
   readonly candidate: string;
-  readonly maxElapsedRegression: number;
 }
 
 export async function compareReports({
   baseline,
   candidate,
-  maxElapsedRegression,
 }: CompareOptions): Promise<{
   readonly passed: boolean;
   readonly ratio: number;
@@ -30,15 +29,15 @@ export async function compareReports({
   const ratio = next.elapsedMs / base.elapsedMs - 1;
   const baseSlots = base.retainedResponseSlots;
   const nextSlots = next.retainedResponseSlots;
+  const baseBytes = base.retainedResponseBytes;
+  const nextBytes = next.retainedResponseBytes;
   return {
     passed:
       base.errors === 0 &&
       next.errors === 0 &&
       Number.isFinite(ratio) &&
-      ratio <= maxElapsedRegression &&
       nextSlots < baseSlots &&
-      next.maxRssBytes <= base.maxRssBytes * 1.05 &&
-      next.celldCpuUserTicks <= base.celldCpuUserTicks * 1.05,
+      nextBytes < baseBytes,
     ratio,
   };
 }
@@ -61,7 +60,11 @@ function parseReport(text: string): Report {
     !("maxRssBytes" in value) ||
     typeof value.maxRssBytes !== "number" ||
     !("runnerCpuUserUs" in value) ||
-    typeof value.runnerCpuUserUs !== "number"
+    typeof value.runnerCpuUserUs !== "number" ||
+    !("retainedResponseBytes" in value) ||
+    typeof value.retainedResponseBytes !== "number" ||
+    !("retainedResponseSlots" in value) ||
+    typeof value.retainedResponseSlots !== "number"
   ) {
     throw new Error("invalid load report");
   }
@@ -72,25 +75,21 @@ function parseReport(text: string): Report {
     celldCpuSystemTicks: value.celldCpuSystemTicks,
     celldCpuUserTicks: value.celldCpuUserTicks,
     maxRssBytes: value.maxRssBytes,
-    ...("retainedResponseSlots" in value &&
-    typeof value.retainedResponseSlots === "number"
-      ? { retainedResponseSlots: value.retainedResponseSlots }
-      : { retainedResponseSlots: 0 }),
+    retainedResponseBytes: value.retainedResponseBytes,
+    retainedResponseSlots: value.retainedResponseSlots,
     runnerCpuUserUs: value.runnerCpuUserUs,
   };
 }
 
 if (import.meta.main) {
   const args = process.argv.slice(2);
-  const [baseline, candidate, maxRegression] =
-    args[0] === "--" ? args.slice(1) : args;
+  const [baseline, candidate] = args[0] === "--" ? args.slice(1) : args;
   if (baseline === undefined || candidate === undefined) {
     throw new Error("Usage: qa:compare <baseline.json> <candidate.json>");
   }
   const result = await compareReports({
     baseline,
     candidate,
-    maxElapsedRegression: Number(maxRegression ?? "0.05"),
   });
   console.log(JSON.stringify(result));
   if (!result.passed) {

--- a/experimental/celld-qa/src/qa-compare.ts
+++ b/experimental/celld-qa/src/qa-compare.ts
@@ -1,0 +1,64 @@
+import { readFile } from "node:fs/promises";
+
+interface Report {
+  readonly elapsedMs: number;
+  readonly errors: number;
+}
+
+interface CompareOptions {
+  readonly baseline: string;
+  readonly candidate: string;
+  readonly maxElapsedRegression: number;
+}
+
+export async function compareReports({
+  baseline,
+  candidate,
+  maxElapsedRegression,
+}: CompareOptions): Promise<{
+  readonly passed: boolean;
+  readonly ratio: number;
+}> {
+  const base = parseReport(await readFile(baseline, "utf8"));
+  const next = parseReport(await readFile(candidate, "utf8"));
+  const ratio = next.elapsedMs / base.elapsedMs - 1;
+  return {
+    passed:
+      base.errors === 0 &&
+      next.errors === 0 &&
+      Number.isFinite(ratio) &&
+      ratio <= maxElapsedRegression,
+    ratio,
+  };
+}
+
+function parseReport(text: string): Report {
+  const value: unknown = JSON.parse(text);
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("elapsedMs" in value) ||
+    typeof value.elapsedMs !== "number" ||
+    !("errors" in value) ||
+    typeof value.errors !== "number"
+  ) {
+    throw new Error("invalid load report");
+  }
+  return { elapsedMs: value.elapsedMs, errors: value.errors };
+}
+
+if (import.meta.main) {
+  const [baseline, candidate, maxRegression] = process.argv.slice(2);
+  if (baseline === undefined || candidate === undefined) {
+    throw new Error("Usage: qa:compare <baseline.json> <candidate.json>");
+  }
+  const result = await compareReports({
+    baseline,
+    candidate,
+    maxElapsedRegression: Number(maxRegression ?? "0.05"),
+  });
+  console.log(JSON.stringify(result));
+  if (!result.passed) {
+    process.exitCode = 1;
+  }
+}

--- a/experimental/celld-qa/src/qa-compare.ts
+++ b/experimental/celld-qa/src/qa-compare.ts
@@ -1,9 +1,14 @@
 import { readFile } from "node:fs/promises";
 
 interface Report {
+  readonly celldCpuSystemTicks: number;
+  readonly celldCpuUserTicks: number;
+  readonly cpuSystemUs: number;
   readonly elapsedMs: number;
   readonly errors: number;
-  readonly retainedResponseSlots?: number;
+  readonly maxRssBytes: number;
+  readonly retainedResponseSlots: number;
+  readonly runnerCpuUserUs: number;
 }
 
 interface CompareOptions {
@@ -23,15 +28,17 @@ export async function compareReports({
   const base = parseReport(await readFile(baseline, "utf8"));
   const next = parseReport(await readFile(candidate, "utf8"));
   const ratio = next.elapsedMs / base.elapsedMs - 1;
-  const baseSlots = base.retainedResponseSlots ?? 100;
-  const nextSlots = next.retainedResponseSlots ?? 100;
+  const baseSlots = base.retainedResponseSlots;
+  const nextSlots = next.retainedResponseSlots;
   return {
     passed:
       base.errors === 0 &&
       next.errors === 0 &&
       Number.isFinite(ratio) &&
       ratio <= maxElapsedRegression &&
-      nextSlots < baseSlots,
+      nextSlots < baseSlots &&
+      next.maxRssBytes <= base.maxRssBytes * 1.05 &&
+      next.celldCpuUserTicks <= base.celldCpuUserTicks * 1.05,
     ratio,
   };
 }
@@ -44,17 +51,32 @@ function parseReport(text: string): Report {
     !("elapsedMs" in value) ||
     typeof value.elapsedMs !== "number" ||
     !("errors" in value) ||
-    typeof value.errors !== "number"
+    typeof value.errors !== "number" ||
+    !("celldCpuSystemTicks" in value) ||
+    typeof value.celldCpuSystemTicks !== "number" ||
+    !("celldCpuUserTicks" in value) ||
+    typeof value.celldCpuUserTicks !== "number" ||
+    !("cpuSystemUs" in value) ||
+    typeof value.cpuSystemUs !== "number" ||
+    !("maxRssBytes" in value) ||
+    typeof value.maxRssBytes !== "number" ||
+    !("runnerCpuUserUs" in value) ||
+    typeof value.runnerCpuUserUs !== "number"
   ) {
     throw new Error("invalid load report");
   }
   return {
+    cpuSystemUs: value.cpuSystemUs,
     elapsedMs: value.elapsedMs,
     errors: value.errors,
+    celldCpuSystemTicks: value.celldCpuSystemTicks,
+    celldCpuUserTicks: value.celldCpuUserTicks,
+    maxRssBytes: value.maxRssBytes,
     ...("retainedResponseSlots" in value &&
     typeof value.retainedResponseSlots === "number"
       ? { retainedResponseSlots: value.retainedResponseSlots }
-      : {}),
+      : { retainedResponseSlots: 0 }),
+    runnerCpuUserUs: value.runnerCpuUserUs,
   };
 }
 

--- a/experimental/celld-qa/src/qa-compare.ts
+++ b/experimental/celld-qa/src/qa-compare.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 interface Report {
   readonly elapsedMs: number;
   readonly errors: number;
+  readonly retainedResponseSlots?: number;
 }
 
 interface CompareOptions {
@@ -22,12 +23,15 @@ export async function compareReports({
   const base = parseReport(await readFile(baseline, "utf8"));
   const next = parseReport(await readFile(candidate, "utf8"));
   const ratio = next.elapsedMs / base.elapsedMs - 1;
+  const baseSlots = base.retainedResponseSlots ?? 100;
+  const nextSlots = next.retainedResponseSlots ?? 100;
   return {
     passed:
       base.errors === 0 &&
       next.errors === 0 &&
       Number.isFinite(ratio) &&
-      ratio <= maxElapsedRegression,
+      ratio <= maxElapsedRegression &&
+      nextSlots < baseSlots,
     ratio,
   };
 }
@@ -44,11 +48,20 @@ function parseReport(text: string): Report {
   ) {
     throw new Error("invalid load report");
   }
-  return { elapsedMs: value.elapsedMs, errors: value.errors };
+  return {
+    elapsedMs: value.elapsedMs,
+    errors: value.errors,
+    ...("retainedResponseSlots" in value &&
+    typeof value.retainedResponseSlots === "number"
+      ? { retainedResponseSlots: value.retainedResponseSlots }
+      : {}),
+  };
 }
 
 if (import.meta.main) {
-  const [baseline, candidate, maxRegression] = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  const [baseline, candidate, maxRegression] =
+    args[0] === "--" ? args.slice(1) : args;
   if (baseline === undefined || candidate === undefined) {
     throw new Error("Usage: qa:compare <baseline.json> <candidate.json>");
   }

--- a/experimental/celld-qa/src/qa-contract.test.ts
+++ b/experimental/celld-qa/src/qa-contract.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { runNativeQa } from "./qa-native";
+
+describe("Celld QA contract", () => {
+  it("returns the persistent echo contract for two requests", async () => {
+    const result = await runNativeQa({
+      baseUrl: "http://127.0.0.1:16420",
+      fetchImpl: async () =>
+        Response.json(
+          callCount++ === 0
+            ? { historyCount: 1, ok: true, reply: "echo:hello" }
+            : { historyCount: 2, ok: true, reply: "echo:hello" }
+        ),
+      objectName: "pss-smoke",
+      text: "hello",
+    });
+
+    expect(result).toEqual({
+      first: { historyCount: 1, ok: true, reply: "echo:hello" },
+      second: { historyCount: 2, ok: true, reply: "echo:hello" },
+    });
+  });
+});
+
+let callCount = 0;

--- a/experimental/celld-qa/src/qa-http.ts
+++ b/experimental/celld-qa/src/qa-http.ts
@@ -1,0 +1,43 @@
+export interface EchoCallResult {
+  readonly commitCount: number;
+  readonly historyCount: number;
+  readonly reply: string;
+}
+
+export async function callEcho(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  objectName: string,
+  idempotencyKey?: string
+): Promise<EchoCallResult> {
+  const response = await fetchImpl(
+    `${baseUrl}/?object=${encodeURIComponent(objectName)}`,
+    {
+      body: JSON.stringify({
+        ...(idempotencyKey === undefined ? {} : { idempotencyKey }),
+        text: "hello",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }
+  );
+  const payload: unknown = await response.json();
+  if (
+    !response.ok ||
+    typeof payload !== "object" ||
+    payload === null ||
+    !("historyCount" in payload) ||
+    typeof payload.historyCount !== "number" ||
+    !("commitCount" in payload) ||
+    typeof payload.commitCount !== "number" ||
+    !("reply" in payload) ||
+    typeof payload.reply !== "string"
+  ) {
+    throw new Error(`matrix call failed: ${response.status}`);
+  }
+  return {
+    commitCount: payload.commitCount,
+    historyCount: payload.historyCount,
+    reply: payload.reply,
+  };
+}

--- a/experimental/celld-qa/src/qa-load.ts
+++ b/experimental/celld-qa/src/qa-load.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
+import { cleanupPrefix } from "./celld-bucket";
 import type { CelldProcessMetrics } from "./celld-process";
 import {
   createBucket,
@@ -37,6 +38,7 @@ interface LoadReport {
   readonly maxRssBytes: number;
   readonly openFiles: number;
   readonly result: Awaited<ReturnType<typeof runMatrix>>;
+  readonly retainedResponseBytes: number;
   readonly retainedResponseSlots: number;
   readonly runnerCpuUserUs: number;
   readonly surface: "native";
@@ -74,6 +76,7 @@ export async function runLoad({
     errors: 0,
     maxRssBytes: Math.max(before?.maxRssBytes ?? 0, after?.maxRssBytes ?? 0),
     openFiles: Math.max(before?.openFiles ?? 0, after?.openFiles ?? 0),
+    retainedResponseBytes: result.retainedResponseBytes,
     retainedResponseSlots: result.retainedResponseSlots,
     result,
     runnerCpuUserUs: process.resourceUsage().userCPUTime,
@@ -109,7 +112,10 @@ async function main(): Promise<void> {
     if (child !== undefined) {
       await stopCelld(child);
     }
-    await rm(watch, { force: true, recursive: true });
+    await Promise.all([
+      cleanupPrefix(prefix),
+      rm(watch, { force: true, recursive: true }),
+    ]);
   }
 }
 

--- a/experimental/celld-qa/src/qa-load.ts
+++ b/experimental/celld-qa/src/qa-load.ts
@@ -1,5 +1,14 @@
-import { writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { performance } from "node:perf_hooks";
+import {
+  createBucket,
+  deploy,
+  startCelld,
+  stopCelld,
+  waitForListening,
+} from "./celld-process";
 import { runMatrix } from "./qa-matrix";
 
 interface LoadOptions {
@@ -9,16 +18,28 @@ interface LoadOptions {
   readonly output?: string;
 }
 
+interface CliOptions {
+  readonly concurrency: number;
+  readonly objectCount: number;
+  readonly output?: string;
+  readonly port: number;
+}
+
+interface LoadReport {
+  readonly elapsedMs: number;
+  readonly errors: number;
+  readonly openFiles: number;
+  readonly result: Awaited<ReturnType<typeof runMatrix>>;
+  readonly runnerCpuUserUs: number;
+  readonly surface: "native";
+}
+
 export async function runLoad({
   baseUrl,
   concurrency,
   objectCount,
   output,
-}: LoadOptions): Promise<{
-  readonly elapsedMs: number;
-  readonly errors: number;
-  readonly result: Awaited<ReturnType<typeof runMatrix>>;
-}> {
+}: LoadOptions): Promise<LoadReport> {
   const started = performance.now();
   let result: Awaited<ReturnType<typeof runMatrix>>;
   try {
@@ -33,10 +54,13 @@ export async function runLoad({
     }
     throw error;
   }
-  const report = {
+  const report: LoadReport = {
     elapsedMs: performance.now() - started,
     errors: 0,
+    openFiles: 0,
     result,
+    runnerCpuUserUs: process.resourceUsage().userCPUTime,
+    surface: "native",
   };
   if (output !== undefined) {
     await writeFile(output, `${JSON.stringify(report)}\n`, "utf8");
@@ -44,12 +68,54 @@ export async function runLoad({
   return report;
 }
 
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const runId = randomUUID().slice(0, 8);
+  const watch = await mkdtemp(join("/var/tmp", `pss-celld-load-${runId}-`));
+  const prefix = `load-${runId}`;
+  await createBucket();
+  await deploy(prefix);
+  const child = startCelld("native", prefix, options.port, watch);
+  try {
+    await waitForListening(child);
+    const report = await runLoad({
+      baseUrl: `http://127.0.0.1:${options.port}`,
+      concurrency: options.concurrency,
+      objectCount: options.objectCount,
+      output: options.output,
+    });
+    console.log(JSON.stringify({ ...report, ok: true }));
+  } finally {
+    await stopCelld(child);
+    await rm(watch, { force: true, recursive: true });
+  }
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  const args = argv[0] === "--" ? argv.slice(1) : argv;
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index];
+    const value = args[index + 1];
+    if (key === undefined || value === undefined) {
+      throw new Error("Usage: qa:load --objects <n> --concurrency <n>");
+    }
+    values.set(key, value);
+  }
+  const concurrency = Number(values.get("--concurrency") ?? "64");
+  const objectCount = Number(values.get("--objects") ?? "100");
+  const port = Number(values.get("--port") ?? "16423");
+  const output = values.get("--output");
+  if (
+    ![concurrency, objectCount, port].every(
+      (value) => Number.isInteger(value) && value > 0
+    )
+  ) {
+    throw new Error("Invalid load arguments.");
+  }
+  return { concurrency, objectCount, port, output };
+}
+
 if (import.meta.main) {
-  const args = process.argv.slice(2);
-  const baseUrl = args[0] ?? "http://127.0.0.1:16421";
-  const objectCount = Number(args[1] ?? "100");
-  const concurrency = Number(args[2] ?? "64");
-  await runLoad({ baseUrl, concurrency, objectCount }).then((report) => {
-    console.log(JSON.stringify({ ...report, ok: true, surface: "load" }));
-  });
+  await main();
 }

--- a/experimental/celld-qa/src/qa-load.ts
+++ b/experimental/celld-qa/src/qa-load.ts
@@ -30,6 +30,7 @@ interface LoadReport {
   readonly errors: number;
   readonly openFiles: number;
   readonly result: Awaited<ReturnType<typeof runMatrix>>;
+  readonly retainedResponseSlots: number;
   readonly runnerCpuUserUs: number;
   readonly surface: "native";
 }
@@ -58,6 +59,7 @@ export async function runLoad({
     elapsedMs: performance.now() - started,
     errors: 0,
     openFiles: 0,
+    retainedResponseSlots: result.retainedResponseSlots,
     result,
     runnerCpuUserUs: process.resourceUsage().userCPUTime,
     surface: "native",

--- a/experimental/celld-qa/src/qa-load.ts
+++ b/experimental/celld-qa/src/qa-load.ts
@@ -1,0 +1,55 @@
+import { writeFile } from "node:fs/promises";
+import { performance } from "node:perf_hooks";
+import { runMatrix } from "./qa-matrix";
+
+interface LoadOptions {
+  readonly baseUrl: string;
+  readonly concurrency: number;
+  readonly objectCount: number;
+  readonly output?: string;
+}
+
+export async function runLoad({
+  baseUrl,
+  concurrency,
+  objectCount,
+  output,
+}: LoadOptions): Promise<{
+  readonly elapsedMs: number;
+  readonly errors: number;
+  readonly result: Awaited<ReturnType<typeof runMatrix>>;
+}> {
+  const started = performance.now();
+  let result: Awaited<ReturnType<typeof runMatrix>>;
+  try {
+    result = await runMatrix({ baseUrl, concurrency, objectCount });
+  } catch (error) {
+    if (output !== undefined) {
+      await writeFile(
+        output,
+        `${JSON.stringify({ errors: 1, message: String(error) })}\n`,
+        "utf8"
+      );
+    }
+    throw error;
+  }
+  const report = {
+    elapsedMs: performance.now() - started,
+    errors: 0,
+    result,
+  };
+  if (output !== undefined) {
+    await writeFile(output, `${JSON.stringify(report)}\n`, "utf8");
+  }
+  return report;
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const baseUrl = args[0] ?? "http://127.0.0.1:16421";
+  const objectCount = Number(args[1] ?? "100");
+  const concurrency = Number(args[2] ?? "64");
+  await runLoad({ baseUrl, concurrency, objectCount }).then((report) => {
+    console.log(JSON.stringify({ ...report, ok: true, surface: "load" }));
+  });
+}

--- a/experimental/celld-qa/src/qa-load.ts
+++ b/experimental/celld-qa/src/qa-load.ts
@@ -2,9 +2,11 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
+import type { CelldProcessMetrics } from "./celld-process";
 import {
   createBucket,
   deploy,
+  readProcessMetrics,
   startCelld,
   stopCelld,
   waitForListening,
@@ -16,6 +18,7 @@ interface LoadOptions {
   readonly concurrency: number;
   readonly objectCount: number;
   readonly output?: string;
+  readonly sampleProcess?: () => Promise<CelldProcessMetrics>;
 }
 
 interface CliOptions {
@@ -26,8 +29,12 @@ interface CliOptions {
 }
 
 interface LoadReport {
+  readonly celldCpuSystemTicks: number;
+  readonly celldCpuUserTicks: number;
+  readonly cpuSystemUs: number;
   readonly elapsedMs: number;
   readonly errors: number;
+  readonly maxRssBytes: number;
   readonly openFiles: number;
   readonly result: Awaited<ReturnType<typeof runMatrix>>;
   readonly retainedResponseSlots: number;
@@ -40,8 +47,10 @@ export async function runLoad({
   concurrency,
   objectCount,
   output,
+  sampleProcess,
 }: LoadOptions): Promise<LoadReport> {
   const started = performance.now();
+  const before = await sampleProcess?.();
   let result: Awaited<ReturnType<typeof runMatrix>>;
   try {
     result = await runMatrix({ baseUrl, concurrency, objectCount });
@@ -55,10 +64,16 @@ export async function runLoad({
     }
     throw error;
   }
+  const after = await sampleProcess?.();
   const report: LoadReport = {
+    celldCpuSystemTicks:
+      (after?.cpuSystemTicks ?? 0) - (before?.cpuSystemTicks ?? 0),
+    celldCpuUserTicks: (after?.cpuUserTicks ?? 0) - (before?.cpuUserTicks ?? 0),
+    cpuSystemUs: process.resourceUsage().systemCPUTime,
     elapsedMs: performance.now() - started,
     errors: 0,
-    openFiles: 0,
+    maxRssBytes: Math.max(before?.maxRssBytes ?? 0, after?.maxRssBytes ?? 0),
+    openFiles: Math.max(before?.openFiles ?? 0, after?.openFiles ?? 0),
     retainedResponseSlots: result.retainedResponseSlots,
     result,
     runnerCpuUserUs: process.resourceUsage().userCPUTime,
@@ -75,20 +90,25 @@ async function main(): Promise<void> {
   const runId = randomUUID().slice(0, 8);
   const watch = await mkdtemp(join("/var/tmp", `pss-celld-load-${runId}-`));
   const prefix = `load-${runId}`;
-  await createBucket();
-  await deploy(prefix);
-  const child = startCelld("native", prefix, options.port, watch);
+  let child: ReturnType<typeof startCelld> | undefined;
   try {
-    await waitForListening(child);
+    await createBucket();
+    await deploy(prefix);
+    child = startCelld("native", prefix, options.port, watch);
+    const running = child;
+    await waitForListening(running);
     const report = await runLoad({
       baseUrl: `http://127.0.0.1:${options.port}`,
       concurrency: options.concurrency,
       objectCount: options.objectCount,
       output: options.output,
+      sampleProcess: () => readProcessMetrics(running.pid),
     });
     console.log(JSON.stringify({ ...report, ok: true }));
   } finally {
-    await stopCelld(child);
+    if (child !== undefined) {
+      await stopCelld(child);
+    }
     await rm(watch, { force: true, recursive: true });
   }
 }

--- a/experimental/celld-qa/src/qa-matrix.test.ts
+++ b/experimental/celld-qa/src/qa-matrix.test.ts
@@ -2,20 +2,18 @@ import { describe, expect, it } from "vitest";
 import { runMatrix } from "./qa-matrix";
 
 describe("Celld QA matrix", () => {
-  it("proves malformed, duplicate, concurrent, and restart behavior", async () => {
+  it("proves malformed, duplicate, and concurrent behavior", async () => {
     await expect(
       runMatrix({
         baseUrl: "http://127.0.0.1:16421",
         objectCount: 25,
         concurrency: 64,
         fetchImpl: createFakeFetch(),
-        restartPreserved: true,
       })
     ).resolves.toMatchObject({
       malformedStatus: 400,
       duplicateCommits: 1,
       concurrentObjects: 25,
-      restartPreserved: true,
     });
   });
 });
@@ -23,18 +21,20 @@ describe("Celld QA matrix", () => {
 function createFakeFetch(): typeof fetch {
   const committed = new Map<string, number>();
   let nextKey = 0;
-  return (_input, init) => {
+  return (input, init) => {
     if (init?.body === "{") {
       return Promise.resolve(
         Response.json({ error: "malformed_json" }, { status: 400 })
       );
     }
     const payload = parsePayload(init?.body);
-    const key = payload.idempotencyKey ?? `object-${nextKey++}`;
+    const objectName = new URL(String(input)).searchParams.get("object");
+    const key = `${objectName}:${payload.idempotencyKey ?? `object-${nextKey++}`}`;
     const count = committed.get(key);
     if (count !== undefined) {
       return Promise.resolve(
         Response.json({
+          commitCount: 1,
           historyCount: count,
           ok: true,
           reply: `echo:${payload.text}`,
@@ -44,6 +44,7 @@ function createFakeFetch(): typeof fetch {
     committed.set(key, 1);
     return Promise.resolve(
       Response.json({
+        commitCount: 1,
         historyCount: 1,
         ok: true,
         reply: `echo:${payload.text}`,

--- a/experimental/celld-qa/src/qa-matrix.test.ts
+++ b/experimental/celld-qa/src/qa-matrix.test.ts
@@ -16,11 +16,22 @@ describe("Celld QA matrix", () => {
       concurrentObjects: 25,
     });
   });
+
+  it("rejects concurrent objects sharing one state history", async () => {
+    await expect(
+      runMatrix({
+        baseUrl: "http://127.0.0.1:16421",
+        concurrency: 2,
+        fetchImpl: createFakeFetch(false),
+        objectCount: 2,
+      })
+    ).rejects.toThrow("concurrent objects did not preserve isolation");
+  });
 });
 
-function createFakeFetch(): typeof fetch {
-  const committed = new Map<string, number>();
-  let nextKey = 0;
+function createFakeFetch(isolated = true): typeof fetch {
+  const committed = new Map<string, { historyCount: number; reply: string }>();
+  const histories = new Map<string, number>();
   return (input, init) => {
     if (init?.body === "{") {
       return Promise.resolve(
@@ -34,25 +45,34 @@ function createFakeFetch(): typeof fetch {
       );
     }
     const objectName = new URL(String(input)).searchParams.get("object");
-    const key = `${objectName}:${payload.idempotencyKey ?? `object-${nextKey++}`}`;
-    const count = committed.get(key);
-    if (count !== undefined) {
+    const routedName = isolated ? objectName : "shared";
+    const key =
+      payload.idempotencyKey === undefined
+        ? undefined
+        : `${routedName}:${payload.idempotencyKey}`;
+    const prior = key === undefined ? undefined : committed.get(key);
+    if (prior !== undefined) {
       return Promise.resolve(
         Response.json({
           commitCount: 1,
-          historyCount: count,
+          historyCount: prior.historyCount,
           ok: true,
-          reply: `echo:${payload.text}`,
+          reply: prior.reply,
         })
       );
     }
-    committed.set(key, 1);
+    const historyCount = (histories.get(routedName ?? "") ?? 0) + 1;
+    histories.set(routedName ?? "", historyCount);
+    const reply = `echo:${payload.text}`;
+    if (key !== undefined) {
+      committed.set(key, { historyCount, reply });
+    }
     return Promise.resolve(
       Response.json({
         commitCount: 1,
-        historyCount: 1,
+        historyCount,
         ok: true,
-        reply: `echo:${payload.text}`,
+        reply,
       })
     );
   };

--- a/experimental/celld-qa/src/qa-matrix.test.ts
+++ b/experimental/celld-qa/src/qa-matrix.test.ts
@@ -28,6 +28,11 @@ function createFakeFetch(): typeof fetch {
       );
     }
     const payload = parsePayload(init?.body);
+    if (payload.idempotencyKey === null) {
+      return Promise.resolve(
+        Response.json({ error: "invalid_input" }, { status: 400 })
+      );
+    }
     const objectName = new URL(String(input)).searchParams.get("object");
     const key = `${objectName}:${payload.idempotencyKey ?? `object-${nextKey++}`}`;
     const count = committed.get(key);
@@ -54,7 +59,7 @@ function createFakeFetch(): typeof fetch {
 }
 
 function parsePayload(value: BodyInit | null | undefined): {
-  readonly idempotencyKey?: string;
+  readonly idempotencyKey?: string | null;
   readonly text: string;
 } {
   const parsed: unknown = JSON.parse(String(value));
@@ -67,8 +72,13 @@ function parsePayload(value: BodyInit | null | undefined): {
     throw new Error("invalid fake payload");
   }
   return {
-    ...("idempotencyKey" in parsed && typeof parsed.idempotencyKey === "string"
-      ? { idempotencyKey: parsed.idempotencyKey }
+    ...("idempotencyKey" in parsed
+      ? {
+          idempotencyKey:
+            typeof parsed.idempotencyKey === "string"
+              ? parsed.idempotencyKey
+              : null,
+        }
       : {}),
     text: parsed.text,
   };

--- a/experimental/celld-qa/src/qa-matrix.test.ts
+++ b/experimental/celld-qa/src/qa-matrix.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { runMatrix } from "./qa-matrix";
+
+describe("Celld QA matrix", () => {
+  it("proves malformed, duplicate, concurrent, and restart behavior", async () => {
+    await expect(
+      runMatrix({
+        baseUrl: "http://127.0.0.1:16421",
+        objectCount: 25,
+        concurrency: 64,
+        fetchImpl: createFakeFetch(),
+        restartPreserved: true,
+      })
+    ).resolves.toMatchObject({
+      malformedStatus: 400,
+      duplicateCommits: 1,
+      concurrentObjects: 25,
+      restartPreserved: true,
+    });
+  });
+});
+
+function createFakeFetch(): typeof fetch {
+  const committed = new Map<string, number>();
+  let nextKey = 0;
+  return (_input, init) => {
+    if (init?.body === "{") {
+      return Promise.resolve(
+        Response.json({ error: "malformed_json" }, { status: 400 })
+      );
+    }
+    const payload = parsePayload(init?.body);
+    const key = payload.idempotencyKey ?? `object-${nextKey++}`;
+    const count = committed.get(key);
+    if (count !== undefined) {
+      return Promise.resolve(
+        Response.json({
+          historyCount: count,
+          ok: true,
+          reply: `echo:${payload.text}`,
+        })
+      );
+    }
+    committed.set(key, 1);
+    return Promise.resolve(
+      Response.json({
+        historyCount: 1,
+        ok: true,
+        reply: `echo:${payload.text}`,
+      })
+    );
+  };
+}
+
+function parsePayload(value: BodyInit | null | undefined): {
+  readonly idempotencyKey?: string;
+  readonly text: string;
+} {
+  const parsed: unknown = JSON.parse(String(value));
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("text" in parsed) ||
+    typeof parsed.text !== "string"
+  ) {
+    throw new Error("invalid fake payload");
+  }
+  return {
+    ...("idempotencyKey" in parsed && typeof parsed.idempotencyKey === "string"
+      ? { idempotencyKey: parsed.idempotencyKey }
+      : {}),
+    text: parsed.text,
+  };
+}

--- a/experimental/celld-qa/src/qa-matrix.ts
+++ b/experimental/celld-qa/src/qa-matrix.ts
@@ -22,6 +22,7 @@ export interface MatrixResult {
   readonly duplicateCommits: 1;
   readonly malformedStatus: 400;
   readonly restartPreserved: boolean;
+  readonly retainedResponseSlots: number;
 }
 
 export async function runMatrix({
@@ -59,19 +60,19 @@ export async function runMatrix({
   }
 
   const objects = Array.from({ length: objectCount }, (_, index) => index);
-  const responses: { readonly reply: string }[] = [];
+  let completedObjects = 0;
   for (let offset = 0; offset < objects.length; offset += concurrency) {
     const batch = objects.slice(offset, offset + concurrency);
-    responses.push(
-      ...(await Promise.all(
-        batch.map((index) => call(fetchImpl, baseUrl, `object-${index}`))
-      ))
+    await Promise.all(
+      batch.map((index) => call(fetchImpl, baseUrl, `object-${index}`))
     );
+    completedObjects += batch.length;
   }
   return {
-    concurrentObjects: responses.length,
+    concurrentObjects: completedObjects,
     duplicateCommits: 1,
     malformedStatus: 400,
+    retainedResponseSlots: 0,
     restartPreserved,
   };
 }

--- a/experimental/celld-qa/src/qa-matrix.ts
+++ b/experimental/celld-qa/src/qa-matrix.ts
@@ -1,0 +1,209 @@
+import { randomUUID } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import {
+  createBucket,
+  deploy,
+  restartCelld,
+  startCelld,
+  stopCelld,
+  waitForListening,
+} from "./celld-process";
+
+interface MatrixOptions {
+  readonly baseUrl: string;
+  readonly concurrency: number;
+  readonly fetchImpl?: typeof fetch;
+  readonly objectCount: number;
+  readonly restartPreserved?: boolean;
+}
+
+export interface MatrixResult {
+  readonly concurrentObjects: number;
+  readonly duplicateCommits: 1;
+  readonly malformedStatus: 400;
+  readonly restartPreserved: boolean;
+}
+
+export async function runMatrix({
+  baseUrl,
+  concurrency,
+  fetchImpl = fetch,
+  objectCount,
+  restartPreserved = false,
+}: MatrixOptions): Promise<MatrixResult> {
+  if (!(Number.isInteger(objectCount) && objectCount > 0)) {
+    throw new Error("objectCount must be positive.");
+  }
+  if (!(Number.isInteger(concurrency) && concurrency > 0)) {
+    throw new Error("concurrency must be positive.");
+  }
+  const malformed = await fetchImpl(baseUrl, {
+    body: "{",
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  if (malformed.status !== 400) {
+    throw new Error(`malformed input returned ${malformed.status}`);
+  }
+
+  const duplicateKey = `duplicate-${Date.now()}`;
+  const duplicate = await Promise.all([
+    call(fetchImpl, baseUrl, "duplicate-object", duplicateKey),
+    call(fetchImpl, baseUrl, "duplicate-object", duplicateKey),
+  ]);
+  if (
+    duplicate[0]?.historyCount !== duplicate[1]?.historyCount ||
+    duplicate[0]?.reply !== duplicate[1]?.reply
+  ) {
+    throw new Error("duplicate idempotency did not converge");
+  }
+
+  const objects = Array.from({ length: objectCount }, (_, index) => index);
+  const responses: { readonly reply: string }[] = [];
+  for (let offset = 0; offset < objects.length; offset += concurrency) {
+    const batch = objects.slice(offset, offset + concurrency);
+    responses.push(
+      ...(await Promise.all(
+        batch.map((index) => call(fetchImpl, baseUrl, `object-${index}`))
+      ))
+    );
+  }
+  return {
+    concurrentObjects: responses.length,
+    duplicateCommits: 1,
+    malformedStatus: 400,
+    restartPreserved,
+  };
+}
+
+interface CliOptions {
+  readonly concurrency: number;
+  readonly containerPort: number;
+  readonly nativePort: number;
+  readonly objectCount: number;
+  readonly report?: string;
+}
+
+interface SurfaceReport extends MatrixResult {
+  readonly port: number;
+  readonly surface: "container" | "native";
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const reports: SurfaceReport[] = [];
+  for (const surface of [
+    { kind: "native" as const, port: options.nativePort },
+    { kind: "container" as const, port: options.containerPort },
+  ]) {
+    const prefix = `matrix-${surface.kind}-${randomUUID().slice(0, 8)}`;
+    const watch = `/var/tmp/pss-celld-${surface.kind}-${randomUUID()}`;
+    await createBucket();
+    await deploy(prefix);
+    let child = startCelld(surface.kind, prefix, surface.port, watch);
+    try {
+      await waitForListening(child);
+      const beforeRestart = await call(
+        fetch,
+        `http://127.0.0.1:${surface.port}`,
+        "restart-object"
+      );
+      if (beforeRestart.historyCount !== 1) {
+        throw new Error("restart probe did not start at count one");
+      }
+      child = await restartCelld(
+        surface.kind,
+        prefix,
+        surface.port,
+        watch,
+        child
+      );
+      const afterRestart = await call(
+        fetch,
+        `http://127.0.0.1:${surface.port}`,
+        "restart-object"
+      );
+      if (afterRestart.historyCount !== 2) {
+        throw new Error("restart probe did not preserve state");
+      }
+      const report = await runMatrix({
+        baseUrl: `http://127.0.0.1:${surface.port}`,
+        concurrency: options.concurrency,
+        objectCount: options.objectCount,
+        restartPreserved: true,
+      });
+      reports.push({ ...report, port: surface.port, surface: surface.kind });
+    } finally {
+      await stopCelld(child);
+    }
+  }
+  const output = { ok: true, reports, surface: "matrix" };
+  if (options.report !== undefined) {
+    await writeFile(options.report, `${JSON.stringify(output)}\n`, "utf8");
+  }
+  console.log(JSON.stringify(output));
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  const args = argv[0] === "--" ? argv.slice(1) : argv;
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index];
+    const value = args[index + 1];
+    if (key === undefined || value === undefined) {
+      throw new Error(
+        "Usage: qa:matrix --native-port <port> --container-port <port>"
+      );
+    }
+    values.set(key, value);
+  }
+  const nativePort = Number(values.get("--native-port") ?? "16421");
+  const containerPort = Number(values.get("--container-port") ?? "16422");
+  const objectCount = Number(values.get("--objects") ?? "25");
+  const concurrency = Number(values.get("--concurrency") ?? "64");
+  const report = values.get("--report");
+  if (
+    ![nativePort, containerPort, objectCount, concurrency].every(
+      (value) => Number.isInteger(value) && value > 0
+    )
+  ) {
+    throw new Error("Invalid matrix arguments.");
+  }
+  return { concurrency, containerPort, nativePort, objectCount, report };
+}
+
+async function call(
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  objectName: string,
+  idempotencyKey?: string
+): Promise<{ readonly historyCount: number; readonly reply: string }> {
+  const response = await fetchImpl(
+    `${baseUrl}/?object=${encodeURIComponent(objectName)}`,
+    {
+      body: JSON.stringify({
+        ...(idempotencyKey === undefined ? {} : { idempotencyKey }),
+        text: "hello",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }
+  );
+  const payload: unknown = await response.json();
+  if (
+    !response.ok ||
+    typeof payload !== "object" ||
+    payload === null ||
+    !("historyCount" in payload) ||
+    typeof payload.historyCount !== "number" ||
+    !("reply" in payload) ||
+    typeof payload.reply !== "string"
+  ) {
+    throw new Error(`matrix call failed: ${response.status}`);
+  }
+  return { historyCount: payload.historyCount, reply: payload.reply };
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/experimental/celld-qa/src/qa-matrix.ts
+++ b/experimental/celld-qa/src/qa-matrix.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import {
   createBucket,
   deploy,
@@ -14,14 +15,12 @@ interface MatrixOptions {
   readonly concurrency: number;
   readonly fetchImpl?: typeof fetch;
   readonly objectCount: number;
-  readonly restartPreserved?: boolean;
 }
 
 export interface MatrixResult {
   readonly concurrentObjects: number;
-  readonly duplicateCommits: 1;
-  readonly malformedStatus: 400;
-  readonly restartPreserved: boolean;
+  readonly duplicateCommits: number;
+  readonly malformedStatus: number;
   readonly retainedResponseSlots: number;
 }
 
@@ -30,7 +29,6 @@ export async function runMatrix({
   concurrency,
   fetchImpl = fetch,
   objectCount,
-  restartPreserved = false,
 }: MatrixOptions): Promise<MatrixResult> {
   if (!(Number.isInteger(objectCount) && objectCount > 0)) {
     throw new Error("objectCount must be positive.");
@@ -54,26 +52,32 @@ export async function runMatrix({
   ]);
   if (
     duplicate[0]?.historyCount !== duplicate[1]?.historyCount ||
-    duplicate[0]?.reply !== duplicate[1]?.reply
+    duplicate[0]?.reply !== duplicate[1]?.reply ||
+    duplicate[0]?.commitCount !== 1 ||
+    duplicate[1]?.commitCount !== 1
   ) {
     throw new Error("duplicate idempotency did not converge");
   }
 
   const objects = Array.from({ length: objectCount }, (_, index) => index);
   let completedObjects = 0;
+  const retainedResponses: { readonly reply: string }[] = [];
+  const retainResponses = process.env.CELLD_QA_RETENTION_MODE === "legacy";
   for (let offset = 0; offset < objects.length; offset += concurrency) {
     const batch = objects.slice(offset, offset + concurrency);
-    await Promise.all(
+    const responses = await Promise.all(
       batch.map((index) => call(fetchImpl, baseUrl, `object-${index}`))
     );
+    if (retainResponses) {
+      retainedResponses.push(...responses);
+    }
     completedObjects += batch.length;
   }
   return {
     concurrentObjects: completedObjects,
-    duplicateCommits: 1,
-    malformedStatus: 400,
-    retainedResponseSlots: 0,
-    restartPreserved,
+    duplicateCommits: duplicate[0]?.commitCount ?? 0,
+    malformedStatus: malformed.status,
+    retainedResponseSlots: retainedResponses.length,
   };
 }
 
@@ -87,6 +91,7 @@ interface CliOptions {
 
 interface SurfaceReport extends MatrixResult {
   readonly port: number;
+  readonly restartPreserved: boolean;
   readonly surface: "container" | "native";
 }
 
@@ -98,11 +103,12 @@ async function main(): Promise<void> {
     { kind: "container" as const, port: options.containerPort },
   ]) {
     const prefix = `matrix-${surface.kind}-${randomUUID().slice(0, 8)}`;
-    const watch = `/var/tmp/pss-celld-${surface.kind}-${randomUUID()}`;
-    await createBucket();
-    await deploy(prefix);
-    let child = startCelld(surface.kind, prefix, surface.port, watch);
+    const watch = await mkdtemp(join("/var/tmp", `pss-celld-${surface.kind}-`));
+    let child: ReturnType<typeof startCelld> | undefined;
     try {
+      await createBucket();
+      await deploy(prefix);
+      child = startCelld(surface.kind, prefix, surface.port, watch);
       await waitForListening(child);
       const beforeRestart = await call(
         fetch,
@@ -131,11 +137,18 @@ async function main(): Promise<void> {
         baseUrl: `http://127.0.0.1:${surface.port}`,
         concurrency: options.concurrency,
         objectCount: options.objectCount,
-        restartPreserved: true,
       });
-      reports.push({ ...report, port: surface.port, surface: surface.kind });
+      reports.push({
+        ...report,
+        port: surface.port,
+        restartPreserved: afterRestart.historyCount === 2,
+        surface: surface.kind,
+      });
     } finally {
-      await stopCelld(child);
+      if (child !== undefined) {
+        await stopCelld(child);
+      }
+      await rm(watch, { force: true, recursive: true });
     }
   }
   const output = { ok: true, reports, surface: "matrix" };
@@ -178,7 +191,11 @@ async function call(
   baseUrl: string,
   objectName: string,
   idempotencyKey?: string
-): Promise<{ readonly historyCount: number; readonly reply: string }> {
+): Promise<{
+  readonly commitCount: number;
+  readonly historyCount: number;
+  readonly reply: string;
+}> {
   const response = await fetchImpl(
     `${baseUrl}/?object=${encodeURIComponent(objectName)}`,
     {
@@ -197,12 +214,18 @@ async function call(
     payload === null ||
     !("historyCount" in payload) ||
     typeof payload.historyCount !== "number" ||
+    !("commitCount" in payload) ||
+    typeof payload.commitCount !== "number" ||
     !("reply" in payload) ||
     typeof payload.reply !== "string"
   ) {
     throw new Error(`matrix call failed: ${response.status}`);
   }
-  return { historyCount: payload.historyCount, reply: payload.reply };
+  return {
+    commitCount: payload.commitCount,
+    historyCount: payload.historyCount,
+    reply: payload.reply,
+  };
 }
 
 if (import.meta.main) {

--- a/experimental/celld-qa/src/qa-matrix.ts
+++ b/experimental/celld-qa/src/qa-matrix.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { cleanupPrefix } from "./celld-bucket";
 import {
   createBucket,
   deploy,
@@ -21,6 +22,7 @@ export interface MatrixResult {
   readonly concurrentObjects: number;
   readonly duplicateCommits: number;
   readonly malformedStatus: number;
+  readonly retainedResponseBytes: number;
   readonly retainedResponseSlots: number;
 }
 
@@ -44,6 +46,14 @@ export async function runMatrix({
   if (malformed.status !== 400) {
     throw new Error(`malformed input returned ${malformed.status}`);
   }
+  const invalidKey = await fetchImpl(baseUrl, {
+    body: JSON.stringify({ idempotencyKey: 42, text: "hello" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  if (invalidKey.status !== 400) {
+    throw new Error(`invalid idempotency key returned ${invalidKey.status}`);
+  }
 
   const duplicateKey = `duplicate-${Date.now()}`;
   const duplicate = await Promise.all([
@@ -62,6 +72,7 @@ export async function runMatrix({
   const objects = Array.from({ length: objectCount }, (_, index) => index);
   let completedObjects = 0;
   const retainedResponses: { readonly reply: string }[] = [];
+  let retainedResponseBytes = 0;
   const retainResponses = process.env.CELLD_QA_RETENTION_MODE === "legacy";
   for (let offset = 0; offset < objects.length; offset += concurrency) {
     const batch = objects.slice(offset, offset + concurrency);
@@ -70,6 +81,7 @@ export async function runMatrix({
     );
     if (retainResponses) {
       retainedResponses.push(...responses);
+      retainedResponseBytes += Buffer.byteLength(JSON.stringify(responses));
     }
     completedObjects += batch.length;
   }
@@ -77,6 +89,7 @@ export async function runMatrix({
     concurrentObjects: completedObjects,
     duplicateCommits: duplicate[0]?.commitCount ?? 0,
     malformedStatus: malformed.status,
+    retainedResponseBytes,
     retainedResponseSlots: retainedResponses.length,
   };
 }
@@ -110,6 +123,12 @@ async function main(): Promise<void> {
       await deploy(prefix);
       child = startCelld(surface.kind, prefix, surface.port, watch);
       await waitForListening(child);
+      const idempotentBeforeRestart = await call(
+        fetch,
+        `http://127.0.0.1:${surface.port}`,
+        "restart-idempotency",
+        "restart-key"
+      );
       const beforeRestart = await call(
         fetch,
         `http://127.0.0.1:${surface.port}`,
@@ -133,6 +152,20 @@ async function main(): Promise<void> {
       if (afterRestart.historyCount !== 2) {
         throw new Error("restart probe did not preserve state");
       }
+      const idempotentAfterRestart = await call(
+        fetch,
+        `http://127.0.0.1:${surface.port}`,
+        "restart-idempotency",
+        "restart-key"
+      );
+      if (
+        idempotentAfterRestart.historyCount !==
+          idempotentBeforeRestart.historyCount ||
+        idempotentAfterRestart.commitCount !==
+          idempotentBeforeRestart.commitCount
+      ) {
+        throw new Error("idempotency result did not survive restart");
+      }
       const report = await runMatrix({
         baseUrl: `http://127.0.0.1:${surface.port}`,
         concurrency: options.concurrency,
@@ -148,7 +181,10 @@ async function main(): Promise<void> {
       if (child !== undefined) {
         await stopCelld(child);
       }
-      await rm(watch, { force: true, recursive: true });
+      await Promise.all([
+        cleanupPrefix(prefix),
+        rm(watch, { force: true, recursive: true }),
+      ]);
     }
   }
   const output = { ok: true, reports, surface: "matrix" };

--- a/experimental/celld-qa/src/qa-matrix.ts
+++ b/experimental/celld-qa/src/qa-matrix.ts
@@ -10,6 +10,7 @@ import {
   stopCelld,
   waitForListening,
 } from "./celld-process";
+import { callEcho } from "./qa-http";
 
 interface MatrixOptions {
   readonly baseUrl: string;
@@ -57,8 +58,8 @@ export async function runMatrix({
 
   const duplicateKey = `duplicate-${Date.now()}`;
   const duplicate = await Promise.all([
-    call(fetchImpl, baseUrl, "duplicate-object", duplicateKey),
-    call(fetchImpl, baseUrl, "duplicate-object", duplicateKey),
+    callEcho(fetchImpl, baseUrl, "duplicate-object", duplicateKey),
+    callEcho(fetchImpl, baseUrl, "duplicate-object", duplicateKey),
   ]);
   if (
     duplicate[0]?.historyCount !== duplicate[1]?.historyCount ||
@@ -77,8 +78,15 @@ export async function runMatrix({
   for (let offset = 0; offset < objects.length; offset += concurrency) {
     const batch = objects.slice(offset, offset + concurrency);
     const responses = await Promise.all(
-      batch.map((index) => call(fetchImpl, baseUrl, `object-${index}`))
+      batch.map((index) => callEcho(fetchImpl, baseUrl, `object-${index}`))
     );
+    if (
+      responses.some(
+        (response) => response.historyCount !== 1 || response.commitCount !== 1
+      )
+    ) {
+      throw new Error("concurrent objects did not preserve isolation");
+    }
     if (retainResponses) {
       retainedResponses.push(...responses);
       retainedResponseBytes += Buffer.byteLength(JSON.stringify(responses));
@@ -123,13 +131,13 @@ async function main(): Promise<void> {
       await deploy(prefix);
       child = startCelld(surface.kind, prefix, surface.port, watch);
       await waitForListening(child);
-      const idempotentBeforeRestart = await call(
+      const idempotentBeforeRestart = await callEcho(
         fetch,
         `http://127.0.0.1:${surface.port}`,
         "restart-idempotency",
         "restart-key"
       );
-      const beforeRestart = await call(
+      const beforeRestart = await callEcho(
         fetch,
         `http://127.0.0.1:${surface.port}`,
         "restart-object"
@@ -144,7 +152,7 @@ async function main(): Promise<void> {
         watch,
         child
       );
-      const afterRestart = await call(
+      const afterRestart = await callEcho(
         fetch,
         `http://127.0.0.1:${surface.port}`,
         "restart-object"
@@ -152,7 +160,7 @@ async function main(): Promise<void> {
       if (afterRestart.historyCount !== 2) {
         throw new Error("restart probe did not preserve state");
       }
-      const idempotentAfterRestart = await call(
+      const idempotentAfterRestart = await callEcho(
         fetch,
         `http://127.0.0.1:${surface.port}`,
         "restart-idempotency",
@@ -220,48 +228,6 @@ function parseArgs(argv: readonly string[]): CliOptions {
     throw new Error("Invalid matrix arguments.");
   }
   return { concurrency, containerPort, nativePort, objectCount, report };
-}
-
-async function call(
-  fetchImpl: typeof fetch,
-  baseUrl: string,
-  objectName: string,
-  idempotencyKey?: string
-): Promise<{
-  readonly commitCount: number;
-  readonly historyCount: number;
-  readonly reply: string;
-}> {
-  const response = await fetchImpl(
-    `${baseUrl}/?object=${encodeURIComponent(objectName)}`,
-    {
-      body: JSON.stringify({
-        ...(idempotencyKey === undefined ? {} : { idempotencyKey }),
-        text: "hello",
-      }),
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    }
-  );
-  const payload: unknown = await response.json();
-  if (
-    !response.ok ||
-    typeof payload !== "object" ||
-    payload === null ||
-    !("historyCount" in payload) ||
-    typeof payload.historyCount !== "number" ||
-    !("commitCount" in payload) ||
-    typeof payload.commitCount !== "number" ||
-    !("reply" in payload) ||
-    typeof payload.reply !== "string"
-  ) {
-    throw new Error(`matrix call failed: ${response.status}`);
-  }
-  return {
-    commitCount: payload.commitCount,
-    historyCount: payload.historyCount,
-    reply: payload.reply,
-  };
 }
 
 if (import.meta.main) {

--- a/experimental/celld-qa/src/qa-native.ts
+++ b/experimental/celld-qa/src/qa-native.ts
@@ -1,0 +1,224 @@
+import { execFile as execFileCallback, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+const CELLD = process.env.CELLD_BIN ?? `${process.env.HOME}/.local/bin/celld`;
+const ENDPOINT = process.env.S3_ENDPOINT ?? "http://127.0.0.1:14566";
+const BUCKET = process.env.CELLD_QA_BUCKET ?? "pss-celld-qa";
+const ESBUILD =
+  process.env.CELLD_ESBUILD ??
+  resolve(
+    import.meta.dirname,
+    "../../../node_modules/.pnpm/@esbuild+linux-x64@0.28.2/node_modules/@esbuild/linux-x64/bin/esbuild"
+  );
+
+interface QaOptions {
+  readonly baseUrl: string;
+  readonly fetchImpl?: typeof fetch;
+  readonly objectName: string;
+  readonly text: string;
+}
+
+interface EchoResult {
+  readonly historyCount: number;
+  readonly ok: true;
+  readonly reply: string;
+}
+
+export async function runNativeQa({
+  baseUrl,
+  fetchImpl,
+  objectName,
+  text,
+}: QaOptions): Promise<{
+  readonly first: EchoResult;
+  readonly second: EchoResult;
+}> {
+  const first = await callEcho(baseUrl, objectName, text, fetchImpl);
+  const second = await callEcho(baseUrl, objectName, text, fetchImpl);
+  if (first.historyCount !== 1 || second.historyCount !== 2) {
+    throw new Error(
+      `unexpected persistent counts: ${first.historyCount}, ${second.historyCount}`
+    );
+  }
+  return { first, second };
+}
+
+async function callEcho(
+  baseUrl: string,
+  objectName: string,
+  text: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<EchoResult> {
+  const response = await fetchImpl(
+    `${baseUrl}/?object=${encodeURIComponent(objectName)}`,
+    {
+      body: JSON.stringify({ text }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }
+  );
+  const value: unknown = await response.json();
+  if (
+    !response.ok ||
+    typeof value !== "object" ||
+    value === null ||
+    !("ok" in value) ||
+    value.ok !== true ||
+    !("reply" in value) ||
+    typeof value.reply !== "string" ||
+    !("historyCount" in value) ||
+    typeof value.historyCount !== "number"
+  ) {
+    throw new Error(`Celld echo failed: ${response.status}`);
+  }
+  return {
+    historyCount: value.historyCount,
+    ok: true,
+    reply: value.reply,
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const port = options.port;
+  const runId = randomUUID().slice(0, 8);
+  const prefix = `qa-${runId}`;
+  const watch = await mkdtemp(join("/var/tmp", "pss-celld-qa-"));
+  let child: ReturnType<typeof spawn> | undefined;
+  try {
+    await createBucket();
+    await deploy(prefix);
+    child = spawnCelld(prefix, port, watch);
+    await waitForListening(child);
+    const result = await runNativeQa({
+      baseUrl: `http://127.0.0.1:${port}`,
+      objectName: options.objectName,
+      text: options.text,
+    });
+    console.log(JSON.stringify({ ...result, ok: true, surface: "native" }));
+  } finally {
+    if (child !== undefined) {
+      await stop(child);
+    }
+    await rm(watch, { force: true, recursive: true });
+  }
+}
+
+function parseArgs(argv: readonly string[]): {
+  readonly objectName: string;
+  readonly port: number;
+  readonly text: string;
+} {
+  const values = new Map<string, string>();
+  const args = argv[0] === "--" ? argv.slice(1) : argv;
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index];
+    const value = args[index + 1];
+    if (key === undefined || value === undefined) {
+      throw new Error(
+        "Usage: qa:native --port <port> --object <name> --text <text>"
+      );
+    }
+    values.set(key, value);
+  }
+  const port = Number(values.get("--port") ?? "16420");
+  const objectName = values.get("--object") ?? "pss-smoke";
+  const text = values.get("--text") ?? "hello";
+  if (
+    !(Number.isInteger(port) && port > 0 && port < 65_536 && text.length > 0)
+  ) {
+    throw new Error("Invalid native QA arguments.");
+  }
+  return { objectName, port, text };
+}
+
+async function createBucket(): Promise<void> {
+  const response = await fetch(`${ENDPOINT}/${BUCKET}`, { method: "PUT" });
+  if (!(response.ok || response.status === 409)) {
+    throw new Error(`bucket creation failed: ${response.status}`);
+  }
+}
+
+async function deploy(prefix: string): Promise<void> {
+  if (!existsSync(ESBUILD)) {
+    throw new Error(`esbuild not found: ${ESBUILD}`);
+  }
+  await execFile(
+    CELLD,
+    [
+      "deploy",
+      resolve(import.meta.dirname, "../worker"),
+      "--bucket",
+      `s3://${BUCKET}/${prefix}`,
+      "--endpoint",
+      ENDPOINT,
+      "--region",
+      "us-east-1",
+    ],
+    {
+      env: { ...process.env, CELLD_ESBUILD: ESBUILD, TMPDIR: "/var/tmp" },
+    }
+  );
+}
+
+function spawnCelld(
+  prefix: string,
+  port: number,
+  watch: string
+): ReturnType<typeof spawn> {
+  return spawn(
+    CELLD,
+    [
+      "--bucket",
+      `s3://${BUCKET}/${prefix}`,
+      "--endpoint",
+      ENDPOINT,
+      "--region",
+      "us-east-1",
+      "--listen",
+      `127.0.0.1:${port}`,
+      "--internal-listen",
+      "127.0.0.1:0",
+    ],
+    {
+      env: { ...process.env, CELLD_WATCH: watch },
+      stdio: ["ignore", "pipe", "pipe"],
+    }
+  );
+}
+
+function waitForListening(child: ReturnType<typeof spawn>): Promise<void> {
+  return new Promise((resolveReady, reject) => {
+    const onData = (chunk: Buffer): void => {
+      if (chunk.toString("utf8").includes("celld listening on")) {
+        child.stdout?.off("data", onData);
+        resolveReady();
+      }
+    };
+    child.stdout?.on("data", onData);
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      reject(new Error(`Celld exited before readiness: ${code}`));
+    });
+  });
+}
+
+async function stop(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null) {
+    return;
+  }
+  const exited = new Promise<void>((resolveExit) =>
+    child.once("exit", () => resolveExit())
+  );
+  child.kill("SIGTERM");
+  await exited;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/experimental/celld-qa/src/qa-native.ts
+++ b/experimental/celld-qa/src/qa-native.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { cleanupPrefix } from "./celld-bucket";
 import {
   createBucket,
   deploy,
@@ -103,7 +104,10 @@ async function main(): Promise<void> {
     if (child !== undefined) {
       await stopCelld(child);
     }
-    await rm(watch, { force: true, recursive: true });
+    await Promise.all([
+      cleanupPrefix(prefix),
+      rm(watch, { force: true, recursive: true }),
+    ]);
   }
 }
 

--- a/experimental/celld-qa/src/qa-native.ts
+++ b/experimental/celld-qa/src/qa-native.ts
@@ -1,20 +1,13 @@
-import { execFile as execFileCallback, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
-import { join, resolve } from "node:path";
-import { promisify } from "node:util";
-
-const execFile = promisify(execFileCallback);
-const CELLD = process.env.CELLD_BIN ?? `${process.env.HOME}/.local/bin/celld`;
-const ENDPOINT = process.env.S3_ENDPOINT ?? "http://127.0.0.1:14566";
-const BUCKET = process.env.CELLD_QA_BUCKET ?? "pss-celld-qa";
-const ESBUILD =
-  process.env.CELLD_ESBUILD ??
-  resolve(
-    import.meta.dirname,
-    "../../../node_modules/.pnpm/@esbuild+linux-x64@0.28.2/node_modules/@esbuild/linux-x64/bin/esbuild"
-  );
+import { join } from "node:path";
+import {
+  createBucket,
+  deploy,
+  startCelld,
+  stopCelld,
+  waitForListening,
+} from "./celld-process";
 
 interface QaOptions {
   readonly baseUrl: string;
@@ -83,39 +76,40 @@ async function callEcho(
   };
 }
 
+interface CliOptions {
+  readonly objectName: string;
+  readonly port: number;
+  readonly text: string;
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
-  const port = options.port;
   const runId = randomUUID().slice(0, 8);
   const prefix = `qa-${runId}`;
   const watch = await mkdtemp(join("/var/tmp", "pss-celld-qa-"));
-  let child: ReturnType<typeof spawn> | undefined;
+  let child: ReturnType<typeof startCelld> | undefined;
   try {
     await createBucket();
     await deploy(prefix);
-    child = spawnCelld(prefix, port, watch);
+    child = startCelld("native", prefix, options.port, watch);
     await waitForListening(child);
     const result = await runNativeQa({
-      baseUrl: `http://127.0.0.1:${port}`,
+      baseUrl: `http://127.0.0.1:${options.port}`,
       objectName: options.objectName,
       text: options.text,
     });
     console.log(JSON.stringify({ ...result, ok: true, surface: "native" }));
   } finally {
     if (child !== undefined) {
-      await stop(child);
+      await stopCelld(child);
     }
     await rm(watch, { force: true, recursive: true });
   }
 }
 
-function parseArgs(argv: readonly string[]): {
-  readonly objectName: string;
-  readonly port: number;
-  readonly text: string;
-} {
-  const values = new Map<string, string>();
+function parseArgs(argv: readonly string[]): CliOptions {
   const args = argv[0] === "--" ? argv.slice(1) : argv;
+  const values = new Map<string, string>();
   for (let index = 0; index < args.length; index += 2) {
     const key = args[index];
     const value = args[index + 1];
@@ -135,88 +129,6 @@ function parseArgs(argv: readonly string[]): {
     throw new Error("Invalid native QA arguments.");
   }
   return { objectName, port, text };
-}
-
-async function createBucket(): Promise<void> {
-  const response = await fetch(`${ENDPOINT}/${BUCKET}`, { method: "PUT" });
-  if (!(response.ok || response.status === 409)) {
-    throw new Error(`bucket creation failed: ${response.status}`);
-  }
-}
-
-async function deploy(prefix: string): Promise<void> {
-  if (!existsSync(ESBUILD)) {
-    throw new Error(`esbuild not found: ${ESBUILD}`);
-  }
-  await execFile(
-    CELLD,
-    [
-      "deploy",
-      resolve(import.meta.dirname, "../worker"),
-      "--bucket",
-      `s3://${BUCKET}/${prefix}`,
-      "--endpoint",
-      ENDPOINT,
-      "--region",
-      "us-east-1",
-    ],
-    {
-      env: { ...process.env, CELLD_ESBUILD: ESBUILD, TMPDIR: "/var/tmp" },
-    }
-  );
-}
-
-function spawnCelld(
-  prefix: string,
-  port: number,
-  watch: string
-): ReturnType<typeof spawn> {
-  return spawn(
-    CELLD,
-    [
-      "--bucket",
-      `s3://${BUCKET}/${prefix}`,
-      "--endpoint",
-      ENDPOINT,
-      "--region",
-      "us-east-1",
-      "--listen",
-      `127.0.0.1:${port}`,
-      "--internal-listen",
-      "127.0.0.1:0",
-    ],
-    {
-      env: { ...process.env, CELLD_WATCH: watch },
-      stdio: ["ignore", "pipe", "pipe"],
-    }
-  );
-}
-
-function waitForListening(child: ReturnType<typeof spawn>): Promise<void> {
-  return new Promise((resolveReady, reject) => {
-    const onData = (chunk: Buffer): void => {
-      if (chunk.toString("utf8").includes("celld listening on")) {
-        child.stdout?.off("data", onData);
-        resolveReady();
-      }
-    };
-    child.stdout?.on("data", onData);
-    child.once("error", reject);
-    child.once("exit", (code) => {
-      reject(new Error(`Celld exited before readiness: ${code}`));
-    });
-  });
-}
-
-async function stop(child: ReturnType<typeof spawn>): Promise<void> {
-  if (child.exitCode !== null) {
-    return;
-  }
-  const exited = new Promise<void>((resolveExit) =>
-    child.once("exit", () => resolveExit())
-  );
-  child.kill("SIGTERM");
-  await exited;
 }
 
 if (import.meta.main) {

--- a/experimental/celld-qa/tsconfig.json
+++ b/experimental/celld-qa/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "customConditions": ["@minpeter/pss-source"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/experimental/celld-qa/tsconfig.json
+++ b/experimental/celld-qa/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
-    "checkJs": false,
+    "checkJs": true,
     "customConditions": ["@minpeter/pss-source"],
     "noEmit": true
   },

--- a/experimental/celld-qa/tsconfig.json
+++ b/experimental/celld-qa/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
     "customConditions": ["@minpeter/pss-source"],
     "noEmit": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "worker/**/*.js"]
 }

--- a/experimental/celld-qa/vitest.config.ts
+++ b/experimental/celld-qa/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+  },
+});

--- a/experimental/celld-qa/worker/index.js
+++ b/experimental/celld-qa/worker/index.js
@@ -1,0 +1,47 @@
+export class Echo {
+  constructor(state) {
+    this.state = state;
+  }
+
+  async fetch(request) {
+    let payload;
+    try {
+      payload = await request.json();
+    } catch {
+      return Response.json({ error: "malformed_json" }, { status: 400 });
+    }
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      typeof payload.text !== "string" ||
+      payload.text.length === 0
+    ) {
+      return Response.json({ error: "invalid_input" }, { status: 400 });
+    }
+    const key =
+      typeof payload.idempotencyKey === "string"
+        ? `idempotency:${payload.idempotencyKey}`
+        : undefined;
+    if (key !== undefined) {
+      const prior = await this.state.storage.get(key);
+      if (prior !== undefined) {
+        return Response.json(prior);
+      }
+    }
+    const count = ((await this.state.storage.get("historyCount")) ?? 0) + 1;
+    const result = { historyCount: count, ok: true, reply: `echo:${payload.text}` };
+    await this.state.storage.put("historyCount", count);
+    if (key !== undefined) {
+      await this.state.storage.put(key, result);
+    }
+    return Response.json(result);
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const objectName = url.searchParams.get("object") || "pss-smoke";
+    return env.ECHO.get(env.ECHO.idFromName(objectName)).fetch(request);
+  },
+};

--- a/experimental/celld-qa/worker/index.js
+++ b/experimental/celld-qa/worker/index.js
@@ -29,7 +29,11 @@ export class Echo {
       }
     }
     const count = ((await this.state.storage.get("historyCount")) ?? 0) + 1;
-    const result = { historyCount: count, ok: true, reply: `echo:${payload.text}` };
+    const result = {
+      historyCount: count,
+      ok: true,
+      reply: `echo:${payload.text}`,
+    };
     await this.state.storage.put("historyCount", count);
     if (key !== undefined) {
       await this.state.storage.put(key, result);
@@ -39,7 +43,7 @@ export class Echo {
 }
 
 export default {
-  async fetch(request, env) {
+  fetch(request, env) {
     const url = new URL(request.url);
     const objectName = url.searchParams.get("object") || "pss-smoke";
     return env.ECHO.get(env.ECHO.idFromName(objectName)).fetch(request);

--- a/experimental/celld-qa/worker/index.js
+++ b/experimental/celld-qa/worker/index.js
@@ -4,30 +4,45 @@ import {
   drainCelldScheduledWork,
 } from "@minpeter/pss-runtime/platform/celld";
 
+/** @typedef {Parameters<typeof createCelldHost>[0]["state"]} CelldState */
+/** @typedef {{ text: string, idempotencyKey?: string }} EchoPayload */
+/** @typedef {{ commitCount: number, historyCount: number, ok: true, reply: string }} EchoResult */
+/** @typedef {{ status: "committed", result: EchoResult } | { status: "pending" } | { status: "reserved" }} Reservation */
+
+/** @type {Parameters<typeof createAgent>[0]["model"]} */
 const model = {
   doGenerate: async ({ prompt }) => ({
     content: [{ text: `echo:${lastUserText(prompt)}`, type: "text" }],
     finishReason: { raw: "stop", unified: "stop" },
     usage: {
-      inputTokens: 0,
-      outputTokens: 0,
-      reasoningTokens: 0,
-      totalTokens: 0,
+      inputTokens: {
+        cacheRead: 0,
+        cacheWrite: 0,
+        noCache: 0,
+        total: 0,
+      },
+      outputTokens: { reasoning: 0, text: 0, total: 0 },
     },
     warnings: [],
   }),
   modelId: "celld-echo",
   provider: "pss-celld-qa",
   specificationVersion: "v4",
+  supportedUrls: {},
+  doStream: async ({ prompt }) => ({
+    stream: echoStream(lastUserText(prompt)),
+  }),
 };
 
 export class Echo {
+  /** @param {CelldState} state */
   constructor(state) {
     this.state = state;
     this.agentPromise = undefined;
     this.idempotency = new Map();
   }
 
+  /** @param {Request} request */
   async fetch(request) {
     let payload;
     try {
@@ -70,6 +85,10 @@ export class Echo {
     }
   }
 
+  /**
+   * @param {EchoPayload} payload
+   * @param {string | undefined} key
+   */
   async process(payload, key) {
     if (key !== undefined) {
       const reservation = await reserve(this.state.storage, key);
@@ -116,6 +135,10 @@ export class Echo {
 }
 
 export default {
+  /**
+   * @param {Request} request
+   * @param {{ ECHO: { idFromName(name: string): unknown, get(id: unknown): { fetch(request: Request): Promise<Response> } } }} env
+   */
   fetch(request, env) {
     const url = new URL(request.url);
     const objectName = url.searchParams.get("object") || "pss-smoke";
@@ -123,20 +146,39 @@ export default {
   },
 };
 
+/** @param {readonly unknown[]} prompt */
 function lastUserText(prompt) {
   const message = prompt.at(-1);
-  if (message === undefined || message.role !== "user") {
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    !("role" in message) ||
+    message.role !== "user" ||
+    !("content" in message)
+  ) {
     return "";
   }
   if (typeof message.content === "string") {
     return message.content;
   }
+  if (!Array.isArray(message.content)) {
+    return "";
+  }
   const part = message.content.find((item) => item.type === "text");
-  return part?.text ?? "";
+  return typeof part?.text === "string" ? part.text : "";
 }
 
+/**
+ * @param {CelldState["storage"]} storage
+ * @param {string} key
+ * @returns {Promise<Reservation>}
+ */
 async function reserve(storage, key) {
+  if (storage.transaction === undefined) {
+    throw new Error("Celld storage transaction() is required.");
+  }
   return await storage.transaction(async (transaction) => {
+    /** @type {Reservation | undefined} */
     const existing = await transaction.get(key);
     if (existing !== undefined) {
       return existing;
@@ -147,10 +189,22 @@ async function reserve(storage, key) {
   });
 }
 
+/**
+ * @param {CelldState["storage"]} storage
+ * @param {string | undefined} key
+ * @param {string} reply
+ * @returns {Promise<EchoResult>}
+ */
 async function commit(storage, key, reply) {
+  if (storage.transaction === undefined) {
+    throw new Error("Celld storage transaction() is required.");
+  }
   return await storage.transaction(async (transaction) => {
-    const historyCount = ((await transaction.get("historyCount")) ?? 0) + 1;
-    const commitCount = ((await transaction.get("commitCount")) ?? 0) + 1;
+    const historyCount =
+      numericStorageValue(await transaction.get("historyCount")) + 1;
+    const commitCount =
+      numericStorageValue(await transaction.get("commitCount")) + 1;
+    /** @type {EchoResult} */
     const result = { commitCount, historyCount, ok: true, reply };
     await transaction.put("commitCount", commitCount);
     await transaction.put("historyCount", historyCount);
@@ -158,5 +212,37 @@ async function commit(storage, key, reply) {
       await transaction.put(key, { result, status: "committed" });
     }
     return result;
+  });
+}
+
+/** @param {unknown} value */
+function numericStorageValue(value) {
+  return typeof value === "number" ? value : 0;
+}
+
+/** @param {string} text */
+function echoStream(text) {
+  return new ReadableStream({
+    start(controller) {
+      const id = "echo";
+      controller.enqueue({ type: "stream-start", warnings: [] });
+      controller.enqueue({ id, type: "text-start" });
+      controller.enqueue({ delta: `echo:${text}`, id, type: "text-delta" });
+      controller.enqueue({ id, type: "text-end" });
+      controller.enqueue({
+        finishReason: { raw: "stop", unified: "stop" },
+        type: "finish",
+        usage: {
+          inputTokens: {
+            cacheRead: 0,
+            cacheWrite: 0,
+            noCache: 0,
+            total: 0,
+          },
+          outputTokens: { reasoning: 0, text: 0, total: 0 },
+        },
+      });
+      controller.close();
+    },
   });
 }

--- a/experimental/celld-qa/worker/index.js
+++ b/experimental/celld-qa/worker/index.js
@@ -1,6 +1,31 @@
+import { createAgent } from "@minpeter/pss-runtime";
+import {
+  createCelldHost,
+  drainCelldScheduledWork,
+} from "@minpeter/pss-runtime/platform/celld";
+
+const model = {
+  doGenerate: async ({ prompt }) => ({
+    content: [{ text: `echo:${lastUserText(prompt)}`, type: "text" }],
+    finishReason: { raw: "stop", unified: "stop" },
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      totalTokens: 0,
+    },
+    warnings: [],
+  }),
+  modelId: "celld-echo",
+  provider: "pss-celld-qa",
+  specificationVersion: "v4",
+};
+
 export class Echo {
   constructor(state) {
     this.state = state;
+    this.agentPromise = undefined;
+    this.idempotency = new Map();
   }
 
   async fetch(request) {
@@ -28,17 +53,78 @@ export class Echo {
         return Response.json(prior);
       }
     }
+    const run = () => this.process(payload, key);
+    if (key === undefined) {
+      return Response.json(await run());
+    }
+    const prior = this.idempotency.get(key) ?? Promise.resolve();
+    const current = prior.then(run);
+    this.idempotency.set(
+      key,
+      current.then(
+        () => undefined,
+        () => undefined
+      )
+    );
+    try {
+      return Response.json(await current);
+    } finally {
+      this.idempotency.delete(key);
+    }
+  }
+
+  async process(payload, key) {
+    if (key !== undefined) {
+      const prior = await this.state.storage.get(key);
+      if (prior !== undefined) {
+        return prior;
+      }
+    }
+    const agent = await this.agent();
+    const turn = await agent.thread("default").send(payload.text);
+    let reply = "";
+    for await (const event of turn.events()) {
+      if (event.type === "assistant-output") {
+        reply += event.text;
+      }
+    }
+    if (turn.runId !== undefined) {
+      await agent.host.scheduler.enqueueRun(turn.runId);
+    }
     const count = ((await this.state.storage.get("historyCount")) ?? 0) + 1;
+    const commitCount =
+      ((await this.state.storage.get("commitCount")) ?? 0) + 1;
     const result = {
+      commitCount,
       historyCount: count,
       ok: true,
-      reply: `echo:${payload.text}`,
+      reply,
     };
+    await this.state.storage.put("commitCount", commitCount);
     await this.state.storage.put("historyCount", count);
     if (key !== undefined) {
       await this.state.storage.put(key, result);
     }
-    return Response.json(result);
+    return result;
+  }
+
+  async agent() {
+    if (this.agentPromise === undefined) {
+      this.agentPromise = createAgent({
+        host: createCelldHost({ state: this.state }),
+        instructions: "Return the requested echo text exactly.",
+        model,
+      });
+    }
+    return await this.agentPromise;
+  }
+
+  async alarm() {
+    const agent = await this.agent();
+    await drainCelldScheduledWork({
+      agentForRun: () => agent,
+      storage: this.state.storage,
+    });
   }
 }
 
@@ -49,3 +135,15 @@ export default {
     return env.ECHO.get(env.ECHO.idFromName(objectName)).fetch(request);
   },
 };
+
+function lastUserText(prompt) {
+  const message = prompt.at(-1);
+  if (message === undefined || message.role !== "user") {
+    return "";
+  }
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  const part = message.content.find((item) => item.type === "text");
+  return part?.text ?? "";
+}

--- a/experimental/celld-qa/worker/index.js
+++ b/experimental/celld-qa/worker/index.js
@@ -39,7 +39,10 @@ export class Echo {
       typeof payload !== "object" ||
       payload === null ||
       typeof payload.text !== "string" ||
-      payload.text.length === 0
+      payload.text.length === 0 ||
+      ("idempotencyKey" in payload &&
+        (typeof payload.idempotencyKey !== "string" ||
+          payload.idempotencyKey.length === 0))
     ) {
       return Response.json({ error: "invalid_input" }, { status: 400 });
     }
@@ -47,15 +50,9 @@ export class Echo {
       typeof payload.idempotencyKey === "string"
         ? `idempotency:${payload.idempotencyKey}`
         : undefined;
-    if (key !== undefined) {
-      const prior = await this.state.storage.get(key);
-      if (prior !== undefined) {
-        return Response.json(prior);
-      }
-    }
     const run = () => this.process(payload, key);
     if (key === undefined) {
-      return Response.json(await run());
+      return await run();
     }
     const prior = this.idempotency.get(key) ?? Promise.resolve();
     const current = prior.then(run);
@@ -67,7 +64,7 @@ export class Echo {
       )
     );
     try {
-      return Response.json(await current);
+      return await current;
     } finally {
       this.idempotency.delete(key);
     }
@@ -75,9 +72,12 @@ export class Echo {
 
   async process(payload, key) {
     if (key !== undefined) {
-      const prior = await this.state.storage.get(key);
-      if (prior !== undefined) {
-        return prior;
+      const reservation = await reserve(this.state.storage, key);
+      if (reservation.status === "committed") {
+        return Response.json(reservation.result);
+      }
+      if (reservation.status === "pending") {
+        return Response.json({ error: "idempotency_pending" }, { status: 409 });
       }
     }
     const agent = await this.agent();
@@ -91,21 +91,8 @@ export class Echo {
     if (turn.runId !== undefined) {
       await agent.host.scheduler.enqueueRun(turn.runId);
     }
-    const count = ((await this.state.storage.get("historyCount")) ?? 0) + 1;
-    const commitCount =
-      ((await this.state.storage.get("commitCount")) ?? 0) + 1;
-    const result = {
-      commitCount,
-      historyCount: count,
-      ok: true,
-      reply,
-    };
-    await this.state.storage.put("commitCount", commitCount);
-    await this.state.storage.put("historyCount", count);
-    if (key !== undefined) {
-      await this.state.storage.put(key, result);
-    }
-    return result;
+    const result = await commit(this.state.storage, key, reply);
+    return Response.json(result);
   }
 
   async agent() {
@@ -146,4 +133,30 @@ function lastUserText(prompt) {
   }
   const part = message.content.find((item) => item.type === "text");
   return part?.text ?? "";
+}
+
+async function reserve(storage, key) {
+  return await storage.transaction(async (transaction) => {
+    const existing = await transaction.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const pending = { status: "pending" };
+    await transaction.put(key, pending);
+    return { status: "reserved" };
+  });
+}
+
+async function commit(storage, key, reply) {
+  return await storage.transaction(async (transaction) => {
+    const historyCount = ((await transaction.get("historyCount")) ?? 0) + 1;
+    const commitCount = ((await transaction.get("commitCount")) ?? 0) + 1;
+    const result = { commitCount, historyCount, ok: true, reply };
+    await transaction.put("commitCount", commitCount);
+    await transaction.put("historyCount", historyCount);
+    if (key !== undefined) {
+      await transaction.put(key, { result, status: "committed" });
+    }
+    return result;
+  });
 }

--- a/experimental/celld-qa/worker/wrangler.jsonc
+++ b/experimental/celld-qa/worker/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  "name": "pss-celld-qa",
+  "main": "index.js",
+  "compatibility_date": "2026-01-01",
+  "durable_objects": {
+    "bindings": [{ "name": "ECHO", "class_name": "Echo" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["Echo"] }]
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -40,6 +40,11 @@
       "@minpeter/pss-source": "./src/platform/file/index.ts",
       "import": "./dist/platform/file/index.js"
     },
+    "./platform/celld": {
+      "types": "./dist/platform/celld/index.d.ts",
+      "@minpeter/pss-source": "./src/platform/celld/index.ts",
+      "import": "./dist/platform/celld/index.js"
+    },
     "./execution": {
       "types": "./dist/execution/index.d.ts",
       "@minpeter/pss-source": "./src/execution/index.ts",

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -559,10 +559,7 @@
       "value encodeJsonl",
       "value servePssProtocol"
     ],
-    "./protocol/node": [
-      "type SpawnPssClientOptions",
-      "value spawnPssClient"
-    ],
+    "./protocol/node": ["type SpawnPssClientOptions", "value spawnPssClient"],
     "./testing": [
       "value agentEvent",
       "value agentEventStream",

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -336,11 +336,16 @@
       "type CelldSchedulerOptions",
       "value ackCelldScheduledRun",
       "value ackCelldScheduledThreadPrompt",
+      "value claimCelldScheduledRun",
+      "value claimCelldScheduledThreadPrompt",
       "value createCelldHost",
       "value createCelldScheduler",
       "value drainCelldScheduledWork",
       "value listCelldScheduledRuns",
-      "value listCelldScheduledThreadPrompts"
+      "value listCelldScheduledThreadPrompts",
+      "value rearmCelldScheduledWork",
+      "value retryCelldScheduledRun",
+      "value retryCelldScheduledThreadPrompt"
     ],
     "./platform/cloudflare": [
       "type AgentTurnDrainResult",
@@ -559,7 +564,10 @@
       "value encodeJsonl",
       "value servePssProtocol"
     ],
-    "./protocol/node": ["type SpawnPssClientOptions", "value spawnPssClient"],
+    "./protocol/node": [
+      "type SpawnPssClientOptions",
+      "value spawnPssClient"
+    ],
     "./testing": [
       "value agentEvent",
       "value agentEventStream",

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -322,6 +322,26 @@
       "value openTelemetry",
       "value traceAgentTurn"
     ],
+    "./platform/celld": [
+      "type CelldDurableObjectState",
+      "type CelldDurableObjectStorage",
+      "type CelldHost",
+      "type CelldHostOptions",
+      "type CelldScheduledWorkAgent",
+      "type CelldScheduledWorkDrainOptions",
+      "type CelldScheduledWorkDrainResult",
+      "type CelldScheduledWorkListOptions",
+      "type CelldScheduledWorkRunContext",
+      "type CelldScheduler",
+      "type CelldSchedulerOptions",
+      "value ackCelldScheduledRun",
+      "value ackCelldScheduledThreadPrompt",
+      "value createCelldHost",
+      "value createCelldScheduler",
+      "value drainCelldScheduledWork",
+      "value listCelldScheduledRuns",
+      "value listCelldScheduledThreadPrompts"
+    ],
     "./platform/cloudflare": [
       "type AgentTurnDrainResult",
       "type AgentTurnDrainStopReason",
@@ -539,7 +559,10 @@
       "value encodeJsonl",
       "value servePssProtocol"
     ],
-    "./protocol/node": ["type SpawnPssClientOptions", "value spawnPssClient"],
+    "./protocol/node": [
+      "type SpawnPssClientOptions",
+      "value spawnPssClient"
+    ],
     "./testing": [
       "value agentEvent",
       "value agentEventStream",

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -564,10 +564,7 @@
       "value encodeJsonl",
       "value servePssProtocol"
     ],
-    "./protocol/node": [
-      "type SpawnPssClientOptions",
-      "value spawnPssClient"
-    ],
+    "./protocol/node": ["type SpawnPssClientOptions", "value spawnPssClient"],
     "./testing": [
       "value agentEvent",
       "value agentEventStream",

--- a/packages/runtime/src/contracts/package-subpaths.test.ts
+++ b/packages/runtime/src/contracts/package-subpaths.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import type { CelldHost, CelldScheduler } from "../platform/celld";
 
 interface RuntimeExport {
   readonly "@minpeter/pss-source": string;
@@ -55,6 +56,30 @@ describe("runtime package subpaths", () => {
       expect(cloudflarePlatform).toHaveProperty(exportName);
     }
   }, 30_000);
+
+  it("declares the Celld adapter as a platform implementation subpath", async () => {
+    const packageJson = await readRuntimePackageJson();
+    const root = await import("../index");
+    const celld = await import("../platform/celld");
+
+    expect(packageJson.exports["./platform/celld"]).toMatchObject({
+      "@minpeter/pss-source": "./src/platform/celld/index.ts",
+      import: "./dist/platform/celld/index.js",
+      types: "./dist/platform/celld/index.d.ts",
+    });
+    expect(celld).toHaveProperty("createCelldHost");
+    expect(celld).toHaveProperty("createCelldScheduler");
+    expect(celld).toHaveProperty("drainCelldScheduledWork");
+    expect(root).not.toHaveProperty("createCelldHost");
+    expect(root).not.toHaveProperty("createCelldScheduler");
+    expect(root).not.toHaveProperty("drainCelldScheduledWork");
+
+    const acceptsCelldTypes = (
+      host: CelldHost,
+      scheduler: CelldScheduler
+    ): readonly [CelldHost, CelldScheduler] => [host, scheduler];
+    expect(acceptsCelldTypes).toBeTypeOf("function");
+  });
 
   it("declares the file adapter as a platform implementation subpath", async () => {
     const packageJson = await readRuntimePackageJson();

--- a/packages/runtime/src/platform/celld/celld-test-storage.ts
+++ b/packages/runtime/src/platform/celld/celld-test-storage.ts
@@ -1,0 +1,65 @@
+import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
+import type { SqlStorage } from "../cloudflare/sql/ports/storage-port";
+import type { CloudflareDurableObjectTransactionStorage } from "../cloudflare/storage/durable-object/durable-object-storage";
+import type { CelldDurableObjectStorage } from "./scheduler-support";
+
+interface TestStorageOptions {
+  readonly setAlarm?: (scheduledTime: Date | number) => Promise<void>;
+}
+
+export function createCelldTestStorage(
+  options: TestStorageOptions = {}
+): CelldDurableObjectStorage & { readonly sql: SqlStorage } {
+  const inner = new InMemoryCloudflareDurableObjectStorage();
+  let alarmTime: number | null = null;
+  const setAlarm = async (
+    scheduledTime: Date | number,
+    delegate: CloudflareDurableObjectTransactionStorage["setAlarm"]
+  ): Promise<void> => {
+    await options.setAlarm?.(scheduledTime);
+    alarmTime =
+      typeof scheduledTime === "number"
+        ? scheduledTime
+        : scheduledTime.getTime();
+    await delegate?.(scheduledTime);
+  };
+  return {
+    delete: (key) => inner.delete(key),
+    deleteAlarm: () => {
+      alarmTime = null;
+      return Promise.resolve();
+    },
+    get: (key) => inner.get(key),
+    getAlarm: () => Promise.resolve(alarmTime),
+    put: (key, value) => inner.put(key, value),
+    setAlarm: (scheduledTime) =>
+      setAlarm(scheduledTime, inner.setAlarm.bind(inner)),
+    sql: inner.sql,
+    transaction: async <T>(
+      operation: (
+        storage: CloudflareDurableObjectTransactionStorage
+      ) => Promise<T>
+    ): Promise<T> => {
+      const previousAlarm = alarmTime;
+      try {
+        return await inner.transaction((transaction) =>
+          operation({
+            delete: (key) => transaction.delete(key),
+            get: (key) => transaction.get(key),
+            put: (key, value) => transaction.put(key, value),
+            setAlarm: (scheduledTime) =>
+              setAlarm(
+                scheduledTime,
+                (time) => transaction.setAlarm?.(time) ?? Promise.resolve()
+              ),
+            sql: transaction.sql ?? inner.sql,
+          })
+        );
+      } catch (error) {
+        alarmTime = previousAlarm;
+        throw error;
+      }
+    },
+    transactionSync: inner.transactionSync.bind(inner),
+  };
+}

--- a/packages/runtime/src/platform/celld/drainer-support.ts
+++ b/packages/runtime/src/platform/celld/drainer-support.ts
@@ -1,0 +1,104 @@
+import type { TurnStatus } from "../../execution/host/types";
+import {
+  normalizedListLimit,
+  type ScheduledThreadPrompt,
+} from "../../execution/scheduled-work";
+import type { AgentEvent } from "../../thread/protocol/events";
+import type {
+  CelldScheduledWorkDrainOptions,
+  CelldScheduledWorkRunContext,
+} from "./drainer";
+import { ackCelldScheduledThreadPrompt } from "./scheduler-claims";
+import type { CelldDurableObjectStorage } from "./scheduler-support";
+
+export interface MutableDrainResult {
+  ackedRuns: string[];
+  ackedThreadPrompts: ScheduledThreadPrompt[];
+  events: AgentEvent[];
+  remaining: number | undefined;
+  skippedRuns: string[];
+  skippedThreadPrompts: ScheduledThreadPrompt[];
+}
+
+export function createDrainResult(
+  limit: number | undefined
+): MutableDrainResult {
+  return {
+    ackedRuns: [],
+    ackedThreadPrompts: [],
+    events: [],
+    remaining: normalizedListLimit(limit),
+    skippedRuns: [],
+    skippedThreadPrompts: [],
+  };
+}
+
+export function listOptions(
+  options: CelldScheduledWorkDrainOptions,
+  limit: number | undefined
+) {
+  return {
+    ...(limit === undefined ? {} : { limit }),
+    ...(options.nowMs === undefined ? {} : { nowMs: options.nowMs }),
+    ...(options.prefix === undefined ? {} : { prefix: options.prefix }),
+  };
+}
+
+export function threadPromptContext(
+  prompt: ScheduledThreadPrompt & { readonly runId: string }
+): CelldScheduledWorkRunContext {
+  return {
+    ...(prompt.idempotencyKey === undefined
+      ? {}
+      : { idempotencyKey: prompt.idempotencyKey }),
+    kind: "thread-prompt",
+    ...(prompt.notificationId === undefined
+      ? {}
+      : { notificationId: prompt.notificationId }),
+    runId: prompt.runId,
+    threadKey: prompt.threadKey,
+  };
+}
+
+export async function ackThreadPrompt(
+  storage: CelldDurableObjectStorage,
+  prompt: ScheduledThreadPrompt,
+  prefix: string | undefined,
+  rearm = true,
+  claimToken?: string
+): Promise<void> {
+  await ackCelldScheduledThreadPrompt(storage, prompt, {
+    claimToken,
+    ...prefixOptions(prefix),
+    rearm,
+  });
+}
+
+export function prefixOptions(prefix: string | undefined): {
+  readonly prefix?: string;
+} {
+  return prefix === undefined ? {} : { prefix };
+}
+
+export function workOptions(
+  options: Pick<CelldScheduledWorkDrainOptions, "nowMs" | "prefix">,
+  claimToken?: string
+): {
+  readonly claimToken?: string;
+  readonly nowMs?: number;
+  readonly prefix?: string;
+} {
+  return {
+    ...(claimToken === undefined ? {} : { claimToken }),
+    ...(options.nowMs === undefined ? {} : { nowMs: options.nowMs }),
+    ...prefixOptions(options.prefix),
+  };
+}
+
+export function decrement(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : Math.max(0, value - 1);
+}
+
+export function isTerminal(status: TurnStatus): boolean {
+  return status === "cancelled" || status === "completed" || status === "error";
+}

--- a/packages/runtime/src/platform/celld/drainer.test.ts
+++ b/packages/runtime/src/platform/celld/drainer.test.ts
@@ -44,9 +44,12 @@ describe("drainCelldScheduledWork", () => {
 
     expect(result.skippedRuns).toEqual(["run-1"]);
     await expect(
-      listCelldScheduledRuns(storage, { nowMs: Date.now() + 1000 })
+      listCelldScheduledRuns(storage, { nowMs: 999 })
+    ).resolves.toEqual([]);
+    await expect(
+      listCelldScheduledRuns(storage, { nowMs: 1000 })
     ).resolves.toEqual(["run-1"]);
-    await expect(storage.getAlarm()).resolves.toBeGreaterThan(Date.now());
+    await expect(storage.getAlarm()).resolves.toBe(1000);
   });
 
   it("claims a scheduled run before only one concurrent drain resumes it", async () => {

--- a/packages/runtime/src/platform/celld/drainer.test.ts
+++ b/packages/runtime/src/platform/celld/drainer.test.ts
@@ -44,8 +44,38 @@ describe("drainCelldScheduledWork", () => {
 
     expect(result.skippedRuns).toEqual(["run-1"]);
     await expect(
-      listCelldScheduledRuns(storage, { nowMs: 0 })
+      listCelldScheduledRuns(storage, { nowMs: Date.now() + 1000 })
     ).resolves.toEqual(["run-1"]);
+    await expect(storage.getAlarm()).resolves.toBeGreaterThan(Date.now());
+  });
+
+  it("claims a scheduled run before only one concurrent drain resumes it", async () => {
+    const storage = createStorage();
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+    await scheduler.enqueueRun("run-1");
+    let resumes = 0;
+    const agent = createAgent({
+      run: turn([{ type: "turn-end" }]),
+      resume: () => {
+        resumes += 1;
+        return Promise.resolve(turn([{ type: "turn-end" }]));
+      },
+    });
+
+    await Promise.all([
+      drainCelldScheduledWork({
+        agentForRun: () => agent,
+        nowMs: 0,
+        storage,
+      }),
+      drainCelldScheduledWork({
+        agentForRun: () => agent,
+        nowMs: 0,
+        storage,
+      }),
+    ]);
+
+    expect(resumes).toBe(1);
   });
 
   it("acknowledges terminal and missing null resumes", async () => {
@@ -71,9 +101,11 @@ describe("drainCelldScheduledWork", () => {
 function createAgent({
   record = null,
   run,
+  resume,
 }: {
   readonly record?: TurnRecord | null;
   readonly run: AgentTurn | null;
+  readonly resume?: () => Promise<AgentTurn | null>;
 }): CelldScheduledWorkAgent {
   return {
     host: {
@@ -83,7 +115,7 @@ function createAgent({
         },
       },
     },
-    resume: () => Promise.resolve(run),
+    resume: resume ?? (() => Promise.resolve(run)),
   };
 }
 

--- a/packages/runtime/src/platform/celld/drainer.test.ts
+++ b/packages/runtime/src/platform/celld/drainer.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { TurnRecord, TurnStatus } from "../../execution/host/types";
+import type { AgentEvent } from "../../thread/protocol/events";
+import type { AgentTurn } from "../../thread/protocol/turn";
+import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare";
+import {
+  type CelldScheduledWorkAgent,
+  drainCelldScheduledWork,
+} from "./drainer";
+import { createCelldScheduler, listCelldScheduledRuns } from "./scheduler";
+
+describe("drainCelldScheduledWork", () => {
+  it("consumes run events and acknowledges completed work", async () => {
+    const storage = createStorage();
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+    await scheduler.enqueueRun("run-1");
+    const events: AgentEvent[] = [{ type: "turn-start" }, { type: "turn-end" }];
+    const agent = createAgent({ run: turn(events) });
+
+    const result = await drainCelldScheduledWork({
+      agentForRun: () => agent,
+      nowMs: 0,
+      storage,
+    });
+
+    expect(result.events).toEqual(events);
+    expect(result.ackedRuns).toEqual(["run-1"]);
+    await expect(
+      listCelldScheduledRuns(storage, { nowMs: 0 })
+    ).resolves.toEqual([]);
+  });
+
+  it("leaves a nonterminal null resume pending", async () => {
+    const storage = createStorage();
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+    await scheduler.enqueueRun("run-1");
+    const agent = createAgent({ record: runRecord("queued"), run: null });
+
+    const result = await drainCelldScheduledWork({
+      agentForRun: () => agent,
+      nowMs: 0,
+      storage,
+    });
+
+    expect(result.skippedRuns).toEqual(["run-1"]);
+    await expect(
+      listCelldScheduledRuns(storage, { nowMs: 0 })
+    ).resolves.toEqual(["run-1"]);
+  });
+
+  it("acknowledges terminal and missing null resumes", async () => {
+    for (const record of [runRecord("completed"), null]) {
+      const storage = createStorage();
+      const scheduler = createCelldScheduler({ clock: () => 0, storage });
+      await scheduler.enqueueRun("run-1");
+
+      const result = await drainCelldScheduledWork({
+        agentForRun: () => createAgent({ record, run: null }),
+        nowMs: 0,
+        storage,
+      });
+
+      expect(result.ackedRuns).toEqual(["run-1"]);
+      await expect(
+        listCelldScheduledRuns(storage, { nowMs: 0 })
+      ).resolves.toEqual([]);
+    }
+  });
+});
+
+function createAgent({
+  record = null,
+  run,
+}: {
+  readonly record?: TurnRecord | null;
+  readonly run: AgentTurn | null;
+}): CelldScheduledWorkAgent {
+  return {
+    host: {
+      store: {
+        turns: {
+          get: () => Promise.resolve(record),
+        },
+      },
+    },
+    resume: () => Promise.resolve(run),
+  };
+}
+
+function turn(values: readonly AgentEvent[]): AgentTurn {
+  async function* events() {
+    yield* values;
+  }
+  return {
+    events,
+    runId: "run-1",
+  };
+}
+
+function runRecord(status: TurnStatus): TurnRecord {
+  return {
+    checkpointVersion: 0,
+    kind: "user-turn",
+    rootRunId: "run-1",
+    runId: "run-1",
+    status,
+    threadKey: "thread-1",
+  };
+}
+
+function createStorage() {
+  const inner = new InMemoryCloudflareDurableObjectStorage();
+  let alarm: number | null = null;
+  return {
+    delete: (key: string) => inner.delete(key),
+    deleteAlarm: () => {
+      alarm = null;
+      return Promise.resolve();
+    },
+    get: <T>(key: string) => inner.get<T>(key),
+    getAlarm: () => Promise.resolve(alarm),
+    put: <T>(key: string, value: T) => inner.put(key, value),
+    setAlarm: async (time: Date | number) => {
+      alarm = typeof time === "number" ? time : time.getTime();
+      await inner.setAlarm(time);
+    },
+    sql: inner.sql,
+    transaction: inner.transaction.bind(inner),
+    transactionSync: inner.transactionSync.bind(inner),
+  };
+}

--- a/packages/runtime/src/platform/celld/drainer.test.ts
+++ b/packages/runtime/src/platform/celld/drainer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { TurnRecord, TurnStatus } from "../../execution/host/types";
 import type { AgentEvent } from "../../thread/protocol/events";
 import type { AgentTurn } from "../../thread/protocol/turn";
-import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare";
+import { createCelldTestStorage } from "./celld-test-storage";
 import {
   type CelldScheduledWorkAgent,
   drainCelldScheduledWork,
@@ -11,7 +11,7 @@ import { createCelldScheduler, listCelldScheduledRuns } from "./scheduler";
 
 describe("drainCelldScheduledWork", () => {
   it("consumes run events and acknowledges completed work", async () => {
-    const storage = createStorage();
+    const storage = createCelldTestStorage();
     const scheduler = createCelldScheduler({ clock: () => 0, storage });
     await scheduler.enqueueRun("run-1");
     const events: AgentEvent[] = [{ type: "turn-start" }, { type: "turn-end" }];
@@ -31,7 +31,7 @@ describe("drainCelldScheduledWork", () => {
   });
 
   it("leaves a nonterminal null resume pending", async () => {
-    const storage = createStorage();
+    const storage = createCelldTestStorage();
     const scheduler = createCelldScheduler({ clock: () => 0, storage });
     await scheduler.enqueueRun("run-1");
     const agent = createAgent({ record: runRecord("queued"), run: null });
@@ -53,7 +53,7 @@ describe("drainCelldScheduledWork", () => {
   });
 
   it("claims a scheduled run before only one concurrent drain resumes it", async () => {
-    const storage = createStorage();
+    const storage = createCelldTestStorage();
     const scheduler = createCelldScheduler({ clock: () => 0, storage });
     await scheduler.enqueueRun("run-1");
     let resumes = 0;
@@ -83,7 +83,7 @@ describe("drainCelldScheduledWork", () => {
 
   it("acknowledges terminal and missing null resumes", async () => {
     for (const record of [runRecord("completed"), null]) {
-      const storage = createStorage();
+      const storage = createCelldTestStorage();
       const scheduler = createCelldScheduler({ clock: () => 0, storage });
       await scheduler.enqueueRun("run-1");
 
@@ -140,27 +140,5 @@ function runRecord(status: TurnStatus): TurnRecord {
     runId: "run-1",
     status,
     threadKey: "thread-1",
-  };
-}
-
-function createStorage() {
-  const inner = new InMemoryCloudflareDurableObjectStorage();
-  let alarm: number | null = null;
-  return {
-    delete: (key: string) => inner.delete(key),
-    deleteAlarm: () => {
-      alarm = null;
-      return Promise.resolve();
-    },
-    get: <T>(key: string) => inner.get<T>(key),
-    getAlarm: () => Promise.resolve(alarm),
-    put: <T>(key: string, value: T) => inner.put(key, value),
-    setAlarm: async (time: Date | number) => {
-      alarm = typeof time === "number" ? time : time.getTime();
-      await inner.setAlarm(time);
-    },
-    sql: inner.sql,
-    transaction: inner.transaction.bind(inner),
-    transactionSync: inner.transactionSync.bind(inner),
   };
 }

--- a/packages/runtime/src/platform/celld/drainer.ts
+++ b/packages/runtime/src/platform/celld/drainer.ts
@@ -8,10 +8,15 @@ import type { AgentTurn } from "../../thread/protocol/turn";
 import {
   ackCelldScheduledRun,
   ackCelldScheduledThreadPrompt,
-  type CelldDurableObjectStorage,
+  claimCelldScheduledRun,
+  claimCelldScheduledThreadPrompt,
   listCelldScheduledRuns,
   listCelldScheduledThreadPrompts,
+  rearmCelldScheduledWork,
+  retryCelldScheduledRun,
+  retryCelldScheduledThreadPrompt,
 } from "./scheduler";
+import type { CelldDurableObjectStorage } from "./scheduler-support";
 
 export interface CelldScheduledWorkAgent {
   readonly host: {
@@ -43,7 +48,7 @@ export interface CelldScheduledWorkDrainOptions {
   readonly onEvent?: (
     context: CelldScheduledWorkRunContext,
     event: AgentEvent
-  ) => void;
+  ) => Promise<void> | void;
   readonly prefix?: string;
   readonly storage: CelldDurableObjectStorage;
 }
@@ -69,11 +74,18 @@ export async function drainCelldScheduledWork(
   options: CelldScheduledWorkDrainOptions
 ): Promise<CelldScheduledWorkDrainResult> {
   const result = createDrainResult(options.limit);
-  await drainRuns(options, result);
-  if (result.remaining !== 0) {
-    await drainThreadPrompts(options, result);
+  try {
+    await drainRuns(options, result);
+    if (result.remaining !== 0) {
+      await drainThreadPrompts(options, result);
+    }
+    return result;
+  } finally {
+    await rearmCelldScheduledWork(
+      options.storage,
+      prefixOptions(options.prefix)
+    );
   }
-  return result;
 }
 
 async function drainRuns(
@@ -86,11 +98,31 @@ async function drainRuns(
     listOptions(options, result.remaining)
   )) {
     const context = { kind: "run", runId } as const;
-    if (await resumeAndDrain(agentForRun, context, result.events, onEvent)) {
-      await ackCelldScheduledRun(storage, runId, prefixOptions(prefix));
-      result.ackedRuns.push(runId);
-    } else {
-      result.skippedRuns.push(runId);
+    if (
+      !(await claimCelldScheduledRun(storage, runId, prefixOptions(prefix)))
+    ) {
+      result.remaining = decrement(result.remaining);
+      continue;
+    }
+    try {
+      if (await resumeAndDrain(agentForRun, context, result.events, onEvent)) {
+        await ackCelldScheduledRun(storage, runId, {
+          ...prefixOptions(prefix),
+          rearm: false,
+        });
+        result.ackedRuns.push(runId);
+      } else {
+        await retryCelldScheduledRun(
+          storage,
+          runId,
+          1000,
+          prefixOptions(prefix)
+        );
+        result.skippedRuns.push(runId);
+      }
+    } catch (error) {
+      await retryCelldScheduledRun(storage, runId, 1000, prefixOptions(prefix));
+      throw error;
     }
     result.remaining = decrement(result.remaining);
   }
@@ -112,11 +144,35 @@ async function drainThreadPrompts(
       continue;
     }
     const context = threadPromptContext({ ...prompt, runId: prompt.runId });
-    if (await resumeAndDrain(agentForRun, context, result.events, onEvent)) {
-      await ackThreadPrompt(storage, prompt, prefix);
-      result.ackedThreadPrompts.push(prompt);
-    } else {
-      result.skippedThreadPrompts.push(prompt);
+    if (
+      !(await claimCelldScheduledThreadPrompt(
+        storage,
+        prompt,
+        prefixOptions(prefix)
+      ))
+    ) {
+      result.remaining = decrement(result.remaining);
+      continue;
+    }
+    try {
+      if (await resumeAndDrain(agentForRun, context, result.events, onEvent)) {
+        await ackThreadPrompt(storage, prompt, prefix, false);
+        result.ackedThreadPrompts.push(prompt);
+      } else {
+        await retryCelldScheduledThreadPrompt(
+          storage,
+          prompt,
+          prefixOptions(prefix)
+        );
+        result.skippedThreadPrompts.push(prompt);
+      }
+    } catch (error) {
+      await retryCelldScheduledThreadPrompt(
+        storage,
+        prompt,
+        prefixOptions(prefix)
+      );
+      throw error;
     }
     result.remaining = decrement(result.remaining);
   }
@@ -136,7 +192,7 @@ async function resumeAndDrain(
   }
   for await (const event of turn.events()) {
     events.push(event);
-    onEvent?.(context, event);
+    await onEvent?.(context, event);
   }
   return true;
 }
@@ -182,9 +238,13 @@ function threadPromptContext(
 async function ackThreadPrompt(
   storage: CelldDurableObjectStorage,
   prompt: ScheduledThreadPrompt,
-  prefix: string | undefined
+  prefix: string | undefined,
+  rearm = true
 ): Promise<void> {
-  await ackCelldScheduledThreadPrompt(storage, prompt, prefixOptions(prefix));
+  await ackCelldScheduledThreadPrompt(storage, prompt, {
+    ...prefixOptions(prefix),
+    rearm,
+  });
 }
 
 function prefixOptions(prefix: string | undefined): {

--- a/packages/runtime/src/platform/celld/drainer.ts
+++ b/packages/runtime/src/platform/celld/drainer.ts
@@ -1,0 +1,202 @@
+import type { TurnRecord, TurnStatus } from "../../execution/host/types";
+import {
+  normalizedListLimit,
+  type ScheduledThreadPrompt,
+} from "../../execution/scheduled-work";
+import type { AgentEvent } from "../../thread/protocol/events";
+import type { AgentTurn } from "../../thread/protocol/turn";
+import {
+  ackCelldScheduledRun,
+  ackCelldScheduledThreadPrompt,
+  type CelldDurableObjectStorage,
+  listCelldScheduledRuns,
+  listCelldScheduledThreadPrompts,
+} from "./scheduler";
+
+export interface CelldScheduledWorkAgent {
+  readonly host: {
+    readonly store: {
+      readonly turns: {
+        get(runId: string): Promise<TurnRecord | null>;
+      };
+    };
+  };
+  resume(runId: string): Promise<AgentTurn | null>;
+}
+
+export type CelldScheduledWorkRunContext =
+  | { readonly kind: "run"; readonly runId: string }
+  | {
+      readonly idempotencyKey?: string;
+      readonly kind: "thread-prompt";
+      readonly notificationId?: string;
+      readonly runId: string;
+      readonly threadKey: string;
+    };
+
+export interface CelldScheduledWorkDrainOptions {
+  readonly agentForRun: (
+    context: CelldScheduledWorkRunContext
+  ) => CelldScheduledWorkAgent | Promise<CelldScheduledWorkAgent>;
+  readonly limit?: number;
+  readonly nowMs?: number;
+  readonly onEvent?: (
+    context: CelldScheduledWorkRunContext,
+    event: AgentEvent
+  ) => void;
+  readonly prefix?: string;
+  readonly storage: CelldDurableObjectStorage;
+}
+
+export interface CelldScheduledWorkDrainResult {
+  readonly ackedRuns: readonly string[];
+  readonly ackedThreadPrompts: readonly ScheduledThreadPrompt[];
+  readonly events: readonly AgentEvent[];
+  readonly skippedRuns: readonly string[];
+  readonly skippedThreadPrompts: readonly ScheduledThreadPrompt[];
+}
+
+interface MutableDrainResult {
+  ackedRuns: string[];
+  ackedThreadPrompts: ScheduledThreadPrompt[];
+  events: AgentEvent[];
+  remaining: number | undefined;
+  skippedRuns: string[];
+  skippedThreadPrompts: ScheduledThreadPrompt[];
+}
+
+export async function drainCelldScheduledWork(
+  options: CelldScheduledWorkDrainOptions
+): Promise<CelldScheduledWorkDrainResult> {
+  const result = createDrainResult(options.limit);
+  await drainRuns(options, result);
+  if (result.remaining !== 0) {
+    await drainThreadPrompts(options, result);
+  }
+  return result;
+}
+
+async function drainRuns(
+  options: CelldScheduledWorkDrainOptions,
+  result: MutableDrainResult
+): Promise<void> {
+  const { agentForRun, onEvent, prefix, storage } = options;
+  for (const runId of await listCelldScheduledRuns(
+    storage,
+    listOptions(options, result.remaining)
+  )) {
+    const context = { kind: "run", runId } as const;
+    if (await resumeAndDrain(agentForRun, context, result.events, onEvent)) {
+      await ackCelldScheduledRun(storage, runId, prefixOptions(prefix));
+      result.ackedRuns.push(runId);
+    } else {
+      result.skippedRuns.push(runId);
+    }
+    result.remaining = decrement(result.remaining);
+  }
+}
+
+async function drainThreadPrompts(
+  options: CelldScheduledWorkDrainOptions,
+  result: MutableDrainResult
+): Promise<void> {
+  const { agentForRun, onEvent, prefix, storage } = options;
+  for (const prompt of await listCelldScheduledThreadPrompts(
+    storage,
+    listOptions(options, result.remaining)
+  )) {
+    if (prompt.runId === undefined) {
+      await ackThreadPrompt(storage, prompt, prefix);
+      result.ackedThreadPrompts.push(prompt);
+      result.remaining = decrement(result.remaining);
+      continue;
+    }
+    const context = threadPromptContext({ ...prompt, runId: prompt.runId });
+    if (await resumeAndDrain(agentForRun, context, result.events, onEvent)) {
+      await ackThreadPrompt(storage, prompt, prefix);
+      result.ackedThreadPrompts.push(prompt);
+    } else {
+      result.skippedThreadPrompts.push(prompt);
+    }
+    result.remaining = decrement(result.remaining);
+  }
+}
+
+async function resumeAndDrain(
+  agentForRun: CelldScheduledWorkDrainOptions["agentForRun"],
+  context: CelldScheduledWorkRunContext,
+  events: AgentEvent[],
+  onEvent: CelldScheduledWorkDrainOptions["onEvent"]
+): Promise<boolean> {
+  const agent = await agentForRun(context);
+  const turn = await agent.resume(context.runId);
+  if (turn === null) {
+    const record = await agent.host.store.turns.get(context.runId);
+    return record === null || isTerminal(record.status);
+  }
+  for await (const event of turn.events()) {
+    events.push(event);
+    onEvent?.(context, event);
+  }
+  return true;
+}
+
+function createDrainResult(limit: number | undefined): MutableDrainResult {
+  return {
+    ackedRuns: [],
+    ackedThreadPrompts: [],
+    events: [],
+    remaining: normalizedListLimit(limit),
+    skippedRuns: [],
+    skippedThreadPrompts: [],
+  };
+}
+
+function listOptions(
+  options: CelldScheduledWorkDrainOptions,
+  limit: number | undefined
+) {
+  return {
+    ...(limit === undefined ? {} : { limit }),
+    ...(options.nowMs === undefined ? {} : { nowMs: options.nowMs }),
+    ...(options.prefix === undefined ? {} : { prefix: options.prefix }),
+  };
+}
+
+function threadPromptContext(
+  prompt: ScheduledThreadPrompt & { readonly runId: string }
+): CelldScheduledWorkRunContext {
+  return {
+    ...(prompt.idempotencyKey === undefined
+      ? {}
+      : { idempotencyKey: prompt.idempotencyKey }),
+    kind: "thread-prompt",
+    ...(prompt.notificationId === undefined
+      ? {}
+      : { notificationId: prompt.notificationId }),
+    runId: prompt.runId,
+    threadKey: prompt.threadKey,
+  };
+}
+
+async function ackThreadPrompt(
+  storage: CelldDurableObjectStorage,
+  prompt: ScheduledThreadPrompt,
+  prefix: string | undefined
+): Promise<void> {
+  await ackCelldScheduledThreadPrompt(storage, prompt, prefixOptions(prefix));
+}
+
+function prefixOptions(prefix: string | undefined): {
+  readonly prefix?: string;
+} {
+  return prefix === undefined ? {} : { prefix };
+}
+
+function decrement(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : Math.max(0, value - 1);
+}
+
+function isTerminal(status: TurnStatus): boolean {
+  return status === "cancelled" || status === "completed" || status === "error";
+}

--- a/packages/runtime/src/platform/celld/drainer.ts
+++ b/packages/runtime/src/platform/celld/drainer.ts
@@ -1,21 +1,29 @@
-import type { TurnRecord, TurnStatus } from "../../execution/host/types";
-import {
-  normalizedListLimit,
-  type ScheduledThreadPrompt,
-} from "../../execution/scheduled-work";
+import type { TurnRecord } from "../../execution/host/types";
+import type { ScheduledThreadPrompt } from "../../execution/scheduled-work";
 import type { AgentEvent } from "../../thread/protocol/events";
 import type { AgentTurn } from "../../thread/protocol/turn";
 import {
-  ackCelldScheduledRun,
-  ackCelldScheduledThreadPrompt,
-  claimCelldScheduledRun,
-  claimCelldScheduledThreadPrompt,
+  ackThreadPrompt,
+  createDrainResult,
+  decrement,
+  isTerminal,
+  listOptions,
+  type MutableDrainResult,
+  threadPromptContext,
+  workOptions,
+} from "./drainer-support";
+import {
   listCelldScheduledRuns,
   listCelldScheduledThreadPrompts,
+} from "./scheduler";
+import {
+  ackCelldScheduledRun,
+  claimCelldScheduledRun,
+  claimCelldScheduledThreadPrompt,
   rearmCelldScheduledWork,
   retryCelldScheduledRun,
   retryCelldScheduledThreadPrompt,
-} from "./scheduler";
+} from "./scheduler-claims";
 import type { CelldDurableObjectStorage } from "./scheduler-support";
 
 export interface CelldScheduledWorkAgent {
@@ -61,15 +69,6 @@ export interface CelldScheduledWorkDrainResult {
   readonly skippedThreadPrompts: readonly ScheduledThreadPrompt[];
 }
 
-interface MutableDrainResult {
-  ackedRuns: string[];
-  ackedThreadPrompts: ScheduledThreadPrompt[];
-  events: AgentEvent[];
-  remaining: number | undefined;
-  skippedRuns: string[];
-  skippedThreadPrompts: ScheduledThreadPrompt[];
-}
-
 export async function drainCelldScheduledWork(
   options: CelldScheduledWorkDrainOptions
 ): Promise<CelldScheduledWorkDrainResult> {
@@ -81,33 +80,33 @@ export async function drainCelldScheduledWork(
     }
     return result;
   } finally {
-    await rearmCelldScheduledWork(
-      options.storage,
-      prefixOptions(options.prefix)
-    );
+    await rearmCelldScheduledWork(options.storage, workOptions(options));
   }
 }
-
 async function drainRuns(
   options: CelldScheduledWorkDrainOptions,
   result: MutableDrainResult
 ): Promise<void> {
-  const { agentForRun, onEvent, prefix, storage } = options;
+  const { agentForRun, onEvent, storage } = options;
   for (const runId of await listCelldScheduledRuns(
     storage,
     listOptions(options, result.remaining)
   )) {
     const context = { kind: "run", runId } as const;
-    if (
-      !(await claimCelldScheduledRun(storage, runId, prefixOptions(prefix)))
-    ) {
+    const claimToken = await claimCelldScheduledRun(
+      storage,
+      runId,
+      workOptions(options)
+    );
+    if (claimToken === undefined) {
       result.remaining = decrement(result.remaining);
       continue;
     }
     try {
       if (await resumeAndDrain(agentForRun, context, result.events, onEvent)) {
         await ackCelldScheduledRun(storage, runId, {
-          ...prefixOptions(prefix),
+          ...workOptions(options),
+          claimToken,
           rearm: false,
         });
         result.ackedRuns.push(runId);
@@ -116,12 +115,17 @@ async function drainRuns(
           storage,
           runId,
           1000,
-          prefixOptions(prefix)
+          workOptions(options, claimToken)
         );
         result.skippedRuns.push(runId);
       }
     } catch (error) {
-      await retryCelldScheduledRun(storage, runId, 1000, prefixOptions(prefix));
+      await retryCelldScheduledRun(
+        storage,
+        runId,
+        1000,
+        workOptions(options, claimToken)
+      );
       throw error;
     }
     result.remaining = decrement(result.remaining);
@@ -144,25 +148,24 @@ async function drainThreadPrompts(
       continue;
     }
     const context = threadPromptContext({ ...prompt, runId: prompt.runId });
-    if (
-      !(await claimCelldScheduledThreadPrompt(
-        storage,
-        prompt,
-        prefixOptions(prefix)
-      ))
-    ) {
+    const claimToken = await claimCelldScheduledThreadPrompt(
+      storage,
+      prompt,
+      workOptions(options)
+    );
+    if (claimToken === undefined) {
       result.remaining = decrement(result.remaining);
       continue;
     }
     try {
       if (await resumeAndDrain(agentForRun, context, result.events, onEvent)) {
-        await ackThreadPrompt(storage, prompt, prefix, false);
+        await ackThreadPrompt(storage, prompt, prefix, false, claimToken);
         result.ackedThreadPrompts.push(prompt);
       } else {
         await retryCelldScheduledThreadPrompt(
           storage,
           prompt,
-          prefixOptions(prefix)
+          workOptions(options, claimToken)
         );
         result.skippedThreadPrompts.push(prompt);
       }
@@ -170,7 +173,7 @@ async function drainThreadPrompts(
       await retryCelldScheduledThreadPrompt(
         storage,
         prompt,
-        prefixOptions(prefix)
+        workOptions(options, claimToken)
       );
       throw error;
     }
@@ -195,68 +198,4 @@ async function resumeAndDrain(
     await onEvent?.(context, event);
   }
   return true;
-}
-
-function createDrainResult(limit: number | undefined): MutableDrainResult {
-  return {
-    ackedRuns: [],
-    ackedThreadPrompts: [],
-    events: [],
-    remaining: normalizedListLimit(limit),
-    skippedRuns: [],
-    skippedThreadPrompts: [],
-  };
-}
-
-function listOptions(
-  options: CelldScheduledWorkDrainOptions,
-  limit: number | undefined
-) {
-  return {
-    ...(limit === undefined ? {} : { limit }),
-    ...(options.nowMs === undefined ? {} : { nowMs: options.nowMs }),
-    ...(options.prefix === undefined ? {} : { prefix: options.prefix }),
-  };
-}
-
-function threadPromptContext(
-  prompt: ScheduledThreadPrompt & { readonly runId: string }
-): CelldScheduledWorkRunContext {
-  return {
-    ...(prompt.idempotencyKey === undefined
-      ? {}
-      : { idempotencyKey: prompt.idempotencyKey }),
-    kind: "thread-prompt",
-    ...(prompt.notificationId === undefined
-      ? {}
-      : { notificationId: prompt.notificationId }),
-    runId: prompt.runId,
-    threadKey: prompt.threadKey,
-  };
-}
-
-async function ackThreadPrompt(
-  storage: CelldDurableObjectStorage,
-  prompt: ScheduledThreadPrompt,
-  prefix: string | undefined,
-  rearm = true
-): Promise<void> {
-  await ackCelldScheduledThreadPrompt(storage, prompt, {
-    ...prefixOptions(prefix),
-    rearm,
-  });
-}
-
-function prefixOptions(prefix: string | undefined): {
-  readonly prefix?: string;
-} {
-  return prefix === undefined ? {} : { prefix };
-}
-
-function decrement(value: number | undefined): number | undefined {
-  return value === undefined ? undefined : Math.max(0, value - 1);
-}
-
-function isTerminal(status: TurnStatus): boolean {
-  return status === "cancelled" || status === "completed" || status === "error";
 }

--- a/packages/runtime/src/platform/celld/host.test.ts
+++ b/packages/runtime/src/platform/celld/host.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { describeAgentHostFaultContract } from "../../contracts/agent-host-fault-contract";
+import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
+import { createCelldHost } from "./host";
+
+let hostPrefix = 0;
+
+describeAgentHostFaultContract({
+  createHost: () => ({
+    host: createCelldHost({
+      prefix: `celld-host-contract-${hostPrefix++}`,
+      state: createState(),
+    }),
+  }),
+  name: "Celld",
+});
+
+describe("createCelldHost", () => {
+  it("composes Cloudflare storage ports with the Celld scheduler", async () => {
+    const state = createState();
+    const host = createCelldHost({ state });
+
+    expect(host.store).toBeDefined();
+    expect(host.attachmentStore).toBeDefined();
+    expect(host.diagnostics).toBeDefined();
+    expect(host.scheduler).toBeDefined();
+
+    await host.scheduler.enqueueRun("celld-run");
+
+    await expect(state.storage.getAlarm()).resolves.toBeDefined();
+  });
+
+  it("requires no Cloudflare Agents SDK object or fiber", () => {
+    const host = createCelldHost({ state: createState() });
+
+    expect(host.scheduler).toBeDefined();
+  });
+});
+
+function createState() {
+  const inner = new InMemoryCloudflareDurableObjectStorage();
+  let alarmTime: number | null = null;
+  const storage = {
+    delete: (key: string) => inner.delete(key),
+    deleteAlarm: () => {
+      alarmTime = null;
+      return Promise.resolve();
+    },
+    get: <T>(key: string) => inner.get<T>(key),
+    getAlarm: () => Promise.resolve(alarmTime),
+    put: <T>(key: string, value: T) => inner.put(key, value),
+    setAlarm: async (scheduledTime: Date | number) => {
+      alarmTime =
+        typeof scheduledTime === "number"
+          ? scheduledTime
+          : scheduledTime.getTime();
+      await inner.setAlarm(scheduledTime);
+    },
+    sql: inner.sql,
+    transaction: inner.transaction.bind(inner),
+    transactionSync: inner.transactionSync.bind(inner),
+  };
+  return {
+    storage,
+    waitUntil: (_promise: Promise<unknown>): void => undefined,
+  };
+}

--- a/packages/runtime/src/platform/celld/host.test.ts
+++ b/packages/runtime/src/platform/celld/host.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { describeAgentHostFaultContract } from "../../contracts/agent-host-fault-contract";
-import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
+import { createCelldTestStorage } from "./celld-test-storage";
 import { createCelldHost } from "./host";
 
 let hostPrefix = 0;
@@ -35,33 +35,36 @@ describe("createCelldHost", () => {
 
     expect(host.scheduler).toBeDefined();
   });
+
+  it("reconciles persisted scheduled work during activation", async () => {
+    const state = createState();
+    state.storage.sql.exec(
+      "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, due_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      "pss-runtime",
+      "celld-run",
+      "orphaned",
+      JSON.stringify({ dueAtMs: 42, value: "orphaned" }),
+      null,
+      "orphaned",
+      42,
+      42
+    );
+
+    createCelldHost({ clock: () => 42, state });
+    await Promise.all(state.waits);
+
+    await expect(state.storage.getAlarm()).resolves.toBe(42);
+  });
 });
 
 function createState() {
-  const inner = new InMemoryCloudflareDurableObjectStorage();
-  let alarmTime: number | null = null;
-  const storage = {
-    delete: (key: string) => inner.delete(key),
-    deleteAlarm: () => {
-      alarmTime = null;
-      return Promise.resolve();
-    },
-    get: <T>(key: string) => inner.get<T>(key),
-    getAlarm: () => Promise.resolve(alarmTime),
-    put: <T>(key: string, value: T) => inner.put(key, value),
-    setAlarm: async (scheduledTime: Date | number) => {
-      alarmTime =
-        typeof scheduledTime === "number"
-          ? scheduledTime
-          : scheduledTime.getTime();
-      await inner.setAlarm(scheduledTime);
-    },
-    sql: inner.sql,
-    transaction: inner.transaction.bind(inner),
-    transactionSync: inner.transactionSync.bind(inner),
-  };
+  const storage = createCelldTestStorage();
+  const waits: Promise<unknown>[] = [];
   return {
     storage,
-    waitUntil: (_promise: Promise<unknown>): void => undefined,
+    waits,
+    waitUntil: (promise: Promise<unknown>): void => {
+      waits.push(promise);
+    },
   };
 }

--- a/packages/runtime/src/platform/celld/host.ts
+++ b/packages/runtime/src/platform/celld/host.ts
@@ -1,11 +1,11 @@
 import type { AgentHost } from "../../execution";
 import type { ThreadStore } from "../../thread/store/types";
-import { createCloudflareStorageHost } from "../cloudflare";
-import {
-  type CelldDurableObjectStorage,
-  type CelldScheduler,
-  createCelldScheduler,
-} from "./scheduler";
+import { createCloudflareStorageHost } from "../cloudflare/host/durable-object-host";
+import { createCelldScheduler } from "./scheduler";
+import type {
+  CelldDurableObjectStorage,
+  CelldScheduler,
+} from "./scheduler-support";
 
 export interface CelldDurableObjectState {
   readonly storage: CelldDurableObjectStorage;

--- a/packages/runtime/src/platform/celld/host.ts
+++ b/packages/runtime/src/platform/celld/host.ts
@@ -1,0 +1,49 @@
+import type { AgentHost } from "../../execution";
+import type { ThreadStore } from "../../thread/store/types";
+import { createCloudflareStorageHost } from "../cloudflare";
+import {
+  type CelldDurableObjectStorage,
+  type CelldScheduler,
+  createCelldScheduler,
+} from "./scheduler";
+
+export interface CelldDurableObjectState {
+  readonly storage: CelldDurableObjectStorage;
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+export interface CelldHostOptions {
+  readonly clock?: () => number;
+  readonly maxPayloadBytes?: number;
+  readonly prefix?: string;
+  readonly state: CelldDurableObjectState;
+  readonly threadStore?: ThreadStore;
+}
+
+export interface CelldHost extends AgentHost {
+  readonly scheduler: CelldScheduler;
+}
+
+export function createCelldHost({
+  clock,
+  maxPayloadBytes,
+  prefix,
+  state,
+  threadStore,
+}: CelldHostOptions): CelldHost {
+  const scheduler = createCelldScheduler({
+    ...(clock === undefined ? {} : { clock }),
+    ...(prefix === undefined ? {} : { prefix }),
+    storage: state.storage,
+  });
+  return {
+    ...createCloudflareStorageHost({
+      ...(maxPayloadBytes === undefined ? {} : { maxPayloadBytes }),
+      ...(prefix === undefined ? {} : { prefix }),
+      scheduler,
+      storage: state.storage,
+      ...(threadStore === undefined ? {} : { threadStore }),
+    }),
+    scheduler,
+  };
+}

--- a/packages/runtime/src/platform/celld/host.ts
+++ b/packages/runtime/src/platform/celld/host.ts
@@ -2,6 +2,7 @@ import type { AgentHost } from "../../execution";
 import type { ThreadStore } from "../../thread/store/types";
 import { createCloudflareStorageHost } from "../cloudflare/host/durable-object-host";
 import { createCelldScheduler } from "./scheduler";
+import { rearmCelldScheduledWork } from "./scheduler-claims";
 import type {
   CelldDurableObjectStorage,
   CelldScheduler,
@@ -36,6 +37,12 @@ export function createCelldHost({
     ...(prefix === undefined ? {} : { prefix }),
     storage: state.storage,
   });
+  state.waitUntil(
+    rearmCelldScheduledWork(state.storage, {
+      ...(clock === undefined ? {} : { nowMs: clock() }),
+      ...(prefix === undefined ? {} : { prefix }),
+    })
+  );
   return {
     ...createCloudflareStorageHost({
       ...(maxPayloadBytes === undefined ? {} : { maxPayloadBytes }),

--- a/packages/runtime/src/platform/celld/index.ts
+++ b/packages/runtime/src/platform/celld/index.ts
@@ -16,11 +16,18 @@ export {
 export {
   ackCelldScheduledRun,
   ackCelldScheduledThreadPrompt,
-  type CelldDurableObjectStorage,
-  type CelldScheduledWorkListOptions,
-  type CelldScheduler,
-  type CelldSchedulerOptions,
+  claimCelldScheduledRun,
+  claimCelldScheduledThreadPrompt,
   createCelldScheduler,
   listCelldScheduledRuns,
   listCelldScheduledThreadPrompts,
+  rearmCelldScheduledWork,
+  retryCelldScheduledRun,
+  retryCelldScheduledThreadPrompt,
 } from "./scheduler";
+export type {
+  CelldDurableObjectStorage,
+  CelldScheduledWorkListOptions,
+  CelldScheduler,
+  CelldSchedulerOptions,
+} from "./scheduler-support";

--- a/packages/runtime/src/platform/celld/index.ts
+++ b/packages/runtime/src/platform/celld/index.ts
@@ -14,17 +14,19 @@ export {
   createCelldHost,
 } from "./host";
 export {
+  createCelldScheduler,
+  listCelldScheduledRuns,
+  listCelldScheduledThreadPrompts,
+} from "./scheduler";
+export {
   ackCelldScheduledRun,
   ackCelldScheduledThreadPrompt,
   claimCelldScheduledRun,
   claimCelldScheduledThreadPrompt,
-  createCelldScheduler,
-  listCelldScheduledRuns,
-  listCelldScheduledThreadPrompts,
   rearmCelldScheduledWork,
   retryCelldScheduledRun,
   retryCelldScheduledThreadPrompt,
-} from "./scheduler";
+} from "./scheduler-claims";
 export type {
   CelldDurableObjectStorage,
   CelldScheduledWorkListOptions,

--- a/packages/runtime/src/platform/celld/index.ts
+++ b/packages/runtime/src/platform/celld/index.ts
@@ -1,0 +1,26 @@
+// biome-ignore-all lint/performance/noBarrelFile: Public package subpath entrypoint required by package exports.
+
+export {
+  type CelldScheduledWorkAgent,
+  type CelldScheduledWorkDrainOptions,
+  type CelldScheduledWorkDrainResult,
+  type CelldScheduledWorkRunContext,
+  drainCelldScheduledWork,
+} from "./drainer";
+export {
+  type CelldDurableObjectState,
+  type CelldHost,
+  type CelldHostOptions,
+  createCelldHost,
+} from "./host";
+export {
+  ackCelldScheduledRun,
+  ackCelldScheduledThreadPrompt,
+  type CelldDurableObjectStorage,
+  type CelldScheduledWorkListOptions,
+  type CelldScheduler,
+  type CelldSchedulerOptions,
+  createCelldScheduler,
+  listCelldScheduledRuns,
+  listCelldScheduledThreadPrompts,
+} from "./scheduler";

--- a/packages/runtime/src/platform/celld/scheduler-claims.ts
+++ b/packages/runtime/src/platform/celld/scheduler-claims.ts
@@ -10,7 +10,7 @@ import type { CelldDurableObjectStorage } from "./scheduler-support";
 import {
   armNextAlarm,
   DEFAULT_PREFIX,
-  insertDueWork,
+  insertDueWorkAndArm,
   RUN_KIND,
   serialize,
   THREAD_PROMPT_KIND,
@@ -86,7 +86,7 @@ export function retryCelldScheduledRun(
   const nowMs = options.nowMs ?? Date.now();
   return serialize(storage, async () => {
     if (options.claimToken === undefined) {
-      await insertDueWork(
+      await insertDueWorkAndArm(
         storage,
         prefix,
         RUN_KIND,
@@ -118,7 +118,7 @@ export function retryCelldScheduledThreadPrompt(
   const nowMs = options.nowMs ?? Date.now();
   return serialize(storage, async () => {
     if (options.claimToken === undefined) {
-      await insertDueWork(
+      await insertDueWorkAndArm(
         storage,
         prefix,
         THREAD_PROMPT_KIND,

--- a/packages/runtime/src/platform/celld/scheduler-claims.ts
+++ b/packages/runtime/src/platform/celld/scheduler-claims.ts
@@ -1,0 +1,195 @@
+import type { ScheduledThreadPrompt } from "../../execution/scheduled-work";
+import { threadPromptScheduledWorkId } from "../../execution/scheduled-work";
+import {
+  ackScheduledWorkLease,
+  claimScheduledWorkLease,
+  releaseScheduledWorkLease,
+} from "../cloudflare/storage/sqlite/scheduled-work-claims";
+import { deleteScheduledWork } from "../cloudflare/storage/sqlite/scheduled-work-table";
+import type { CelldDurableObjectStorage } from "./scheduler-support";
+import {
+  armNextAlarm,
+  DEFAULT_PREFIX,
+  insertDueWork,
+  RUN_KIND,
+  serialize,
+  THREAD_PROMPT_KIND,
+} from "./scheduler-support";
+
+interface ClaimOptions {
+  readonly leaseMs?: number;
+  readonly nowMs?: number;
+  readonly prefix?: string;
+}
+
+interface MutationOptions {
+  readonly claimToken?: string;
+  readonly nowMs?: number;
+  readonly prefix?: string;
+  readonly rearm?: boolean;
+}
+
+export function claimCelldScheduledRun(
+  storage: CelldDurableObjectStorage,
+  runId: string,
+  options: ClaimOptions = {}
+): Promise<string | undefined> {
+  return serialize(storage, () =>
+    claimScheduledWorkLease(
+      storage,
+      options.prefix ?? DEFAULT_PREFIX,
+      RUN_KIND,
+      runId,
+      options.nowMs,
+      options.leaseMs
+    )
+  );
+}
+
+export function claimCelldScheduledThreadPrompt(
+  storage: CelldDurableObjectStorage,
+  prompt: ScheduledThreadPrompt,
+  options: ClaimOptions = {}
+): Promise<string | undefined> {
+  return serialize(storage, () =>
+    claimScheduledWorkLease(
+      storage,
+      options.prefix ?? DEFAULT_PREFIX,
+      THREAD_PROMPT_KIND,
+      threadPromptScheduledWorkId(prompt),
+      options.nowMs,
+      options.leaseMs
+    )
+  );
+}
+
+export function rearmCelldScheduledWork(
+  storage: CelldDurableObjectStorage,
+  options: ClaimOptions = {}
+): Promise<void> {
+  return serialize(storage, () =>
+    armNextAlarm(
+      storage,
+      options.prefix ?? DEFAULT_PREFIX,
+      options.nowMs ?? Date.now()
+    )
+  );
+}
+
+export function retryCelldScheduledRun(
+  storage: CelldDurableObjectStorage,
+  runId: string,
+  delayMs: number,
+  options: MutationOptions = {}
+): Promise<void> {
+  const prefix = options.prefix ?? DEFAULT_PREFIX;
+  const nowMs = options.nowMs ?? Date.now();
+  return serialize(storage, async () => {
+    if (options.claimToken === undefined) {
+      await insertDueWork(
+        storage,
+        prefix,
+        RUN_KIND,
+        runId,
+        runId,
+        nowMs + Math.max(0, Math.floor(delayMs)),
+        { runId }
+      );
+    } else {
+      await releaseScheduledWorkLease(
+        storage,
+        prefix,
+        RUN_KIND,
+        runId,
+        options.claimToken,
+        nowMs + Math.max(0, Math.floor(delayMs))
+      );
+    }
+    await armNextAlarm(storage, prefix, nowMs);
+  });
+}
+
+export function retryCelldScheduledThreadPrompt(
+  storage: CelldDurableObjectStorage,
+  prompt: ScheduledThreadPrompt,
+  options: MutationOptions = {}
+): Promise<void> {
+  const prefix = options.prefix ?? DEFAULT_PREFIX;
+  const nowMs = options.nowMs ?? Date.now();
+  return serialize(storage, async () => {
+    if (options.claimToken === undefined) {
+      await insertDueWork(
+        storage,
+        prefix,
+        THREAD_PROMPT_KIND,
+        threadPromptScheduledWorkId(prompt),
+        prompt,
+        nowMs,
+        { runId: prompt.runId, threadKey: prompt.threadKey }
+      );
+    } else {
+      await releaseScheduledWorkLease(
+        storage,
+        prefix,
+        THREAD_PROMPT_KIND,
+        threadPromptScheduledWorkId(prompt),
+        options.claimToken,
+        nowMs
+      );
+    }
+    await armNextAlarm(storage, prefix, nowMs);
+  });
+}
+
+export async function ackCelldScheduledRun(
+  storage: CelldDurableObjectStorage,
+  runId: string,
+  options: MutationOptions = {}
+): Promise<void> {
+  await serialize(storage, async () => {
+    const prefix = options.prefix ?? DEFAULT_PREFIX;
+    if (options.claimToken === undefined) {
+      await deleteScheduledWork(storage, prefix, RUN_KIND, runId);
+    } else {
+      await ackScheduledWorkLease(
+        storage,
+        prefix,
+        RUN_KIND,
+        runId,
+        options.claimToken
+      );
+    }
+    if (options.rearm !== false) {
+      await armNextAlarm(storage, prefix, options.nowMs ?? Date.now());
+    }
+  });
+}
+
+export async function ackCelldScheduledThreadPrompt(
+  storage: CelldDurableObjectStorage,
+  prompt: ScheduledThreadPrompt,
+  options: MutationOptions = {}
+): Promise<void> {
+  await serialize(storage, async () => {
+    const prefix = options.prefix ?? DEFAULT_PREFIX;
+    if (options.claimToken === undefined) {
+      await deleteScheduledWork(
+        storage,
+        prefix,
+        THREAD_PROMPT_KIND,
+        threadPromptScheduledWorkId(prompt)
+      );
+    } else {
+      await ackScheduledWorkLease(
+        storage,
+        prefix,
+        THREAD_PROMPT_KIND,
+        threadPromptScheduledWorkId(prompt),
+        options.claimToken
+      );
+    }
+    if (options.rearm !== false) {
+      await armNextAlarm(storage, prefix, options.nowMs ?? Date.now());
+    }
+  });
+}

--- a/packages/runtime/src/platform/celld/scheduler-support.ts
+++ b/packages/runtime/src/platform/celld/scheduler-support.ts
@@ -4,7 +4,10 @@ import {
   type ScheduledThreadPrompt,
 } from "../../execution/scheduled-work";
 import type { CloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
-import { withTransaction } from "../cloudflare/storage/durable-object/sql-access";
+import {
+  requiredSqlStorage,
+  withTransaction,
+} from "../cloudflare/storage/durable-object/sql-access";
 import {
   insertScheduledWorkInTransaction,
   selectNextScheduledWork,
@@ -82,8 +85,23 @@ export async function insertDueWorkAndArm<T>(
     if (transaction.setAlarm === undefined) {
       throw new Error("Celld storage transaction setAlarm() is required.");
     }
+    const sql = requiredSqlStorage(transaction, "Celld scheduled work alarm");
+    const persistedDueAt = ([RUN_KIND, THREAD_PROMPT_KIND] as const)
+      .flatMap((scheduledKind) => {
+        const row = sql
+          .exec<{ readonly due_at: number | null }>(
+            "SELECT due_at FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND due_at IS NOT NULL ORDER BY due_at, rowid LIMIT 1",
+            prefix,
+            scheduledKind
+          )
+          .toArray()[0];
+        return typeof row?.due_at === "number" ? [row.due_at] : [];
+      })
+      .reduce((earliest, value) => Math.min(earliest, value), dueAtMs);
     await transaction.setAlarm(
-      currentAlarm === null ? dueAtMs : Math.min(currentAlarm, dueAtMs)
+      currentAlarm === null
+        ? persistedDueAt
+        : Math.min(currentAlarm, persistedDueAt)
     );
   });
 }

--- a/packages/runtime/src/platform/celld/scheduler-support.ts
+++ b/packages/runtime/src/platform/celld/scheduler-support.ts
@@ -4,9 +4,11 @@ import {
   type ScheduledThreadPrompt,
 } from "../../execution/scheduled-work";
 import type { CloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
+import { withTransaction } from "../cloudflare/storage/durable-object/sql-access";
 import {
-  insertScheduledWork,
-  selectScheduledWork,
+  insertScheduledWorkInTransaction,
+  selectNextScheduledWork,
+  selectScheduledWorkDue,
 } from "../cloudflare/storage/sqlite/scheduled-work-table";
 
 export const DEFAULT_PREFIX = "pss-runtime";
@@ -58,7 +60,7 @@ export function serialize<T>(
   return current;
 }
 
-export async function insertDueWork<T>(
+export async function insertDueWorkAndArm<T>(
   storage: CelldDurableObjectStorage,
   prefix: string,
   kind: typeof RUN_KIND | typeof THREAD_PROMPT_KIND,
@@ -67,14 +69,23 @@ export async function insertDueWork<T>(
   dueAtMs: number,
   indexes: { readonly runId?: string; readonly threadKey?: string }
 ): Promise<void> {
-  await insertScheduledWork(
-    storage,
-    prefix,
-    kind,
-    workId,
-    { dueAtMs, value } satisfies DuePayload<T>,
-    indexes
-  );
+  const currentAlarm = await storage.getAlarm();
+  await withTransaction(storage, async (transaction) => {
+    insertScheduledWorkInTransaction(
+      transaction,
+      prefix,
+      kind,
+      workId,
+      { dueAtMs, value } satisfies DuePayload<T>,
+      { ...indexes, dueAtMs }
+    );
+    if (transaction.setAlarm === undefined) {
+      throw new Error("Celld storage transaction setAlarm() is required.");
+    }
+    await transaction.setAlarm(
+      currentAlarm === null ? dueAtMs : Math.min(currentAlarm, dueAtMs)
+    );
+  });
 }
 
 export function listDueWork<T>(
@@ -89,35 +100,23 @@ export function listDueWork<T>(
   if (limit === 0) {
     return [];
   }
-  return selectScheduledWork(storage, prefix, kind)
-    .filter(
-      (row) =>
-        row.claimed_until === undefined ||
-        row.claimed_until === null ||
-        row.claimed_until <= nowMs
-    )
+  return selectScheduledWorkDue(storage, prefix, kind, nowMs, limit)
     .map((row) => requiredDuePayload(row.payload))
     .flatMap((value) => {
-      if (value === undefined) {
-        return [];
-      }
       const parsed = parseValue(value.value);
-      return parsed === undefined
-        ? []
-        : [{ dueAtMs: value.dueAtMs, value: parsed }];
-    })
-    .filter((value) => value.dueAtMs <= nowMs)
-    .sort((left, right) => left.dueAtMs - right.dueAtMs)
-    .slice(0, limit)
-    .map((value) => value.value);
+      if (parsed === undefined) {
+        throw new Error("Invalid Celld scheduled work value.");
+      }
+      return [parsed];
+    });
 }
 
 export async function armNextAlarm(
   storage: CelldDurableObjectStorage,
   prefix: string,
-  nowMs = Date.now()
+  _nowMs = Date.now()
 ): Promise<void> {
-  const dueAtMs = earliestDueAt(storage, prefix, nowMs);
+  const dueAtMs = earliestDueAt(storage, prefix);
   if (dueAtMs === undefined) {
     await storage.deleteAlarm();
     return;
@@ -129,22 +128,12 @@ export async function armNextAlarm(
 
 function earliestDueAt(
   storage: CelldDurableObjectStorage,
-  prefix: string,
-  nowMs: number
+  prefix: string
 ): number | undefined {
-  const values = ([RUN_KIND, THREAD_PROMPT_KIND] as const).flatMap((kind) =>
-    selectScheduledWork(storage, prefix, kind)
-      .map((row) => {
-        if (
-          typeof row.claimed_until === "number" &&
-          row.claimed_until > nowMs
-        ) {
-          return row.claimed_until;
-        }
-        return requiredDuePayload(row.payload).dueAtMs;
-      })
-      .filter((value): value is number => value !== undefined)
-  );
+  const values = ([RUN_KIND, THREAD_PROMPT_KIND] as const).flatMap((kind) => {
+    const row = selectNextScheduledWork(storage, prefix, kind);
+    return typeof row?.due_at === "number" ? [row.due_at] : [];
+  });
   return values.length === 0 ? undefined : Math.min(...values);
 }
 

--- a/packages/runtime/src/platform/celld/scheduler-support.ts
+++ b/packages/runtime/src/platform/celld/scheduler-support.ts
@@ -1,0 +1,161 @@
+import type { HostScheduler } from "../../execution";
+import {
+  isScheduledThreadPrompt,
+  type ScheduledThreadPrompt,
+} from "../../execution/scheduled-work";
+import type { CloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
+import {
+  insertScheduledWork,
+  selectScheduledWork,
+} from "../cloudflare/storage/sqlite/scheduled-work-table";
+
+export const DEFAULT_PREFIX = "pss-runtime";
+export const RUN_KIND = "celld-run";
+export const THREAD_PROMPT_KIND = "celld-thread-prompt";
+export const storageOperations = new WeakMap<object, Promise<void>>();
+
+export interface CelldScheduledWorkListOptions {
+  readonly limit?: number;
+  readonly nowMs?: number;
+  readonly prefix?: string;
+}
+
+export interface CelldSchedulerOptions {
+  readonly clock?: () => number;
+  readonly prefix?: string;
+  readonly storage: CelldDurableObjectStorage;
+}
+
+export interface CelldScheduler extends HostScheduler {
+  readonly storage: CelldDurableObjectStorage;
+}
+
+export interface CelldDurableObjectStorage
+  extends CloudflareDurableObjectStorage {
+  deleteAlarm(): Promise<void>;
+  getAlarm(): Promise<number | null>;
+  setAlarm(scheduledTime: Date | number): Promise<void>;
+}
+
+interface DuePayload<T> {
+  readonly dueAtMs: number;
+  readonly value: T;
+}
+
+export function serialize<T>(
+  storage: CelldDurableObjectStorage,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = storageOperations.get(storage) ?? Promise.resolve();
+  const current = previous.then(operation);
+  storageOperations.set(
+    storage,
+    current.then(
+      () => undefined,
+      () => undefined
+    )
+  );
+  return current;
+}
+
+export async function insertDueWork<T>(
+  storage: CelldDurableObjectStorage,
+  prefix: string,
+  kind: typeof RUN_KIND | typeof THREAD_PROMPT_KIND,
+  workId: string,
+  value: T,
+  dueAtMs: number,
+  indexes: { readonly runId?: string; readonly threadKey?: string }
+): Promise<void> {
+  await insertScheduledWork(
+    storage,
+    prefix,
+    kind,
+    workId,
+    { dueAtMs, value } satisfies DuePayload<T>,
+    indexes
+  );
+}
+
+export function listDueWork<T>(
+  storage: CelldDurableObjectStorage,
+  kind: typeof RUN_KIND | typeof THREAD_PROMPT_KIND,
+  options: CelldScheduledWorkListOptions,
+  parseValue: (value: unknown) => T | undefined
+): T[] {
+  const prefix = options.prefix ?? DEFAULT_PREFIX;
+  const nowMs = options.nowMs ?? Date.now();
+  const limit = normalizeLimit(options.limit);
+  if (limit === 0) {
+    return [];
+  }
+  return selectScheduledWork(storage, prefix, kind)
+    .map((row) => parseDuePayload(row.payload))
+    .flatMap((value) => {
+      if (value === undefined) {
+        return [];
+      }
+      const parsed = parseValue(value.value);
+      return parsed === undefined
+        ? []
+        : [{ dueAtMs: value.dueAtMs, value: parsed }];
+    })
+    .filter((value) => value.dueAtMs <= nowMs)
+    .sort((left, right) => left.dueAtMs - right.dueAtMs)
+    .slice(0, limit)
+    .map((value) => value.value);
+}
+
+export async function armNextAlarm(
+  storage: CelldDurableObjectStorage,
+  prefix: string
+): Promise<void> {
+  const dueAtMs = earliestDueAt(storage, prefix);
+  if (dueAtMs === undefined) {
+    await storage.deleteAlarm();
+    return;
+  }
+  if ((await storage.getAlarm()) !== dueAtMs) {
+    await storage.setAlarm(dueAtMs);
+  }
+}
+
+function earliestDueAt(
+  storage: CelldDurableObjectStorage,
+  prefix: string
+): number | undefined {
+  const values = ([RUN_KIND, THREAD_PROMPT_KIND] as const).flatMap((kind) =>
+    selectScheduledWork(storage, prefix, kind)
+      .map((row) => parseDuePayload(row.payload)?.dueAtMs)
+      .filter((value): value is number => value !== undefined)
+  );
+  return values.length === 0 ? undefined : Math.min(...values);
+}
+
+function parseDuePayload(payload: string): DuePayload<unknown> | undefined {
+  try {
+    const value: unknown = JSON.parse(payload);
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      "dueAtMs" in value &&
+      typeof value.dueAtMs === "number" &&
+      Number.isFinite(value.dueAtMs) &&
+      "value" in value
+    ) {
+      return { dueAtMs: value.dueAtMs, value: value.value };
+    }
+  } catch {
+    return;
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  return limit === undefined ? undefined : Math.max(0, Math.floor(limit));
+}
+
+export function parseThreadPrompt(
+  value: unknown
+): ScheduledThreadPrompt | undefined {
+  return isScheduledThreadPrompt(value) ? value : undefined;
+}

--- a/packages/runtime/src/platform/celld/scheduler-support.ts
+++ b/packages/runtime/src/platform/celld/scheduler-support.ts
@@ -90,7 +90,13 @@ export function listDueWork<T>(
     return [];
   }
   return selectScheduledWork(storage, prefix, kind)
-    .map((row) => parseDuePayload(row.payload))
+    .filter(
+      (row) =>
+        row.claimed_until === undefined ||
+        row.claimed_until === null ||
+        row.claimed_until <= nowMs
+    )
+    .map((row) => requiredDuePayload(row.payload))
     .flatMap((value) => {
       if (value === undefined) {
         return [];
@@ -108,9 +114,10 @@ export function listDueWork<T>(
 
 export async function armNextAlarm(
   storage: CelldDurableObjectStorage,
-  prefix: string
+  prefix: string,
+  nowMs = Date.now()
 ): Promise<void> {
-  const dueAtMs = earliestDueAt(storage, prefix);
+  const dueAtMs = earliestDueAt(storage, prefix, nowMs);
   if (dueAtMs === undefined) {
     await storage.deleteAlarm();
     return;
@@ -122,11 +129,20 @@ export async function armNextAlarm(
 
 function earliestDueAt(
   storage: CelldDurableObjectStorage,
-  prefix: string
+  prefix: string,
+  nowMs: number
 ): number | undefined {
   const values = ([RUN_KIND, THREAD_PROMPT_KIND] as const).flatMap((kind) =>
     selectScheduledWork(storage, prefix, kind)
-      .map((row) => parseDuePayload(row.payload)?.dueAtMs)
+      .map((row) => {
+        if (
+          typeof row.claimed_until === "number" &&
+          row.claimed_until > nowMs
+        ) {
+          return row.claimed_until;
+        }
+        return requiredDuePayload(row.payload).dueAtMs;
+      })
       .filter((value): value is number => value !== undefined)
   );
   return values.length === 0 ? undefined : Math.min(...values);
@@ -148,6 +164,14 @@ function parseDuePayload(payload: string): DuePayload<unknown> | undefined {
   } catch {
     return;
   }
+}
+
+function requiredDuePayload(payload: string): DuePayload<unknown> {
+  const value = parseDuePayload(payload);
+  if (value === undefined) {
+    throw new Error("Invalid Celld scheduled work payload.");
+  }
+  return value;
 }
 
 function normalizeLimit(limit: number | undefined): number | undefined {

--- a/packages/runtime/src/platform/celld/scheduler.test.ts
+++ b/packages/runtime/src/platform/celld/scheduler.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from "vitest";
 import { describeExecutionSchedulerContract } from "../../contracts/execution-scheduler/contract";
 import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
 import {
-  ackCelldScheduledRun,
-  ackCelldScheduledThreadPrompt,
   createCelldScheduler,
   listCelldScheduledRuns,
   listCelldScheduledThreadPrompts,
 } from "./scheduler";
+import {
+  ackCelldScheduledRun,
+  ackCelldScheduledThreadPrompt,
+  claimCelldScheduledRun,
+  rearmCelldScheduledWork,
+} from "./scheduler-claims";
 
 describeExecutionSchedulerContract({
   createHarness: () => {
@@ -139,6 +143,44 @@ describe("Celld due-aware alarm HostScheduler", () => {
     await ackCelldScheduledRun(storage, "late");
     expect(await listCelldScheduledRuns(storage, { nowMs: 500 })).toEqual([]);
     expect(await storage.getAlarm()).toBeNull();
+  });
+
+  it("keeps a claimed run recoverable after its lease expires", async () => {
+    const storage = createAlarmCapableStorage();
+    const scheduler = createCelldScheduler({ clock: () => 1000, storage });
+
+    await scheduler.enqueueRun("recoverable");
+    const claim = await claimCelldScheduledRun(storage, "recoverable", {
+      leaseMs: 100,
+      nowMs: 1000,
+    });
+
+    expect(claim).toEqual(expect.any(String));
+    expect(await listCelldScheduledRuns(storage, { nowMs: 1000 })).toEqual([]);
+
+    await rearmCelldScheduledWork(storage, { nowMs: 1000 });
+    expect(await storage.getAlarm()).toBe(1100);
+    expect(await listCelldScheduledRuns(storage, { nowMs: 1100 })).toEqual([
+      "recoverable",
+    ]);
+  });
+
+  it("rejects malformed durable work instead of dropping its alarm", async () => {
+    const storage = createAlarmCapableStorage();
+    storage.sql.exec(
+      "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "pss-runtime",
+      "celld-run",
+      "broken",
+      "{",
+      null,
+      "broken",
+      0
+    );
+
+    await expect(
+      rearmCelldScheduledWork(storage, { nowMs: 0 })
+    ).rejects.toThrow("Invalid Celld scheduled work payload.");
   });
 });
 

--- a/packages/runtime/src/platform/celld/scheduler.test.ts
+++ b/packages/runtime/src/platform/celld/scheduler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { describeExecutionSchedulerContract } from "../../contracts/execution-scheduler/contract";
-import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
+import { createCelldTestStorage } from "./celld-test-storage";
 import {
   createCelldScheduler,
   listCelldScheduledRuns,
@@ -48,7 +48,7 @@ describe("Celld due-aware alarm HostScheduler", () => {
     expect(queuedBeforeAlarm).toEqual([["run-1"]]);
   });
 
-  it("leaves work queued when setAlarm rejects", async () => {
+  it("rolls back queued work when setAlarm rejects", async () => {
     const storage = createAlarmCapableStorage({
       setAlarm: () => Promise.reject(new Error("alarm unavailable")),
     });
@@ -58,9 +58,7 @@ describe("Celld due-aware alarm HostScheduler", () => {
       "alarm unavailable"
     );
 
-    expect(await listCelldScheduledRuns(storage, { nowMs: 0 })).toEqual([
-      "run-1",
-    ]);
+    expect(await listCelldScheduledRuns(storage, { nowMs: 0 })).toEqual([]);
     expect(await storage.getAlarm()).toBeNull();
   });
 
@@ -150,6 +148,7 @@ describe("Celld due-aware alarm HostScheduler", () => {
     const scheduler = createCelldScheduler({ clock: () => 1000, storage });
 
     await scheduler.enqueueRun("recoverable");
+    await storage.deleteAlarm();
     const claim = await claimCelldScheduledRun(storage, "recoverable", {
       leaseMs: 100,
       nowMs: 1000,
@@ -157,6 +156,7 @@ describe("Celld due-aware alarm HostScheduler", () => {
 
     expect(claim).toEqual(expect.any(String));
     expect(await listCelldScheduledRuns(storage, { nowMs: 1000 })).toEqual([]);
+    expect(await storage.getAlarm()).toBe(1100);
 
     await rearmCelldScheduledWork(storage, { nowMs: 1000 });
     expect(await storage.getAlarm()).toBe(1100);
@@ -165,22 +165,42 @@ describe("Celld due-aware alarm HostScheduler", () => {
     ]);
   });
 
-  it("rejects malformed durable work instead of dropping its alarm", async () => {
+  it("rejects malformed durable work before draining it", async () => {
     const storage = createAlarmCapableStorage();
     storage.sql.exec(
-      "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, due_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
       "pss-runtime",
       "celld-run",
       "broken",
       "{",
       null,
       "broken",
+      0,
       0
     );
 
-    await expect(
-      rearmCelldScheduledWork(storage, { nowMs: 0 })
-    ).rejects.toThrow("Invalid Celld scheduled work payload.");
+    await expect(listCelldScheduledRuns(storage, { nowMs: 0 })).rejects.toThrow(
+      "Invalid Celld scheduled work payload."
+    );
+  });
+
+  it("rejects kind-invalid durable work instead of hot-looping", async () => {
+    const storage = createAlarmCapableStorage();
+    storage.sql.exec(
+      "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, due_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      "pss-runtime",
+      "celld-run",
+      "wrong-kind",
+      JSON.stringify({ dueAtMs: 0, value: 42 }),
+      null,
+      "wrong-kind",
+      0,
+      0
+    );
+
+    await expect(listCelldScheduledRuns(storage, { nowMs: 0 })).rejects.toThrow(
+      "Invalid Celld scheduled work value."
+    );
   });
 });
 
@@ -191,27 +211,5 @@ function createAlarmCapableStorage(
     readonly setAlarm?: (scheduledTime: Date | number) => Promise<void>;
   } = {}
 ) {
-  const inner = new InMemoryCloudflareDurableObjectStorage();
-  let alarmTime: number | null = null;
-  return {
-    delete: (key: string) => inner.delete(key),
-    deleteAlarm: () => {
-      alarmTime = null;
-      return Promise.resolve();
-    },
-    get: <T>(key: string) => inner.get<T>(key),
-    getAlarm: () => Promise.resolve(alarmTime),
-    put: <T>(key: string, value: T) => inner.put(key, value),
-    setAlarm: async (scheduledTime: Date | number) => {
-      await options.setAlarm?.(scheduledTime);
-      alarmTime =
-        typeof scheduledTime === "number"
-          ? scheduledTime
-          : scheduledTime.getTime();
-      await inner.setAlarm(scheduledTime);
-    },
-    sql: inner.sql,
-    transaction: inner.transaction.bind(inner),
-    transactionSync: inner.transactionSync.bind(inner),
-  };
+  return createCelldTestStorage(options);
 }

--- a/packages/runtime/src/platform/celld/scheduler.test.ts
+++ b/packages/runtime/src/platform/celld/scheduler.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { describeExecutionSchedulerContract } from "../../contracts/execution-scheduler/contract";
+import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare/host/durable-object-host";
+import {
+  ackCelldScheduledRun,
+  ackCelldScheduledThreadPrompt,
+  createCelldScheduler,
+  listCelldScheduledRuns,
+  listCelldScheduledThreadPrompts,
+} from "./scheduler";
+
+describeExecutionSchedulerContract({
+  createHarness: () => {
+    const storage = createAlarmCapableStorage();
+    return {
+      ackRun: (runId) => ackCelldScheduledRun(storage, runId),
+      ackThreadPrompt: (prompt) =>
+        ackCelldScheduledThreadPrompt(storage, prompt),
+      listRuns: (options) => listCelldScheduledRuns(storage, options),
+      listThreadPrompts: (options) =>
+        listCelldScheduledThreadPrompts(storage, options),
+      scheduler: createCelldScheduler({ storage }),
+    };
+  },
+  name: "Celld",
+  supportsDueTimeFiltering: true,
+});
+
+describe("Celld due-aware alarm HostScheduler", () => {
+  it("persists queued work before setAlarm", async () => {
+    const queuedBeforeAlarm: string[][] = [];
+    let storage: AlarmCapableStorage;
+    storage = createAlarmCapableStorage({
+      setAlarm: async () => {
+        queuedBeforeAlarm.push([
+          ...(await listCelldScheduledRuns(storage, { nowMs: 1000 })),
+        ]);
+      },
+    });
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+
+    await scheduler.enqueueRun("run-1", { runAfterMs: 10 });
+
+    expect(queuedBeforeAlarm).toEqual([["run-1"]]);
+  });
+
+  it("leaves work queued when setAlarm rejects", async () => {
+    const storage = createAlarmCapableStorage({
+      setAlarm: () => Promise.reject(new Error("alarm unavailable")),
+    });
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+
+    await expect(scheduler.enqueueRun("run-1")).rejects.toThrow(
+      "alarm unavailable"
+    );
+
+    expect(await listCelldScheduledRuns(storage, { nowMs: 0 })).toEqual([
+      "run-1",
+    ]);
+    expect(await storage.getAlarm()).toBeNull();
+  });
+
+  it("computes due time with max(0, floor(runAfterMs))", async () => {
+    const storage = createAlarmCapableStorage();
+    const scheduler = createCelldScheduler({ clock: () => 1000, storage });
+
+    await scheduler.enqueueRun("floored", { runAfterMs: 250.9 });
+    expect(await listCelldScheduledRuns(storage, { nowMs: 1249 })).toEqual([]);
+    expect(await listCelldScheduledRuns(storage, { nowMs: 1250 })).toEqual([
+      "floored",
+    ]);
+    expect(await storage.getAlarm()).toBe(1250);
+
+    await scheduler.enqueueRun("clamped", { runAfterMs: -7.2 });
+    expect(await listCelldScheduledRuns(storage, { nowMs: 1000 })).toEqual([
+      "clamped",
+    ]);
+    expect(await storage.getAlarm()).toBe(1000);
+  });
+
+  it("does not postpone an earlier alarm when later work is enqueued", async () => {
+    const storage = createAlarmCapableStorage();
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+
+    await scheduler.enqueueRun("early", { runAfterMs: 100 });
+    expect(await storage.getAlarm()).toBe(100);
+
+    await scheduler.enqueueRun("late", { runAfterMs: 500 });
+    expect(await storage.getAlarm()).toBe(100);
+  });
+
+  it("treats resumeThread as due immediately", async () => {
+    const storage = createAlarmCapableStorage();
+    const scheduler = createCelldScheduler({ clock: () => 42, storage });
+
+    await scheduler.resumeThread("thread-1", { runId: "run-1" });
+
+    expect(
+      await listCelldScheduledThreadPrompts(storage, { nowMs: 41 })
+    ).toEqual([]);
+    expect(
+      await listCelldScheduledThreadPrompts(storage, { nowMs: 42 })
+    ).toEqual([{ runId: "run-1", threadKey: "thread-1" }]);
+    expect(await storage.getAlarm()).toBe(42);
+  });
+
+  it("keeps duplicate work as one row", async () => {
+    const storage = createAlarmCapableStorage();
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+
+    await scheduler.enqueueRun("run-1", { runAfterMs: 1000 });
+    await scheduler.enqueueRun("run-1", { runAfterMs: 4000 });
+    await scheduler.resumeThread("thread-1", { runId: "run-2" });
+    await scheduler.resumeThread("thread-1", { runId: "run-2" });
+
+    expect(await listCelldScheduledRuns(storage, { nowMs: 1000 })).toEqual([
+      "run-1",
+    ]);
+    expect(
+      await listCelldScheduledThreadPrompts(storage, { nowMs: 0 })
+    ).toHaveLength(1);
+    expect(await storage.getAlarm()).toBe(0);
+  });
+
+  it("rearms the next due item after ack", async () => {
+    const storage = createAlarmCapableStorage();
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+
+    await scheduler.enqueueRun("early", { runAfterMs: 100 });
+    await scheduler.enqueueRun("late", { runAfterMs: 500 });
+    expect(await storage.getAlarm()).toBe(100);
+
+    await ackCelldScheduledRun(storage, "early");
+    expect(await listCelldScheduledRuns(storage, { nowMs: 500 })).toEqual([
+      "late",
+    ]);
+    expect(await storage.getAlarm()).toBe(500);
+
+    await ackCelldScheduledRun(storage, "late");
+    expect(await listCelldScheduledRuns(storage, { nowMs: 500 })).toEqual([]);
+    expect(await storage.getAlarm()).toBeNull();
+  });
+});
+
+type AlarmCapableStorage = ReturnType<typeof createAlarmCapableStorage>;
+
+function createAlarmCapableStorage(
+  options: {
+    readonly setAlarm?: (scheduledTime: Date | number) => Promise<void>;
+  } = {}
+) {
+  const inner = new InMemoryCloudflareDurableObjectStorage();
+  let alarmTime: number | null = null;
+  return {
+    delete: (key: string) => inner.delete(key),
+    deleteAlarm: () => {
+      alarmTime = null;
+      return Promise.resolve();
+    },
+    get: <T>(key: string) => inner.get<T>(key),
+    getAlarm: () => Promise.resolve(alarmTime),
+    put: <T>(key: string, value: T) => inner.put(key, value),
+    setAlarm: async (scheduledTime: Date | number) => {
+      await options.setAlarm?.(scheduledTime);
+      alarmTime =
+        typeof scheduledTime === "number"
+          ? scheduledTime
+          : scheduledTime.getTime();
+      await inner.setAlarm(scheduledTime);
+    },
+    sql: inner.sql,
+    transaction: inner.transaction.bind(inner),
+    transactionSync: inner.transactionSync.bind(inner),
+  };
+}

--- a/packages/runtime/src/platform/celld/scheduler.test.ts
+++ b/packages/runtime/src/platform/celld/scheduler.test.ts
@@ -124,6 +124,17 @@ describe("Celld due-aware alarm HostScheduler", () => {
     expect(await storage.getAlarm()).toBe(0);
   });
 
+  it("restores an earlier persisted alarm on duplicate enqueue", async () => {
+    const storage = createAlarmCapableStorage();
+    const scheduler = createCelldScheduler({ clock: () => 0, storage });
+
+    await scheduler.enqueueRun("run-1", { runAfterMs: 1000 });
+    await storage.deleteAlarm();
+    await scheduler.enqueueRun("run-1", { runAfterMs: 4000 });
+
+    expect(await storage.getAlarm()).toBe(1000);
+  });
+
   it("rearms the next due item after ack", async () => {
     const storage = createAlarmCapableStorage();
     const scheduler = createCelldScheduler({ clock: () => 0, storage });

--- a/packages/runtime/src/platform/celld/scheduler.ts
+++ b/packages/runtime/src/platform/celld/scheduler.ts
@@ -1,47 +1,25 @@
-import type { HostScheduler } from "../../execution";
+import type { ScheduledThreadPrompt } from "../../execution/scheduled-work";
+import { threadPromptScheduledWorkId } from "../../execution/scheduled-work";
 import {
-  isScheduledThreadPrompt,
-  type ScheduledThreadPrompt,
-  threadPromptScheduledWorkId,
-} from "../../execution/scheduled-work";
-import type { CloudflareDurableObjectStorage } from "../cloudflare";
-import {
+  claimScheduledWork,
   deleteScheduledWork,
-  insertScheduledWork,
-  selectScheduledWork,
 } from "../cloudflare/storage/sqlite/scheduled-work-table";
-
-const DEFAULT_PREFIX = "pss-runtime";
-const RUN_KIND = "celld-run";
-const THREAD_PROMPT_KIND = "celld-thread-prompt";
-
-export interface CelldDurableObjectStorage
-  extends CloudflareDurableObjectStorage {
-  deleteAlarm(): Promise<void>;
-  getAlarm(): Promise<number | null>;
-  setAlarm(scheduledTime: Date | number): Promise<void>;
-}
-
-export interface CelldScheduledWorkListOptions {
-  readonly limit?: number;
-  readonly nowMs?: number;
-  readonly prefix?: string;
-}
-
-export interface CelldSchedulerOptions {
-  readonly clock?: () => number;
-  readonly prefix?: string;
-  readonly storage: CelldDurableObjectStorage;
-}
-
-export interface CelldScheduler extends HostScheduler {
-  readonly storage: CelldDurableObjectStorage;
-}
-
-interface DuePayload<T> {
-  readonly dueAtMs: number;
-  readonly value: T;
-}
+import type {
+  CelldDurableObjectStorage,
+  CelldScheduledWorkListOptions,
+  CelldScheduler,
+  CelldSchedulerOptions,
+} from "./scheduler-support";
+import {
+  armNextAlarm,
+  DEFAULT_PREFIX,
+  insertDueWork,
+  listDueWork,
+  parseThreadPrompt,
+  RUN_KIND,
+  serialize,
+  THREAD_PROMPT_KIND,
+} from "./scheduler-support";
 
 export function createCelldScheduler({
   clock = Date.now,
@@ -49,32 +27,34 @@ export function createCelldScheduler({
   storage,
 }: CelldSchedulerOptions): CelldScheduler {
   return {
-    enqueueRun: async (runId, options = {}) => {
-      const dueAtMs =
-        clock() + Math.max(0, Math.floor(options.runAfterMs ?? 0));
-      await insertDueWork(storage, prefix, RUN_KIND, runId, runId, dueAtMs, {
-        runId,
-      });
-      await armNextAlarm(storage, prefix);
-    },
-    resumeThread: async (threadKey, options) => {
-      const prompt: ScheduledThreadPrompt = {
-        idempotencyKey: options.idempotencyKey,
-        notificationId: options.notificationId,
-        runId: options.runId,
-        threadKey,
-      };
-      await insertDueWork(
-        storage,
-        prefix,
-        THREAD_PROMPT_KIND,
-        threadPromptScheduledWorkId(prompt),
-        prompt,
-        clock(),
-        { runId: options.runId, threadKey }
-      );
-      await armNextAlarm(storage, prefix);
-    },
+    enqueueRun: (runId, options = {}) =>
+      serialize(storage, async () => {
+        const dueAtMs =
+          clock() + Math.max(0, Math.floor(options.runAfterMs ?? 0));
+        await insertDueWork(storage, prefix, RUN_KIND, runId, runId, dueAtMs, {
+          runId,
+        });
+        await armNextAlarm(storage, prefix);
+      }),
+    resumeThread: (threadKey, options) =>
+      serialize(storage, async () => {
+        const prompt: ScheduledThreadPrompt = {
+          idempotencyKey: options.idempotencyKey,
+          notificationId: options.notificationId,
+          runId: options.runId,
+          threadKey,
+        };
+        await insertDueWork(
+          storage,
+          prefix,
+          THREAD_PROMPT_KIND,
+          threadPromptScheduledWorkId(prompt),
+          prompt,
+          clock(),
+          { runId: options.runId, threadKey }
+        );
+        await armNextAlarm(storage, prefix);
+      }),
     storage,
   };
 }
@@ -95,128 +75,122 @@ export function listCelldScheduledThreadPrompts(
   options: CelldScheduledWorkListOptions = {}
 ): Promise<readonly ScheduledThreadPrompt[]> {
   return Promise.resolve(
-    listDueWork(storage, THREAD_PROMPT_KIND, options, (value) =>
-      isScheduledThreadPrompt(value) ? value : undefined
+    listDueWork(storage, THREAD_PROMPT_KIND, options, parseThreadPrompt)
+  );
+}
+
+export function claimCelldScheduledRun(
+  storage: CelldDurableObjectStorage,
+  runId: string,
+  options: { readonly prefix?: string } = {}
+): Promise<boolean> {
+  return serialize(storage, () =>
+    claimScheduledWork(
+      storage,
+      options.prefix ?? DEFAULT_PREFIX,
+      RUN_KIND,
+      runId
     )
   );
 }
 
-export async function ackCelldScheduledRun(
+export function claimCelldScheduledThreadPrompt(
+  storage: CelldDurableObjectStorage,
+  prompt: ScheduledThreadPrompt,
+  options: { readonly prefix?: string } = {}
+): Promise<boolean> {
+  return serialize(storage, () =>
+    claimScheduledWork(
+      storage,
+      options.prefix ?? DEFAULT_PREFIX,
+      THREAD_PROMPT_KIND,
+      threadPromptScheduledWorkId(prompt)
+    )
+  );
+}
+
+export function rearmCelldScheduledWork(
+  storage: CelldDurableObjectStorage,
+  options: { readonly prefix?: string } = {}
+): Promise<void> {
+  return serialize(storage, () =>
+    armNextAlarm(storage, options.prefix ?? DEFAULT_PREFIX)
+  );
+}
+
+export function retryCelldScheduledRun(
   storage: CelldDurableObjectStorage,
   runId: string,
+  delayMs: number,
   options: { readonly prefix?: string } = {}
 ): Promise<void> {
   const prefix = options.prefix ?? DEFAULT_PREFIX;
-  await deleteScheduledWork(storage, prefix, RUN_KIND, runId);
-  await armNextAlarm(storage, prefix);
+  return serialize(storage, async () => {
+    await insertDueWork(
+      storage,
+      prefix,
+      RUN_KIND,
+      runId,
+      runId,
+      Date.now() + Math.max(0, Math.floor(delayMs)),
+      { runId }
+    );
+    await armNextAlarm(storage, prefix);
+  });
 }
 
-export async function ackCelldScheduledThreadPrompt(
+export function retryCelldScheduledThreadPrompt(
   storage: CelldDurableObjectStorage,
   prompt: ScheduledThreadPrompt,
   options: { readonly prefix?: string } = {}
 ): Promise<void> {
   const prefix = options.prefix ?? DEFAULT_PREFIX;
-  await deleteScheduledWork(
-    storage,
-    prefix,
-    THREAD_PROMPT_KIND,
-    threadPromptScheduledWorkId(prompt)
-  );
-  await armNextAlarm(storage, prefix);
+  return serialize(storage, async () => {
+    await insertDueWork(
+      storage,
+      prefix,
+      THREAD_PROMPT_KIND,
+      threadPromptScheduledWorkId(prompt),
+      prompt,
+      Date.now(),
+      { runId: prompt.runId, threadKey: prompt.threadKey }
+    );
+    await armNextAlarm(storage, prefix);
+  });
 }
 
-async function insertDueWork<T>(
+export async function ackCelldScheduledRun(
   storage: CelldDurableObjectStorage,
-  prefix: string,
-  kind: typeof RUN_KIND | typeof THREAD_PROMPT_KIND,
-  workId: string,
-  value: T,
-  dueAtMs: number,
-  indexes: { readonly runId?: string; readonly threadKey?: string }
+  runId: string,
+  options: { readonly prefix?: string; readonly rearm?: boolean } = {}
 ): Promise<void> {
-  await insertScheduledWork(
-    storage,
-    prefix,
-    kind,
-    workId,
-    { dueAtMs, value } satisfies DuePayload<T>,
-    indexes
-  );
-}
-
-function listDueWork<T>(
-  storage: CelldDurableObjectStorage,
-  kind: typeof RUN_KIND | typeof THREAD_PROMPT_KIND,
-  options: CelldScheduledWorkListOptions,
-  parseValue: (value: unknown) => T | undefined
-): T[] {
-  const prefix = options.prefix ?? DEFAULT_PREFIX;
-  const nowMs = options.nowMs ?? Date.now();
-  const limit = normalizeLimit(options.limit);
-  if (limit === 0) {
-    return [];
-  }
-  const values = selectScheduledWork(storage, prefix, kind)
-    .map((row) => parseDuePayload(row.payload))
-    .flatMap((value) => {
-      if (value === undefined) {
-        return [];
-      }
-      const parsed = parseValue(value.value);
-      return parsed === undefined
-        ? []
-        : [{ dueAtMs: value.dueAtMs, value: parsed }];
-    })
-    .filter((value) => value.dueAtMs <= nowMs)
-    .sort((left, right) => left.dueAtMs - right.dueAtMs);
-  return values.slice(0, limit).map((value) => value.value);
-}
-
-async function armNextAlarm(
-  storage: CelldDurableObjectStorage,
-  prefix: string
-): Promise<void> {
-  const dueAtMs = earliestDueAt(storage, prefix);
-  if (dueAtMs === undefined) {
-    await storage.deleteAlarm();
-    return;
-  }
-  if ((await storage.getAlarm()) !== dueAtMs) {
-    await storage.setAlarm(dueAtMs);
-  }
-}
-
-function earliestDueAt(
-  storage: CelldDurableObjectStorage,
-  prefix: string
-): number | undefined {
-  const values = ([RUN_KIND, THREAD_PROMPT_KIND] as const).flatMap((kind) =>
-    selectScheduledWork(storage, prefix, kind)
-      .map((row) => parseDuePayload(row.payload)?.dueAtMs)
-      .filter((value): value is number => value !== undefined)
-  );
-  return values.length === 0 ? undefined : Math.min(...values);
-}
-
-function parseDuePayload(payload: string): DuePayload<unknown> | undefined {
-  try {
-    const value: unknown = JSON.parse(payload);
-    if (
-      typeof value === "object" &&
-      value !== null &&
-      "dueAtMs" in value &&
-      typeof value.dueAtMs === "number" &&
-      Number.isFinite(value.dueAtMs) &&
-      "value" in value
-    ) {
-      return { dueAtMs: value.dueAtMs, value: value.value };
+  await serialize(storage, async () => {
+    await deleteScheduledWork(
+      storage,
+      options.prefix ?? DEFAULT_PREFIX,
+      RUN_KIND,
+      runId
+    );
+    if (options.rearm !== false) {
+      await armNextAlarm(storage, options.prefix ?? DEFAULT_PREFIX);
     }
-  } catch {
-    return;
-  }
+  });
 }
 
-function normalizeLimit(limit: number | undefined): number | undefined {
-  return limit === undefined ? undefined : Math.max(0, Math.floor(limit));
+export async function ackCelldScheduledThreadPrompt(
+  storage: CelldDurableObjectStorage,
+  prompt: ScheduledThreadPrompt,
+  options: { readonly prefix?: string; readonly rearm?: boolean } = {}
+): Promise<void> {
+  await serialize(storage, async () => {
+    await deleteScheduledWork(
+      storage,
+      options.prefix ?? DEFAULT_PREFIX,
+      THREAD_PROMPT_KIND,
+      threadPromptScheduledWorkId(prompt)
+    );
+    if (options.rearm !== false) {
+      await armNextAlarm(storage, options.prefix ?? DEFAULT_PREFIX);
+    }
+  });
 }

--- a/packages/runtime/src/platform/celld/scheduler.ts
+++ b/packages/runtime/src/platform/celld/scheduler.ts
@@ -7,9 +7,8 @@ import type {
   CelldSchedulerOptions,
 } from "./scheduler-support";
 import {
-  armNextAlarm,
   DEFAULT_PREFIX,
-  insertDueWork,
+  insertDueWorkAndArm,
   listDueWork,
   parseThreadPrompt,
   RUN_KIND,
@@ -27,10 +26,15 @@ export function createCelldScheduler({
       serialize(storage, async () => {
         const dueAtMs =
           clock() + Math.max(0, Math.floor(options.runAfterMs ?? 0));
-        await insertDueWork(storage, prefix, RUN_KIND, runId, runId, dueAtMs, {
+        await insertDueWorkAndArm(
+          storage,
+          prefix,
+          RUN_KIND,
           runId,
-        });
-        await armNextAlarm(storage, prefix, clock());
+          runId,
+          dueAtMs,
+          { runId }
+        );
       }),
     resumeThread: (threadKey, options) =>
       serialize(storage, async () => {
@@ -40,7 +44,7 @@ export function createCelldScheduler({
           runId: options.runId,
           threadKey,
         };
-        await insertDueWork(
+        await insertDueWorkAndArm(
           storage,
           prefix,
           THREAD_PROMPT_KIND,
@@ -49,7 +53,6 @@ export function createCelldScheduler({
           clock(),
           { runId: options.runId, threadKey }
         );
-        await armNextAlarm(storage, prefix, clock());
       }),
     storage,
   };
@@ -59,7 +62,7 @@ export function listCelldScheduledRuns(
   storage: CelldDurableObjectStorage,
   options: CelldScheduledWorkListOptions = {}
 ): Promise<readonly string[]> {
-  return Promise.resolve(
+  return Promise.resolve().then(() =>
     listDueWork(storage, RUN_KIND, options, (value) =>
       typeof value === "string" ? value : undefined
     )
@@ -70,7 +73,7 @@ export function listCelldScheduledThreadPrompts(
   storage: CelldDurableObjectStorage,
   options: CelldScheduledWorkListOptions = {}
 ): Promise<readonly ScheduledThreadPrompt[]> {
-  return Promise.resolve(
+  return Promise.resolve().then(() =>
     listDueWork(storage, THREAD_PROMPT_KIND, options, parseThreadPrompt)
   );
 }

--- a/packages/runtime/src/platform/celld/scheduler.ts
+++ b/packages/runtime/src/platform/celld/scheduler.ts
@@ -1,0 +1,222 @@
+import type { HostScheduler } from "../../execution";
+import {
+  isScheduledThreadPrompt,
+  type ScheduledThreadPrompt,
+  threadPromptScheduledWorkId,
+} from "../../execution/scheduled-work";
+import type { CloudflareDurableObjectStorage } from "../cloudflare";
+import {
+  deleteScheduledWork,
+  insertScheduledWork,
+  selectScheduledWork,
+} from "../cloudflare/storage/sqlite/scheduled-work-table";
+
+const DEFAULT_PREFIX = "pss-runtime";
+const RUN_KIND = "celld-run";
+const THREAD_PROMPT_KIND = "celld-thread-prompt";
+
+export interface CelldDurableObjectStorage
+  extends CloudflareDurableObjectStorage {
+  deleteAlarm(): Promise<void>;
+  getAlarm(): Promise<number | null>;
+  setAlarm(scheduledTime: Date | number): Promise<void>;
+}
+
+export interface CelldScheduledWorkListOptions {
+  readonly limit?: number;
+  readonly nowMs?: number;
+  readonly prefix?: string;
+}
+
+export interface CelldSchedulerOptions {
+  readonly clock?: () => number;
+  readonly prefix?: string;
+  readonly storage: CelldDurableObjectStorage;
+}
+
+export interface CelldScheduler extends HostScheduler {
+  readonly storage: CelldDurableObjectStorage;
+}
+
+interface DuePayload<T> {
+  readonly dueAtMs: number;
+  readonly value: T;
+}
+
+export function createCelldScheduler({
+  clock = Date.now,
+  prefix = DEFAULT_PREFIX,
+  storage,
+}: CelldSchedulerOptions): CelldScheduler {
+  return {
+    enqueueRun: async (runId, options = {}) => {
+      const dueAtMs =
+        clock() + Math.max(0, Math.floor(options.runAfterMs ?? 0));
+      await insertDueWork(storage, prefix, RUN_KIND, runId, runId, dueAtMs, {
+        runId,
+      });
+      await armNextAlarm(storage, prefix);
+    },
+    resumeThread: async (threadKey, options) => {
+      const prompt: ScheduledThreadPrompt = {
+        idempotencyKey: options.idempotencyKey,
+        notificationId: options.notificationId,
+        runId: options.runId,
+        threadKey,
+      };
+      await insertDueWork(
+        storage,
+        prefix,
+        THREAD_PROMPT_KIND,
+        threadPromptScheduledWorkId(prompt),
+        prompt,
+        clock(),
+        { runId: options.runId, threadKey }
+      );
+      await armNextAlarm(storage, prefix);
+    },
+    storage,
+  };
+}
+
+export function listCelldScheduledRuns(
+  storage: CelldDurableObjectStorage,
+  options: CelldScheduledWorkListOptions = {}
+): Promise<readonly string[]> {
+  return Promise.resolve(
+    listDueWork(storage, RUN_KIND, options, (value) =>
+      typeof value === "string" ? value : undefined
+    )
+  );
+}
+
+export function listCelldScheduledThreadPrompts(
+  storage: CelldDurableObjectStorage,
+  options: CelldScheduledWorkListOptions = {}
+): Promise<readonly ScheduledThreadPrompt[]> {
+  return Promise.resolve(
+    listDueWork(storage, THREAD_PROMPT_KIND, options, (value) =>
+      isScheduledThreadPrompt(value) ? value : undefined
+    )
+  );
+}
+
+export async function ackCelldScheduledRun(
+  storage: CelldDurableObjectStorage,
+  runId: string,
+  options: { readonly prefix?: string } = {}
+): Promise<void> {
+  const prefix = options.prefix ?? DEFAULT_PREFIX;
+  await deleteScheduledWork(storage, prefix, RUN_KIND, runId);
+  await armNextAlarm(storage, prefix);
+}
+
+export async function ackCelldScheduledThreadPrompt(
+  storage: CelldDurableObjectStorage,
+  prompt: ScheduledThreadPrompt,
+  options: { readonly prefix?: string } = {}
+): Promise<void> {
+  const prefix = options.prefix ?? DEFAULT_PREFIX;
+  await deleteScheduledWork(
+    storage,
+    prefix,
+    THREAD_PROMPT_KIND,
+    threadPromptScheduledWorkId(prompt)
+  );
+  await armNextAlarm(storage, prefix);
+}
+
+async function insertDueWork<T>(
+  storage: CelldDurableObjectStorage,
+  prefix: string,
+  kind: typeof RUN_KIND | typeof THREAD_PROMPT_KIND,
+  workId: string,
+  value: T,
+  dueAtMs: number,
+  indexes: { readonly runId?: string; readonly threadKey?: string }
+): Promise<void> {
+  await insertScheduledWork(
+    storage,
+    prefix,
+    kind,
+    workId,
+    { dueAtMs, value } satisfies DuePayload<T>,
+    indexes
+  );
+}
+
+function listDueWork<T>(
+  storage: CelldDurableObjectStorage,
+  kind: typeof RUN_KIND | typeof THREAD_PROMPT_KIND,
+  options: CelldScheduledWorkListOptions,
+  parseValue: (value: unknown) => T | undefined
+): T[] {
+  const prefix = options.prefix ?? DEFAULT_PREFIX;
+  const nowMs = options.nowMs ?? Date.now();
+  const limit = normalizeLimit(options.limit);
+  if (limit === 0) {
+    return [];
+  }
+  const values = selectScheduledWork(storage, prefix, kind)
+    .map((row) => parseDuePayload(row.payload))
+    .flatMap((value) => {
+      if (value === undefined) {
+        return [];
+      }
+      const parsed = parseValue(value.value);
+      return parsed === undefined
+        ? []
+        : [{ dueAtMs: value.dueAtMs, value: parsed }];
+    })
+    .filter((value) => value.dueAtMs <= nowMs)
+    .sort((left, right) => left.dueAtMs - right.dueAtMs);
+  return values.slice(0, limit).map((value) => value.value);
+}
+
+async function armNextAlarm(
+  storage: CelldDurableObjectStorage,
+  prefix: string
+): Promise<void> {
+  const dueAtMs = earliestDueAt(storage, prefix);
+  if (dueAtMs === undefined) {
+    await storage.deleteAlarm();
+    return;
+  }
+  if ((await storage.getAlarm()) !== dueAtMs) {
+    await storage.setAlarm(dueAtMs);
+  }
+}
+
+function earliestDueAt(
+  storage: CelldDurableObjectStorage,
+  prefix: string
+): number | undefined {
+  const values = ([RUN_KIND, THREAD_PROMPT_KIND] as const).flatMap((kind) =>
+    selectScheduledWork(storage, prefix, kind)
+      .map((row) => parseDuePayload(row.payload)?.dueAtMs)
+      .filter((value): value is number => value !== undefined)
+  );
+  return values.length === 0 ? undefined : Math.min(...values);
+}
+
+function parseDuePayload(payload: string): DuePayload<unknown> | undefined {
+  try {
+    const value: unknown = JSON.parse(payload);
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      "dueAtMs" in value &&
+      typeof value.dueAtMs === "number" &&
+      Number.isFinite(value.dueAtMs) &&
+      "value" in value
+    ) {
+      return { dueAtMs: value.dueAtMs, value: value.value };
+    }
+  } catch {
+    return;
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  return limit === undefined ? undefined : Math.max(0, Math.floor(limit));
+}

--- a/packages/runtime/src/platform/celld/scheduler.ts
+++ b/packages/runtime/src/platform/celld/scheduler.ts
@@ -1,9 +1,5 @@
 import type { ScheduledThreadPrompt } from "../../execution/scheduled-work";
 import { threadPromptScheduledWorkId } from "../../execution/scheduled-work";
-import {
-  claimScheduledWork,
-  deleteScheduledWork,
-} from "../cloudflare/storage/sqlite/scheduled-work-table";
 import type {
   CelldDurableObjectStorage,
   CelldScheduledWorkListOptions,
@@ -34,7 +30,7 @@ export function createCelldScheduler({
         await insertDueWork(storage, prefix, RUN_KIND, runId, runId, dueAtMs, {
           runId,
         });
-        await armNextAlarm(storage, prefix);
+        await armNextAlarm(storage, prefix, clock());
       }),
     resumeThread: (threadKey, options) =>
       serialize(storage, async () => {
@@ -53,7 +49,7 @@ export function createCelldScheduler({
           clock(),
           { runId: options.runId, threadKey }
         );
-        await armNextAlarm(storage, prefix);
+        await armNextAlarm(storage, prefix, clock());
       }),
     storage,
   };
@@ -77,120 +73,4 @@ export function listCelldScheduledThreadPrompts(
   return Promise.resolve(
     listDueWork(storage, THREAD_PROMPT_KIND, options, parseThreadPrompt)
   );
-}
-
-export function claimCelldScheduledRun(
-  storage: CelldDurableObjectStorage,
-  runId: string,
-  options: { readonly prefix?: string } = {}
-): Promise<boolean> {
-  return serialize(storage, () =>
-    claimScheduledWork(
-      storage,
-      options.prefix ?? DEFAULT_PREFIX,
-      RUN_KIND,
-      runId
-    )
-  );
-}
-
-export function claimCelldScheduledThreadPrompt(
-  storage: CelldDurableObjectStorage,
-  prompt: ScheduledThreadPrompt,
-  options: { readonly prefix?: string } = {}
-): Promise<boolean> {
-  return serialize(storage, () =>
-    claimScheduledWork(
-      storage,
-      options.prefix ?? DEFAULT_PREFIX,
-      THREAD_PROMPT_KIND,
-      threadPromptScheduledWorkId(prompt)
-    )
-  );
-}
-
-export function rearmCelldScheduledWork(
-  storage: CelldDurableObjectStorage,
-  options: { readonly prefix?: string } = {}
-): Promise<void> {
-  return serialize(storage, () =>
-    armNextAlarm(storage, options.prefix ?? DEFAULT_PREFIX)
-  );
-}
-
-export function retryCelldScheduledRun(
-  storage: CelldDurableObjectStorage,
-  runId: string,
-  delayMs: number,
-  options: { readonly prefix?: string } = {}
-): Promise<void> {
-  const prefix = options.prefix ?? DEFAULT_PREFIX;
-  return serialize(storage, async () => {
-    await insertDueWork(
-      storage,
-      prefix,
-      RUN_KIND,
-      runId,
-      runId,
-      Date.now() + Math.max(0, Math.floor(delayMs)),
-      { runId }
-    );
-    await armNextAlarm(storage, prefix);
-  });
-}
-
-export function retryCelldScheduledThreadPrompt(
-  storage: CelldDurableObjectStorage,
-  prompt: ScheduledThreadPrompt,
-  options: { readonly prefix?: string } = {}
-): Promise<void> {
-  const prefix = options.prefix ?? DEFAULT_PREFIX;
-  return serialize(storage, async () => {
-    await insertDueWork(
-      storage,
-      prefix,
-      THREAD_PROMPT_KIND,
-      threadPromptScheduledWorkId(prompt),
-      prompt,
-      Date.now(),
-      { runId: prompt.runId, threadKey: prompt.threadKey }
-    );
-    await armNextAlarm(storage, prefix);
-  });
-}
-
-export async function ackCelldScheduledRun(
-  storage: CelldDurableObjectStorage,
-  runId: string,
-  options: { readonly prefix?: string; readonly rearm?: boolean } = {}
-): Promise<void> {
-  await serialize(storage, async () => {
-    await deleteScheduledWork(
-      storage,
-      options.prefix ?? DEFAULT_PREFIX,
-      RUN_KIND,
-      runId
-    );
-    if (options.rearm !== false) {
-      await armNextAlarm(storage, options.prefix ?? DEFAULT_PREFIX);
-    }
-  });
-}
-
-export async function ackCelldScheduledThreadPrompt(
-  storage: CelldDurableObjectStorage,
-  prompt: ScheduledThreadPrompt,
-  options: { readonly prefix?: string; readonly rearm?: boolean } = {}
-): Promise<void> {
-  await serialize(storage, async () => {
-    await deleteScheduledWork(
-      storage,
-      options.prefix ?? DEFAULT_PREFIX,
-      THREAD_PROMPT_KIND,
-      threadPromptScheduledWorkId(prompt)
-    );
-    if (options.rearm !== false) {
-      await armNextAlarm(storage, options.prefix ?? DEFAULT_PREFIX);
-    }
-  });
 }

--- a/packages/runtime/src/platform/celld/sdk-shape.test.ts
+++ b/packages/runtime/src/platform/celld/sdk-shape.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryCloudflareDurableObjectStorage } from "../cloudflare";
+import {
+  type CelldDurableObjectState,
+  type CelldDurableObjectStorage,
+  createCelldHost,
+  createCelldScheduler,
+} from "./index";
+
+const storage = new InMemoryCloudflareDurableObjectStorage();
+const cloudflareStorage = {
+  delete: (key: string) => storage.delete(key),
+  getAlarm: async (): Promise<number | null> =>
+    Promise.resolve(storage.alarmTime()?.valueOf() ?? null),
+  get: <T>(key: string) => storage.get<T>(key),
+  put: <T>(key: string, value: T) => storage.put(key, value),
+  setAlarm: (scheduledTime: number | Date) => storage.setAlarm(scheduledTime),
+  sql: storage.sql,
+  transaction: storage.transaction.bind(storage),
+  deleteAlarm: async (): Promise<void> => {
+    await storage.setAlarm(0);
+  },
+} satisfies CelldDurableObjectStorage;
+
+const state = {
+  storage: cloudflareStorage,
+  waitUntil: (_promise: Promise<unknown>): void => undefined,
+} satisfies CelldDurableObjectState;
+
+describe("Celld SDK structural shape", () => {
+  it("accepts Durable Object storage and state without Celld or fiber SDK types", () => {
+    const scheduler = createCelldScheduler({ storage: state.storage });
+    const host = createCelldHost({ state });
+
+    expect(scheduler).toBeDefined();
+    expect(host).toBeDefined();
+  });
+});

--- a/packages/runtime/src/platform/cloudflare/agents/scheduled-work.ts
+++ b/packages/runtime/src/platform/cloudflare/agents/scheduled-work.ts
@@ -3,12 +3,12 @@ import {
   parseScheduledThreadPromptPayload,
 } from "../host/scheduled-work-codec";
 import type { CloudflareDurableObjectStorage } from "../storage/durable-object/durable-object-storage";
+import { insertScheduledWork } from "../storage/sqlite/scheduled-work-table";
 import {
   deleteScheduledWorkGroup,
   hasScheduledWorkGroup,
-  insertScheduledWork,
   type ScheduledWorkTarget,
-} from "../storage/sqlite/scheduled-work-table";
+} from "../storage/sqlite/scheduled-work-table-groups";
 import {
   assertNeverPayload,
   type CloudflareAgentsFiberPayload,

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/scheduled-work-select.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/scheduled-work-select.ts
@@ -16,6 +16,8 @@ export function scheduledWorkTableInfoRows(): unknown[] {
     { name: "thread_key" },
     { name: "run_id" },
     { name: "created_at" },
+    { name: "claim_token" },
+    { name: "claimed_until" },
   ];
 }
 
@@ -44,6 +46,8 @@ export function selectScheduledWorkRowsWithOffset(
     )
     .slice(offset, offset + limit)
     .map((row) => ({
+      claimed_until: row.claimed_until,
+      claim_token: row.claim_token,
       payload: row.payload,
       run_id: row.run_id,
       thread_key: row.thread_key,

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/scheduled-work-select.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/scheduled-work-select.ts
@@ -1,9 +1,9 @@
 import { numberBinding, stringBinding } from "./bindings";
 import type { InMemoryDurableObjectSqlState, ScheduledWorkRow } from "./state";
 
-export function isScheduledWorkOffsetQuery(query: string): boolean {
+export function isScheduledWorkQuery(query: string): boolean {
   return (
-    query.includes("from pss_scheduled_work") && query.includes("offset ?")
+    query.startsWith("select ") && query.includes("from pss_scheduled_work")
   );
 }
 
@@ -16,12 +16,13 @@ export function scheduledWorkTableInfoRows(): unknown[] {
     { name: "thread_key" },
     { name: "run_id" },
     { name: "created_at" },
+    { name: "due_at" },
     { name: "claim_token" },
     { name: "claimed_until" },
   ];
 }
 
-export function selectScheduledWorkRowsWithOffset(
+export function selectScheduledWorkRows(
   state: InMemoryDurableObjectSqlState,
   query: string,
   bindings: readonly unknown[]
@@ -31,26 +32,86 @@ export function selectScheduledWorkRowsWithOffset(
   const workId = query.includes("work_id = ?")
     ? stringBinding(bindings[2])
     : undefined;
-  const limit = numberBinding(bindings[workId === undefined ? 2 : 3]);
-  const offset = numberBinding(bindings[workId === undefined ? 3 : 4]);
+  const claimToken = query.includes("claim_token = ?")
+    ? stringBinding(bindings[3])
+    : undefined;
+  const dueBefore = query.includes("due_at <= ?")
+    ? numberBinding(bindings[2])
+    : undefined;
+  const limit = selectedLimit(query, bindings, {
+    dueBefore,
+    workId,
+  });
+  const offset = query.includes("offset ?")
+    ? numberBinding(bindings[workId === undefined ? 3 : 4])
+    : 0;
   return state.scheduledWork
     .filter(
       (row) =>
         row.prefix === prefix &&
         row.kind === kind &&
-        (workId === undefined || row.work_id === workId)
+        (workId === undefined || row.work_id === workId) &&
+        (claimToken === undefined || row.claim_token === claimToken) &&
+        (dueBefore === undefined ||
+          (row.due_at !== null && row.due_at <= dueBefore)) &&
+        (!query.includes("due_at is not null") || row.due_at !== null)
     )
-    .sort(
-      (left: ScheduledWorkRow, right: ScheduledWorkRow) =>
-        left.created_at - right.created_at
-    )
-    .slice(offset, offset + limit)
-    .map((row) => ({
-      claimed_until: row.claimed_until,
-      claim_token: row.claim_token,
-      payload: row.payload,
-      run_id: row.run_id,
-      thread_key: row.thread_key,
-      work_id: row.work_id,
-    }));
+    .sort((left, right) => compareRows(left, right, query))
+    .slice(offset, limit === undefined ? undefined : offset + limit)
+    .map((row) => projectRow(row, query));
+}
+
+function selectedLimit(
+  query: string,
+  bindings: readonly unknown[],
+  options: {
+    readonly dueBefore: number | undefined;
+    readonly workId: string | undefined;
+  }
+): number | undefined {
+  if (query.includes("limit 1")) {
+    return 1;
+  }
+  if (!query.includes("limit ?")) {
+    return;
+  }
+  if (options.dueBefore !== undefined) {
+    return numberBinding(bindings[3]);
+  }
+  return numberBinding(bindings[options.workId === undefined ? 2 : 3]);
+}
+
+function compareRows(
+  left: ScheduledWorkRow,
+  right: ScheduledWorkRow,
+  query: string
+): number {
+  if (query.includes("order by due_at")) {
+    return (
+      (left.due_at ?? Number.MAX_SAFE_INTEGER) -
+      (right.due_at ?? Number.MAX_SAFE_INTEGER)
+    );
+  }
+  return left.created_at - right.created_at;
+}
+
+function projectRow(row: ScheduledWorkRow, query: string): unknown {
+  if (query.startsWith("select work_id from")) {
+    return { work_id: row.work_id };
+  }
+  if (query.startsWith("select claim_token from")) {
+    return { claim_token: row.claim_token };
+  }
+  if (query.startsWith("select due_at from")) {
+    return { due_at: row.due_at };
+  }
+  return {
+    claimed_until: row.claimed_until,
+    claim_token: row.claim_token,
+    due_at: row.due_at,
+    payload: row.payload,
+    run_id: row.run_id,
+    thread_key: row.thread_key,
+    work_id: row.work_id,
+  };
 }

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/scheduled-work-write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/scheduled-work-write.ts
@@ -1,0 +1,195 @@
+import {
+  nullableStringBinding,
+  numberBinding,
+  stringBinding,
+} from "./bindings";
+import type { InMemoryDurableObjectSqlState } from "./state";
+
+export function writeScheduledWorkStatement(
+  state: InMemoryDurableObjectSqlState,
+  query: string,
+  bindings: readonly unknown[]
+): boolean {
+  if (query.startsWith("insert into pss_scheduled_work")) {
+    insertScheduledWork(state, bindings);
+    return true;
+  }
+  if (query.startsWith("update pss_scheduled_work set claim_token = null")) {
+    releaseScheduledWork(state, bindings);
+    return true;
+  }
+  if (query.startsWith("update pss_scheduled_work set claim_token")) {
+    claimScheduledWork(state, bindings);
+    return true;
+  }
+  if (query.startsWith("delete from pss_scheduled_work")) {
+    deleteScheduledWork(state, query, bindings);
+    return true;
+  }
+  return false;
+}
+
+function insertScheduledWork(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const hasDueAt = bindings.length > 7;
+  const prefix = stringBinding(bindings[0]);
+  const kind = stringBinding(bindings[1]);
+  const workId = stringBinding(bindings[2]);
+  state.scheduledWork = state.scheduledWork.filter(
+    (row) =>
+      !(row.prefix === prefix && row.kind === kind && row.work_id === workId)
+  );
+  state.scheduledWork.push({
+    claimed_until: null,
+    claim_token: null,
+    created_at: numberBinding(bindings[hasDueAt ? 7 : 6]),
+    due_at:
+      hasDueAt && bindings[6] !== null ? numberBinding(bindings[6]) : null,
+    kind,
+    payload: stringBinding(bindings[3]),
+    prefix,
+    run_id: nullableStringBinding(bindings[5]),
+    thread_key: nullableStringBinding(bindings[4]),
+    work_id: workId,
+  });
+}
+
+function claimScheduledWork(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const token = stringBinding(bindings[0]);
+  const claimedUntil = numberBinding(bindings[1]);
+  const dueAt = numberBinding(bindings[2]);
+  const prefix = stringBinding(bindings[3]);
+  const kind = stringBinding(bindings[4]);
+  const workId = stringBinding(bindings[5]);
+  const nowMs = numberBinding(bindings[6]);
+  const row = state.scheduledWork.find(
+    (candidate) =>
+      candidate.prefix === prefix &&
+      candidate.kind === kind &&
+      candidate.work_id === workId &&
+      (candidate.claimed_until === null || candidate.claimed_until <= nowMs)
+  );
+  if (row !== undefined) {
+    row.claim_token = token;
+    row.claimed_until = claimedUntil;
+    row.due_at = dueAt;
+  }
+}
+
+function releaseScheduledWork(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const payload = stringBinding(bindings[0]);
+  const dueAt = numberBinding(bindings[1]);
+  const createdAt = numberBinding(bindings[2]);
+  const prefix = stringBinding(bindings[3]);
+  const kind = stringBinding(bindings[4]);
+  const workId = stringBinding(bindings[5]);
+  const token = stringBinding(bindings[6]);
+  const row = state.scheduledWork.find(
+    (candidate) =>
+      candidate.prefix === prefix &&
+      candidate.kind === kind &&
+      candidate.work_id === workId &&
+      candidate.claim_token === token
+  );
+  if (row !== undefined) {
+    row.claim_token = null;
+    row.claimed_until = null;
+    row.created_at = createdAt;
+    row.due_at = dueAt;
+    row.payload = payload;
+  }
+}
+
+function deleteScheduledWork(
+  state: InMemoryDurableObjectSqlState,
+  query: string,
+  bindings: readonly unknown[]
+): void {
+  const prefix = stringBinding(bindings[0]);
+  if (deleteIndexedRows(state, query, bindings, prefix)) {
+    return;
+  }
+  const kind = stringBinding(bindings[1]);
+  const workId = stringBinding(bindings[2]);
+  const token =
+    query.includes("claim_token = ?") && bindings.length > 3
+      ? stringBinding(bindings[3])
+      : undefined;
+  state.scheduledWork = state.scheduledWork.filter(
+    (row) =>
+      !(
+        row.prefix === prefix &&
+        row.kind === kind &&
+        row.work_id === workId &&
+        (token === undefined || row.claim_token === token)
+      )
+  );
+}
+
+function deleteIndexedRows(
+  state: InMemoryDurableObjectSqlState,
+  query: string,
+  bindings: readonly unknown[],
+  prefix: string
+): boolean {
+  const selectors = [
+    {
+      marker: "payload like ?",
+      matches: (row: { readonly payload: string }, value: string) =>
+        sqliteLikeMatches(row.payload, value),
+    },
+    {
+      marker: "thread_key = ?",
+      matches: (row: { readonly thread_key: string | null }, value: string) =>
+        row.thread_key === value,
+    },
+    {
+      marker: "run_id = ?",
+      matches: (row: { readonly run_id: string | null }, value: string) =>
+        row.run_id === value,
+    },
+  ];
+  const selector = selectors.find((candidate) =>
+    query.includes(candidate.marker)
+  );
+  if (selector === undefined) {
+    return false;
+  }
+  const value = stringBinding(bindings[1]);
+  state.scheduledWork = state.scheduledWork.filter(
+    (row) => !(row.prefix === prefix && selector.matches(row, value))
+  );
+  return true;
+}
+
+function sqliteLikeMatches(value: string, pattern: string): boolean {
+  let source = "^";
+  let escaping = false;
+  for (const char of pattern) {
+    if (escaping) {
+      source += escapeRegExp(char);
+      escaping = false;
+    } else if (char === "\\") {
+      escaping = true;
+    } else if (char === "%") {
+      source += ".*";
+    } else if (char === "_") {
+      source += ".";
+    } else {
+      source += escapeRegExp(char);
+    }
+  }
+  return new RegExp(`${source}${escaping ? "\\\\" : ""}$`, "s").test(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
@@ -243,8 +243,6 @@ function selectScheduledWorkRows(
       return { work_id: row.work_id };
     }
     return {
-      claimed_until: row.claimed_until,
-      claim_token: row.claim_token,
       payload: row.payload,
       run_id: row.run_id,
       thread_key: row.thread_key,

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/select.ts
@@ -243,6 +243,8 @@ function selectScheduledWorkRows(
       return { work_id: row.work_id };
     }
     return {
+      claimed_until: row.claimed_until,
+      claim_token: row.claim_token,
       payload: row.payload,
       run_id: row.run_id,
       thread_key: row.thread_key,

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
@@ -25,7 +25,7 @@ export interface ThreadInputRow {
   readonly admitted_at_ms: number;
   readonly admitted_seq: number;
   readonly claim_id: string | null;
-  readonly created_at: number;
+  created_at: number;
   readonly kind: string;
   readonly message_id: string;
   readonly placement: string | null;
@@ -108,9 +108,11 @@ export interface CheckpointRow {
 }
 
 export interface ScheduledWorkRow {
-  readonly created_at: number;
+  claim_token: string | null;
+  claimed_until: number | null;
+  created_at: number;
   readonly kind: string;
-  readonly payload: string;
+  payload: string;
   readonly prefix: string;
   readonly run_id: string | null;
   readonly thread_key: string | null;

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/state.ts
@@ -111,6 +111,7 @@ export interface ScheduledWorkRow {
   claim_token: string | null;
   claimed_until: number | null;
   created_at: number;
+  due_at: number | null;
   readonly kind: string;
   payload: string;
   readonly prefix: string;

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/storage.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/storage.ts
@@ -1,8 +1,8 @@
 import type { SqlStorage, SqlStorageCursorLike } from "../ports/storage-port";
 import {
-  isScheduledWorkOffsetQuery,
+  isScheduledWorkQuery,
   scheduledWorkTableInfoRows,
-  selectScheduledWorkRowsWithOffset,
+  selectScheduledWorkRows,
 } from "./scheduled-work-select";
 import { selectSqlRows } from "./select";
 import {
@@ -44,9 +44,9 @@ export class InMemoryDurableObjectSqlStorage implements SqlStorage {
       return toCursor<T>(scheduledWorkTableInfoRows());
     }
 
-    if (isScheduledWorkOffsetQuery(normalized)) {
+    if (isScheduledWorkQuery(normalized)) {
       return toCursor<T>(
-        selectScheduledWorkRowsWithOffset(this.#state, normalized, bindings)
+        selectScheduledWorkRows(this.#state, normalized, bindings)
       );
     }
 

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/write.ts
@@ -80,6 +80,14 @@ export function writeSqlStatement(
     writeScheduledWork(state, bindings);
     return;
   }
+  if (query.startsWith("update pss_scheduled_work set claim_token = null")) {
+    releaseScheduledWork(state, bindings);
+    return;
+  }
+  if (query.startsWith("update pss_scheduled_work set claim_token")) {
+    claimScheduledWork(state, bindings);
+    return;
+  }
   if (query.startsWith("delete from pss_scheduled_work")) {
     deleteScheduledWork(state, query, bindings);
     return;
@@ -202,6 +210,8 @@ function writeScheduledWork(
       !(row.prefix === prefix && row.kind === kind && row.work_id === workId)
   );
   state.scheduledWork.push({
+    claimed_until: null,
+    claim_token: null,
     created_at: numberBinding(bindings[6]),
     kind,
     payload: stringBinding(bindings[3]),
@@ -210,6 +220,54 @@ function writeScheduledWork(
     thread_key: nullableStringBinding(bindings[4]),
     work_id: workId,
   });
+}
+
+function claimScheduledWork(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const token = stringBinding(bindings[0]);
+  const claimedUntil = numberBinding(bindings[1]);
+  const prefix = stringBinding(bindings[2]);
+  const kind = stringBinding(bindings[3]);
+  const workId = stringBinding(bindings[4]);
+  const nowMs = numberBinding(bindings[5]);
+  const row = state.scheduledWork.find(
+    (candidate) =>
+      candidate.prefix === prefix &&
+      candidate.kind === kind &&
+      candidate.work_id === workId &&
+      (candidate.claimed_until === null || candidate.claimed_until <= nowMs)
+  );
+  if (row !== undefined) {
+    row.claim_token = token;
+    row.claimed_until = claimedUntil;
+  }
+}
+
+function releaseScheduledWork(
+  state: InMemoryDurableObjectSqlState,
+  bindings: readonly unknown[]
+): void {
+  const payload = stringBinding(bindings[0]);
+  const createdAt = numberBinding(bindings[1]);
+  const prefix = stringBinding(bindings[2]);
+  const kind = stringBinding(bindings[3]);
+  const workId = stringBinding(bindings[4]);
+  const token = stringBinding(bindings[5]);
+  const row = state.scheduledWork.find(
+    (candidate) =>
+      candidate.prefix === prefix &&
+      candidate.kind === kind &&
+      candidate.work_id === workId &&
+      candidate.claim_token === token
+  );
+  if (row !== undefined) {
+    row.claim_token = null;
+    row.claimed_until = null;
+    row.created_at = createdAt;
+    row.payload = payload;
+  }
 }
 
 function deleteScheduledWork(
@@ -242,9 +300,18 @@ function deleteScheduledWork(
   }
   const kind = stringBinding(bindings[1]);
   const workId = stringBinding(bindings[2]);
+  const token =
+    query.includes("claim_token = ?") && bindings.length > 3
+      ? stringBinding(bindings[3])
+      : undefined;
   state.scheduledWork = state.scheduledWork.filter(
     (row) =>
-      !(row.prefix === prefix && row.kind === kind && row.work_id === workId)
+      !(
+        row.prefix === prefix &&
+        row.kind === kind &&
+        row.work_id === workId &&
+        (token === undefined || row.claim_token === token)
+      )
   );
 }
 

--- a/packages/runtime/src/platform/cloudflare/sql/durable-object-test/write.ts
+++ b/packages/runtime/src/platform/cloudflare/sql/durable-object-test/write.ts
@@ -1,10 +1,7 @@
-import {
-  nullableStringBinding,
-  numberBinding,
-  stringBinding,
-} from "./bindings";
+import { numberBinding, stringBinding } from "./bindings";
 import { writeNotificationStatement } from "./notification-write";
 import { writeRunStatement } from "./run-write";
+import { writeScheduledWorkStatement } from "./scheduled-work-write";
 import type { InMemoryDurableObjectSqlState, PayloadChunkRow } from "./state";
 import { writeThreadStatement } from "./thread-write";
 
@@ -76,20 +73,7 @@ export function writeSqlStatement(
     writeCheckpoint(state, bindings);
     return;
   }
-  if (query.startsWith("insert into pss_scheduled_work")) {
-    writeScheduledWork(state, bindings);
-    return;
-  }
-  if (query.startsWith("update pss_scheduled_work set claim_token = null")) {
-    releaseScheduledWork(state, bindings);
-    return;
-  }
-  if (query.startsWith("update pss_scheduled_work set claim_token")) {
-    claimScheduledWork(state, bindings);
-    return;
-  }
-  if (query.startsWith("delete from pss_scheduled_work")) {
-    deleteScheduledWork(state, query, bindings);
+  if (writeScheduledWorkStatement(state, query, bindings)) {
     return;
   }
   throw new Error(
@@ -196,154 +180,4 @@ function writeCheckpoint(
     run_key: runKey,
     version,
   });
-}
-
-function writeScheduledWork(
-  state: InMemoryDurableObjectSqlState,
-  bindings: readonly unknown[]
-): void {
-  const prefix = stringBinding(bindings[0]);
-  const kind = stringBinding(bindings[1]);
-  const workId = stringBinding(bindings[2]);
-  state.scheduledWork = state.scheduledWork.filter(
-    (row) =>
-      !(row.prefix === prefix && row.kind === kind && row.work_id === workId)
-  );
-  state.scheduledWork.push({
-    claimed_until: null,
-    claim_token: null,
-    created_at: numberBinding(bindings[6]),
-    kind,
-    payload: stringBinding(bindings[3]),
-    prefix,
-    run_id: nullableStringBinding(bindings[5]),
-    thread_key: nullableStringBinding(bindings[4]),
-    work_id: workId,
-  });
-}
-
-function claimScheduledWork(
-  state: InMemoryDurableObjectSqlState,
-  bindings: readonly unknown[]
-): void {
-  const token = stringBinding(bindings[0]);
-  const claimedUntil = numberBinding(bindings[1]);
-  const prefix = stringBinding(bindings[2]);
-  const kind = stringBinding(bindings[3]);
-  const workId = stringBinding(bindings[4]);
-  const nowMs = numberBinding(bindings[5]);
-  const row = state.scheduledWork.find(
-    (candidate) =>
-      candidate.prefix === prefix &&
-      candidate.kind === kind &&
-      candidate.work_id === workId &&
-      (candidate.claimed_until === null || candidate.claimed_until <= nowMs)
-  );
-  if (row !== undefined) {
-    row.claim_token = token;
-    row.claimed_until = claimedUntil;
-  }
-}
-
-function releaseScheduledWork(
-  state: InMemoryDurableObjectSqlState,
-  bindings: readonly unknown[]
-): void {
-  const payload = stringBinding(bindings[0]);
-  const createdAt = numberBinding(bindings[1]);
-  const prefix = stringBinding(bindings[2]);
-  const kind = stringBinding(bindings[3]);
-  const workId = stringBinding(bindings[4]);
-  const token = stringBinding(bindings[5]);
-  const row = state.scheduledWork.find(
-    (candidate) =>
-      candidate.prefix === prefix &&
-      candidate.kind === kind &&
-      candidate.work_id === workId &&
-      candidate.claim_token === token
-  );
-  if (row !== undefined) {
-    row.claim_token = null;
-    row.claimed_until = null;
-    row.created_at = createdAt;
-    row.payload = payload;
-  }
-}
-
-function deleteScheduledWork(
-  state: InMemoryDurableObjectSqlState,
-  query: string,
-  bindings: readonly unknown[]
-): void {
-  const prefix = stringBinding(bindings[0]);
-  if (query.includes("payload like ?")) {
-    const pattern = stringBinding(bindings[1]);
-    state.scheduledWork = state.scheduledWork.filter(
-      (row) =>
-        !(row.prefix === prefix && sqliteLikeMatches(row.payload, pattern))
-    );
-    return;
-  }
-  if (query.includes("thread_key = ?")) {
-    const threadKey = stringBinding(bindings[1]);
-    state.scheduledWork = state.scheduledWork.filter(
-      (row) => !(row.prefix === prefix && row.thread_key === threadKey)
-    );
-    return;
-  }
-  if (query.includes("run_id = ?")) {
-    const runId = stringBinding(bindings[1]);
-    state.scheduledWork = state.scheduledWork.filter(
-      (row) => !(row.prefix === prefix && row.run_id === runId)
-    );
-    return;
-  }
-  const kind = stringBinding(bindings[1]);
-  const workId = stringBinding(bindings[2]);
-  const token =
-    query.includes("claim_token = ?") && bindings.length > 3
-      ? stringBinding(bindings[3])
-      : undefined;
-  state.scheduledWork = state.scheduledWork.filter(
-    (row) =>
-      !(
-        row.prefix === prefix &&
-        row.kind === kind &&
-        row.work_id === workId &&
-        (token === undefined || row.claim_token === token)
-      )
-  );
-}
-
-function sqliteLikeMatches(value: string, pattern: string): boolean {
-  let source = "^";
-  let escaping = false;
-  for (const char of pattern) {
-    if (escaping) {
-      source += escapeRegExp(char);
-      escaping = false;
-      continue;
-    }
-    if (char === "\\") {
-      escaping = true;
-      continue;
-    }
-    if (char === "%") {
-      source += ".*";
-      continue;
-    }
-    if (char === "_") {
-      source += ".";
-      continue;
-    }
-    source += escapeRegExp(char);
-  }
-  if (escaping) {
-    source += "\\\\";
-  }
-  return new RegExp(`${source}$`, "s").test(value);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-claims.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-claims.ts
@@ -24,13 +24,14 @@ export async function claimScheduledWorkLease(
   leaseMs = SCHEDULED_WORK_LEASE_MS
 ): Promise<string | undefined> {
   const token = crypto.randomUUID();
-  return await withTransaction(storage, (tx) => {
+  return await withTransaction(storage, async (tx) => {
     const sql = requiredClaimSql(tx);
     ensureScheduledWorkSchema(sql);
     const leaseUntil = nowMs + Math.max(1, Math.floor(leaseMs));
     sql.exec(
-      "UPDATE pss_scheduled_work SET claim_token = ?, claimed_until = ? WHERE prefix = ? AND kind = ? AND work_id = ? AND (claimed_until IS NULL OR claimed_until <= ?)",
+      "UPDATE pss_scheduled_work SET claim_token = ?, claimed_until = ?, due_at = ? WHERE prefix = ? AND kind = ? AND work_id = ? AND (claimed_until IS NULL OR claimed_until <= ?)",
       token,
+      leaseUntil,
       leaseUntil,
       prefix,
       kind,
@@ -45,7 +46,11 @@ export async function claimScheduledWorkLease(
         workId
       )
       .toArray()[0]?.claim_token;
-    return Promise.resolve(claimed === token ? token : undefined);
+    if (claimed !== token) {
+      return;
+    }
+    await armScheduledWorkTransaction(tx, sql, prefix);
+    return token;
   });
 }
 
@@ -57,7 +62,7 @@ export async function releaseScheduledWorkLease(
   claimToken: string,
   dueAtMs: number
 ): Promise<boolean> {
-  return await withTransaction(storage, (tx) => {
+  return await withTransaction(storage, async (tx) => {
     const sql = requiredClaimSql(tx);
     ensureScheduledWorkSchema(sql);
     const payload = sql
@@ -70,20 +75,20 @@ export async function releaseScheduledWorkLease(
       )
       .toArray()[0]?.payload;
     if (payload === undefined) {
-      return Promise.resolve(false);
+      return false;
     }
     sql.exec(
-      "UPDATE pss_scheduled_work SET claim_token = NULL, claimed_until = NULL, payload = ?, created_at = ? WHERE prefix = ? AND kind = ? AND work_id = ? AND claim_token = ?",
+      "UPDATE pss_scheduled_work SET claim_token = NULL, claimed_until = NULL, payload = ?, due_at = ?, created_at = ? WHERE prefix = ? AND kind = ? AND work_id = ? AND claim_token = ?",
       withDueAt(payload, dueAtMs),
+      dueAtMs,
       dueAtMs,
       prefix,
       kind,
       workId,
       claimToken
     );
-    return Promise.resolve(
-      hasClaim(sql, prefix, kind, workId, claimToken) === false
-    );
+    await armScheduledWorkTransaction(tx, sql, prefix);
+    return true;
   });
 }
 
@@ -105,9 +110,12 @@ export async function ackScheduledWorkLease(
   workId: string,
   claimToken: string
 ): Promise<boolean> {
-  return await withTransaction(storage, (tx) => {
+  return await withTransaction(storage, async (tx) => {
     const sql = requiredClaimSql(tx);
     ensureScheduledWorkSchema(sql);
+    if (!hasClaim(sql, prefix, kind, workId, claimToken)) {
+      return false;
+    }
     sql.exec(
       "DELETE FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND work_id = ? AND claim_token = ?",
       prefix,
@@ -115,10 +123,43 @@ export async function ackScheduledWorkLease(
       workId,
       claimToken
     );
-    return Promise.resolve(
-      hasClaim(sql, prefix, kind, workId, claimToken) === false
-    );
+    await armScheduledWorkTransaction(tx, sql, prefix);
+    return true;
   });
+}
+
+async function armScheduledWorkTransaction(
+  storage: CloudflareDurableObjectTransactionStorage,
+  sql: SqlStorage,
+  prefix: string
+): Promise<void> {
+  const next = earliestScheduledAt(sql, prefix);
+  if (next === undefined) {
+    return;
+  }
+  if (storage.setAlarm === undefined) {
+    throw new Error("Celld storage transaction setAlarm() is required.");
+  }
+  await storage.setAlarm(next);
+}
+
+function earliestScheduledAt(
+  sql: SqlStorage,
+  prefix: string
+): number | undefined {
+  const times = (["celld-run", "celld-thread-prompt"] as const).flatMap(
+    (kind) => {
+      const row = sql
+        .exec<ScheduledWorkRow>(
+          "SELECT due_at FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND due_at IS NOT NULL ORDER BY due_at, rowid LIMIT 1",
+          prefix,
+          kind
+        )
+        .toArray()[0];
+      return typeof row?.due_at === "number" ? [row.due_at] : [];
+    }
+  );
+  return times.length === 0 ? undefined : Math.min(...times);
 }
 
 function hasClaim(

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-claims.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-claims.ts
@@ -1,0 +1,148 @@
+import type { SqlStorage } from "../../sql/ports/storage-port";
+import type {
+  CloudflareDurableObjectStorage,
+  CloudflareDurableObjectTransactionStorage,
+} from "../durable-object/durable-object-storage";
+import {
+  requiredSqlStorage,
+  withTransaction,
+} from "../durable-object/sql-access";
+import type {
+  ScheduledWorkKind,
+  ScheduledWorkRow,
+} from "./scheduled-work-table";
+import { ensureScheduledWorkSchema } from "./scheduled-work-table-schema";
+
+export const SCHEDULED_WORK_LEASE_MS = 120_000;
+
+export async function claimScheduledWorkLease(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  kind: ScheduledWorkKind,
+  workId: string,
+  nowMs = Date.now(),
+  leaseMs = SCHEDULED_WORK_LEASE_MS
+): Promise<string | undefined> {
+  const token = crypto.randomUUID();
+  return await withTransaction(storage, (tx) => {
+    const sql = requiredClaimSql(tx);
+    ensureScheduledWorkSchema(sql);
+    const leaseUntil = nowMs + Math.max(1, Math.floor(leaseMs));
+    sql.exec(
+      "UPDATE pss_scheduled_work SET claim_token = ?, claimed_until = ? WHERE prefix = ? AND kind = ? AND work_id = ? AND (claimed_until IS NULL OR claimed_until <= ?)",
+      token,
+      leaseUntil,
+      prefix,
+      kind,
+      workId,
+      nowMs
+    );
+    const claimed = sql
+      .exec<ScheduledWorkRow>(
+        "SELECT claim_token FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND work_id = ?",
+        prefix,
+        kind,
+        workId
+      )
+      .toArray()[0]?.claim_token;
+    return Promise.resolve(claimed === token ? token : undefined);
+  });
+}
+
+export async function releaseScheduledWorkLease(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  kind: ScheduledWorkKind,
+  workId: string,
+  claimToken: string,
+  dueAtMs: number
+): Promise<boolean> {
+  return await withTransaction(storage, (tx) => {
+    const sql = requiredClaimSql(tx);
+    ensureScheduledWorkSchema(sql);
+    const payload = sql
+      .exec<ScheduledWorkRow>(
+        "SELECT payload FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND work_id = ? AND claim_token = ?",
+        prefix,
+        kind,
+        workId,
+        claimToken
+      )
+      .toArray()[0]?.payload;
+    if (payload === undefined) {
+      return Promise.resolve(false);
+    }
+    sql.exec(
+      "UPDATE pss_scheduled_work SET claim_token = NULL, claimed_until = NULL, payload = ?, created_at = ? WHERE prefix = ? AND kind = ? AND work_id = ? AND claim_token = ?",
+      withDueAt(payload, dueAtMs),
+      dueAtMs,
+      prefix,
+      kind,
+      workId,
+      claimToken
+    );
+    return Promise.resolve(
+      hasClaim(sql, prefix, kind, workId, claimToken) === false
+    );
+  });
+}
+
+function withDueAt(payload: string, dueAtMs: number): string {
+  const value: unknown = JSON.parse(payload);
+  if (typeof value !== "object" || value === null || !("value" in value)) {
+    throw new Error("Invalid scheduled work payload.");
+  }
+  return JSON.stringify({
+    dueAtMs: Math.max(0, Math.floor(dueAtMs)),
+    value: value.value,
+  });
+}
+
+export async function ackScheduledWorkLease(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  kind: ScheduledWorkKind,
+  workId: string,
+  claimToken: string
+): Promise<boolean> {
+  return await withTransaction(storage, (tx) => {
+    const sql = requiredClaimSql(tx);
+    ensureScheduledWorkSchema(sql);
+    sql.exec(
+      "DELETE FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND work_id = ? AND claim_token = ?",
+      prefix,
+      kind,
+      workId,
+      claimToken
+    );
+    return Promise.resolve(
+      hasClaim(sql, prefix, kind, workId, claimToken) === false
+    );
+  });
+}
+
+function hasClaim(
+  sql: SqlStorage,
+  prefix: string,
+  kind: ScheduledWorkKind,
+  workId: string,
+  claimToken: string
+): boolean {
+  return (
+    sql
+      .exec(
+        "SELECT claim_token FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND work_id = ? AND claim_token = ?",
+        prefix,
+        kind,
+        workId,
+        claimToken
+      )
+      .toArray().length > 0
+  );
+}
+
+function requiredClaimSql(
+  storage: CloudflareDurableObjectTransactionStorage
+): SqlStorage {
+  return requiredSqlStorage(storage, "Cloudflare scheduled work claims");
+}

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table-groups.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table-groups.ts
@@ -1,0 +1,78 @@
+import type { SqlStorage } from "../../sql/ports/storage-port";
+import type {
+  CloudflareDurableObjectStorage,
+  CloudflareDurableObjectTransactionStorage,
+} from "../durable-object/durable-object-storage";
+import {
+  requiredSqlStorage,
+  withTransaction,
+} from "../durable-object/sql-access";
+import type {
+  ScheduledWorkKind,
+  ScheduledWorkRow,
+} from "./scheduled-work-table";
+import { ensureScheduledWorkSchema } from "./scheduled-work-table-schema";
+
+export interface ScheduledWorkTarget {
+  readonly kind: ScheduledWorkKind;
+  readonly matchesPayload?: (payload: string) => boolean;
+  readonly workId: string;
+}
+
+export async function deleteScheduledWorkGroup(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  targets: readonly ScheduledWorkTarget[]
+): Promise<boolean> {
+  return await withTransaction(storage, (transaction) => {
+    const sql = requiredGroupSql(transaction);
+    ensureScheduledWorkSchema(sql);
+    let deleted = false;
+    for (const target of targets) {
+      for (const row of matchingRows(sql, prefix, target)) {
+        sql.exec(
+          "DELETE FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND work_id = ?",
+          prefix,
+          target.kind,
+          row.work_id
+        );
+        deleted = true;
+      }
+    }
+    return Promise.resolve(deleted);
+  });
+}
+
+export function hasScheduledWorkGroup(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  targets: readonly ScheduledWorkTarget[]
+): boolean {
+  const sql = requiredGroupSql(storage);
+  ensureScheduledWorkSchema(sql);
+  return targets.some((target) => matchingRows(sql, prefix, target).length > 0);
+}
+
+function matchingRows(
+  sql: SqlStorage,
+  prefix: string,
+  target: ScheduledWorkTarget
+): ScheduledWorkRow[] {
+  const rows = sql
+    .exec<ScheduledWorkRow>(
+      "SELECT work_id, payload FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND work_id = ?",
+      prefix,
+      target.kind,
+      target.workId
+    )
+    .toArray();
+  return target.matchesPayload === undefined
+    ? rows
+    : rows.filter((row) => target.matchesPayload?.(row.payload));
+}
+
+function requiredGroupSql(
+  storage: CloudflareDurableObjectTransactionStorage
+): SqlStorage {
+  return requiredSqlStorage(storage, "Cloudflare scheduled work group");
+}

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table-schema.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table-schema.ts
@@ -1,5 +1,27 @@
 import type { SqlStorage } from "../../sql/ports/storage-port";
 
+export function ensureScheduledWorkSchema(sql: SqlStorage): void {
+  sql.exec(
+    "CREATE TABLE IF NOT EXISTS pss_scheduled_work (prefix TEXT NOT NULL, kind TEXT NOT NULL, work_id TEXT NOT NULL, payload TEXT NOT NULL, thread_key TEXT, run_id TEXT, created_at INTEGER NOT NULL)"
+  );
+  ensureScheduledWorkColumn(sql, "thread_key");
+  ensureScheduledWorkColumn(sql, "run_id");
+  ensureScheduledWorkColumn(sql, "claim_token");
+  ensureScheduledWorkColumn(sql, "claimed_until");
+  sql.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS pss_scheduled_work_key ON pss_scheduled_work (prefix, kind, work_id)"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_due ON pss_scheduled_work (prefix, kind, created_at, work_id)"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_thread ON pss_scheduled_work (prefix, thread_key)"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_run ON pss_scheduled_work (prefix, run_id)"
+  );
+}
+
 export function hasScheduledWorkColumn(
   sql: SqlStorage,
   column: string
@@ -8,4 +30,15 @@ export function hasScheduledWorkColumn(
     .exec<{ readonly name: string }>("PRAGMA table_info(pss_scheduled_work)")
     .toArray()
     .some((row) => row.name === column);
+}
+
+function ensureScheduledWorkColumn(sql: SqlStorage, column: string): void {
+  if (hasScheduledWorkColumn(sql, column)) {
+    return;
+  }
+  sql.exec(
+    `ALTER TABLE pss_scheduled_work ADD COLUMN ${column} ${
+      column === "claimed_until" ? "INTEGER" : "TEXT"
+    }`
+  );
 }

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table-schema.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table-schema.ts
@@ -2,17 +2,21 @@ import type { SqlStorage } from "../../sql/ports/storage-port";
 
 export function ensureScheduledWorkSchema(sql: SqlStorage): void {
   sql.exec(
-    "CREATE TABLE IF NOT EXISTS pss_scheduled_work (prefix TEXT NOT NULL, kind TEXT NOT NULL, work_id TEXT NOT NULL, payload TEXT NOT NULL, thread_key TEXT, run_id TEXT, created_at INTEGER NOT NULL)"
+    "CREATE TABLE IF NOT EXISTS pss_scheduled_work (prefix TEXT NOT NULL, kind TEXT NOT NULL, work_id TEXT NOT NULL, payload TEXT NOT NULL, thread_key TEXT, run_id TEXT, due_at INTEGER, created_at INTEGER NOT NULL)"
   );
   ensureScheduledWorkColumn(sql, "thread_key");
   ensureScheduledWorkColumn(sql, "run_id");
   ensureScheduledWorkColumn(sql, "claim_token");
   ensureScheduledWorkColumn(sql, "claimed_until");
+  ensureScheduledWorkColumn(sql, "due_at");
   sql.exec(
     "CREATE UNIQUE INDEX IF NOT EXISTS pss_scheduled_work_key ON pss_scheduled_work (prefix, kind, work_id)"
   );
   sql.exec(
     "CREATE INDEX IF NOT EXISTS pss_scheduled_work_due ON pss_scheduled_work (prefix, kind, created_at, work_id)"
+  );
+  sql.exec(
+    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_celld_due ON pss_scheduled_work (prefix, kind, due_at, work_id)"
   );
   sql.exec(
     "CREATE INDEX IF NOT EXISTS pss_scheduled_work_thread ON pss_scheduled_work (prefix, thread_key)"
@@ -38,7 +42,7 @@ function ensureScheduledWorkColumn(sql: SqlStorage, column: string): void {
   }
   sql.exec(
     `ALTER TABLE pss_scheduled_work ADD COLUMN ${column} ${
-      column === "claimed_until" ? "INTEGER" : "TEXT"
+      column === "claimed_until" || column === "due_at" ? "INTEGER" : "TEXT"
     }`
   );
 }

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table.ts
@@ -11,7 +11,7 @@ import {
   requiredSqlStorage,
   withTransaction,
 } from "../durable-object/sql-access";
-import { hasScheduledWorkColumn } from "./scheduled-work-table-schema";
+import { ensureScheduledWorkSchema } from "./scheduled-work-table-schema";
 
 export type ScheduledWorkKind =
   | "agents-run"
@@ -21,6 +21,8 @@ export type ScheduledWorkKind =
   | SharedScheduledWorkKind;
 
 export interface ScheduledWorkRow {
+  readonly claim_token?: string | null;
+  readonly claimed_until?: number | null;
   readonly payload: string;
   readonly run_id?: string | null;
   readonly thread_key?: string | null;
@@ -65,7 +67,7 @@ export function selectScheduledWork(
   if (limit !== undefined) {
     return sql
       .exec<ScheduledWorkRow>(
-        "SELECT work_id, payload FROM pss_scheduled_work WHERE prefix = ? AND kind = ? ORDER BY created_at, rowid LIMIT ? OFFSET ?",
+        "SELECT work_id, payload, claim_token, claimed_until FROM pss_scheduled_work WHERE prefix = ? AND kind = ? ORDER BY created_at, rowid LIMIT ? OFFSET ?",
         prefix,
         kind,
         normalizedListLimit(limit),
@@ -75,7 +77,7 @@ export function selectScheduledWork(
   }
   return sql
     .exec<ScheduledWorkRow>(
-      "SELECT work_id, payload FROM pss_scheduled_work WHERE prefix = ? AND kind = ? ORDER BY created_at, rowid",
+      "SELECT work_id, payload, claim_token, claimed_until FROM pss_scheduled_work WHERE prefix = ? AND kind = ? ORDER BY created_at, rowid",
       prefix,
       kind
     )
@@ -235,30 +237,6 @@ function deleteScheduledWorkRow(
     kind,
     workId
   );
-}
-
-function ensureScheduledWorkSchema(sql: SqlStorage): void {
-  sql.exec(
-    "CREATE TABLE IF NOT EXISTS pss_scheduled_work (prefix TEXT NOT NULL, kind TEXT NOT NULL, work_id TEXT NOT NULL, payload TEXT NOT NULL, thread_key TEXT, run_id TEXT, created_at INTEGER NOT NULL, PRIMARY KEY (prefix, kind, work_id))"
-  );
-  ensureScheduledWorkColumn(sql, "thread_key");
-  ensureScheduledWorkColumn(sql, "run_id");
-  sql.exec(
-    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_due ON pss_scheduled_work (prefix, kind, created_at, work_id)"
-  );
-  sql.exec(
-    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_thread ON pss_scheduled_work (prefix, thread_key)"
-  );
-  sql.exec(
-    "CREATE INDEX IF NOT EXISTS pss_scheduled_work_run ON pss_scheduled_work (prefix, run_id)"
-  );
-}
-
-function ensureScheduledWorkColumn(sql: SqlStorage, column: string): void {
-  if (hasScheduledWorkColumn(sql, column)) {
-    return;
-  }
-  sql.exec(`ALTER TABLE pss_scheduled_work ADD COLUMN ${column} TEXT`);
 }
 
 function requiredScheduledWorkTableSql(

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table.ts
@@ -16,6 +16,8 @@ import { hasScheduledWorkColumn } from "./scheduled-work-table-schema";
 export type ScheduledWorkKind =
   | "agents-run"
   | "agents-thread-prompt"
+  | "celld-run"
+  | "celld-thread-prompt"
   | SharedScheduledWorkKind;
 
 export interface ScheduledWorkRow {

--- a/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table.ts
+++ b/packages/runtime/src/platform/cloudflare/storage/sqlite/scheduled-work-table.ts
@@ -23,6 +23,7 @@ export type ScheduledWorkKind =
 export interface ScheduledWorkRow {
   readonly claim_token?: string | null;
   readonly claimed_until?: number | null;
+  readonly due_at?: number | null;
   readonly payload: string;
   readonly run_id?: string | null;
   readonly thread_key?: string | null;
@@ -30,6 +31,7 @@ export interface ScheduledWorkRow {
 }
 
 export interface ScheduledWorkIndexes {
+  readonly dueAtMs?: number;
   readonly runId?: string;
   readonly threadKey?: string;
 }
@@ -43,8 +45,8 @@ export async function insertScheduledWork(
   indexes: ScheduledWorkIndexes
 ): Promise<void> {
   await withTransaction(storage, (tx) => {
-    insertScheduledWorkRow(
-      requiredScheduledWorkTableSql(tx),
+    insertScheduledWorkInTransaction(
+      tx,
       prefix,
       kind,
       workId,
@@ -53,6 +55,24 @@ export async function insertScheduledWork(
     );
     return Promise.resolve();
   });
+}
+
+export function insertScheduledWorkInTransaction(
+  storage: CloudflareDurableObjectTransactionStorage,
+  prefix: string,
+  kind: ScheduledWorkKind,
+  workId: string,
+  payload: unknown,
+  indexes: ScheduledWorkIndexes
+): void {
+  insertScheduledWorkRow(
+    requiredScheduledWorkTableSql(storage),
+    prefix,
+    kind,
+    workId,
+    payload,
+    indexes
+  );
 }
 
 export function selectScheduledWork(
@@ -84,6 +104,43 @@ export function selectScheduledWork(
     .toArray();
 }
 
+export function selectScheduledWorkDue(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  kind: ScheduledWorkKind,
+  nowMs: number,
+  limit?: number
+): ScheduledWorkRow[] {
+  const sql = requiredScheduledWorkTableSql(storage);
+  ensureScheduledWorkSchema(sql);
+  const normalizedLimit = normalizedListLimit(limit) ?? Number.MAX_SAFE_INTEGER;
+  return sql
+    .exec<ScheduledWorkRow>(
+      "SELECT work_id, payload, claim_token, claimed_until, due_at FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND due_at <= ? ORDER BY due_at, rowid LIMIT ?",
+      prefix,
+      kind,
+      nowMs,
+      normalizedLimit
+    )
+    .toArray();
+}
+
+export function selectNextScheduledWork(
+  storage: CloudflareDurableObjectStorage,
+  prefix: string,
+  kind: ScheduledWorkKind
+): ScheduledWorkRow | undefined {
+  const sql = requiredScheduledWorkTableSql(storage);
+  ensureScheduledWorkSchema(sql);
+  return sql
+    .exec<ScheduledWorkRow>(
+      "SELECT work_id, payload, claim_token, claimed_until, due_at FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND due_at IS NOT NULL ORDER BY due_at, rowid LIMIT 1",
+      prefix,
+      kind
+    )
+    .toArray()[0];
+}
+
 export function deleteScheduledWork(
   storage: CloudflareDurableObjectStorage,
   prefix: string,
@@ -110,65 +167,6 @@ export async function claimScheduledWork(
   );
 }
 
-export interface ScheduledWorkTarget {
-  readonly kind: ScheduledWorkKind;
-  readonly matchesPayload?: (payload: string) => boolean;
-  readonly workId: string;
-}
-
-// Deletes every row matching any target in ONE transaction, so a claim that
-// spans two kinds (an agents row plus its alarm-interop counterpart) cannot
-// be split by a crash. Returns whether at least one row was deleted.
-export async function deleteScheduledWorkGroup(
-  storage: CloudflareDurableObjectStorage,
-  prefix: string,
-  targets: readonly ScheduledWorkTarget[]
-): Promise<boolean> {
-  return await withTransaction(storage, (tx) => {
-    const sql = requiredScheduledWorkTableSql(tx);
-    ensureScheduledWorkSchema(sql);
-    let deleted = false;
-    for (const target of targets) {
-      for (const row of matchingScheduledWorkRows(sql, prefix, target)) {
-        deleteScheduledWorkRow(sql, prefix, target.kind, row.work_id);
-        deleted = true;
-      }
-    }
-    return Promise.resolve(deleted);
-  });
-}
-
-export function hasScheduledWorkGroup(
-  storage: CloudflareDurableObjectStorage,
-  prefix: string,
-  targets: readonly ScheduledWorkTarget[]
-): boolean {
-  const sql = requiredScheduledWorkTableSql(storage);
-  ensureScheduledWorkSchema(sql);
-  return targets.some(
-    (target) => matchingScheduledWorkRows(sql, prefix, target).length > 0
-  );
-}
-
-function matchingScheduledWorkRows(
-  sql: SqlStorage,
-  prefix: string,
-  target: ScheduledWorkTarget
-): ScheduledWorkRow[] {
-  const rows = sql
-    .exec<ScheduledWorkRow>(
-      "SELECT work_id, payload FROM pss_scheduled_work WHERE prefix = ? AND kind = ? AND work_id = ?",
-      prefix,
-      target.kind,
-      target.workId
-    )
-    .toArray();
-  const matches = target.matchesPayload;
-  return matches === undefined
-    ? rows
-    : rows.filter((row) => matches(row.payload));
-}
-
 function insertScheduledWorkRow(
   sql: SqlStorage,
   prefix: string,
@@ -190,13 +188,14 @@ function insertScheduledWorkRow(
     return;
   }
   sql.exec(
-    "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO pss_scheduled_work (prefix, kind, work_id, payload, thread_key, run_id, due_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
     prefix,
     kind,
     workId,
     JSON.stringify(payload),
     indexes.threadKey ?? null,
     indexes.runId ?? null,
+    indexes.dueAtMs ?? null,
     Date.now()
   );
 }

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "src/platform/cloudflare/index.ts",
     // Edge-only: static .wasm imports for Workers (not pulled into Node CF barrel).
     "src/platform/cloudflare/image-codecs-edge.ts",
+    "src/platform/celld/index.ts",
     "src/platform/file/index.ts",
     "src/platform/memory/index.ts",
     "src/platform/sql-queue/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,22 @@ importers:
 
   experimental/bench-shared: {}
 
+  experimental/celld-qa:
+    dependencies:
+      '@minpeter/pss-runtime':
+        specifier: workspace:^
+        version: link:../../packages/runtime
+    devDependencies:
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.12)(yaml@2.9.0)
+
   experimental/compaction-score:
     dependencies:
       '@minpeter/pss-coding-agent':

--- a/scripts/runtime-public-api-format.mjs
+++ b/scripts/runtime-public-api-format.mjs
@@ -1,0 +1,40 @@
+const INLINE_WIDTH = 80;
+const ARRAY_PROPERTY_PATTERN = /^(\s+)"[^"]+": \[$/;
+const STRING_ITEM_PATTERN = /^\s+"[^"]+"[,]?$/;
+
+export function formatRuntimePublicApiSnapshot(snapshot) {
+  const lines = JSON.stringify(snapshot, null, 2).split("\n");
+  const formatted = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const start = ARRAY_PROPERTY_PATTERN.exec(line);
+    if (start === null) {
+      formatted.push(line);
+      continue;
+    }
+    const indentation = start[1];
+    const endIndex = lines.findIndex(
+      (candidate, candidateIndex) =>
+        candidateIndex > index &&
+        (candidate === `${indentation}]` || candidate === `${indentation}],`)
+    );
+    if (endIndex < 0) {
+      formatted.push(line);
+      continue;
+    }
+    const items = lines.slice(index + 1, endIndex);
+    const candidate = `${line}${items.map((item) => item.trim()).join(" ")}${lines[
+      endIndex
+    ].trim()}`;
+    if (
+      candidate.length <= INLINE_WIDTH &&
+      items.every((item) => STRING_ITEM_PATTERN.test(item))
+    ) {
+      formatted.push(candidate);
+      index = endIndex;
+      continue;
+    }
+    formatted.push(line);
+  }
+  return `${formatted.join("\n")}\n`;
+}

--- a/scripts/runtime-public-api-snapshot.mjs
+++ b/scripts/runtime-public-api-snapshot.mjs
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { parse } from "@babel/parser";
+import { formatRuntimePublicApiSnapshot } from "./runtime-public-api-format.mjs";
 
 export const RUNTIME_API_SNAPSHOT_PATH = join(
   "packages",
@@ -268,6 +269,6 @@ export function findRuntimePublicApiSnapshotErrors({ cwd, packages }) {
 export function writeRuntimePublicApiSnapshot(cwd = process.cwd()) {
   const snapshotFile = join(cwd, RUNTIME_API_SNAPSHOT_PATH);
   const snapshot = collectRuntimePublicApi(cwd);
-  writeFileSync(snapshotFile, `${JSON.stringify(snapshot, null, 2)}\n`);
+  writeFileSync(snapshotFile, formatRuntimePublicApiSnapshot(snapshot));
   return snapshotFile;
 }

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -26,6 +26,7 @@ const releaseIgnore = [
   "@minpeter/pss-benchmark-nextjs",
   "@minpeter/pss-edit-format-bench",
   "@minpeter/pss-runtime-edge-image-qa",
+  "@minpeter/pss-celld-qa",
   "@minpeter/pss-example-background-subagent",
   "@minpeter/pss-example-basic",
   "@minpeter/pss-example-evals",


### PR DESCRIPTION
## Summary

- add `@minpeter/pss-runtime/platform/celld` with SQLite-backed host and crash-atomic alarm scheduling
- add durable lease recovery, indexed due-work queries, activation reconciliation, and token-guarded acknowledgements
- add deterministic native/container Celld QA for malformed input, durable idempotency, isolation, restart persistence, cleanup, and causal response-retention profiling

## Verification

- `pnpm build`
- `pnpm test` (19/19 tasks; runtime 1375 passed, scripts 85 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm api:check`
- `pnpm verify:release`
- `pnpm check:compatibility`
- `pnpm check:tegami-notes`
- real Celld native happy path: `echo:hello`, history 1 -> 2
- native + container matrix: 25 isolated objects, concurrency 64, malformed 400, duplicate commit 1, restart preserved
- causal harness retention: 100 objects / 5602 bytes -> 0 / 0; unchanged comparator fails, candidate passes

## Review

Five independent post-implementation review lanes approved final head `31845340`.

## Notes

Celld CPU, VmHWM, elapsed time, and open-file metrics are observational only; the optimization gate covers only runner-owned retained response objects and bytes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@minpeter/pss-runtime/platform/celld`, a new platform subpath for self-hosted Durable Objects deployments with SQLite-backed scheduling, durable lease claims, and crash-atomic alarm re-arming. Extends the shared scheduled-work storage with due-time and claim columns; existing Cloudflare behavior is unchanged.

**New Features**
- Exports `createCelldHost`, `createCelldScheduler`, claim/ack/rearm/retry helpers, and `drainCelldScheduledWork`.
- Adds the private `experimental/celld-qa` package with native and container matrix coverage for malformed input, idempotency, isolation, restart persistence, and cleanup.

**Refactors**
- Splits shared scheduled-work storage into schema, table, claim, and group modules and updates the in-memory SQL test double to match.

<sup>Written for commit 318453409eb8e5bf7f9894dcebbf59189a61151c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

