### PR TITLE
test(celld): add Compose S3 workflow

### DIFF
--- a/.tegami/2026-08-28-celld-compose.md
+++ b/.tegami/2026-08-28-celld-compose.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Add a Compose-based Celld development loop
+
+Add an ephemeral LocalStack S3 Compose service and document the native,
+container, and load-measurement commands used by the private Celld QA package.

--- a/experimental/celld-qa/README.md
+++ b/experimental/celld-qa/README.md
@@ -9,10 +9,55 @@ S3-compatible endpoint that passes Celld's conditional-write probe. Community
 MinIO is not a supported backend. Set `S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, and
 `AWS_SECRET_ACCESS_KEY` before running the scripts.
 
+## Docker Compose development loop
+
+The package includes an ephemeral LocalStack S3 service bound only to loopback.
+Build the runtime first because the deployed QA worker imports the published
+`@minpeter/pss-runtime/platform/celld` subpath.
+
+```sh
+pnpm --filter @minpeter/pss-runtime build
+pnpm --filter @minpeter/pss-celld-qa qa:s3:up
+```
+
+The default QA environment already matches the Compose service:
+
+```sh
+export S3_ENDPOINT=http://127.0.0.1:14566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+```
+
+Run the native smoke test and native/container durability matrix:
+
 ```sh
 pnpm --filter @minpeter/pss-celld-qa qa:native -- --port 16420 --object pss-smoke --text hello
 pnpm --filter @minpeter/pss-celld-qa qa:matrix -- --native-port 16421 --container-port 16422 --objects 25 --concurrency 64
 ```
+
+Capture the reproducible response-retention baseline and candidate:
+
+```sh
+CELLD_QA_RETENTION_MODE=legacy pnpm --filter @minpeter/pss-celld-qa qa:load -- \
+  --port 16423 --objects 100 --concurrency 64 \
+  --output /var/tmp/pss-celld-baseline.json
+pnpm --filter @minpeter/pss-celld-qa qa:load -- \
+  --port 16423 --objects 100 --concurrency 64 \
+  --output /var/tmp/pss-celld-candidate.json
+pnpm --filter @minpeter/pss-celld-qa qa:compare -- \
+  /var/tmp/pss-celld-baseline.json /var/tmp/pss-celld-candidate.json
+```
+
+Stop the S3 service and remove its ephemeral data:
+
+```sh
+pnpm --filter @minpeter/pss-celld-qa qa:s3:down
+```
+
+Set `CELLD_QA_S3_PORT` before `qa:s3:up` to change the host port, and set
+`S3_ENDPOINT` to the matching URL for the QA commands. The Compose file does
+not declare a persistent volume, so `qa:s3:down` removes all LocalStack data.
 
 The matrix performs malformed-input, duplicate-idempotency, concurrent
 object, restart-persistence, and completed-idempotency replay checks on both

--- a/experimental/celld-qa/compose.yaml
+++ b/experimental/celld-qa/compose.yaml
@@ -1,0 +1,22 @@
+services:
+  localstack:
+    image: localstack/localstack:4.8.1
+    ports:
+      - "127.0.0.1:${CELLD_QA_S3_PORT:-14566}:4566"
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-test}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-test}
+      EAGER_SERVICE_LOADING: "1"
+      SERVICES: s3
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          curl -fsS http://localhost:4566/_localstack/health |
+          grep -Eq '"s3"[[:space:]]*:[[:space:]]*"(available|running)"'
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+    stop_grace_period: 10s

--- a/experimental/celld-qa/package.json
+++ b/experimental/celld-qa/package.json
@@ -7,6 +7,8 @@
     "qa:load": "tsx src/qa-load.ts",
     "qa:matrix": "tsx src/qa-matrix.ts",
     "qa:native": "tsx src/qa-native.ts",
+    "qa:s3:down": "docker compose --file compose.yaml down --volumes --remove-orphans",
+    "qa:s3:up": "docker compose --file compose.yaml up --detach --wait",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },


### PR DESCRIPTION
## Summary

- add an ephemeral loopback-only LocalStack S3 Compose service for local Celld development
- add `qa:s3:up` and `qa:s3:down` package scripts with a health-gated startup
- document the native, native/container matrix, and baseline/candidate load workflow

## Verification

- `docker compose --file experimental/celld-qa/compose.yaml config --quiet`
- `pnpm --filter @minpeter/pss-celld-qa qa:s3:up` and health endpoint ready
- native QA: `echo:hello`, history `1 -> 2`
- native/container matrix: 25 isolated objects at concurrency 64; malformed 400, duplicate commit 1, restart preserved
- load baseline: 100 retained responses / 5602 bytes
- unchanged comparator: RED, exit 1
- candidate: 0 retained responses / 0 bytes; comparator GREEN
- `qa:s3:down` removed the container and network; ports 14566/16420-16423 and Celld processes were absent
- Celld QA tests and typecheck
- root typecheck, lint, and Tegami validation

## Notes

The Compose service is ephemeral by design and declares no persistent volume. Community MinIO remains unsupported because Celld requires a conditional-write-capable bucket backend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ephemeral loopback-only LocalStack S3 Compose service so local Celld QA runs no longer depend on a manually provisioned S3 backend, and documents the native, matrix, and load-measurement workflow.

**New Features**
- Adds `qa:s3:up` and `qa:s3:down` package scripts with a health-gated startup and volume cleanup.
- Documents the Compose service, environment defaults, and baseline/candidate load comparison commands.
- The Compose file stays ephemeral; `qa:s3:down` removes all data, and community MinIO remains unsupported.

<sup>Written for commit cf3670fa97eb114795d8f65dbcbd5bbe225b237d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

