### PR TITLE
fix(runtime): calibrate CJK prompt units by UTF-8 bytes

### DIFF
--- a/.tegami/2026-08-31-cjk-context-token-units.md
+++ b/.tegami/2026-08-31-cjk-context-token-units.md
@@ -1,0 +1,15 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Measure prompt tokens in serialized UTF-8 bytes
+
+Default prompt measurement counted UTF-16 code units, so CJK text cost the
+same units as ASCII of equal length. Adaptive calibration learned an inflated
+marginal scale from CJK requests and applied it to every later request,
+including ASCII prose and tool results, which could reject prompts that fit.
+Measurement now divides serialized UTF-8 byte length by four. ASCII estimates
+are unchanged; non-ASCII estimates increase and never decrease relative to the
+previous basis.

--- a/packages/runtime/src/llm/context-gate.test.ts
+++ b/packages/runtime/src/llm/context-gate.test.ts
@@ -40,6 +40,60 @@ describe("model prompt measurement", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it("distinguishes Japanese prompt density from equal-length ASCII", () => {
+    // Given
+    const ascii = { content: "a".repeat(372), role: "user" } as const;
+    const japanese = { content: "日".repeat(372), role: "user" } as const;
+
+    // When
+    const measured = defaultModelPromptMeasurementProfile.measureMessages([
+      ascii,
+      japanese,
+    ]);
+
+    // Then
+    expect(measured).toEqual([100, 286]);
+  });
+
+  it.each([
+    ["ascii", { content: "hello world", role: "user" }],
+    ["japanese", { content: "日本語のテキスト", role: "user" }],
+    ["korean", { content: "한국어 텍스트", role: "user" }],
+    ["emoji surrogate pair", { content: "😀😀😀", role: "user" }],
+    ["lone high surrogate", { content: "\uD800", role: "user" }],
+    ["lone low surrogate", { content: "\uDC00", role: "user" }],
+    ["mixed scripts", { content: "ab日😀", role: "user" }],
+    ["empty", { content: "", role: "user" }],
+  ] as const)(
+    "never measures below the legacy unit basis (%s)",
+    (_name, message) => {
+      // Given
+      const legacy = JSON.stringify(message).length / 4;
+
+      // When
+      const [measured] = defaultModelPromptMeasurementProfile.measureMessages([
+        message,
+      ]);
+
+      // Then
+      expect(measured).toBeGreaterThanOrEqual(legacy);
+    }
+  );
+
+  it("leaves pure-ASCII measurement exactly unchanged", () => {
+    // Given
+    const message = { content: "hello world", role: "user" } as const;
+    const legacy = JSON.stringify(message).length / 4;
+
+    // When
+    const measured = defaultModelPromptMeasurementProfile.measureMessages([
+      message,
+    ]);
+
+    // Then
+    expect(measured).toEqual([legacy]);
+  });
+
   it("projects the complete function-tool surface sent by the AI SDK", async () => {
     const description = vi.fn(() => "Dynamic search");
     const tools = await modelPromptTools({

--- a/packages/runtime/src/llm/context-gate.ts
+++ b/packages/runtime/src/llm/context-gate.ts
@@ -1,44 +1,24 @@
-import { asSchema, jsonSchema, type ModelMessage, type ToolSet } from "ai";
+import type { ModelMessage } from "ai";
 import type { PreparedModelToolChoice } from "./model-step-preparation";
+import {
+  defaultModelPromptMeasurementProfile,
+  type ModelContextTokenEstimateInput,
+  type ModelPromptTool,
+} from "./prompt-measurement";
 
-export interface ModelContextTokenEstimateInput {
-  readonly instructions?: string;
-  readonly messages: readonly ModelMessage[];
-  readonly toolChoice?: PreparedModelToolChoice;
-  readonly tools?: readonly ModelPromptTool[];
-}
-
-export interface ModelPromptTool {
-  readonly args?: Readonly<Record<string, unknown>>;
-  readonly description?: string;
-  readonly id?: string;
-  readonly inputExamples?: readonly unknown[];
-  readonly inputSchema?: unknown;
-  readonly name: string;
-  readonly providerOptions?: Readonly<Record<string, unknown>>;
-  readonly strict?: boolean;
-  readonly type?: string;
-}
-
-/** Product-neutral units measured for one provider-visible model request. */
-export interface ModelPromptMeasurement {
-  /** Stable identity for fixed prompt content; used for safe marginal calibration. */
-  readonly fixedFingerprint: string;
-  /** Instructions, tool definitions, tool choice, and request framing. */
-  readonly fixedUnits: number;
-  /** Marginal cost aligned by index with the input messages. */
-  readonly messageUnits: readonly number[];
-  readonly totalUnits: number;
-}
-
-export interface ModelPromptMeasurementProfile {
-  readonly measureMessages: (
-    messages: readonly ModelMessage[]
-  ) => readonly number[];
-  readonly measurePrompt: (
-    input: ModelContextTokenEstimateInput
-  ) => ModelPromptMeasurement;
-}
+export type {
+  ModelContextTokenEstimateInput,
+  ModelPromptMeasurement,
+  ModelPromptMeasurementProfile,
+  ModelPromptTool,
+} from "./prompt-measurement";
+// biome-ignore lint/performance/noBarrelFile: Stable compatibility entrypoint after splitting prompt measurement.
+export {
+  defaultModelPromptMeasurementProfile,
+  estimateModelMessagesTokens,
+  materializeModelPromptTools,
+  modelPromptTools,
+} from "./prompt-measurement";
 
 /**
  * A budget source consulted before every model request. The gate calls
@@ -130,142 +110,4 @@ function estimatePromptTokens(
   }
 
   return defaultModelPromptMeasurementProfile.measurePrompt(input).totalUnits;
-}
-
-export const defaultModelPromptMeasurementProfile = Object.freeze({
-  measureMessages(messages: readonly ModelMessage[]) {
-    return messages.map((message) => countJsonUnits(message));
-  },
-  measurePrompt(input: ModelContextTokenEstimateInput) {
-    const messageUnits = measureDefaultMessageUnits(input.messages);
-    const toolChoice = providerPromptToolChoice(input.toolChoice);
-    const fixedUnits = countJsonUnits({
-      instructions: input.instructions,
-      toolChoice,
-      tools: input.tools,
-    });
-    return {
-      fixedFingerprint: JSON.stringify(
-        {
-          instructions: input.instructions,
-          toolChoice,
-          tools: input.tools,
-        },
-        promptTokenEstimateReplacer
-      ),
-      fixedUnits,
-      messageUnits,
-      totalUnits:
-        fixedUnits + messageUnits.reduce((sum, units) => sum + units, 0),
-    };
-  },
-}) satisfies ModelPromptMeasurementProfile;
-
-export function estimateModelMessagesTokens(
-  messages: readonly ModelMessage[]
-): number {
-  return Math.ceil(
-    JSON.stringify(messages, promptTokenEstimateReplacer).length / 4
-  );
-}
-
-function countJsonUnits(value: unknown): number {
-  return JSON.stringify(value, promptTokenEstimateReplacer).length / 4;
-}
-
-function measureDefaultMessageUnits(
-  messages: readonly ModelMessage[]
-): readonly number[] {
-  return messages.map((message) => countJsonUnits(message));
-}
-
-export async function modelPromptTools(
-  tools: ToolSet | undefined
-): Promise<readonly ModelPromptTool[] | undefined> {
-  return (await materializeModelPromptTools(tools)).promptTools;
-}
-
-export async function materializeModelPromptTools(
-  tools: ToolSet | undefined
-): Promise<{
-  readonly promptTools?: readonly ModelPromptTool[];
-  readonly tools?: ToolSet;
-}> {
-  if (!tools) {
-    return {};
-  }
-  const entries = await Promise.all(
-    Object.entries(tools).map(async ([name, tool]) => {
-      if (tool.type === "provider") {
-        return [
-          name,
-          tool,
-          { args: tool.args, id: tool.id, name, type: tool.type },
-        ] as const;
-      }
-      const description =
-        typeof tool.description === "function"
-          ? tool.description({
-              context: undefined,
-            })
-          : tool.description;
-      const schema = asSchema(tool.inputSchema);
-      const resolvedInputSchema = await schema.jsonSchema;
-      const promptTool = {
-        ...(description === undefined ? {} : { description }),
-        ...(tool.inputExamples === undefined
-          ? {}
-          : { inputExamples: tool.inputExamples }),
-        inputSchema: resolvedInputSchema,
-        name,
-        ...(tool.providerOptions === undefined
-          ? {}
-          : { providerOptions: tool.providerOptions }),
-        ...(tool.strict === undefined ? {} : { strict: tool.strict }),
-        type: "function",
-      };
-      return [
-        name,
-        {
-          ...tool,
-          ...(description === undefined ? {} : { description }),
-          inputSchema: jsonSchema(
-            resolvedInputSchema,
-            schema.validate ? { validate: schema.validate } : undefined
-          ),
-        },
-        promptTool,
-      ] as const;
-    })
-  );
-  return {
-    promptTools: entries.map((entry) => entry[2]),
-    tools: Object.fromEntries(entries.map(([name, tool]) => [name, tool])),
-  };
-}
-
-function providerPromptToolChoice(
-  toolChoice: PreparedModelToolChoice | undefined
-): unknown {
-  if (toolChoice === undefined) {
-    return { type: "auto" };
-  }
-  return typeof toolChoice === "string" ? { type: toolChoice } : toolChoice;
-}
-
-function promptTokenEstimateReplacer(_key: string, value: unknown): unknown {
-  if (ArrayBuffer.isView(value)) {
-    return binaryPromptTokenEstimate(value.byteLength);
-  }
-  if (value instanceof ArrayBuffer) {
-    return binaryPromptTokenEstimate(value.byteLength);
-  }
-  return value;
-}
-
-function binaryPromptTokenEstimate(byteLength: number): {
-  readonly byteLength: number;
-  readonly type: "binary";
-} {
-  return { byteLength, type: "binary" };
 }

--- a/packages/runtime/src/llm/context-tokens.test.ts
+++ b/packages/runtime/src/llm/context-tokens.test.ts
@@ -1,4 +1,6 @@
+import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
+import { defaultModelPromptMeasurementProfile } from "./context-gate";
 import {
   ContextTokenCalibrationRegistry,
   ContextTokenMeter,
@@ -229,6 +231,111 @@ describe("ContextTokenMeter", () => {
     });
 
     expect(meter.inputUpperBound()).toBeGreaterThanOrEqual(1050);
+  });
+
+  it("does not broadcast CJK calibration density to ASCII and tool results", () => {
+    // Given
+    const registry = new ContextTokenCalibrationRegistry();
+    const meter = new ContextTokenMeter(registry);
+    const instructions = "i".repeat(400);
+    const scope = "prov\0mod";
+    const begin = (attemptId: string, messages: readonly ModelMessage[]) => {
+      const prompt = defaultModelPromptMeasurementProfile.measurePrompt({
+        instructions,
+        messages,
+      });
+      meter.begin({
+        attemptId,
+        fixedFingerprint: prompt.fixedFingerprint,
+        measurement: prompt,
+        scope,
+      });
+    };
+    const asciiTraining: readonly ModelMessage[] = [
+      { content: "a".repeat(372), role: "user" },
+    ];
+    const cjkTraining: readonly ModelMessage[] = [
+      ...asciiTraining,
+      { content: "日".repeat(372), role: "user" },
+    ];
+    const current: readonly ModelMessage[] = [
+      { content: "a".repeat(332), role: "user" },
+      { content: "a".repeat(332), role: "user" },
+      { content: "a".repeat(332), role: "user" },
+      {
+        content: [
+          {
+            output: { type: "text", value: "x".repeat(400) },
+            toolCallId: "call-1",
+            toolName: "read_file",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+      { content: "日".repeat(252), role: "user" },
+    ];
+    begin("train-ascii", asciiTraining);
+    meter.report("train-ascii", {
+      attemptId: "train-ascii",
+      inputTokens: 200,
+      type: "model-usage",
+    });
+    begin("train-cjk", cjkTraining);
+    meter.report("train-cjk", {
+      attemptId: "train-cjk",
+      inputTokens: 400,
+      type: "model-usage",
+    });
+    begin("current", current);
+
+    // When
+    const snapshot = meter.snapshot();
+    const upperBound = meter.inputUpperBound();
+
+    // Then
+    expect(snapshot.calibration.observations).toBe(2);
+    expect.soft(snapshot.currentRequest.input).toEqual({
+      basis: "calibrated",
+      marginTokens: 143,
+      tokens: 711,
+    });
+    expect.soft(upperBound).toBe(854);
+  });
+
+  it("keeps a repeated CJK prompt above its reported provider input", () => {
+    // Given
+    const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
+    const messages: readonly ModelMessage[] = [
+      { content: "日".repeat(372), role: "user" },
+    ];
+    const prompt = defaultModelPromptMeasurementProfile.measurePrompt({
+      instructions: "i".repeat(400),
+      messages,
+    });
+    meter.begin({
+      attemptId: "reported",
+      fixedFingerprint: prompt.fixedFingerprint,
+      measurement: prompt,
+      scope: "prov\0cjk-repeat",
+    });
+    meter.report("reported", {
+      attemptId: "reported",
+      inputTokens: 900,
+      type: "model-usage",
+    });
+    meter.begin({
+      attemptId: "repeat",
+      fixedFingerprint: prompt.fixedFingerprint,
+      measurement: prompt,
+      scope: "prov\0cjk-repeat",
+    });
+
+    // When
+    const upperBound = meter.inputUpperBound();
+
+    // Then
+    expect(upperBound).toBeGreaterThanOrEqual(900);
   });
 
   it("pins calibration values in an immutable view", () => {

--- a/packages/runtime/src/llm/prompt-measurement.ts
+++ b/packages/runtime/src/llm/prompt-measurement.ts
@@ -1,0 +1,179 @@
+import { asSchema, jsonSchema, type ModelMessage, type ToolSet } from "ai";
+import type { PreparedModelToolChoice } from "./model-step-preparation";
+
+export interface ModelContextTokenEstimateInput {
+  readonly instructions?: string;
+  readonly messages: readonly ModelMessage[];
+  readonly toolChoice?: PreparedModelToolChoice;
+  readonly tools?: readonly ModelPromptTool[];
+}
+
+export interface ModelPromptTool {
+  readonly args?: Readonly<Record<string, unknown>>;
+  readonly description?: string;
+  readonly id?: string;
+  readonly inputExamples?: readonly unknown[];
+  readonly inputSchema?: unknown;
+  readonly name: string;
+  readonly providerOptions?: Readonly<Record<string, unknown>>;
+  readonly strict?: boolean;
+  readonly type?: string;
+}
+
+/** Product-neutral units measured for one provider-visible model request. */
+export interface ModelPromptMeasurement {
+  /** Stable identity for fixed prompt content; used for safe marginal calibration. */
+  readonly fixedFingerprint: string;
+  /** Instructions, tool definitions, tool choice, and request framing. */
+  readonly fixedUnits: number;
+  /** Marginal cost aligned by index with the input messages. */
+  readonly messageUnits: readonly number[];
+  readonly totalUnits: number;
+}
+
+export interface ModelPromptMeasurementProfile {
+  readonly measureMessages: (
+    messages: readonly ModelMessage[]
+  ) => readonly number[];
+  readonly measurePrompt: (
+    input: ModelContextTokenEstimateInput
+  ) => ModelPromptMeasurement;
+}
+
+export const defaultModelPromptMeasurementProfile = Object.freeze({
+  measureMessages(messages: readonly ModelMessage[]) {
+    return messages.map((message) => countJsonUnits(message));
+  },
+  measurePrompt(input: ModelContextTokenEstimateInput) {
+    const messageUnits = measureDefaultMessageUnits(input.messages);
+    const toolChoice = providerPromptToolChoice(input.toolChoice);
+    const fixedUnits = countJsonUnits({
+      instructions: input.instructions,
+      toolChoice,
+      tools: input.tools,
+    });
+    return {
+      fixedFingerprint: JSON.stringify(
+        {
+          instructions: input.instructions,
+          toolChoice,
+          tools: input.tools,
+        },
+        promptTokenEstimateReplacer
+      ),
+      fixedUnits,
+      messageUnits,
+      totalUnits:
+        fixedUnits + messageUnits.reduce((sum, units) => sum + units, 0),
+    };
+  },
+}) satisfies ModelPromptMeasurementProfile;
+
+export function estimateModelMessagesTokens(
+  messages: readonly ModelMessage[]
+): number {
+  return Math.ceil(
+    JSON.stringify(messages, promptTokenEstimateReplacer).length / 4
+  );
+}
+
+function countJsonUnits(value: unknown): number {
+  return JSON.stringify(value, promptTokenEstimateReplacer).length / 4;
+}
+
+function measureDefaultMessageUnits(
+  messages: readonly ModelMessage[]
+): readonly number[] {
+  return messages.map((message) => countJsonUnits(message));
+}
+
+export async function modelPromptTools(
+  tools: ToolSet | undefined
+): Promise<readonly ModelPromptTool[] | undefined> {
+  return (await materializeModelPromptTools(tools)).promptTools;
+}
+
+export async function materializeModelPromptTools(
+  tools: ToolSet | undefined
+): Promise<{
+  readonly promptTools?: readonly ModelPromptTool[];
+  readonly tools?: ToolSet;
+}> {
+  if (!tools) {
+    return {};
+  }
+  const entries = await Promise.all(
+    Object.entries(tools).map(async ([name, tool]) => {
+      if (tool.type === "provider") {
+        return [
+          name,
+          tool,
+          { args: tool.args, id: tool.id, name, type: tool.type },
+        ] as const;
+      }
+      const description =
+        typeof tool.description === "function"
+          ? tool.description({
+              context: undefined,
+            })
+          : tool.description;
+      const schema = asSchema(tool.inputSchema);
+      const resolvedInputSchema = await schema.jsonSchema;
+      const promptTool = {
+        ...(description === undefined ? {} : { description }),
+        ...(tool.inputExamples === undefined
+          ? {}
+          : { inputExamples: tool.inputExamples }),
+        inputSchema: resolvedInputSchema,
+        name,
+        ...(tool.providerOptions === undefined
+          ? {}
+          : { providerOptions: tool.providerOptions }),
+        ...(tool.strict === undefined ? {} : { strict: tool.strict }),
+        type: "function",
+      };
+      return [
+        name,
+        {
+          ...tool,
+          ...(description === undefined ? {} : { description }),
+          inputSchema: jsonSchema(
+            resolvedInputSchema,
+            schema.validate ? { validate: schema.validate } : undefined
+          ),
+        },
+        promptTool,
+      ] as const;
+    })
+  );
+  return {
+    promptTools: entries.map((entry) => entry[2]),
+    tools: Object.fromEntries(entries.map(([name, tool]) => [name, tool])),
+  };
+}
+
+function providerPromptToolChoice(
+  toolChoice: PreparedModelToolChoice | undefined
+): unknown {
+  if (toolChoice === undefined) {
+    return { type: "auto" };
+  }
+  return typeof toolChoice === "string" ? { type: toolChoice } : toolChoice;
+}
+
+function promptTokenEstimateReplacer(_key: string, value: unknown): unknown {
+  if (ArrayBuffer.isView(value)) {
+    return binaryPromptTokenEstimate(value.byteLength);
+  }
+  if (value instanceof ArrayBuffer) {
+    return binaryPromptTokenEstimate(value.byteLength);
+  }
+  return value;
+}
+
+function binaryPromptTokenEstimate(byteLength: number): {
+  readonly byteLength: number;
+  readonly type: "binary";
+} {
+  return { byteLength, type: "binary" };
+}

--- a/packages/runtime/src/llm/prompt-measurement.ts
+++ b/packages/runtime/src/llm/prompt-measurement.ts
@@ -1,6 +1,8 @@
 import { asSchema, jsonSchema, type ModelMessage, type ToolSet } from "ai";
 import type { PreparedModelToolChoice } from "./model-step-preparation";
 
+const promptUnitEncoder = new TextEncoder();
+
 export interface ModelContextTokenEstimateInput {
   readonly instructions?: string;
   readonly messages: readonly ModelMessage[];
@@ -72,13 +74,16 @@ export const defaultModelPromptMeasurementProfile = Object.freeze({
 export function estimateModelMessagesTokens(
   messages: readonly ModelMessage[]
 ): number {
-  return Math.ceil(
-    JSON.stringify(messages, promptTokenEstimateReplacer).length / 4
-  );
+  return Math.ceil(serializedPromptUnits(messages));
 }
 
 function countJsonUnits(value: unknown): number {
-  return JSON.stringify(value, promptTokenEstimateReplacer).length / 4;
+  return serializedPromptUnits(value);
+}
+
+function serializedPromptUnits(value: unknown): number {
+  const json = JSON.stringify(value, promptTokenEstimateReplacer);
+  return promptUnitEncoder.encode(json).length / 4;
 }
 
 function measureDefaultMessageUnits(


### PR DESCRIPTION
## Summary

- measure serialized prompt text in UTF-8 bytes so CJK calibration does not inflate unrelated ASCII and tool-result estimates
- preserve ASCII estimates, conservative underestimation bounds, binary normalization, and calibration max-ratchet behavior
- split prompt measurement from context-gate enforcement without changing the public API

Closes #383

## Verification

- deterministic RED reproduced independently with the old mechanism: 2 failed / 25 passed, including inflated upper bound 1270 versus 854
- focused GREEN: 27/27
- five-file regression: 40/40
- runtime suite: 272 files, 1651 passed, 5 skipped
- runtime typecheck, build, API snapshot, root lint, Tegami validation, and changed-file LSP diagnostics: PASS
- built package QA resolved `@minpeter/pss-runtime` to `dist/index.js` and emitted `ISSUE_383_QA_PASS`; forced-negative control emitted no PASS token
- independent verifier verdict: unconditional APPROVE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CJK prompt token estimation so calibration no longer inflates ASCII and tool-result estimates, preventing valid prompts from being rejected.

- Prompt measurement now uses serialized UTF-8 byte length divided by 4 instead of UTF-16 code units; ASCII estimates stay identical and non-ASCII estimates only increase.
- Splits prompt measurement into `prompt-measurement.ts`, re-exported from `context-gate`, with no public API change.
- Closes #383.

<sup>Written for commit 5a88ac0902bbfb80ff43dccd2a8ec279d3a557c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

