### PR TITLE
feat(runtime): expose context gates and preserve compaction progress

### DIFF
--- a/.tegami/2026-08-31-context-gate-option.md
+++ b/.tegami/2026-08-31-context-gate-option.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Configure the context gate independently
+
+`createAgent` now accepts an explicit `contextGate` that takes whole-object precedence over compaction budget metadata without changing speculative compaction thresholds.

--- a/.tegami/2026-08-31-overflow-compaction-progress.md
+++ b/.tegami/2026-08-31-overflow-compaction-progress.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Advance overflow compaction past tool-heavy turns
+
+When backward range selection collapses inside a tool exchange, compaction now advances to the next valid boundary without weakening tool-exchange integrity.

--- a/.tegami/2026-08-31-stable-compaction-identity.md
+++ b/.tegami/2026-08-31-stable-compaction-identity.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Reuse speculative summaries across thread reconstruction
+
+Process-local speculative candidates now survive same-Agent thread reconstruction in a bounded cache while remaining isolated when a compaction policy is shared by multiple Agents.

--- a/.tegami/2026-09-03-detached-compaction-provenance.md
+++ b/.tegami/2026-09-03-detached-compaction-provenance.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Isolate detached compaction summaries
+
+Prevent summaries produced from transformed or unknown model context from becoming reusable by later standard-context compaction episodes.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1243,6 +1243,23 @@ over-budget turns without rewriting history. A bare function without budget
 properties runs with the local gate off and compaction reacts to
 provider-thrown context-window errors only.
 
+Use `contextGate` to enforce a budget with a custom compaction policy or no
+compaction at all. The explicit gate takes precedence as a whole object over
+budget properties carried by `compaction`; fields are never merged. It does not
+move `speculativeCompaction`'s prepare or promote thresholds, which remain
+scaled to that policy's own budget:
+
+```ts
+const agent = await createAgent({
+  contextGate: {
+    bufferTokens: 8_000,
+    maxInputTokens: () => 200_000,
+    onOverflow: "error",
+  },
+  model,
+});
+```
+
 Force runtime-owned compaction on an idle thread with `thread.compact()`. The
 manual path shares automatic compaction's attachment hydration, model-context
 transforms, prior-summary handling, hooks, single-flight, and freshness checks.
@@ -1262,7 +1279,7 @@ race from empty history. It inherits the configured compaction policy's
 validated summary and returns the hook dispatcher's boolean commit decision.
 
 The context gate estimates the prompt immediately before `generateText`, calling
-the compaction's `maxInputTokens` property on every request. With `onOverflow: "error"`,
+the resolved gate's `maxInputTokens()` on every request. With `onOverflow: "error"`,
 the turn fails before the provider is called. With `onOverflow: "compact"` (the
 default), the runtime runs blocking compaction and retries once.
 Provider-thrown context-window errors still use the same blocking

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1193,6 +1193,10 @@ For store/alarm-only DO tooling use `createDurableObjectStorageHost` from
 `@minpeter/pss-runtime/platform/durable-object`.
 
 Speculative compaction prepares a summary in the background before promoting it.
+Prepared candidates are process-local and bounded to 32 entries per policy. A
+candidate is reused when the same Agent reconstructs a thread handle, while a
+policy shared by multiple Agents keeps each owner's candidates isolated. A new
+Agent or process starts cold; speculative candidates are not persisted.
 Each episode has one absolute pre-commit deadline:
 `DEFAULT_COMPACTION_DEADLINE_MS` (15 seconds), unless the policy supplies
 `deadlineMs`. The deadline covers preparation, summaries, retries, transforms,

--- a/packages/runtime/src/agent/core/agent-model-options.ts
+++ b/packages/runtime/src/agent/core/agent-model-options.ts
@@ -1,0 +1,30 @@
+import type { AgentHost } from "../../execution/host/types";
+import type { AgentModelOptions, AgentOptions } from "./options";
+
+export function createAgentModelOptions(
+  options: AgentOptions,
+  host: AgentHost
+): AgentModelOptions {
+  return {
+    alwaysActiveTools: options.alwaysActiveTools,
+    attachmentStore:
+      options.host?.attachmentStore ??
+      options.attachmentStore ??
+      host.attachmentStore,
+    contextGate:
+      options.contextGate ??
+      (options.compaction?.maxInputTokens
+        ? {
+            ...options.compaction,
+            maxInputTokens: options.compaction.maxInputTokens,
+          }
+        : false),
+    diagnostics: host.diagnostics,
+    instructions: options.instructions,
+    model: options.model,
+    prepareModelStep: options.prepareModelStep,
+    toolChoice: options.toolChoice,
+    toolOrder: options.toolOrder,
+    tools: options.tools,
+  };
+}

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -15,6 +15,7 @@ import {
 import type { ThreadStore } from "../../thread/store/types";
 import { stableAgentNamespace } from "../identity/namespace";
 import { type ClaimedTurnRecord, resumeAgentTurn } from "../resume/resume";
+import { createAgentModelOptions } from "./agent-model-options";
 import { AgentHookRuntime } from "./hook-runtime";
 import { threadStoreForHost } from "./host-thread-store";
 import {
@@ -94,26 +95,7 @@ export class Agent {
     this.#notificationOverlays = validatedOptions.notificationOverlays;
     this.#compaction = validatedOptions.compaction;
     this.#contextTokens = validatedOptions.contextTokens;
-    this.#modelOptions = {
-      alwaysActiveTools: validatedOptions.alwaysActiveTools,
-      attachmentStore:
-        providedHost?.attachmentStore ??
-        validatedOptions.attachmentStore ??
-        this.#host.attachmentStore,
-      contextGate: validatedOptions.compaction?.maxInputTokens
-        ? {
-            ...validatedOptions.compaction,
-            maxInputTokens: validatedOptions.compaction.maxInputTokens,
-          }
-        : false,
-      diagnostics: this.#host.diagnostics,
-      instructions: validatedOptions.instructions,
-      model: validatedOptions.model,
-      prepareModelStep: validatedOptions.prepareModelStep,
-      toolChoice: validatedOptions.toolChoice,
-      toolOrder: validatedOptions.toolOrder,
-      tools: validatedOptions.tools,
-    };
+    this.#modelOptions = createAgentModelOptions(validatedOptions, this.#host);
   }
 
   /**

--- a/packages/runtime/src/agent/core/agent.ts
+++ b/packages/runtime/src/agent/core/agent.ts
@@ -61,6 +61,7 @@ export type AgentConstructorOptions = AgentOptions;
 
 export class Agent {
   readonly #modelOptions: AgentModelOptions;
+  readonly #compactionOwner = Object.freeze({});
   readonly #threads = new Map<string, AgentThreadEntry>();
   readonly #contextTokenRegistry = new ContextTokenCalibrationRegistry();
   readonly #contextTokens?: AgentOptions["contextTokens"];
@@ -181,7 +182,12 @@ export class Agent {
         ),
         contextTokens: this.#contextTokens,
       },
-      { key, migrations: this.#threadMigrations, store: this.#store },
+      {
+        compactionOwner: this.#compactionOwner,
+        key,
+        migrations: this.#threadMigrations,
+        store: this.#store,
+      },
       {
         compaction: this.#compaction,
         executionHost: this.#host,

--- a/packages/runtime/src/agent/core/options-context-gate-validation.ts
+++ b/packages/runtime/src/agent/core/options-context-gate-validation.ts
@@ -1,0 +1,56 @@
+import type { ContextBudgetSource } from "../../llm/context-gate";
+
+export function snapshotAgentContextGate(
+  contextGate: unknown
+): ContextBudgetSource {
+  if (typeof contextGate !== "object" || contextGate === null) {
+    throw new TypeError("Agent: options.contextGate must be an object.");
+  }
+
+  const bufferTokens: unknown = Reflect.get(contextGate, "bufferTokens");
+  const estimateTokens: unknown = Reflect.get(contextGate, "estimateTokens");
+  const maxInputTokens: unknown = Reflect.get(contextGate, "maxInputTokens");
+  const onOverflow: unknown = Reflect.get(contextGate, "onOverflow");
+
+  if (typeof maxInputTokens !== "function") {
+    throw new TypeError(
+      "Agent: options.contextGate.maxInputTokens must be a function."
+    );
+  }
+  if (estimateTokens !== undefined && typeof estimateTokens !== "function") {
+    throw new TypeError(
+      "Agent: options.contextGate.estimateTokens must be a function."
+    );
+  }
+  if (
+    bufferTokens !== undefined &&
+    !(
+      typeof bufferTokens === "number" &&
+      Number.isSafeInteger(bufferTokens) &&
+      bufferTokens >= 0
+    )
+  ) {
+    throw new TypeError(
+      "Agent: options.contextGate.bufferTokens must be a non-negative integer."
+    );
+  }
+  if (
+    onOverflow !== undefined &&
+    onOverflow !== "compact" &&
+    onOverflow !== "error"
+  ) {
+    throw new TypeError(
+      'Agent: options.contextGate.onOverflow must be "compact" or "error".'
+    );
+  }
+
+  const snapshot: ContextBudgetSource = {
+    ...(bufferTokens === undefined ? {} : { bufferTokens }),
+    ...(estimateTokens === undefined
+      ? {}
+      : { estimateTokens: (input) => estimateTokens(input) }),
+    maxInputTokens: () => maxInputTokens(),
+    ...(onOverflow === undefined ? {} : { onOverflow }),
+  };
+  return Object.freeze(snapshot);
+}

--- a/packages/runtime/src/agent/core/options-context-gate.test.ts
+++ b/packages/runtime/src/agent/core/options-context-gate.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { ContextBudgetSource } from "../../llm/context-gate";
+import { createCallbackModel } from "../../testing/test-fixtures";
+import { Agent, createAgent } from "./agent";
+import { assertAgentOptions } from "./options";
+
+const model = () => createCallbackModel(() => []);
+const expectInvalid = (contextGate: unknown, message: string): void => {
+  expect(() => assertAgentOptions({ contextGate, model: model() })).toThrow(
+    message
+  );
+};
+
+describe("AgentOptions.contextGate", () => {
+  it("rejects a non-function maxInputTokens", () => {
+    expectInvalid(
+      { maxInputTokens: 1 },
+      "Agent: options.contextGate.maxInputTokens must be a function."
+    );
+  });
+
+  it("requires maxInputTokens", () => {
+    expectInvalid(
+      {},
+      "Agent: options.contextGate.maxInputTokens must be a function."
+    );
+  });
+
+  it("rejects a function gate", () => {
+    expectInvalid(() => 1, "Agent: options.contextGate must be an object.");
+  });
+
+  it("rejects a non-function estimateTokens", () => {
+    expectInvalid(
+      { estimateTokens: 5, maxInputTokens: (): number => 1 },
+      "Agent: options.contextGate.estimateTokens must be a function."
+    );
+  });
+
+  it("rejects a negative bufferTokens", () => {
+    expectInvalid(
+      { bufferTokens: -1, maxInputTokens: (): number => 1 },
+      "Agent: options.contextGate.bufferTokens must be a non-negative integer."
+    );
+  });
+
+  it("rejects a fractional bufferTokens", () => {
+    expectInvalid(
+      { bufferTokens: 1.5, maxInputTokens: (): number => 1 },
+      "Agent: options.contextGate.bufferTokens must be a non-negative integer."
+    );
+  });
+
+  it("rejects an invalid onOverflow", () => {
+    expectInvalid(
+      { maxInputTokens: (): number => 1, onOverflow: "retry" },
+      'Agent: options.contextGate.onOverflow must be "compact" or "error".'
+    );
+  });
+
+  it("accepts all supported budget properties", () => {
+    expect(() =>
+      assertAgentOptions({
+        contextGate: {
+          bufferTokens: 0,
+          estimateTokens: () => 1,
+          maxInputTokens: () => 1,
+          onOverflow: "error",
+        },
+        model: model(),
+      })
+    ).not.toThrow();
+  });
+
+  it("reads nested contextGate capabilities once in Agent", () => {
+    const contextGate: ContextBudgetSource = { maxInputTokens: () => 1 };
+    let reads = 0;
+    Object.defineProperty(contextGate, "maxInputTokens", {
+      enumerable: true,
+      get: () => {
+        reads += 1;
+        if (reads > 1) {
+          throw new Error("NESTED_SECRET_SENTINEL");
+        }
+        return () => 100;
+      },
+    });
+
+    expect(() => new Agent({ contextGate, model: model() })).not.toThrow();
+    expect(reads).toBe(1);
+  });
+
+  it("reads nested contextGate capabilities once in createAgent", async () => {
+    const contextGate: ContextBudgetSource = { maxInputTokens: () => 1 };
+    let reads = 0;
+    Object.defineProperty(contextGate, "maxInputTokens", {
+      enumerable: true,
+      get: () => {
+        reads += 1;
+        if (reads > 1) {
+          throw new Error("NESTED_SECRET_SENTINEL");
+        }
+        return () => 100;
+      },
+    });
+
+    await expect(
+      createAgent({ contextGate, model: model() })
+    ).resolves.toBeInstanceOf(Agent);
+    expect(reads).toBe(1);
+  });
+});

--- a/packages/runtime/src/agent/core/options.ts
+++ b/packages/runtime/src/agent/core/options.ts
@@ -21,12 +21,14 @@ import {
   type AgentInstrumentation,
   normalizeAgentInstrumentations,
 } from "./instrumentation";
+import { snapshotAgentContextGate } from "./options-context-gate-validation";
 import { assertThreadStateMigrationList } from "./options-thread-migration-validation";
 
 export interface AgentOptions {
   readonly alwaysActiveTools?: readonly string[];
   readonly attachmentStore?: HostAttachmentStore;
   readonly compaction?: AgentCompaction;
+  readonly contextGate?: ContextBudgetSource;
   readonly contextTokens?: ContextTokenOptions;
   readonly hooks?: AgentHooks;
   readonly host?: AgentHost;
@@ -85,6 +87,7 @@ export function assertAgentOptions(
   const toolOrder: unknown = Reflect.get(options, "toolOrder");
   const prepareModelStep: unknown = Reflect.get(options, "prepareModelStep");
   const compaction: unknown = Reflect.get(options, "compaction");
+  const contextGate: unknown = Reflect.get(options, "contextGate");
   const instrumentations: unknown = Reflect.get(options, "instrumentations");
   const threadMigrations: unknown = Reflect.get(options, "threadMigrations");
 
@@ -100,6 +103,9 @@ export function assertAgentOptions(
   if (compaction !== undefined) {
     snapshotAgentCompaction(compaction);
   }
+  if (contextGate !== undefined) {
+    snapshotAgentContextGate(contextGate);
+  }
   normalizeAgentInstrumentations(instrumentations);
   assertThreadStateMigrationList(threadMigrations);
   normalizeThreadStateMigrations(threadMigrations);
@@ -113,6 +119,7 @@ export function snapshotAgentOptions(options: AgentOptions): AgentOptions {
     throw new TypeError("Agent options must be a non-null object.");
   }
   const compaction: unknown = options.compaction;
+  const contextGate: unknown = options.contextGate;
   const tools: unknown = options.tools;
   const snapshot: AgentOptions = {
     alwaysActiveTools: options.alwaysActiveTools,
@@ -121,6 +128,10 @@ export function snapshotAgentOptions(options: AgentOptions): AgentOptions {
       compaction === undefined
         ? undefined
         : snapshotAgentCompaction(compaction),
+    contextGate:
+      contextGate === undefined
+        ? undefined
+        : snapshotAgentContextGate(contextGate),
     contextTokens: options.contextTokens,
     hooks: options.hooks,
     host: options.host,

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -26,6 +26,7 @@ import type {
   AgentOptions,
   CompactionContextMessage,
   CompactionSummaryOptions,
+  ContextBudgetSource,
   HostAttachmentStore,
   ModelToolCacheFingerprintMetadata,
   PrepareModelStep,
@@ -183,9 +184,11 @@ describe("runtime public exports", () => {
         return turn;
       },
     } satisfies AgentInstrumentation;
+    const contextGate = { maxInputTokens: () => 128_000 };
     const enabledOptions = {
       attachmentStore,
       compaction,
+      contextGate,
       instrumentations: [instrumentation],
       model,
       notificationOverlays: ["runtime context"],
@@ -230,7 +233,11 @@ describe("runtime public exports", () => {
       ReturnType<typeof runtimeThreadStoreKey>
     >().toEqualTypeOf<string>();
     expect(enabledOptions.compaction).toBe(compaction);
+    expect(enabledOptions.contextGate).toBe(contextGate);
     expect(enabledOptions.attachmentStore).toBe(attachmentStore);
+    expectTypeOf<
+      NonNullable<AgentOptions["contextGate"]>
+    >().toEqualTypeOf<ContextBudgetSource>();
     expect(enabledOptions.instrumentations).toEqual([instrumentation]);
     expect(enabledOptions.notificationOverlays).toEqual(["runtime context"]);
     expect(compactionInput.startSeq).toBe(0);

--- a/packages/runtime/src/testing/model-fixtures.ts
+++ b/packages/runtime/src/testing/model-fixtures.ts
@@ -52,7 +52,8 @@ export const createScriptedModel = (
   outputs: readonly ModelStepOutput[]
 ): LanguageModel => createScriptedModelOptions(outputs).model;
 
-export interface ScriptedModelOptions extends ModelGenerationOptions {
+export interface ScriptedModelOptions
+  extends Omit<ModelGenerationOptions, "contextGate"> {
   readonly model: MockLanguageModelV4;
 }
 

--- a/packages/runtime/src/thread/handle/automatic-compaction-resilience.test.ts
+++ b/packages/runtime/src/thread/handle/automatic-compaction-resilience.test.ts
@@ -25,8 +25,10 @@ describe("Agent thread automatic compaction resilience", () => {
     const model = createScriptedModelOptions([
       [assistantMessage([toolCall]), toolResultFor(toolCall)],
       [assistantMessage("tool turn complete")],
-      [assistantMessage("follow-up complete")],
+      // First-compaction forward progress prepares immediately after the tool turn,
+      // so its summary response deliberately precedes the next user-turn response.
       [assistantMessage("tool turn summarized")],
+      [assistantMessage("follow-up complete")],
       [assistantMessage("after summary complete")],
     ]);
     const agent = agentWithCompaction({

--- a/packages/runtime/src/thread/handle/context-gate-option.test.ts
+++ b/packages/runtime/src/thread/handle/context-gate-option.test.ts
@@ -1,0 +1,127 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { hostWithThreads } from "../../testing/host-with-threads";
+import {
+  assistantMessage,
+  createCallbackModel,
+} from "../../testing/test-fixtures";
+import type { AgentCompactionReason } from "../runtime/auto-compaction-types";
+import { agentWithCompaction } from "./automatic-compaction.test-support";
+import { collect, SpyStore } from "./test-support";
+
+const oversizedText = "x".repeat(400);
+
+describe("Agent contextGate option", () => {
+  it("uses the explicit gate as a whole object instead of compaction metadata", async () => {
+    const seenReasons: AgentCompactionReason[] = [];
+    const compactionMax = vi.fn(() => 64);
+    const compaction = Object.assign(
+      (context: { readonly reason: AgentCompactionReason }) => {
+        if (context.reason !== "overflow") {
+          return;
+        }
+        seenReasons.push(context.reason);
+        return { endSeqExclusive: 1, startSeq: 0, summary: "S" };
+      },
+      { maxInputTokens: compactionMax, onOverflow: "compact" as const }
+    );
+    let calls = 0;
+    const agent = agentWithCompaction({
+      compaction,
+      contextGate: { maxInputTokens: () => 100_000 },
+      host: hostWithThreads(new SpyStore()),
+      model: createCallbackModel(() => {
+        calls += 1;
+        return [assistantMessage("DONE")];
+      }),
+    });
+
+    const events = await collect(
+      await agent.thread("explicit").send(oversizedText)
+    );
+
+    expect(events).toContainEqual({ text: "DONE", type: "assistant-output" });
+    expect(seenReasons).toEqual([]);
+    expect(calls).toBe(1);
+    expect(compactionMax).not.toHaveBeenCalled();
+  });
+
+  it("admits input beyond the compaction budget without replacing history", async () => {
+    const input = "y".repeat(600_000);
+    const histories: ModelMessage[][] = [];
+    let calls = 0;
+    const agent = agentWithCompaction({
+      compaction: Object.assign((): undefined => undefined, {
+        maxInputTokens: () => 128_000,
+        onOverflow: "compact" as const,
+      }),
+      contextGate: { maxInputTokens: () => 200_000 },
+      host: hostWithThreads(new SpyStore()),
+      model: createCallbackModel(({ history }) => {
+        calls += 1;
+        histories.push([...history]);
+        return [assistantMessage("DONE")];
+      }),
+    });
+
+    const events = await collect(await agent.thread("large").send(input));
+
+    expect(events).toContainEqual({ text: "DONE", type: "assistant-output" });
+    expect(calls).toBe(1);
+    expect(
+      histories.some((history) => JSON.stringify(history).includes(input))
+    ).toBe(true);
+  });
+
+  it("enforces an explicit gate without compaction", async () => {
+    let calls = 0;
+    const agent = agentWithCompaction({
+      contextGate: { maxInputTokens: () => 64, onOverflow: "error" },
+      host: hostWithThreads(new SpyStore()),
+      model: createCallbackModel(() => {
+        calls += 1;
+        return [assistantMessage("DONE")];
+      }),
+    });
+
+    const events = await collect(
+      await agent.thread("gate-only").send(oversizedText)
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        error: { category: "unknown", version: 1 },
+        type: "turn-error",
+      })
+    );
+    expect(calls).toBe(0);
+  });
+
+  it("preserves compaction budget fallback when no explicit gate exists", async () => {
+    const seenReasons: AgentCompactionReason[] = [];
+    let calls = 0;
+    const compaction = Object.assign(
+      (context: { readonly reason: AgentCompactionReason }) => {
+        if (context.reason !== "overflow") {
+          return;
+        }
+        seenReasons.push(context.reason);
+        return { endSeqExclusive: 1, startSeq: 0, summary: "S" };
+      },
+      { maxInputTokens: () => 64, onOverflow: "compact" as const }
+    );
+    const agent = agentWithCompaction({
+      compaction,
+      host: hostWithThreads(new SpyStore()),
+      model: createCallbackModel(() => {
+        calls += 1;
+        return [assistantMessage("DONE")];
+      }),
+    });
+
+    await collect(await agent.thread("fallback").send(oversizedText));
+
+    expect(seenReasons).toEqual(["overflow"]);
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/runtime/src/thread/runtime/auto-compaction-range-progress.test.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-range-progress.test.ts
@@ -1,0 +1,243 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import type { ThreadCompactionRecord } from "../state/snapshot";
+import { selectAutoCompactionRange } from "./auto-compaction-range";
+
+const userMessage = (text: string): ModelMessage => ({
+  content: text,
+  role: "user",
+});
+
+const assistantMessage = (text: string): ModelMessage => ({
+  content: text,
+  role: "assistant",
+});
+
+const assistantToolCallMessage = (toolCallId: string): ModelMessage => ({
+  content: [
+    {
+      input: { query: "old" },
+      toolCallId,
+      toolName: "lookup",
+      type: "tool-call",
+    },
+  ],
+  role: "assistant",
+});
+
+const toolResultMessage = (toolCallId: string): ModelMessage => ({
+  content: [
+    {
+      output: { type: "text", value: "result" },
+      toolCallId,
+      toolName: "lookup",
+      type: "tool-result",
+    },
+  ],
+  role: "tool",
+});
+
+const compactionRecord = (
+  endSeqExclusive: number,
+  summary = "old"
+): ThreadCompactionRecord => ({
+  endSeqExclusive,
+  schemaVersion: 1,
+  startSeq: 0,
+  summary: { content: summary, role: "system" },
+});
+
+const tenTokensPerMessage = (messages: readonly ModelMessage[]): number =>
+  messages.length * 10;
+
+const historyWithToolExchange = (): readonly ModelMessage[] => [
+  userMessage("u0"),
+  assistantMessage("a1"),
+  userMessage("u2"),
+  assistantToolCallMessage("call-1"),
+  toolResultMessage("call-1"),
+  assistantMessage("a5"),
+  userMessage("u6"),
+  assistantMessage("a7"),
+];
+
+describe("selectAutoCompactionRange forward progress", () => {
+  it("advances to the next safe boundary when backward selection collapses", () => {
+    // Given: a covered prefix followed by a tool exchange around the target.
+    const history = historyWithToolExchange();
+
+    // When: selecting a range whose backward candidates are unsafe.
+    const range = selectAutoCompactionRange({
+      compactions: [compactionRecord(2)],
+      history,
+      policy: {
+        estimateTokens: tenTokensPerMessage,
+        retainTokens: 30,
+        triggerTokens: 1,
+      },
+    });
+
+    // Then: selection advances past the complete tool exchange.
+    expect(range).toEqual({ endSeqExclusive: 6, startSeq: 0 });
+  });
+
+  it("keeps chained tool exchanges whole when advancing", () => {
+    // Given: two chained exchanges followed by a terminal assistant response.
+    const history = [
+      userMessage("u0"),
+      assistantMessage("a1"),
+      userMessage("u2"),
+      assistantToolCallMessage("call-a"),
+      toolResultMessage("call-a"),
+      assistantToolCallMessage("call-b"),
+      toolResultMessage("call-b"),
+      assistantMessage("a7"),
+      userMessage("u8"),
+      assistantMessage("a9"),
+    ];
+
+    // When: the target lands inside the chained exchanges.
+    const range = selectAutoCompactionRange({
+      compactions: [compactionRecord(2)],
+      history,
+      policy: {
+        estimateTokens: tenTokensPerMessage,
+        retainTokens: 30,
+        triggerTokens: 1,
+      },
+    });
+
+    // Then: both exchanges are included through the terminal assistant.
+    expect(range).toEqual({ endSeqExclusive: 8, startSeq: 0 });
+  });
+
+  it("prefers a safe backward boundary when one exists", () => {
+    // Given: a safe boundary before a tool exchange.
+    const history = [
+      userMessage("u0"),
+      assistantMessage("a1"),
+      userMessage("u2"),
+      assistantToolCallMessage("call-1"),
+      toolResultMessage("call-1"),
+      userMessage("u5"),
+      assistantMessage("a6"),
+      userMessage("u7"),
+      assistantMessage("a8"),
+    ];
+
+    // When: the target lands after that safe boundary.
+    const range = selectAutoCompactionRange({
+      compactions: [],
+      history,
+      policy: {
+        estimateTokens: tenTokensPerMessage,
+        retainTokens: 30,
+        triggerTokens: 1,
+      },
+    });
+
+    // Then: the existing backward preference is preserved.
+    expect(range).toEqual({ endSeqExclusive: 2, startSeq: 0 });
+  });
+
+  it("does not recompact when the target equals the covered prefix", () => {
+    // Given: only a covered summary and the requested tail remain.
+    const history = historyWithToolExchange();
+
+    // When: selection targets no messages beyond the covered prefix.
+    const range = selectAutoCompactionRange({
+      compactions: [compactionRecord(6)],
+      history,
+      policy: {
+        estimateTokens: tenTokensPerMessage,
+        retainTokens: 20,
+        triggerTokens: 1,
+      },
+    });
+
+    // Then: no redundant compaction is selected.
+    expect(range).toBeUndefined();
+  });
+
+  it("returns undefined when no later terminal boundary exists", () => {
+    // Given: history ending in a tool result without a terminal assistant.
+    const history = [
+      userMessage("u0"),
+      assistantMessage("a1"),
+      userMessage("u2"),
+      assistantToolCallMessage("call-1"),
+      toolResultMessage("call-1"),
+    ];
+
+    // When: backward selection collapses inside the tool exchange.
+    const range = selectAutoCompactionRange({
+      compactions: [compactionRecord(2)],
+      history,
+      policy: {
+        estimateTokens: tenTokensPerMessage,
+        retainTokens: 10,
+        triggerTokens: 1,
+      },
+    });
+
+    // Then: validity wins over forced progress.
+    expect(range).toBeUndefined();
+  });
+
+  it("accepts a safe boundary at the end of history", () => {
+    // Given: a tool exchange ending in a terminal assistant at history end.
+    const history = [
+      userMessage("u0"),
+      assistantMessage("a1"),
+      userMessage("u2"),
+      assistantToolCallMessage("call-1"),
+      toolResultMessage("call-1"),
+      assistantMessage("a5"),
+    ];
+
+    // When: the first later safe boundary is history.length.
+    const range = selectAutoCompactionRange({
+      compactions: [compactionRecord(2)],
+      history,
+      policy: {
+        estimateTokens: tenTokensPerMessage,
+        retainTokens: 10,
+        triggerTokens: 1,
+      },
+    });
+
+    // Then: the inclusive scan accepts the end boundary.
+    expect(range).toEqual({ endSeqExclusive: 6, startSeq: 0 });
+  });
+
+  it("keeps the compressibility floor after advancing", () => {
+    // Given: a tiny source whose only safe boundary is after a tool exchange.
+    const history = [
+      userMessage("u"),
+      assistantToolCallMessage("call-1"),
+      toolResultMessage("call-1"),
+      assistantMessage("a"),
+    ];
+    const contentLengthEstimator = (messages: readonly ModelMessage[]) =>
+      messages.reduce(
+        (total, message) =>
+          total +
+          (typeof message.content === "string" ? message.content.length : 0),
+        0
+      );
+
+    // When: forward selection finds the end-of-history boundary.
+    const range = selectAutoCompactionRange({
+      compactions: [],
+      history,
+      policy: {
+        estimateTokens: contentLengthEstimator,
+        retainTokens: 20,
+        triggerTokens: 1,
+      },
+    });
+
+    // Then: the source remains rejected as smaller than its wrapper.
+    expect(range).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/thread/runtime/auto-compaction-range-progress.test.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-range-progress.test.ts
@@ -62,6 +62,34 @@ const historyWithToolExchange = (): readonly ModelMessage[] => [
 ];
 
 describe("selectAutoCompactionRange forward progress", () => {
+  it("advances on a first compaction when backward selection collapses", () => {
+    // Given: no covered prefix and a tool-heavy history with no safe boundary before the target.
+    const history = [
+      userMessage("u0"),
+      assistantToolCallMessage("call-1"),
+      toolResultMessage("call-1"),
+      assistantToolCallMessage("call-2"),
+      toolResultMessage("call-2"),
+      assistantMessage("a5"),
+      userMessage("u6"),
+      assistantMessage("a7"),
+    ];
+
+    // When: the first compaction target lands inside the tool-heavy prefix.
+    const range = selectAutoCompactionRange({
+      compactions: [],
+      history,
+      policy: {
+        estimateTokens: tenTokensPerMessage,
+        retainTokens: 30,
+        triggerTokens: 1,
+      },
+    });
+
+    // Then: selection advances to the first safe boundary after the complete exchanges.
+    expect(range).toEqual({ endSeqExclusive: 6, startSeq: 0 });
+  });
+
   it("advances to the next safe boundary when backward selection collapses", () => {
     // Given: a covered prefix followed by a tool exchange around the target.
     const history = historyWithToolExchange();
@@ -211,28 +239,35 @@ describe("selectAutoCompactionRange forward progress", () => {
   });
 
   it("keeps the compressibility floor after advancing", () => {
-    // Given: a tiny source whose only safe boundary is after a tool exchange.
+    // Given: a covered prefix and a tiny source whose next safe boundary follows a tool exchange.
     const history = [
-      userMessage("u"),
+      userMessage("u0"),
+      assistantMessage("a1"),
+      userMessage("u2"),
       assistantToolCallMessage("call-1"),
       toolResultMessage("call-1"),
-      assistantMessage("a"),
+      assistantMessage("a5"),
+      userMessage("u6"),
+      assistantMessage("a7"),
     ];
-    const contentLengthEstimator = (messages: readonly ModelMessage[]) =>
+    const floorDecidingEstimator = (messages: readonly ModelMessage[]) =>
       messages.reduce(
         (total, message) =>
           total +
-          (typeof message.content === "string" ? message.content.length : 0),
+          (typeof message.content === "string" &&
+          message.content.includes("<summary>\n\n</summary>")
+            ? 10
+            : 1),
         0
       );
 
-    // When: forward selection finds the end-of-history boundary.
+    // When: backward selection collapses and forward selection finds boundary 6.
     const range = selectAutoCompactionRange({
-      compactions: [],
+      compactions: [compactionRecord(2, "old")],
       history,
       policy: {
-        estimateTokens: contentLengthEstimator,
-        retainTokens: 20,
+        estimateTokens: floorDecidingEstimator,
+        retainTokens: 3,
         triggerTokens: 1,
       },
     });

--- a/packages/runtime/src/thread/runtime/auto-compaction-range.test.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-range.test.ts
@@ -258,7 +258,7 @@ describe("selectAutoCompactionRange", () => {
     ).toBeUndefined();
   });
 
-  it("returns undefined when the safe boundary collapses onto the covered prefix", () => {
+  it("advances past the covered prefix when the backward boundary collapses", () => {
     const history = [
       userMessage("u0"),
       assistantMessage("a1"),
@@ -274,7 +274,7 @@ describe("selectAutoCompactionRange", () => {
         history,
         policy: policy({ retainTokens: 10, triggerTokens: 30 }),
       })
-    ).toBeUndefined();
+    ).toEqual({ endSeqExclusive: 6, startSeq: 0 });
   });
 
   it("counts static instruction tokens toward the trigger", () => {

--- a/packages/runtime/src/thread/runtime/auto-compaction-range.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-range.ts
@@ -131,9 +131,6 @@ function selectSafeCompactionBoundary(
   if (end > coveredEnd) {
     return end;
   }
-  if (coveredEnd === 0) {
-    return;
-  }
   for (end = targetEnd + 1; end <= history.length; end += 1) {
     if (isSafeCompactionBoundary(history, end)) {
       return end;

--- a/packages/runtime/src/thread/runtime/auto-compaction-range.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-range.ts
@@ -71,15 +71,17 @@ export function selectAutoCompactionRange({
     tailStart -= 1;
   }
 
-  let endSeqExclusive = coveredEnd + tailStart;
-  while (
-    endSeqExclusive > coveredEnd &&
-    !isSafeCompactionBoundary(history, endSeqExclusive)
-  ) {
-    endSeqExclusive -= 1;
+  const targetEndSeqExclusive = coveredEnd + tailStart;
+  if (targetEndSeqExclusive <= coveredEnd) {
+    return;
   }
 
-  if (endSeqExclusive <= coveredEnd) {
+  const endSeqExclusive = selectSafeCompactionBoundary(
+    history,
+    coveredEnd,
+    targetEndSeqExclusive
+  );
+  if (endSeqExclusive === undefined) {
     return;
   }
 
@@ -112,6 +114,29 @@ export function latestPrefixCompaction(
     const record = compactions[index];
     if (record?.startSeq === 0) {
       return record;
+    }
+  }
+  return;
+}
+
+function selectSafeCompactionBoundary(
+  history: readonly ModelMessage[],
+  coveredEnd: number,
+  targetEnd: number
+): number | undefined {
+  let end = targetEnd;
+  while (end > coveredEnd && !isSafeCompactionBoundary(history, end)) {
+    end -= 1;
+  }
+  if (end > coveredEnd) {
+    return end;
+  }
+  if (coveredEnd === 0) {
+    return;
+  }
+  for (end = targetEnd + 1; end <= history.length; end += 1) {
+    if (isSafeCompactionBoundary(history, end)) {
+      return end;
     }
   }
   return;

--- a/packages/runtime/src/thread/runtime/compaction-thread-identity.ts
+++ b/packages/runtime/src/thread/runtime/compaction-thread-identity.ts
@@ -1,0 +1,28 @@
+export interface CompactionThreadIdentityParts {
+  readonly owner: Readonly<object>;
+  readonly threadKey: string;
+}
+
+const identityParts = new WeakMap<
+  Readonly<object>,
+  CompactionThreadIdentityParts
+>();
+
+export function createCompactionThreadIdentity(
+  owner: Readonly<object>,
+  threadKey: string
+): Readonly<object> {
+  const identity = Object.freeze({});
+  identityParts.set(identity, Object.freeze({ owner, threadKey }));
+  return identity;
+}
+
+export function compactionThreadIdentityParts(
+  identity: Readonly<object>
+): CompactionThreadIdentityParts {
+  const parts = identityParts.get(identity);
+  if (parts === undefined) {
+    throw new TypeError("Unknown runtime compaction thread identity.");
+  }
+  return parts;
+}

--- a/packages/runtime/src/thread/runtime/speculative-candidate-cache.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-candidate-cache.test.ts
@@ -88,25 +88,42 @@ describe("SpeculativeCandidateCache", () => {
     expect(cache.get(key)?.value).toBe("current");
   });
 
-  it("counts installed candidates and pending reservations in one bound", () => {
-    // Given: 31 installed candidates followed by one unresolved reservation.
+  it("hard-caps installed candidates plus pending reservations", () => {
+    // Given: every cache slot has an installed candidate.
     const cache = new SpeculativeCandidateCache<Candidate>();
-    for (
-      let index = 0;
-      index < SPECULATIVE_CANDIDATE_CACHE_MAX - 1;
-      index += 1
-    ) {
-      install(cache, String(index), String(index));
+    const keys = Array.from(
+      { length: SPECULATIVE_CANDIDATE_CACHE_MAX },
+      (_, index) => String(index)
+    );
+    for (const key of keys) {
+      install(cache, key, key);
     }
-    const pending = cache.reserve(identity("pending"));
 
-    // When: one more candidate consumes the 33rd aggregate slot.
-    install(cache, "overflow", "overflow");
+    // When: replacement work reserves once against every installed candidate.
+    const evictions = keys.map(() => vi.fn());
+    const pending = keys.map((key, index) =>
+      cache.reserve(identity(key), evictions[index])
+    );
 
-    // Then: the installed LRU is evicted and the unresolved slot remains counted.
-    expect(cache.get(identity("0"))).toBeUndefined();
-    expect(cache.size).toBe(SPECULATIVE_CANDIDATE_CACHE_MAX);
-    cache.release(pending);
+    // Then: LRU eviction keeps the aggregate bounded and invalidates pending work.
+    const installedCount = keys.filter(
+      (key) => cache.get(identity(key)) !== undefined
+    ).length;
+    const liveReservationCount = evictions.filter(
+      (onEvict) => !onEvict.mock.calls.length
+    ).length;
+    expect(installedCount + liveReservationCount).toBeLessThanOrEqual(
+      SPECULATIVE_CANDIDATE_CACHE_MAX
+    );
+    const installResults = pending.map((reservation) =>
+      cache.install(reservation, { value: "replacement" })
+    );
+    expect(installResults).toContain(false);
+    for (const [index, installed] of installResults.entries()) {
+      if (!installed) {
+        expect(evictions[index]).toHaveBeenCalledOnce();
+      }
+    }
   });
 
   it("retains a touched unresolved reservation over an older installed slot", () => {

--- a/packages/runtime/src/thread/runtime/speculative-candidate-cache.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-candidate-cache.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { createCompactionThreadIdentity } from "./compaction-thread-identity";
+import {
+  SPECULATIVE_CANDIDATE_CACHE_MAX,
+  SpeculativeCandidateCache,
+} from "./speculative-candidate-cache";
+
+interface Candidate {
+  readonly value: string;
+}
+
+const owner = Object.freeze({});
+const identity = (key: string) => createCompactionThreadIdentity(owner, key);
+const install = (
+  cache: SpeculativeCandidateCache<Candidate>,
+  key: string,
+  value: string
+): void => {
+  const reservation = cache.reserve(identity(key));
+  expect(cache.install(reservation, { value })).toBe(true);
+  cache.release(reservation);
+};
+
+describe("SpeculativeCandidateCache", () => {
+  it("evicts the least recently used candidate while retaining a touched entry", () => {
+    // Given: a full candidate cache whose first entry is touched.
+    const cache = new SpeculativeCandidateCache<Candidate>();
+    for (let index = 0; index < SPECULATIVE_CANDIDATE_CACHE_MAX; index += 1) {
+      install(cache, String(index), String(index));
+    }
+    expect(cache.get(identity("0"))?.value).toBe("0");
+
+    // When: one more candidate is installed.
+    install(cache, "overflow", "overflow");
+
+    // Then: key 1 is evicted while the touched key remains.
+    expect(cache.get(identity("1"))).toBeUndefined();
+    expect(cache.get(identity("0"))?.value).toBe("0");
+    expect(cache.size).toBe(SPECULATIVE_CANDIDATE_CACHE_MAX);
+  });
+
+  it("rejects an in-flight install after eviction and fresh reuse", () => {
+    // Given: an old reservation whose slot is subsequently installed and evicted.
+    const cache = new SpeculativeCandidateCache<Candidate>();
+    const key = identity("0");
+    const old = cache.reserve(key);
+    const first = cache.reserve(key);
+    expect(cache.install(first, { value: "first" })).toBe(true);
+    cache.release(first);
+    for (let index = 1; index <= SPECULATIVE_CANDIDATE_CACHE_MAX; index += 1) {
+      install(cache, String(index), String(index));
+    }
+    const fresh = cache.reserve(key);
+    expect(cache.install(fresh, { value: "fresh" })).toBe(true);
+    cache.release(fresh);
+
+    // When: the old in-flight work settles.
+    const installed = cache.install(old, { value: "stale" });
+    cache.release(old);
+
+    // Then: CAS refuses to overwrite the fresh candidate.
+    expect(installed).toBe(false);
+    expect(cache.get(key)?.value).toBe("fresh");
+    expect(cache.size).toBeLessThanOrEqual(SPECULATIVE_CANDIDATE_CACHE_MAX);
+  });
+
+  it("prevents absent-evicted-absent ABA installation", () => {
+    // Given: an absent reservation followed by install, eviction, and reuse.
+    const cache = new SpeculativeCandidateCache<Candidate>();
+    const key = identity("aba");
+    const oldAbsent = cache.reserve(key);
+    const installed = cache.reserve(key);
+    expect(cache.install(installed, { value: "temporary" })).toBe(true);
+    cache.release(installed);
+    for (let index = 0; index < SPECULATIVE_CANDIDATE_CACHE_MAX; index += 1) {
+      install(cache, `fill-${index}`, String(index));
+    }
+    const current = cache.reserve(key);
+    expect(cache.install(current, { value: "current" })).toBe(true);
+    cache.release(current);
+
+    // When: the original absent reservation attempts installation.
+    const accepted = cache.install(oldAbsent, { value: "stale" });
+    cache.release(oldAbsent);
+
+    // Then: versioned CAS rejects the ABA result.
+    expect(accepted).toBe(false);
+    expect(cache.get(key)?.value).toBe("current");
+  });
+
+  it("rejects releasing one reservation twice", () => {
+    // Given: a released absent reservation.
+    const cache = new SpeculativeCandidateCache<Candidate>();
+    const reservation = cache.reserve(identity("release"));
+    cache.release(reservation);
+
+    // When/Then: a second release is rejected.
+    expect(() => cache.release(reservation)).toThrow(
+      "Speculative candidate reservation was already released."
+    );
+  });
+});

--- a/packages/runtime/src/thread/runtime/speculative-candidate-cache.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-candidate-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createCompactionThreadIdentity } from "./compaction-thread-identity";
 import {
   SPECULATIVE_CANDIDATE_CACHE_MAX,
@@ -88,15 +88,58 @@ describe("SpeculativeCandidateCache", () => {
     expect(cache.get(key)?.value).toBe("current");
   });
 
-  it("rejects releasing one reservation twice", () => {
+  it("counts installed candidates and pending reservations in one bound", () => {
+    // Given: 31 installed candidates followed by one unresolved reservation.
+    const cache = new SpeculativeCandidateCache<Candidate>();
+    for (
+      let index = 0;
+      index < SPECULATIVE_CANDIDATE_CACHE_MAX - 1;
+      index += 1
+    ) {
+      install(cache, String(index), String(index));
+    }
+    const pending = cache.reserve(identity("pending"));
+
+    // When: one more candidate consumes the 33rd aggregate slot.
+    install(cache, "overflow", "overflow");
+
+    // Then: the installed LRU is evicted and the unresolved slot remains counted.
+    expect(cache.get(identity("0"))).toBeUndefined();
+    expect(cache.size).toBe(SPECULATIVE_CANDIDATE_CACHE_MAX);
+    cache.release(pending);
+  });
+
+  it("retains a touched unresolved reservation over an older installed slot", () => {
+    // Given: the oldest slot is unresolved before 31 candidates are installed.
+    const cache = new SpeculativeCandidateCache<Candidate>();
+    const evicted = vi.fn();
+    const pending = cache.reserve(identity("pending"), evicted);
+    for (
+      let index = 0;
+      index < SPECULATIVE_CANDIDATE_CACHE_MAX - 1;
+      index += 1
+    ) {
+      install(cache, String(index), String(index));
+    }
+    cache.touch(identity("pending"));
+
+    // When: a 33rd slot is reserved.
+    const overflow = cache.reserve(identity("overflow"));
+
+    // Then: the oldest installed slot leaves while the joined job remains.
+    expect(cache.get(identity("0"))).toBeUndefined();
+    expect(evicted).not.toHaveBeenCalled();
+    cache.release(pending);
+    cache.release(overflow);
+  });
+
+  it("makes reservation release idempotent", () => {
     // Given: a released absent reservation.
     const cache = new SpeculativeCandidateCache<Candidate>();
     const reservation = cache.reserve(identity("release"));
     cache.release(reservation);
 
-    // When/Then: a second release is rejected.
-    expect(() => cache.release(reservation)).toThrow(
-      "Speculative candidate reservation was already released."
-    );
+    // When/Then: a racing second cleanup is harmless.
+    expect(() => cache.release(reservation)).not.toThrow();
   });
 });

--- a/packages/runtime/src/thread/runtime/speculative-candidate-cache.ts
+++ b/packages/runtime/src/thread/runtime/speculative-candidate-cache.ts
@@ -5,13 +5,14 @@ export const SPECULATIVE_CANDIDATE_CACHE_MAX = 32;
 interface CandidateSlot<Value extends object> {
   candidate?: Value;
   readonly owner: Readonly<object>;
-  reservations: number;
+  readonly reservations: Set<CandidateReservation<Value>>;
   readonly threadKey: string;
   version: Readonly<object>;
 }
 
 export interface CandidateReservation<Value extends object> {
   readonly expectedCandidate: Value | undefined;
+  readonly onEvict: (() => void) | undefined;
   readonly owner: Readonly<object>;
   released: boolean;
   readonly slot: CandidateSlot<Value>;
@@ -40,7 +41,18 @@ export class SpeculativeCandidateCache<Value extends object> {
     return slot.candidate;
   }
 
-  reserve(identity: Readonly<object>): CandidateReservation<Value> {
+  touch(identity: Readonly<object>): void {
+    const { owner, threadKey } = compactionThreadIdentityParts(identity);
+    const slot = this.#owners.get(owner)?.get(threadKey);
+    if (slot !== undefined) {
+      this.#touch(slot);
+    }
+  }
+
+  reserve(
+    identity: Readonly<object>,
+    onEvict?: () => void
+  ): CandidateReservation<Value> {
     const { owner, threadKey } = compactionThreadIdentityParts(identity);
     let ownerSlots = this.#owners.get(owner);
     if (ownerSlots === undefined) {
@@ -51,21 +63,25 @@ export class SpeculativeCandidateCache<Value extends object> {
     if (slot === undefined) {
       slot = {
         owner,
-        reservations: 0,
+        reservations: new Set(),
         threadKey,
         version: Object.freeze({}),
       };
       ownerSlots.set(threadKey, slot);
     }
-    slot.reservations += 1;
-    return {
+    const reservation = {
       expectedCandidate: slot.candidate,
+      onEvict,
       owner,
       released: false,
       slot,
       threadKey,
       version: slot.version,
     };
+    slot.reservations.add(reservation);
+    this.#touch(slot);
+    this.#evict();
+    return reservation;
   }
 
   install(reservation: CandidateReservation<Value>, next: Value): boolean {
@@ -81,20 +97,17 @@ export class SpeculativeCandidateCache<Value extends object> {
     slot.candidate = next;
     slot.version = Object.freeze({});
     this.#touch(slot);
-    this.#evict();
     return true;
   }
 
   release(reservation: CandidateReservation<Value>): void {
     if (reservation.released) {
-      throw new TypeError(
-        "Speculative candidate reservation was already released."
-      );
+      return;
     }
     reservation.released = true;
     const slot = reservation.slot;
-    slot.reservations -= 1;
-    if (slot.candidate === undefined && slot.reservations === 0) {
+    slot.reservations.delete(reservation);
+    if (slot.candidate === undefined && slot.reservations.size === 0) {
       this.#removeSlot(slot);
     }
   }
@@ -108,8 +121,9 @@ export class SpeculativeCandidateCache<Value extends object> {
       this.#lru.delete(oldest);
       oldest.candidate = undefined;
       oldest.version = Object.freeze({});
-      if (oldest.reservations === 0) {
-        this.#removeSlot(oldest);
+      this.#removeSlot(oldest);
+      for (const reservation of [...oldest.reservations]) {
+        reservation.onEvict?.();
       }
     }
   }
@@ -119,6 +133,7 @@ export class SpeculativeCandidateCache<Value extends object> {
     if (ownerSlots?.get(slot.threadKey) !== slot) {
       return;
     }
+    this.#lru.delete(slot);
     ownerSlots.delete(slot.threadKey);
     if (ownerSlots.size === 0) {
       this.#owners.delete(slot.owner);

--- a/packages/runtime/src/thread/runtime/speculative-candidate-cache.ts
+++ b/packages/runtime/src/thread/runtime/speculative-candidate-cache.ts
@@ -28,7 +28,7 @@ export class SpeculativeCandidateCache<Value extends object> {
   readonly #lru = new Map<CandidateSlot<Value>, true>();
 
   get size(): number {
-    return this.#lru.size;
+    return this.#entryCount();
   }
 
   get(identity: Readonly<object>): Value | undefined {
@@ -80,7 +80,7 @@ export class SpeculativeCandidateCache<Value extends object> {
     };
     slot.reservations.add(reservation);
     this.#touch(slot);
-    this.#evict();
+    this.#evict(slot, reservation);
     return reservation;
   }
 
@@ -88,12 +88,15 @@ export class SpeculativeCandidateCache<Value extends object> {
     const ownerSlots = this.#owners.get(reservation.owner);
     const slot = reservation.slot;
     if (
+      reservation.released ||
+      !slot.reservations.has(reservation) ||
       ownerSlots?.get(reservation.threadKey) !== slot ||
       slot.version !== reservation.version ||
       slot.candidate !== reservation.expectedCandidate
     ) {
       return false;
     }
+    slot.reservations.delete(reservation);
     slot.candidate = next;
     slot.version = Object.freeze({});
     this.#touch(slot);
@@ -112,19 +115,60 @@ export class SpeculativeCandidateCache<Value extends object> {
     }
   }
 
-  #evict(): void {
-    while (this.#lru.size > SPECULATIVE_CANDIDATE_CACHE_MAX) {
-      const oldest = this.#lru.keys().next().value;
-      if (oldest === undefined) {
+  #entryCount(): number {
+    let count = 0;
+    for (const slot of this.#lru.keys()) {
+      count += slot.reservations.size;
+      if (slot.candidate !== undefined) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  #evict(
+    protectedSlot: CandidateSlot<Value>,
+    protectedReservation: CandidateReservation<Value>
+  ): void {
+    while (this.#entryCount() > SPECULATIVE_CANDIDATE_CACHE_MAX) {
+      let oldest: CandidateSlot<Value> | undefined;
+      for (const slot of this.#lru.keys()) {
+        if (slot !== protectedSlot) {
+          oldest = slot;
+          break;
+        }
+      }
+      if (oldest !== undefined) {
+        this.#evictSlot(oldest);
+        continue;
+      }
+      let oldestReservation: CandidateReservation<Value> | undefined;
+      for (const reservation of protectedSlot.reservations) {
+        if (reservation !== protectedReservation) {
+          oldestReservation = reservation;
+          break;
+        }
+      }
+      if (oldestReservation === undefined) {
         return;
       }
-      this.#lru.delete(oldest);
-      oldest.candidate = undefined;
-      oldest.version = Object.freeze({});
-      this.#removeSlot(oldest);
-      for (const reservation of [...oldest.reservations]) {
-        reservation.onEvict?.();
-      }
+      this.#evictReservation(oldestReservation);
+    }
+  }
+
+  #evictReservation(reservation: CandidateReservation<Value>): void {
+    reservation.slot.reservations.delete(reservation);
+    reservation.onEvict?.();
+  }
+
+  #evictSlot(slot: CandidateSlot<Value>): void {
+    const reservations = [...slot.reservations];
+    slot.candidate = undefined;
+    slot.version = Object.freeze({});
+    slot.reservations.clear();
+    this.#removeSlot(slot);
+    for (const reservation of reservations) {
+      reservation.onEvict?.();
     }
   }
 

--- a/packages/runtime/src/thread/runtime/speculative-candidate-cache.ts
+++ b/packages/runtime/src/thread/runtime/speculative-candidate-cache.ts
@@ -1,0 +1,132 @@
+import { compactionThreadIdentityParts } from "./compaction-thread-identity";
+
+export const SPECULATIVE_CANDIDATE_CACHE_MAX = 32;
+
+interface CandidateSlot<Value extends object> {
+  candidate?: Value;
+  readonly owner: Readonly<object>;
+  reservations: number;
+  readonly threadKey: string;
+  version: Readonly<object>;
+}
+
+export interface CandidateReservation<Value extends object> {
+  readonly expectedCandidate: Value | undefined;
+  readonly owner: Readonly<object>;
+  released: boolean;
+  readonly slot: CandidateSlot<Value>;
+  readonly threadKey: string;
+  readonly version: Readonly<object>;
+}
+
+export class SpeculativeCandidateCache<Value extends object> {
+  readonly #owners = new WeakMap<
+    Readonly<object>,
+    Map<string, CandidateSlot<Value>>
+  >();
+  readonly #lru = new Map<CandidateSlot<Value>, true>();
+
+  get size(): number {
+    return this.#lru.size;
+  }
+
+  get(identity: Readonly<object>): Value | undefined {
+    const { owner, threadKey } = compactionThreadIdentityParts(identity);
+    const slot = this.#owners.get(owner)?.get(threadKey);
+    if (slot?.candidate === undefined) {
+      return;
+    }
+    this.#touch(slot);
+    return slot.candidate;
+  }
+
+  reserve(identity: Readonly<object>): CandidateReservation<Value> {
+    const { owner, threadKey } = compactionThreadIdentityParts(identity);
+    let ownerSlots = this.#owners.get(owner);
+    if (ownerSlots === undefined) {
+      ownerSlots = new Map();
+      this.#owners.set(owner, ownerSlots);
+    }
+    let slot = ownerSlots.get(threadKey);
+    if (slot === undefined) {
+      slot = {
+        owner,
+        reservations: 0,
+        threadKey,
+        version: Object.freeze({}),
+      };
+      ownerSlots.set(threadKey, slot);
+    }
+    slot.reservations += 1;
+    return {
+      expectedCandidate: slot.candidate,
+      owner,
+      released: false,
+      slot,
+      threadKey,
+      version: slot.version,
+    };
+  }
+
+  install(reservation: CandidateReservation<Value>, next: Value): boolean {
+    const ownerSlots = this.#owners.get(reservation.owner);
+    const slot = reservation.slot;
+    if (
+      ownerSlots?.get(reservation.threadKey) !== slot ||
+      slot.version !== reservation.version ||
+      slot.candidate !== reservation.expectedCandidate
+    ) {
+      return false;
+    }
+    slot.candidate = next;
+    slot.version = Object.freeze({});
+    this.#touch(slot);
+    this.#evict();
+    return true;
+  }
+
+  release(reservation: CandidateReservation<Value>): void {
+    if (reservation.released) {
+      throw new TypeError(
+        "Speculative candidate reservation was already released."
+      );
+    }
+    reservation.released = true;
+    const slot = reservation.slot;
+    slot.reservations -= 1;
+    if (slot.candidate === undefined && slot.reservations === 0) {
+      this.#removeSlot(slot);
+    }
+  }
+
+  #evict(): void {
+    while (this.#lru.size > SPECULATIVE_CANDIDATE_CACHE_MAX) {
+      const oldest = this.#lru.keys().next().value;
+      if (oldest === undefined) {
+        return;
+      }
+      this.#lru.delete(oldest);
+      oldest.candidate = undefined;
+      oldest.version = Object.freeze({});
+      if (oldest.reservations === 0) {
+        this.#removeSlot(oldest);
+      }
+    }
+  }
+
+  #removeSlot(slot: CandidateSlot<Value>): void {
+    const ownerSlots = this.#owners.get(slot.owner);
+    if (ownerSlots?.get(slot.threadKey) !== slot) {
+      return;
+    }
+    ownerSlots.delete(slot.threadKey);
+    if (ownerSlots.size === 0) {
+      this.#owners.delete(slot.owner);
+    }
+  }
+
+  #touch(slot: CandidateSlot<Value>): void {
+    this.#lru.delete(slot);
+    this.#lru.set(slot, true);
+  }
+}

--- a/packages/runtime/src/thread/runtime/speculative-compaction-abort-rollback.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-abort-rollback.test.ts
@@ -106,7 +106,7 @@ describe("speculativeCompaction", () => {
     expect(summarize).toHaveBeenCalledTimes(2);
   });
 
-  it("installs a completed promotion fallback after its episode aborts", async () => {
+  it("does not replace a standard candidate with a transformed fallback after abort", async () => {
     const controller = new AbortController();
     let resolveFallback: (summary: string) => void = () => {
       throw new TypeError("fallback promise was not initialized");
@@ -146,7 +146,7 @@ describe("speculativeCompaction", () => {
       context(promotedHistory, summarize, { reason: "overflow" })
     );
 
-    expect(promoted?.summary).toBe("late fallback");
+    expect(promoted?.summary).toBe("prepared");
     expect(summarize).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/runtime/src/thread/runtime/speculative-compaction-candidate-reuse.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-candidate-reuse.test.ts
@@ -1,6 +1,7 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentCompactionContext } from "./auto-compaction-types";
+import { createCompactionThreadIdentity } from "./compaction-thread-identity";
 import { speculativeCompaction } from "./speculative-compaction";
 import { context, message } from "./speculative-compaction-test-support";
 
@@ -8,7 +9,10 @@ describe("speculativeCompaction", () => {
   it("isolates candidates by runtime thread identity even when keys match", async () => {
     const summarizeA = vi.fn(async () => "summary A");
     const summarizeB = vi.fn(async () => "summary B");
-    const identityB = Object.freeze({});
+    const identityB = createCompactionThreadIdentity(
+      Object.freeze({}),
+      "thread"
+    );
     const compaction = speculativeCompaction({
       estimateTokens: (messages) => messages.length * 10,
       maxInputTokens: 100,

--- a/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
@@ -15,7 +15,9 @@ import type {
   AutoCompactionRange,
   ThreadTokenEstimator,
 } from "./auto-compaction-types";
+import { SpeculativeCandidateCache } from "./speculative-candidate-cache";
 import {
+  type DetachedSummaryInstallation,
   type DetachedSummaryJob,
   DetachedSummaryJobs,
 } from "./speculative-compaction-detached";
@@ -42,7 +44,7 @@ interface CandidateStoreOptions {
  * happen after the originating episode settled.
  */
 export class SpeculativeCompactionCandidates {
-  readonly #candidates = new WeakMap<object, SpeculativeCandidate>();
+  readonly #candidates = new SpeculativeCandidateCache<SpeculativeCandidate>();
   readonly #estimate: ThreadTokenEstimator;
   readonly #jobs = new DetachedSummaryJobs();
   readonly #max: number;
@@ -58,7 +60,6 @@ export class SpeculativeCompactionCandidates {
     if (context.modelContextProvenance !== "standard") {
       return;
     }
-    const expectedCurrent = this.#candidates.get(context.threadIdentity);
     const expectedInstallation = this.#getFresh(context);
     if (expectedInstallation?.replacementConsumed) {
       return;
@@ -74,12 +75,7 @@ export class SpeculativeCompactionCandidates {
     await this.#jobs.startOrJoin(
       context,
       range,
-      this.#installDetached(
-        context,
-        range,
-        expectedCurrent,
-        expectedInstallation !== undefined
-      )
+      this.#installDetached(context, range, expectedInstallation !== undefined)
     ).promise;
     context.signal.throwIfAborted();
   }
@@ -96,11 +92,10 @@ export class SpeculativeCompactionCandidates {
     if (range === undefined) {
       return;
     }
-    const expectedCurrent = this.#candidates.get(context.threadIdentity);
     const job = this.#jobs.startOrJoin(
       context,
       range,
-      this.#installDetached(context, range, expectedCurrent)
+      this.#installDetached(context, range)
     );
     const summary = await job.promise;
     context.signal.throwIfAborted();
@@ -145,27 +140,30 @@ export class SpeculativeCompactionCandidates {
   #installDetached(
     context: AgentCompactionContext,
     range: AutoCompactionRange,
-    expectedCurrent: SpeculativeCandidate | undefined,
-    replacedFresh: boolean = expectedCurrent !== undefined
-  ): (summary: string) => void {
-    const compactions = structuredClone(context.compactions);
-    const hydratedPrefix = structuredClone(
-      context.estimatedHistory.slice(0, range.endSeqExclusive)
-    );
-    const prefix = structuredClone(
-      context.history.slice(0, range.endSeqExclusive)
-    );
-    return (summary) => {
-      if (this.#candidates.get(context.threadIdentity) !== expectedCurrent) {
-        return;
-      }
-      this.#candidates.set(context.threadIdentity, {
-        compactions,
-        hydratedPrefix,
-        input: { ...range, summary },
-        prefix,
-        replacementConsumed: replacedFresh,
-      });
+    replacedFresh = false
+  ): () => DetachedSummaryInstallation {
+    return () => {
+      const reservation = this.#candidates.reserve(context.threadIdentity);
+      const compactions = structuredClone(context.compactions);
+      const hydratedPrefix = structuredClone(
+        context.estimatedHistory.slice(0, range.endSeqExclusive)
+      );
+      const prefix = structuredClone(
+        context.history.slice(0, range.endSeqExclusive)
+      );
+      return {
+        install: (summary) => {
+          this.#candidates.install(reservation, {
+            compactions,
+            hydratedPrefix,
+            input: { ...range, summary },
+            prefix,
+            replacementConsumed:
+              replacedFresh || reservation.expectedCandidate !== undefined,
+          });
+        },
+        release: () => this.#candidates.release(reservation),
+      };
     };
   }
 

--- a/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
@@ -36,13 +36,9 @@ interface CandidateStoreOptions {
   readonly retain: number;
 }
 
-/**
- * Candidates are installed by detached summary jobs, never synchronously by an
- * episode, so a deadline that bounds the caller's wait cannot destroy finished
- * provider work. Freshness is enforced at consumption by #getFresh and #fits;
- * there is deliberately no abort-rollback listener because detached installs
- * happen after the originating episode settled.
- */
+// Candidates are installed by detached summary jobs, never synchronously by an
+// episode, so a deadline cannot destroy finished provider work. Freshness is
+// enforced at consumption; detached installs can follow episode settlement.
 export class SpeculativeCompactionCandidates {
   readonly #candidates = new SpeculativeCandidateCache<SpeculativeCandidate>();
   readonly #estimate: ThreadTokenEstimator;
@@ -158,6 +154,9 @@ export class SpeculativeCompactionCandidates {
       );
       return {
         install: (summary) => {
+          if (context.modelContextProvenance !== "standard") {
+            return;
+          }
           this.#candidates.install(reservation, {
             compactions,
             hydratedPrefix,

--- a/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-candidates.ts
@@ -125,6 +125,8 @@ export class SpeculativeCompactionCandidates {
     return (
       job.range.startSeq === range.startSeq &&
       job.range.endSeqExclusive === range.endSeqExclusive &&
+      job.modelContextProvenance === context.modelContextProvenance &&
+      equalSnapshot(job.modelContext, context.modelContext) &&
       equalSnapshot(job.compactions, context.compactions) &&
       equalSnapshot(
         job.prefix,
@@ -141,9 +143,12 @@ export class SpeculativeCompactionCandidates {
     context: AgentCompactionContext,
     range: AutoCompactionRange,
     replacedFresh = false
-  ): () => DetachedSummaryInstallation {
-    return () => {
-      const reservation = this.#candidates.reserve(context.threadIdentity);
+  ): (onEvict: () => void) => DetachedSummaryInstallation {
+    return (onEvict) => {
+      const reservation = this.#candidates.reserve(
+        context.threadIdentity,
+        onEvict
+      );
       const compactions = structuredClone(context.compactions);
       const hydratedPrefix = structuredClone(
         context.estimatedHistory.slice(0, range.endSeqExclusive)
@@ -163,6 +168,7 @@ export class SpeculativeCompactionCandidates {
           });
         },
         release: () => this.#candidates.release(reservation),
+        touch: () => this.#candidates.touch(context.threadIdentity),
       };
     };
   }

--- a/packages/runtime/src/thread/runtime/speculative-compaction-context-isolation.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-context-isolation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentCompactionContext } from "./auto-compaction-types";
+import { policy } from "./speculative-compaction-detached-test-support";
+import { context, message } from "./speculative-compaction-test-support";
+
+describe("speculative compaction context isolation", () => {
+  it.each([
+    ["different unknown model contexts", "unknown", "unknown", "A", "B"],
+    ["different provenance", "transformed", "unknown", "A", "A"],
+    ["unproven unknown contexts", "unknown", "unknown", "A", "A"],
+  ] as const)(
+    "does not cross-reuse %s",
+    async (_case, provenanceA, provenanceB, contextA, contextB) => {
+      const summarizeA = vi
+        .fn<AgentCompactionContext["summarize"]>()
+        .mockResolvedValue("SUMMARY_A");
+      const summarizeB = vi
+        .fn<AgentCompactionContext["summarize"]>()
+        .mockResolvedValue("SUMMARY_B");
+      const history = Array.from({ length: 6 }, (_, index) =>
+        message(String(index), index % 2 === 0 ? "user" : "assistant")
+      );
+      const compaction = policy();
+      const pendingA = compaction(
+        context(history, summarizeA, {
+          modelContext: [{ content: contextA, role: "system" }, ...history],
+          modelContextProvenance: provenanceA,
+          reason: "overflow",
+        })
+      );
+      const pendingB = compaction(
+        context(history, summarizeB, {
+          modelContext: [{ content: contextB, role: "system" }, ...history],
+          modelContextProvenance: provenanceB,
+          reason: "overflow",
+        })
+      );
+
+      await expect(Promise.resolve(pendingA)).resolves.toMatchObject({
+        summary: "SUMMARY_A",
+      });
+      await expect(Promise.resolve(pendingB)).resolves.toMatchObject({
+        summary: "SUMMARY_B",
+      });
+      expect(summarizeA).toHaveBeenCalledTimes(1);
+      expect(summarizeB).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/packages/runtime/src/thread/runtime/speculative-compaction-context-isolation.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-context-isolation.test.ts
@@ -4,6 +4,54 @@ import { policy } from "./speculative-compaction-detached-test-support";
 import { context, message } from "./speculative-compaction-test-support";
 
 describe("speculative compaction context isolation", () => {
+  it.each(["transformed", "unknown"] as const)(
+    "does not install a late %s result for a later standard episode",
+    async (modelContextProvenance) => {
+      // Given: a non-standard overflow whose summary outlives its episode.
+      const originatingEpisode = new AbortController();
+      let resolveSummary: (summary: string) => void = () => {
+        throw new TypeError("summary promise was not initialized");
+      };
+      const summary = new Promise<string>((resolve) => {
+        resolveSummary = resolve;
+      });
+      const summarize = vi
+        .fn<AgentCompactionContext["summarize"]>()
+        .mockReturnValueOnce(summary)
+        .mockResolvedValueOnce("FRESH_STANDARD_SUMMARY");
+      const history = Array.from({ length: 6 }, (_, index) =>
+        message(String(index), index % 2 === 0 ? "user" : "assistant")
+      );
+      const compaction = policy();
+      const pending = compaction(
+        context(history, summarize, {
+          modelContext: [
+            { content: "TENANT_A_SECRET", role: "system" },
+            ...history,
+          ],
+          modelContextProvenance,
+          reason: "overflow",
+          signal: originatingEpisode.signal,
+        })
+      );
+      expect(summarize).toHaveBeenCalledTimes(1);
+
+      // When: the origin aborts, its result settles, and standard context runs.
+      originatingEpisode.abort();
+      resolveSummary("TENANT_A_SUMMARY");
+      await expect(Promise.resolve(pending)).rejects.toMatchObject({
+        name: "AbortError",
+      });
+      const standard = await compaction(
+        context(history, summarize, { reason: "overflow" })
+      );
+
+      // Then: standard context makes and receives a fresh provider call.
+      expect(standard?.summary).toBe("FRESH_STANDARD_SUMMARY");
+      expect(summarize).toHaveBeenCalledTimes(2);
+    }
+  );
+
   it.each([
     ["different unknown model contexts", "unknown", "unknown", "A", "B"],
     ["different provenance", "transformed", "unknown", "A", "A"],

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached-jobs.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached-jobs.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DETACHED_SUMMARY_BACKSTOP_MS } from "./auto-compaction-types";
+import { createCompactionThreadIdentity } from "./compaction-thread-identity";
+import { DetachedSummaryJobs } from "./speculative-compaction-detached";
+import { context, message } from "./speculative-compaction-test-support";
+
+const range = { endSeqExclusive: 6, startSeq: 0 };
+const history = Array.from({ length: 6 }, (_, index) =>
+  message(String(index), index % 2 === 0 ? "user" : "assistant")
+);
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("DetachedSummaryJobs", () => {
+  it("bounds unresolved jobs and releases the oldest without provider settlement", () => {
+    const owner = Object.freeze({});
+    const jobs = new DetachedSummaryJobs();
+    const releases = vi.fn();
+    const signals: (AbortSignal | undefined)[] = [];
+    const aborted = vi.fn();
+
+    for (let index = 0; index < 33; index += 1) {
+      const threadKey = `thread-${index}`;
+      jobs.startOrJoin(
+        context(
+          history,
+          vi.fn((_range, options) => {
+            signals.push(options?.signal);
+            options?.signal?.addEventListener("abort", aborted, { once: true });
+            return new Promise<string>(() => undefined);
+          }),
+          {
+            threadIdentity: createCompactionThreadIdentity(owner, threadKey),
+            threadKey,
+          }
+        ),
+        range,
+        () => ({ install: vi.fn(), release: releases })
+      );
+    }
+
+    expect(signals).toHaveLength(33);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(aborted).toHaveBeenCalledTimes(1);
+    expect(releases).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases an unresolved job when its backstop aborts", async () => {
+    vi.useFakeTimers();
+    const jobs = new DetachedSummaryJobs();
+    const releases = vi.fn();
+    const aborted = vi.fn();
+    let signal: AbortSignal | undefined;
+
+    jobs.startOrJoin(
+      context(
+        history,
+        vi.fn((_range, options) => {
+          signal = options?.signal;
+          signal?.addEventListener("abort", aborted, { once: true });
+          return new Promise<string>(() => undefined);
+        })
+      ),
+      range,
+      () => ({ install: vi.fn(), release: releases })
+    );
+
+    expect(signal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(DETACHED_SUMMARY_BACKSTOP_MS);
+    expect(signal?.aborted).toBe(true);
+    expect(aborted).toHaveBeenCalledTimes(1);
+    expect(releases).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts and releases a replaced job exactly once across later settlement", async () => {
+    vi.useFakeTimers();
+    const jobs = new DetachedSummaryJobs();
+    const releases = vi.fn();
+    let firstSignal: AbortSignal | undefined;
+    let resolveFirst: (summary: string) => void = () => {
+      throw new TypeError("first summary promise was not initialized");
+    };
+    const firstSummary = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const first = jobs.startOrJoin(
+      context(
+        history,
+        vi.fn((_range, options) => {
+          firstSignal = options?.signal;
+          return firstSummary;
+        }),
+        { modelContext: [{ content: "A", role: "system" }, ...history] }
+      ),
+      range,
+      () => ({ install: vi.fn(), release: releases })
+    );
+
+    jobs.startOrJoin(
+      context(
+        history,
+        vi.fn(() => new Promise<string>(() => undefined)),
+        {
+          modelContext: [{ content: "B", role: "system" }, ...history],
+        }
+      ),
+      range,
+      () => ({ install: vi.fn(), release: releases })
+    );
+
+    expect(firstSignal?.aborted).toBe(true);
+    expect(releases).toHaveBeenCalledTimes(1);
+    resolveFirst("late");
+    await expect(first.promise).resolves.toBe("late");
+    expect(releases).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached-test-support.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached-test-support.ts
@@ -55,8 +55,12 @@ export function policy(): AgentCompaction {
   });
 }
 
-export async function stateWithHistory(key: string): Promise<ThreadState> {
+export async function stateWithHistory(
+  key: string,
+  compactionOwner?: Readonly<object>
+): Promise<ThreadState> {
   const state = new ThreadState({
+    ...(compactionOwner === undefined ? {} : { compactionOwner }),
     key,
     store: new MemoryThreadStore(),
   });

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached.test.ts
@@ -189,4 +189,56 @@ describe("speculativeCompaction detached summaries", () => {
 
     await expect(Promise.resolve(pending)).resolves.toBeUndefined();
   });
+
+  it("does not join a detached summary from another transformed model context", async () => {
+    const history = Array.from({ length: 6 }, (_, index) =>
+      message(String(index), index % 2 === 0 ? "user" : "assistant")
+    );
+    let resolveA: (summary: string) => void = () => {
+      throw new TypeError("summary A promise was not initialized");
+    };
+    let resolveB: (summary: string) => void = () => {
+      throw new TypeError("summary B promise was not initialized");
+    };
+    const summaryA = new Promise<string>((resolve) => {
+      resolveA = resolve;
+    });
+    const summaryB = new Promise<string>((resolve) => {
+      resolveB = resolve;
+    });
+    const summarizeA = vi
+      .fn<AgentCompactionContext["summarize"]>()
+      .mockReturnValue(summaryA);
+    const summarizeB = vi
+      .fn<AgentCompactionContext["summarize"]>()
+      .mockReturnValue(summaryB);
+    const compaction = policy();
+
+    const pendingA = compaction(
+      context(history, summarizeA, {
+        modelContext: [{ content: "CONTEXT_A", role: "system" }, ...history],
+        modelContextProvenance: "transformed",
+        reason: "overflow",
+      })
+    );
+    const pendingB = compaction(
+      context(history, summarizeB, {
+        modelContext: [{ content: "CONTEXT_B", role: "system" }, ...history],
+        modelContextProvenance: "transformed",
+        reason: "overflow",
+      })
+    );
+
+    expect(summarizeA).toHaveBeenCalledTimes(1);
+    expect(summarizeB).toHaveBeenCalledTimes(1);
+    resolveA("SUMMARY_A");
+    resolveB("SUMMARY_B");
+
+    await expect(Promise.resolve(pendingA)).resolves.toMatchObject({
+      summary: "SUMMARY_A",
+    });
+    await expect(Promise.resolve(pendingB)).resolves.toMatchObject({
+      summary: "SUMMARY_B",
+    });
+  });
 });

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
@@ -3,60 +3,104 @@ import type { ThreadCompactionRecord } from "../state/snapshot";
 import { equalSnapshot } from "../state/snapshot-equal";
 import type {
   AgentCompactionContext,
+  AgentCompactionModelContextProvenance,
   AutoCompactionRange,
 } from "./auto-compaction-types";
+import { DETACHED_SUMMARY_BACKSTOP_MS } from "./auto-compaction-types";
 import { compactionThreadIdentityParts } from "./compaction-thread-identity";
+import { SPECULATIVE_CANDIDATE_CACHE_MAX } from "./speculative-candidate-cache";
 
 export interface DetachedSummaryJob {
+  readonly cancel: () => void;
   readonly compactions: readonly ThreadCompactionRecord[];
   readonly hydratedPrefix: readonly ModelMessage[];
+  readonly modelContext: readonly ModelMessage[];
+  readonly modelContextProvenance: AgentCompactionModelContextProvenance;
   readonly prefix: readonly ModelMessage[];
   readonly promise: Promise<string>;
   readonly range: AutoCompactionRange;
+  readonly refresh: () => void;
   readonly token: Readonly<object>;
 }
 
 export interface DetachedSummaryInstallation {
   readonly install: (summary: string) => void;
   readonly release: () => void;
+  readonly touch?: () => void;
 }
 
 /**
  * Process-local, single-flight registry for summary provider calls that
- * outlive their originating compaction episode. The episode deadline bounds
- * the caller's wait, never the detached work; a second episode joins the
- * in-flight call instead of starting another.
+ * outlive their originating compaction episode. Jobs own their cancellation
+ * and cleanup independently of provider settlement.
  */
 export class DetachedSummaryJobs {
   readonly #jobs = new WeakMap<
     Readonly<object>,
     Map<string, DetachedSummaryJob>
   >();
+  readonly #lru = new Map<DetachedSummaryJob, true>();
 
   startOrJoin(
     context: AgentCompactionContext,
     range: AutoCompactionRange,
-    installationFactory: () => DetachedSummaryInstallation
+    installationFactory: (onEvict: () => void) => DetachedSummaryInstallation
   ): DetachedSummaryJob {
     const { owner, threadKey } = compactionThreadIdentityParts(
       context.threadIdentity
     );
-    let ownerJobs = this.#jobs.get(owner);
-    const existing = ownerJobs?.get(threadKey);
+    const existing = this.#jobs.get(owner)?.get(threadKey);
     if (existing !== undefined && matchesContext(existing, context)) {
+      existing.refresh();
+      this.#touch(existing);
       return existing;
     }
+    existing?.cancel();
 
-    const installation = installationFactory();
-    const token = Object.freeze({});
+    const controller = new AbortController();
+    let finalized = false;
+    let job: DetachedSummaryJob | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let installation: DetachedSummaryInstallation;
+    const finalize = (abort: boolean): void => {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      if (abort) {
+        controller.abort(
+          new Error("Detached compaction summary lifecycle ended.")
+        );
+      }
+      installation.release();
+      if (job === undefined) {
+        return;
+      }
+      this.#lru.delete(job);
+      const currentJobs = this.#jobs.get(owner);
+      if (currentJobs?.get(threadKey) === job) {
+        currentJobs.delete(threadKey);
+        if (currentJobs.size === 0) {
+          this.#jobs.delete(owner);
+        }
+      }
+    };
+
+    installation = installationFactory(() => finalize(true));
     let pending: Promise<string>;
     try {
-      pending = context.summarize(range, { lifetime: "detached" });
+      pending = context.summarize(range, {
+        lifetime: "detached",
+        signal: controller.signal,
+      });
     } catch (error) {
       installation.release();
       throw error;
     }
-    let job: DetachedSummaryJob;
+    const token = Object.freeze({});
     const promise = pending
       .then((summary) => {
         const current = this.#jobs.get(owner)?.get(threadKey);
@@ -65,43 +109,61 @@ export class DetachedSummaryJobs {
         }
         return summary;
       })
-      .finally(() => {
-        installation.release();
-        const currentJobs = this.#jobs.get(owner);
-        if (currentJobs?.get(threadKey) === job) {
-          currentJobs.delete(threadKey);
-          if (currentJobs.size === 0) {
-            this.#jobs.delete(owner);
-          }
-        }
-      });
+      .finally(() => finalize(false));
+    // Preserve rejection for joiners while observing abandoned detached calls.
+    promise.catch(() => undefined);
     job = {
-      compactions: context.compactions,
-      hydratedPrefix: context.estimatedHistory.slice(0, range.endSeqExclusive),
-      prefix: context.history.slice(0, range.endSeqExclusive),
+      cancel: () => finalize(true),
+      compactions: structuredClone(context.compactions),
+      hydratedPrefix: structuredClone(
+        context.estimatedHistory.slice(0, range.endSeqExclusive)
+      ),
+      modelContext: structuredClone(context.modelContext),
+      modelContextProvenance: context.modelContextProvenance,
+      prefix: structuredClone(context.history.slice(0, range.endSeqExclusive)),
       promise,
       range,
+      refresh: () => installation.touch?.(),
       token,
     };
+    let ownerJobs = this.#jobs.get(owner);
     if (ownerJobs === undefined) {
       ownerJobs = new Map();
       this.#jobs.set(owner, ownerJobs);
     }
     ownerJobs.set(threadKey, job);
+    this.#touch(job);
+    timer = setTimeout(() => finalize(true), DETACHED_SUMMARY_BACKSTOP_MS);
+    timer.unref();
+    this.#evict();
     return job;
+  }
+
+  #evict(): void {
+    while (this.#lru.size > SPECULATIVE_CANDIDATE_CACHE_MAX) {
+      const oldest = this.#lru.keys().next().value;
+      if (oldest === undefined) {
+        return;
+      }
+      oldest.cancel();
+    }
+  }
+
+  #touch(job: DetachedSummaryJob): void {
+    this.#lru.delete(job);
+    this.#lru.set(job, true);
   }
 }
 
-/**
- * Single-flight means one in-flight call per context snapshot. A job captured
- * before the thread drifted is not a duplicate of the work this context needs,
- * so it neither joins nor blocks a fresh call.
- */
+/** Jobs join only when every summary-bearing context input is unchanged. */
 function matchesContext(
   job: DetachedSummaryJob,
   context: AgentCompactionContext
 ): boolean {
   return (
+    context.modelContextProvenance !== "unknown" &&
+    job.modelContextProvenance === context.modelContextProvenance &&
+    equalSnapshot(job.modelContext, context.modelContext) &&
     equalSnapshot(job.compactions, context.compactions) &&
     equalSnapshot(
       job.prefix,

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
@@ -5,6 +5,7 @@ import type {
   AgentCompactionContext,
   AutoCompactionRange,
 } from "./auto-compaction-types";
+import { compactionThreadIdentityParts } from "./compaction-thread-identity";
 
 export interface DetachedSummaryJob {
   readonly compactions: readonly ThreadCompactionRecord[];
@@ -15,6 +16,11 @@ export interface DetachedSummaryJob {
   readonly token: Readonly<object>;
 }
 
+export interface DetachedSummaryInstallation {
+  readonly install: (summary: string) => void;
+  readonly release: () => void;
+}
+
 /**
  * Process-local, single-flight registry for summary provider calls that
  * outlive their originating compaction episode. The episode deadline bounds
@@ -22,28 +28,54 @@ export interface DetachedSummaryJob {
  * in-flight call instead of starting another.
  */
 export class DetachedSummaryJobs {
-  readonly #jobs = new WeakMap<object, DetachedSummaryJob>();
+  readonly #jobs = new WeakMap<
+    Readonly<object>,
+    Map<string, DetachedSummaryJob>
+  >();
 
   startOrJoin(
     context: AgentCompactionContext,
     range: AutoCompactionRange,
-    install: (summary: string) => void
+    installationFactory: () => DetachedSummaryInstallation
   ): DetachedSummaryJob {
-    const existing = this.#jobs.get(context.threadIdentity);
+    const { owner, threadKey } = compactionThreadIdentityParts(
+      context.threadIdentity
+    );
+    let ownerJobs = this.#jobs.get(owner);
+    const existing = ownerJobs?.get(threadKey);
     if (existing !== undefined && matchesContext(existing, context)) {
       return existing;
     }
+
+    const installation = installationFactory();
     const token = Object.freeze({});
-    const promise = context
-      .summarize(range, { lifetime: "detached" })
+    let pending: Promise<string>;
+    try {
+      pending = context.summarize(range, { lifetime: "detached" });
+    } catch (error) {
+      installation.release();
+      throw error;
+    }
+    let job: DetachedSummaryJob;
+    const promise = pending
       .then((summary) => {
-        const current = this.#jobs.get(context.threadIdentity);
+        const current = this.#jobs.get(owner)?.get(threadKey);
         if (summary.trim() && current?.token === token) {
-          install(summary);
+          installation.install(summary);
         }
         return summary;
+      })
+      .finally(() => {
+        installation.release();
+        const currentJobs = this.#jobs.get(owner);
+        if (currentJobs?.get(threadKey) === job) {
+          currentJobs.delete(threadKey);
+          if (currentJobs.size === 0) {
+            this.#jobs.delete(owner);
+          }
+        }
       });
-    const job: DetachedSummaryJob = {
+    job = {
       compactions: context.compactions,
       hydratedPrefix: context.estimatedHistory.slice(0, range.endSeqExclusive),
       prefix: context.history.slice(0, range.endSeqExclusive),
@@ -51,13 +83,11 @@ export class DetachedSummaryJobs {
       range,
       token,
     };
-    this.#jobs.set(context.threadIdentity, job);
-    const release = (): void => {
-      if (this.#jobs.get(context.threadIdentity) === job) {
-        this.#jobs.delete(context.threadIdentity);
-      }
-    };
-    promise.then(release, release);
+    if (ownerJobs === undefined) {
+      ownerJobs = new Map();
+      this.#jobs.set(owner, ownerJobs);
+    }
+    ownerJobs.set(threadKey, job);
     return job;
   }
 }

--- a/packages/runtime/src/thread/runtime/speculative-compaction-reconstruction.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-reconstruction.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
+import type { RuntimeDiagnostic } from "../../diagnostics";
 import { MemoryThreadStore } from "../../platform/memory";
+import { createDeferred } from "../../testing/async-fixtures";
+import { hostWithThreads } from "../../testing/host-with-threads";
+import {
+  assistantMessage,
+  createCallbackModel,
+} from "../../testing/test-fixtures";
+import { agentWithCompaction } from "../handle/automatic-compaction.test-support";
+import { collect, SpyStore } from "../handle/test-support";
 import { ThreadState } from "../state/thread-state";
 import type { AgentCompactionContext } from "./auto-compaction-types";
 import { createCompactionThreadIdentity } from "./compaction-thread-identity";
@@ -100,4 +109,115 @@ describe("speculative compaction reconstruction", () => {
       expect(summarize).toHaveBeenCalledTimes(2);
     }
   );
+
+  it("isolates and reuses shared-policy candidates through real Agent reconstruction", async () => {
+    // Given: separate Agent owners share a policy and thread key but have distinct instructions.
+    const storeA = new SpyStore();
+    const storeB = new SpyStore();
+    const preparedA = createDeferred();
+    const preparedB = createDeferred();
+    const completedA = createDeferred();
+    const completedB = createDeferred();
+    const baseHostA = hostWithThreads(storeA);
+    const baseHostB = hostWithThreads(storeB);
+    const hostA = {
+      ...baseHostA,
+      diagnostics: {
+        report(diagnostic: RuntimeDiagnostic): void {
+          if (
+            diagnostic.code === "compaction.skipped" &&
+            diagnostic.compaction?.summaryCalls === 1
+          ) {
+            preparedA.resolve();
+          }
+          if (diagnostic.code === "compaction.completed") {
+            completedA.resolve();
+          }
+        },
+      },
+    };
+    const hostB = {
+      ...baseHostB,
+      diagnostics: {
+        report(diagnostic: RuntimeDiagnostic): void {
+          if (
+            diagnostic.code === "compaction.skipped" &&
+            diagnostic.compaction?.summaryCalls === 1
+          ) {
+            preparedB.resolve();
+          }
+          if (diagnostic.code === "compaction.completed") {
+            completedB.resolve();
+          }
+        },
+      },
+    };
+    const compaction = speculativeCompaction({
+      estimateTokens: (messages) => messages.length * 10,
+      maxInputTokens: 100,
+      prepareRatio: 0.5,
+      promoteRatio: 0.7,
+      retainRatio: 0.2,
+    });
+    let providerCallsA = 0;
+    let providerCallsB = 0;
+    const agentA = agentWithCompaction({
+      compaction,
+      host: hostA,
+      instructions: "AGENT_A",
+      model: createCallbackModel(() => {
+        providerCallsA += 1;
+        if (providerCallsA <= 2) {
+          return [assistantMessage("DONE")];
+        }
+        if (providerCallsA === 3 || providerCallsA === 5) {
+          return [];
+        }
+        return [assistantMessage("AGENT_A")];
+      }),
+    });
+    const agentB = agentWithCompaction({
+      compaction,
+      host: hostB,
+      instructions: "AGENT_B",
+      model: createCallbackModel(() => {
+        providerCallsB += 1;
+        if (providerCallsB <= 2) {
+          return [assistantMessage("DONE")];
+        }
+        if (providerCallsB === 3 || providerCallsB === 5) {
+          return [];
+        }
+        return [assistantMessage("AGENT_B")];
+      }),
+    });
+    const threadA = agentA.thread("alpha");
+    const threadB = agentB.thread("alpha");
+    const inputs = ["turn-1", "turn-2", "turn-3", "turn-4"] as const;
+    for (const input of inputs.slice(0, 3)) {
+      await Promise.all([
+        collect(await threadA.send(input)),
+        collect(await threadB.send(input)),
+      ]);
+    }
+    await Promise.all([preparedA.promise, preparedB.promise]);
+    await Promise.all([threadA.dispose(), threadB.dispose()]);
+
+    // When: each Agent reacquires alpha and sends the same promotion turn.
+    await Promise.all([
+      collect(await agentA.thread("alpha").send(inputs[3])),
+      collect(await agentB.thread("alpha").send(inputs[3])),
+    ]);
+    await Promise.all([completedA.promise, completedB.promise]);
+
+    // Then: each reconstructed Agent commits only its own prepared candidate.
+    expect(storeA.threads.get("alpha")?.state).toMatchObject({
+      compactions: [{ summary: { content: "AGENT_A", role: "system" } }],
+    });
+    expect(storeB.threads.get("alpha")?.state).toMatchObject({
+      compactions: [{ summary: { content: "AGENT_B", role: "system" } }],
+    });
+    expect(providerCallsA).toBe(5);
+    expect(providerCallsB).toBe(5);
+  }, 5000);
 });

--- a/packages/runtime/src/thread/runtime/speculative-compaction-reconstruction.test.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-reconstruction.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { MemoryThreadStore } from "../../platform/memory";
+import { ThreadState } from "../state/thread-state";
+import type { AgentCompactionContext } from "./auto-compaction-types";
+import { createCompactionThreadIdentity } from "./compaction-thread-identity";
+import { speculativeCompaction } from "./speculative-compaction";
+import { context, message } from "./speculative-compaction-test-support";
+
+describe("speculative compaction reconstruction", () => {
+  it("reuses a prepared candidate after same-owner thread reconstruction", async () => {
+    // Given: two reconstructed states for one host-controlled thread key.
+    const store = new MemoryThreadStore();
+    const owner = Object.freeze({});
+    const firstState = new ThreadState({
+      compactionOwner: owner,
+      key: "alpha",
+      store,
+    });
+    const secondState = new ThreadState({
+      compactionOwner: owner,
+      key: "alpha",
+      store,
+    });
+    const summarize = vi
+      .fn<AgentCompactionContext["summarize"]>()
+      .mockResolvedValueOnce("summary 1")
+      .mockResolvedValueOnce("summary 2");
+    const compaction = speculativeCompaction({
+      estimateTokens: (messages) => messages.length * 10,
+      maxInputTokens: 100,
+      prepareRatio: 0.5,
+      promoteRatio: 0.7,
+      retainRatio: 0.2,
+    });
+    const prepared = Array.from({ length: 6 }, (_, index) =>
+      message(String(index), index % 2 === 0 ? "user" : "assistant")
+    );
+    await compaction(
+      context(prepared, summarize, {
+        threadIdentity: firstState.compactionIdentity,
+        threadKey: "alpha",
+      })
+    );
+
+    // When: the reconstructed state promotes with one additional tail message.
+    const promoted = await compaction(
+      context([...prepared, message("tail")], summarize, {
+        threadIdentity: secondState.compactionIdentity,
+        threadKey: "alpha",
+      })
+    );
+
+    // Then: the previously paid summary is reused.
+    expect(promoted?.summary).toBe("summary 1");
+    expect(summarize).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["a\u0000b", "a:b"])(
+    "keeps hostile thread key %j in its exact owner slot",
+    async (threadKey) => {
+      // Given: equal histories under exact keys owned by one host.
+      const owner = Object.freeze({});
+      const otherKey = threadKey === "a:b" ? "a\u0000b" : "a:b";
+      const summarize = vi
+        .fn<AgentCompactionContext["summarize"]>()
+        .mockResolvedValueOnce(`summary ${threadKey}`)
+        .mockResolvedValueOnce(`summary ${otherKey}`);
+      const compaction = speculativeCompaction({
+        estimateTokens: (messages) => messages.length * 10,
+        maxInputTokens: 100,
+        prepareRatio: 0.5,
+        promoteRatio: 0.7,
+        retainRatio: 0.2,
+      });
+      const history = Array.from({ length: 6 }, (_, index) =>
+        message(String(index), index % 2 === 0 ? "user" : "assistant")
+      );
+      const identity = createCompactionThreadIdentity(owner, threadKey);
+      const otherIdentity = createCompactionThreadIdentity(owner, otherKey);
+      await compaction(
+        context(history, summarize, { threadIdentity: identity, threadKey })
+      );
+      await compaction(
+        context(history, summarize, {
+          threadIdentity: otherIdentity,
+          threadKey: otherKey,
+        })
+      );
+
+      // When: the exact key is reconstructed and promoted.
+      const promoted = await compaction(
+        context([...history, message("tail")], summarize, {
+          threadIdentity: createCompactionThreadIdentity(owner, threadKey),
+          threadKey,
+        })
+      );
+
+      // Then: it reuses only its own candidate.
+      expect(promoted?.summary).toBe(`summary ${threadKey}`);
+      expect(summarize).toHaveBeenCalledTimes(2);
+    }
+  );
+});

--- a/packages/runtime/src/thread/runtime/speculative-compaction-test-support.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-test-support.ts
@@ -5,12 +5,16 @@ import {
 } from "../state/context";
 import type { ThreadCompactionRecord } from "../state/snapshot";
 import type { AgentCompactionContext } from "./auto-compaction-types";
+import { createCompactionThreadIdentity } from "./compaction-thread-identity";
 
 export const message = (
   content: string,
   role: "user" | "assistant" = "user"
 ): ModelMessage => ({ content, role });
-const threadIdentity = Object.freeze({});
+const threadIdentity = createCompactionThreadIdentity(
+  Object.freeze({}),
+  "thread"
+);
 
 export function context(
   history: readonly ModelMessage[],

--- a/packages/runtime/src/thread/state/thread-state-types.ts
+++ b/packages/runtime/src/thread/state/thread-state-types.ts
@@ -1,0 +1,32 @@
+import type {
+  ExpectedThreadVersion,
+  ThreadStore,
+  ThreadStoreCommit,
+} from "../store/types";
+import type { ThreadStateMigration } from "./migrations";
+
+export interface ThreadPersistenceOptions {
+  readonly compactionOwner?: Readonly<object>;
+  readonly key: string;
+  readonly migrations?: readonly ThreadStateMigration[];
+  readonly store: ThreadStore;
+}
+
+export interface PreparedThreadCommit {
+  readonly expectedVersion: ExpectedThreadVersion;
+  readonly key: string;
+  readonly next: ThreadStoreCommit;
+}
+
+export interface ThreadCheckpointReference {
+  readonly kind: "thread-reference";
+  readonly schemaVersion: 1;
+  readonly threadKey: string;
+  readonly threadVersion: string | null;
+}
+
+export interface ThreadCompactionInput {
+  readonly endSeqExclusive: number;
+  readonly startSeq: number;
+  readonly summary: string;
+}

--- a/packages/runtime/src/thread/state/thread-state.ts
+++ b/packages/runtime/src/thread/state/thread-state.ts
@@ -1,14 +1,9 @@
 import type { ModelMessage } from "ai";
 import { deferred } from "../../internal/deferred";
-import type {
-  CommitResult,
-  ExpectedThreadVersion,
-  ThreadStore,
-  ThreadStoreCommit,
-} from "../store/types";
+import { createCompactionThreadIdentity } from "../runtime/compaction-thread-identity";
+import type { CommitResult } from "../store/types";
 import type { ThreadContextMessage } from "./context";
 import { ModelMessageHistory, recordCompactionForCommit } from "./history";
-import type { ThreadStateMigration } from "./migrations";
 import type { ThreadCompactionRecord } from "./snapshot";
 import {
   createThreadPersistenceMachine,
@@ -17,21 +12,22 @@ import {
   ThreadStatePersistence,
   ThreadWriteQueue,
 } from "./thread-state-persistence";
+import type {
+  PreparedThreadCommit,
+  ThreadCheckpointReference,
+  ThreadCompactionInput,
+  ThreadPersistenceOptions,
+} from "./thread-state-types";
+
+export type {
+  PreparedThreadCommit,
+  ThreadCheckpointReference,
+  ThreadCompactionInput,
+  ThreadPersistenceOptions,
+} from "./thread-state-types";
 
 /** @internal exported for unit tests of special-key seeding */
 export const seedAppliedMigrations = seedAppliedMigrationMarkers;
-
-export interface ThreadPersistenceOptions {
-  readonly key: string;
-  readonly migrations?: readonly ThreadStateMigration[];
-  readonly store: ThreadStore;
-}
-
-export interface PreparedThreadCommit {
-  readonly expectedVersion: ExpectedThreadVersion;
-  readonly key: string;
-  readonly next: ThreadStoreCommit;
-}
 
 export class ThreadCommitConflictError extends Error {
   constructor(key: string) {
@@ -39,30 +35,21 @@ export class ThreadCommitConflictError extends Error {
   }
 }
 
-export interface ThreadCheckpointReference {
-  readonly kind: "thread-reference";
-  readonly schemaVersion: 1;
-  readonly threadKey: string;
-  readonly threadVersion: string | null;
-}
-
-export interface ThreadCompactionInput {
-  readonly endSeqExclusive: number;
-  readonly startSeq: number;
-  readonly summary: string;
-}
-
 type HistoryUserInput = Parameters<ModelMessageHistory["appendUserInput"]>[0];
 
 export class ThreadState {
   /** Opaque identity for runtime-owned per-thread caches. */
-  readonly compactionIdentity: object = Object.freeze({});
+  readonly compactionIdentity: Readonly<object>;
   readonly #machine = createThreadPersistenceMachine();
   readonly #persistence: ThreadStatePersistence;
   #history = new ModelMessageHistory();
   readonly #writes = new ThreadWriteQueue();
 
   constructor(persistence: ThreadPersistenceOptions) {
+    this.compactionIdentity = createCompactionThreadIdentity(
+      persistence.compactionOwner ?? Object.freeze({}),
+      persistence.key
+    );
     this.#persistence = new ThreadStatePersistence(
       persistence,
       ThreadCommitConflictError

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3317,8 +3317,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -4378,8 +4378,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quansync@1.0.0:
@@ -6804,7 +6804,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6935,7 +6935,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -7604,7 +7604,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -7644,7 +7644,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -8842,7 +8842,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1


### PR DESCRIPTION
## Summary

- add an explicit `createAgent({ contextGate })` option that takes precedence over compaction metadata while preserving existing fallback behavior
- advance overflow compaction to the first safe tool-exchange boundary, including first-compaction histories, without splitting tool calls/results or bypassing the compressibility floor
- preserve bounded, owner-scoped speculative candidates across same-Agent thread reconstruction while isolating Agents that share a compaction policy
- bind detached summaries to full model-context provenance and enforce one aggregate 32-slot bound across pending and installed candidate lifecycle state

Closes #365

## Verification

- deterministic RED evidence captured for explicit-gate fallback, tool-heavy no-progress, reconstruction candidate loss, first-compaction starvation, floor mutation, Agent-owner mutation, transformed-context crossover, pending-job overflow, and abort-ignoring backstop cleanup
- independent verifier initially returned REQUEST_CHANGES for B1-B4; deep remediation `a6d6acd4` fixed all four, and the same verifier independently returned unconditional APPROVE
- security review reproduced transformed-context summary crossover and unbounded unresolved jobs; deep remediation `62d0ac3a` fixed both, and the same security reviewer returned PASS after independently running 11 files / 51 tests and the full runtime suite (279 files / 1690 passed / 5 skipped)
- resident ultrabrain then independently returned unconditional APPROVE for cumulative head `d9076485`, including the crossover fix and lock refresh
- post-rebase/post-remediation targeted tests: 7 files / 33 tests PASS; full runtime suite: 279 files / 1692 passed / 5 skipped; complete repository build/test/typecheck/lint/API/Tegami and dependency audit gates pass locally
- patched transitive `qs@6.16.0` and `fast-uri@3.1.6` in a lock-only commit `38b1e0d9`; Node 24 audit threshold is clear, with one low advisory below the configured moderate threshold
- built-dist/manual QA emitted `ISSUE_365_POST_REBASE_QA_PASS`, prior O1/O2/O3 drivers emitted `ISSUE_365_QA_PASS`, security remediation emitted `ISSUE_365_REMEDIATION_QA_PASS`, and crossover remediation emitted `ISSUE_365_CROSSOVER_QA_PASS`; temporary drivers were removed
- branch is based on merged #399 (`c3ee6ce5`) and is clean
