### PR TITLE
fix(runtime): settle drain joiners after restart

### DIFF
--- a/.tegami/2026-09-03-drain-restart-race.md
+++ b/.tegami/2026-09-03-drain-restart-race.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Keep restarted drain turns successful
+
+Wait for a requested queue-drain restart before settling joined callers, so a
+queued turn cannot receive a failure and then execute anyway.

--- a/packages/runtime/src/thread/handle/agent-thread-drain.test.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.test.ts
@@ -1,11 +1,52 @@
 import { describe, expect, it, vi } from "vitest";
+import { Agent } from "../../agent/core/agent";
+import type { AgentHost, ThreadInputInbox } from "../../execution";
+import { deferred } from "../../internal/deferred";
+import { createInMemoryHost } from "../../platform/memory";
+import {
+  assistantMessage,
+  createCallbackModel,
+  eventTypes,
+} from "../../testing/test-fixtures";
 import {
   recoverOrCancelReleasedDrain,
   removeQueuedInputsByIdentity,
   retryReleasedThreadDrain,
 } from "./agent-thread-drain";
+import { collect } from "./test-support";
 
 describe("released thread drain restart", () => {
+  it("does not fail a queued turn that executes during restart", async () => {
+    const claimFailure = deferred();
+    const host = hostWithOneBlockedClaimFailure(claimFailure.promise);
+    const queuedExecuted = deferred();
+    let modelCalls = 0;
+    const thread = new Agent({
+      host,
+      model: createCallbackModel(({ history }) => {
+        modelCalls += 1;
+        if (JSON.stringify(history).includes("second")) {
+          queuedExecuted.resolve();
+        }
+        return [assistantMessage(`DONE ${modelCalls}`)];
+      }),
+    }).thread("drain-restart-race");
+
+    const first = await thread.send("first");
+    const second = await thread.send("second");
+    const firstEvents = collect(first);
+    const secondEvents = collect(second);
+
+    claimFailure.reject(new Error("transient claim failure"));
+
+    await queuedExecuted.promise;
+    await firstEvents;
+    const queuedEvents = await secondEvents;
+    expect(modelCalls).toBe(2);
+    expect(eventTypes(queuedEvents)).not.toContain("turn-error");
+    expect(queuedEvents.at(-1)?.type).toBe("turn-end");
+  });
+
   it("retries a transient restart failure without another notification", async () => {
     const drain = vi
       .fn<() => Promise<void>>()
@@ -83,3 +124,39 @@ describe("released thread drain restart", () => {
     expect(queue).toEqual([later]);
   });
 });
+
+function hostWithOneBlockedClaimFailure(
+  claimFailure: Promise<void>
+): AgentHost {
+  const host = createInMemoryHost();
+  let failNextClaim = true;
+  const inputs: ThreadInputInbox = {
+    ack: (record) => host.store.inputs.ack(record),
+    admit: (input) => host.store.inputs.admit(input),
+    claimNext: async (threadKey, boundary, options) => {
+      if (failNextClaim) {
+        failNextClaim = false;
+        await claimFailure;
+      }
+      return await host.store.inputs.claimNext(threadKey, boundary, options);
+    },
+    markPromoted: (record) => host.store.inputs.markPromoted(record),
+    recoverClaims: (threadKey) => host.store.inputs.recoverClaims(threadKey),
+    releaseClaim: (record) => host.store.inputs.releaseClaim(record),
+  };
+  return {
+    attachmentStore: host.attachmentStore,
+    diagnostics: host.diagnostics,
+    scheduler: host.scheduler,
+    store: {
+      checkpoints: host.store.checkpoints,
+      events: host.store.events,
+      inputs,
+      notifications: host.store.notifications,
+      threadEvents: host.store.threadEvents,
+      threads: host.store.threads,
+      transaction: (callback) => host.store.transaction(callback),
+      turns: host.store.turns,
+    },
+  };
+}

--- a/packages/runtime/src/thread/handle/agent-thread-drain.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-drain.ts
@@ -81,11 +81,15 @@ export async function drainAgentThreadInputQueue(
       });
     }
   );
-  loop.then(loopSettled.resolve, loopSettled.reject);
 
+  let loopFailure: { readonly error: unknown } | undefined;
   try {
     await loop;
-  } finally {
+  } catch (error) {
+    loopFailure = { error };
+  }
+
+  try {
     const state = drain.state;
     const shouldRestart =
       state.tag === "draining" &&
@@ -95,8 +99,16 @@ export async function drainAgentThreadInputQueue(
     // The loop has settled: every activated turn must have been released.
     assertThreadMachineInvariants(context);
     if (shouldRestart) {
+      // Joiners queued work for the next pass, so their shared promise follows
+      // that restart rather than a failure from the pass they did not join.
       await drainAgentThreadInputQueue(context);
+    } else if (loopFailure) {
+      throw loopFailure.error;
     }
+    loopSettled.resolve();
+  } catch (error) {
+    loopSettled.reject(error);
+    throw error;
   }
 }
 

--- a/packages/runtime/src/thread/handle/agent-thread-machines.ts
+++ b/packages/runtime/src/thread/handle/agent-thread-machines.ts
@@ -83,7 +83,12 @@ export type ThreadDrainState =
   | { readonly tag: "idle" }
   | {
       readonly tag: "draining";
-      /** Settles when the current drain loop ends (before any restart). */
+      /**
+       * Settles when the drain chain settles: when a restart is requested,
+       * the promise stays pending until the restarted loop (and any further
+       * restarts) ends, so joiners never observe a superseded pass failure
+       * while their queued turn still executes.
+       */
       readonly promise: Promise<void>;
       /** A concurrent drain request arrived; restart the loop after this one ends. */
       readonly restartRequested: boolean;


### PR DESCRIPTION
Fixes a HIGH finding confirmed by the 2026-09-03 full review of main (`.omo/reviews/main-2026-09-03/full-review.md`, claim-verified with file:line evidence).

## Evidence

- Failing-first regression: `.omo/evidence/drain-restart-race-red.txt` (RED before the fix)
- Green after fix: `.omo/evidence/drain-restart-race-green.txt`
- Full gates (package tests, typecheck, lint, build): see `.omo/evidence/` in the branch worktree
- Tegami entry included

Branch: `fix/2026-09-03-drain-restart-race` (atomic commit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where drain joiners could receive a failure from a pass they did not join, causing a queued turn to fail and still execute. Joiners now wait through requested restarts before settling, so the restarted turn completes successfully; a regression test covers transient claim failures.

<sup>Written for commit 91375723d220647a24c1672693658dd1d161d758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

