### PR TITLE
fix(runtime): guard detached timer unref

### DIFF
--- a/.tegami/2026-09-03-edge-timer-unref.md
+++ b/.tegami/2026-09-03-edge-timer-unref.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Support web and edge runtime timers
+
+Guard detached compaction timer `unref` calls so numeric web timer handles do not crash summary startup or cleanup.

--- a/packages/runtime/src/thread/runtime/auto-compaction-summary-lifetime.ts
+++ b/packages/runtime/src/thread/runtime/auto-compaction-summary-lifetime.ts
@@ -2,6 +2,7 @@ import {
   type CompactionSummaryOptions,
   DETACHED_SUMMARY_BACKSTOP_MS,
 } from "./auto-compaction-types";
+import { unrefTimer } from "./unref-timer";
 
 export interface SummaryLifetimeSignal {
   readonly release: () => void;
@@ -35,7 +36,7 @@ export function resolveSummaryLifetimeSignal({
       new Error("Detached compaction summary exceeded the safety backstop.")
     );
   }, DETACHED_SUMMARY_BACKSTOP_MS);
-  timer.unref();
+  unrefTimer(timer);
   return {
     release: () => clearTimeout(timer),
     signal: options.signal

--- a/packages/runtime/src/thread/runtime/edge-timer-unref.test.ts
+++ b/packages/runtime/src/thread/runtime/edge-timer-unref.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveSummaryLifetimeSignal } from "./auto-compaction-summary-lifetime";
+import { createCompactionThreadIdentity } from "./compaction-thread-identity";
+import { DetachedSummaryJobs } from "./speculative-compaction-detached";
+import { context, message } from "./speculative-compaction-test-support";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("detached compaction on web timers", () => {
+  it("supports numeric timer handles for startup, cancellation, and cleanup", () => {
+    const clearTimeoutMock = vi.fn();
+    vi.stubGlobal(
+      "setTimeout",
+      vi.fn(() => 1)
+    );
+    vi.stubGlobal("clearTimeout", clearTimeoutMock);
+
+    const lifetime = resolveSummaryLifetimeSignal({
+      episodeSignal: new AbortController().signal,
+      options: { lifetime: "detached" },
+    });
+    expect(lifetime.signal.aborted).toBe(false);
+    lifetime.release();
+
+    const owner = Object.freeze({});
+    const releases = vi.fn();
+    const jobs = new DetachedSummaryJobs();
+    const job = jobs.startOrJoin(
+      context(
+        [message("history", "user")],
+        vi.fn(() => new Promise<string>(() => undefined)),
+        {
+          threadIdentity: createCompactionThreadIdentity(owner, "edge"),
+          threadKey: "edge",
+        }
+      ),
+      { endSeqExclusive: 1, startSeq: 0 },
+      () => ({ install: vi.fn(), release: releases })
+    );
+
+    job.cancel();
+
+    expect(releases).toHaveBeenCalledTimes(1);
+    expect(clearTimeoutMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
+++ b/packages/runtime/src/thread/runtime/speculative-compaction-detached.ts
@@ -9,6 +9,7 @@ import type {
 import { DETACHED_SUMMARY_BACKSTOP_MS } from "./auto-compaction-types";
 import { compactionThreadIdentityParts } from "./compaction-thread-identity";
 import { SPECULATIVE_CANDIDATE_CACHE_MAX } from "./speculative-candidate-cache";
+import { unrefTimer } from "./unref-timer";
 
 export interface DetachedSummaryJob {
   readonly cancel: () => void;
@@ -134,7 +135,7 @@ export class DetachedSummaryJobs {
     ownerJobs.set(threadKey, job);
     this.#touch(job);
     timer = setTimeout(() => finalize(true), DETACHED_SUMMARY_BACKSTOP_MS);
-    timer.unref();
+    unrefTimer(timer);
     this.#evict();
     return job;
   }

--- a/packages/runtime/src/thread/runtime/unref-timer.ts
+++ b/packages/runtime/src/thread/runtime/unref-timer.ts
@@ -1,0 +1,10 @@
+export function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  if (
+    typeof timer === "object" &&
+    timer !== null &&
+    "unref" in timer &&
+    typeof timer.unref === "function"
+  ) {
+    timer.unref();
+  }
+}


### PR DESCRIPTION
Fixes a HIGH finding confirmed by the 2026-09-03 full review of main (`.omo/reviews/main-2026-09-03/full-review.md`, claim-verified with file:line evidence).

## Evidence

- Failing-first regression: `.omo/evidence/edge-timer-unref-red.txt` (RED before the fix)
- Green after fix: `.omo/evidence/edge-timer-unref-green.txt`
- Full gates (package tests, typecheck, lint, build): see `.omo/evidence/` in the branch worktree
- Tegami entry included

Branch: `fix/2026-09-03-edge-timer-unref` (atomic commit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a HIGH-severity crash where detached compaction timers called `unref()` on web and edge runtimes, where `setTimeout` returns a numeric handle instead of a Node.js `Timeout` object. Summary startup and cleanup no longer throw in those environments.

- Adds `unrefTimer` helper that only calls `unref()` when the handle is an object with an `unref` function.
- Updates both detached compaction timer call sites to use the helper.
- Adds a regression test covering startup, cancellation, and cleanup with numeric timer handles.
- Includes a patch changeset for `@minpeter/pss-runtime`.

<sup>Written for commit 3f1198f48f05da7acd0a9f785421309c57e75c0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

