### PR TITLE
fix(runtime): fail closed on missing checkpoints

### DIFF
--- a/.tegami/2026-09-03-checkpoint-fail-closed.md
+++ b/.tegami/2026-09-03-checkpoint-fail-closed.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Fail closed on missing checkpoints
+
+Checkpoint adapters now surface checkpoint corruption when authoritative run metadata references a missing checkpoint, preventing resume from silently restarting at step one.

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -299,6 +299,7 @@
       "type TurnTransitionExpected",
       "type TurnTransitionResult",
       "type TurnTransitionUpdate",
+      "value CheckpointCorruptionError",
       "value ThreadInputDuplicateConflictError",
       "value ToolExecutionNeedsRecoveryError",
       "value UnsupportedCheckpointFencingError",

--- a/packages/runtime/src/contracts/execution-store/checkpoint-contract.ts
+++ b/packages/runtime/src/contracts/execution-store/checkpoint-contract.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type {
-  Checkpoint,
-  HostStore,
-  LeaseFencedCheckpointStore,
-  TurnStatus,
+import {
+  type Checkpoint,
+  CheckpointCorruptionError,
+  type HostStore,
+  type LeaseFencedCheckpointStore,
+  type TurnStatus,
 } from "../../execution";
 import { createQueuedRun } from "./fixtures";
 
@@ -21,6 +22,22 @@ const TERMINAL_STATUSES = [
 export function describeCheckpointStoreContract({
   createStore,
 }: CheckpointContractOptions): void {
+  describe("checkpoint reads", () => {
+    it("fails closed when authority references a missing checkpoint", async () => {
+      // Given: a run whose authoritative version has no checkpoint payload.
+      const store = createStore();
+      const run = createQueuedRun();
+      await store.turns.create(run);
+      await store.turns.update({ ...run, checkpointVersion: 1 });
+
+      // When: the authoritative checkpoint is requested.
+      const read = store.checkpoints.latest(run.runId);
+
+      // Then: corruption is surfaced instead of becoming a new run.
+      await expect(read).rejects.toBeInstanceOf(CheckpointCorruptionError);
+    });
+  });
+
   describe("checkpoint writes", () => {
     it("preserves the released legacy append result", async () => {
       // Given: a run at checkpoint version zero.

--- a/packages/runtime/src/execution/host/checkpoint-corruption.ts
+++ b/packages/runtime/src/execution/host/checkpoint-corruption.ts
@@ -1,0 +1,13 @@
+export class CheckpointCorruptionError extends Error {
+  readonly checkpointVersion: number;
+  readonly runId: string;
+
+  constructor(runId: string, checkpointVersion: number) {
+    super(
+      `Checkpoint authority for run ${runId} references missing version ${checkpointVersion}.`
+    );
+    this.name = "CheckpointCorruptionError";
+    this.checkpointVersion = checkpointVersion;
+    this.runId = runId;
+  }
+}

--- a/packages/runtime/src/execution/index.ts
+++ b/packages/runtime/src/execution/index.ts
@@ -11,6 +11,7 @@ export type {
   DispatchedAgentNotification,
 } from "./dispatch/notification-dispatch";
 export { dispatchAgentNotification } from "./dispatch/notification-dispatch";
+export { CheckpointCorruptionError } from "./host/checkpoint-corruption";
 export { UnsupportedCheckpointFencingError } from "./host/checkpoint-fencing";
 export {
   createEventCursor,

--- a/packages/runtime/src/platform/durable-object/storage/sqlite/checkpoint-store.ts
+++ b/packages/runtime/src/platform/durable-object/storage/sqlite/checkpoint-store.ts
@@ -7,6 +7,7 @@ import type {
   LeaseFencedCheckpointWriteResult,
   TurnRecord,
 } from "../../../../execution";
+import { CheckpointCorruptionError } from "../../../../execution/host/checkpoint-corruption";
 import {
   decideCheckpointVersionWrite,
   decideLeaseFencedCheckpointWrite,
@@ -131,7 +132,10 @@ export class DurableObjectSqliteCheckpointStore
           row.checkpoint
         )
       : null;
-    return checkpoint ? (JSON.parse(checkpoint) as Checkpoint) : null;
+    if (!checkpoint) {
+      throw new CheckpointCorruptionError(runId, run.checkpointVersion);
+    }
+    return JSON.parse(checkpoint) as Checkpoint;
   }
 
   async #persist(

--- a/packages/runtime/src/platform/file/storage/file-execution-store/checkpoint-store.ts
+++ b/packages/runtime/src/platform/file/storage/file-execution-store/checkpoint-store.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { CheckpointCorruptionError } from "../../../../execution/host/checkpoint-corruption";
 import {
   decideCheckpointVersionWrite,
   decideLeaseFencedCheckpointWrite,
@@ -18,17 +19,10 @@ import { parseRunCheckpoint } from "./schemas";
 import type { DataDirectoryResolver } from "./types";
 import { encodeKey } from "./utils";
 
-export class FileCheckpointCorruptionError extends Error {
-  readonly checkpointVersion: number;
-  readonly runId: string;
-
+export class FileCheckpointCorruptionError extends CheckpointCorruptionError {
   constructor(runId: string, checkpointVersion: number) {
-    super(
-      `File checkpoint authority for run ${runId} references missing version ${checkpointVersion}.`
-    );
+    super(runId, checkpointVersion);
     this.name = "FileCheckpointCorruptionError";
-    this.checkpointVersion = checkpointVersion;
-    this.runId = runId;
   }
 }
 

--- a/packages/runtime/src/platform/memory/execution/checkpoint-store.ts
+++ b/packages/runtime/src/platform/memory/execution/checkpoint-store.ts
@@ -1,3 +1,4 @@
+import { CheckpointCorruptionError } from "../../../execution/host/checkpoint-corruption";
 import {
   decideCheckpointVersionWrite,
   decideLeaseFencedCheckpointWrite,
@@ -67,7 +68,10 @@ export class InMemoryCheckpointStore
     const checkpoint = checkpoints.find(
       (candidate) => candidate.version === run.checkpointVersion
     );
-    return Promise.resolve(checkpoint ? structuredClone(checkpoint) : null);
+    if (!checkpoint) {
+      throw new CheckpointCorruptionError(runId, run.checkpointVersion);
+    }
+    return Promise.resolve(structuredClone(checkpoint));
   }
 
   #persist(


### PR DESCRIPTION
Fixes a HIGH finding confirmed by the 2026-09-03 full review of main (`.omo/reviews/main-2026-09-03/full-review.md`, claim-verified with file:line evidence).

## Evidence

- Failing-first regression: `.omo/evidence/checkpoint-fail-closed-red.txt` (RED before the fix)
- Green after fix: `.omo/evidence/checkpoint-fail-closed-green.txt`
- Full gates (package tests, typecheck, lint, build): see `.omo/evidence/` in the branch worktree
- Tegami entry included

Branch: `fix/2026-09-03-checkpoint-fail-closed` (atomic commit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checkpoint adapters now fail closed when authoritative run metadata references a missing checkpoint, instead of silently returning `null` and restarting the run at step one.

**Migration**
- `FileCheckpointCorruptionError` now extends the new shared `CheckpointCorruptionError`; existing callers catching the old class still work, but code checking `instanceof CheckpointCorruptionError` will now match it.
- `CheckpointCorruptionError` is now exported from the package's public API.

<sup>Written for commit 564950bfbb77a1e64ee379c4064794dc6faede75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

