### PR TITLE
fix(tui): cancel pending selectors on exit

### DIFF
--- a/.tegami/2026-09-03-tui-exit-hang.md
+++ b/.tegami/2026-09-03-tui-exit-hang.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Let the TUI exit while selectors are pending
+
+Cancel pending model and session selector waits when exit is requested so catalog loading or an open picker cannot keep the process alive.

--- a/apps/coding-agent/src/tui/agent-exit.test.ts
+++ b/apps/coding-agent/src/tui/agent-exit.test.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from "@earendil-works/pi-tui";
-import { describe, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const terminalHarness = vi.hoisted(() => ({
   send: undefined as ((data: string) => void) | undefined,
@@ -136,8 +136,9 @@ describe.sequential("TUI selector exit", () => {
     await expectExitBefore(run, () => catalog.resolve([]));
   });
 
-  it("exits while the model selector is open", async () => {
+  it("exits while the model selector is open and settles the selector itself", async () => {
     const opened = deferred<void>();
+    const switchModel = vi.fn();
     const run = createAgentTUI({
       ...baseConfig(),
       modelSelector: {
@@ -146,13 +147,18 @@ describe.sequential("TUI selector exit", () => {
           return "model-a";
         },
         listModelIds: () => Promise.resolve(["model-a"]),
-        switchModel: vi.fn(),
+        switchModel,
       },
     });
 
     await opened.promise;
     requestExit();
 
-    await expectExitBefore(run, () => terminalHarness.send?.("\u001b"));
+    // No manual Escape: exit must settle the selector through its own
+    // cancellation path. A stale selection key sent after the TUI stopped
+    // must not reach a leaked selector and switch the model.
+    await expectExitBefore(run, () => undefined);
+    terminalHarness.send?.("\r");
+    expect(switchModel).not.toHaveBeenCalled();
   });
 });

--- a/apps/coding-agent/src/tui/agent-exit.test.ts
+++ b/apps/coding-agent/src/tui/agent-exit.test.ts
@@ -1,0 +1,158 @@
+import type { Terminal } from "@earendil-works/pi-tui";
+import { describe, it, vi } from "vitest";
+
+const terminalHarness = vi.hoisted(() => ({
+  send: undefined as ((data: string) => void) | undefined,
+}));
+
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  const noop = (): void => undefined;
+
+  class TestTerminal implements Terminal {
+    readonly clearFromCursor = noop;
+    readonly clearLine = noop;
+    readonly clearScreen = noop;
+    readonly columns = 80;
+    readonly hideCursor = noop;
+    readonly kittyProtocolActive = false;
+    readonly moveBy = noop;
+    readonly rows = 24;
+    readonly setProgress = noop;
+    readonly setTitle = noop;
+    readonly showCursor = noop;
+    readonly stop = noop;
+    readonly write = noop;
+
+    drainInput(): Promise<void> {
+      return Promise.resolve();
+    }
+    start(onInput: (data: string) => void): void {
+      terminalHarness.send = onInput;
+    }
+  }
+
+  return { ...actual, ProcessTerminal: TestTerminal };
+});
+
+import { type AgentTUIConfig, createAgentTUI } from "./agent";
+
+const deferred = <T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+} => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, reject, resolve };
+};
+
+const submitModelCommandAfterSetup = (): void => {
+  // The outer microtask lets createAgentTUI continue past onSetup; the inner
+  // one runs after its input waiter has been installed.
+  queueMicrotask(() => {
+    queueMicrotask(() => {
+      for (const input of "/model") {
+        terminalHarness.send?.(input);
+      }
+      terminalHarness.send?.("\r");
+    });
+  });
+};
+
+const requestExit = (): void => {
+  process.emit("SIGINT", "SIGINT");
+  process.emit("SIGINT", "SIGINT");
+};
+
+const baseConfig = (): Pick<
+  AgentTUIConfig,
+  "commands" | "onSetup" | "thread"
+> => ({
+  commands: [
+    {
+      description: "Select a model",
+      execute: () => ({ action: { type: "select-model" }, success: true }),
+      name: "model",
+    },
+  ],
+  onSetup: submitModelCommandAfterSetup,
+  thread: {
+    interrupt: vi.fn(),
+    send: vi.fn(() => {
+      throw new Error("unexpected model turn");
+    }),
+    steer: vi.fn(() => {
+      throw new Error("unexpected model steering");
+    }),
+  },
+});
+
+const expectExitBefore = async (
+  run: Promise<void>,
+  cleanup: () => void
+): Promise<void> => {
+  const timeout = deferred<never>();
+  const signal = AbortSignal.timeout(250);
+  signal.addEventListener(
+    "abort",
+    () =>
+      timeout.reject(new Error("TUI did not exit after exit was requested")),
+    { once: true }
+  );
+
+  try {
+    await Promise.race([run, timeout.promise]);
+  } finally {
+    cleanup();
+    await run;
+  }
+};
+
+describe.sequential("TUI selector exit", () => {
+  it("exits while the model catalog is loading", async () => {
+    const catalog = deferred<string[]>();
+    const loading = deferred<void>();
+    const run = createAgentTUI({
+      ...baseConfig(),
+      modelSelector: {
+        currentModelId: () => "model-a",
+        listModelIds: () => {
+          loading.resolve();
+          return catalog.promise;
+        },
+        switchModel: vi.fn(),
+      },
+    });
+
+    await loading.promise;
+    requestExit();
+
+    await expectExitBefore(run, () => catalog.resolve([]));
+  });
+
+  it("exits while the model selector is open", async () => {
+    const opened = deferred<void>();
+    const run = createAgentTUI({
+      ...baseConfig(),
+      modelSelector: {
+        currentModelId: () => {
+          opened.resolve();
+          return "model-a";
+        },
+        listModelIds: () => Promise.resolve(["model-a"]),
+        switchModel: vi.fn(),
+      },
+    });
+
+    await opened.promise;
+    requestExit();
+
+    await expectExitBefore(run, () => terminalHarness.send?.("\u001b"));
+  });
+});

--- a/apps/coding-agent/src/tui/agent-exit.test.ts
+++ b/apps/coding-agent/src/tui/agent-exit.test.ts
@@ -161,4 +161,52 @@ describe.sequential("TUI selector exit", () => {
     terminalHarness.send?.("\r");
     expect(switchModel).not.toHaveBeenCalled();
   });
+
+  it("removes the selector abort listener after normal cancellation", async () => {
+    const addEventListener = vi.spyOn(
+      AbortSignal.prototype,
+      "addEventListener"
+    );
+    const removeEventListener = vi.spyOn(
+      AbortSignal.prototype,
+      "removeEventListener"
+    );
+    const opened = deferred<void>();
+    let listenersBeforeCommand = 0;
+    const run = createAgentTUI({
+      ...baseConfig(),
+      onSetup: () => {
+        listenersBeforeCommand = addEventListener.mock.calls.length;
+        submitModelCommandAfterSetup();
+      },
+      modelSelector: {
+        currentModelId: () => {
+          opened.resolve();
+          return "model-a";
+        },
+        listModelIds: () => Promise.resolve(["model-a"]),
+        switchModel: vi.fn(),
+      },
+    });
+
+    try {
+      await opened.promise;
+      const selectorAbortListeners = addEventListener.mock.calls
+        .slice(listenersBeforeCommand)
+        .filter(([type]) => type === "abort");
+      expect(selectorAbortListeners).toHaveLength(1);
+      const selectorAbortListener = selectorAbortListeners[0]?.[1];
+      terminalHarness.send?.("\u001b");
+
+      expect(removeEventListener).toHaveBeenCalledWith(
+        "abort",
+        selectorAbortListener
+      );
+    } finally {
+      requestExit();
+      await expectExitBefore(run, () => undefined);
+      addEventListener.mockRestore();
+      removeEventListener.mockRestore();
+    }
+  });
 });

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -87,6 +87,7 @@ const CTRL_C_ETX = "\u0003";
 const MODEL_SELECTOR_COMPACT_ROWS = 16;
 const MODEL_SELECTOR_COMPACT_CHROME_ROWS = 4;
 const MODEL_SELECTOR_STANDARD_CHROME_ROWS = 10;
+const EXIT_REQUESTED = Symbol("exit-requested");
 
 const style = (prefix: string, text: string): string =>
   `${prefix}${text}${ANSI_RESET}`;
@@ -780,6 +781,17 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   let activeSessionSelector: SessionSelectorComponent | undefined;
   let commandInputListenerActive = false;
   const extensionUiController = new AbortController();
+  const exitRequested = new Promise<typeof EXIT_REQUESTED>((resolve) => {
+    extensionUiController.signal.addEventListener(
+      "abort",
+      () => resolve(EXIT_REQUESTED),
+      { once: true }
+    );
+  });
+  const untilExit = <T>(
+    operation: Promise<T>
+  ): Promise<T | typeof EXIT_REQUESTED> =>
+    Promise.race([operation, exitRequested]);
 
   const clearStatus = (): void => {
     foregroundStatusMessage = null;
@@ -1234,7 +1246,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     showLoader("Loading model catalog...");
     let modelIds: string[];
     try {
-      modelIds = await selectorConfig.listModelIds();
+      const result = await untilExit(selectorConfig.listModelIds());
+      if (result === EXIT_REQUESTED) {
+        return;
+      }
+      modelIds = result;
     } catch (error) {
       clearStatus();
       addSystemMessage(
@@ -1254,7 +1270,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
 
-    const selection = await new Promise<string | undefined>((resolve) => {
+    const pendingSelection = new Promise<string | undefined>((resolve) => {
       // Let the selector own ctrl+c/escape while it is mounted.
       commandInputListenerActive = true;
       let selector: ModelSelectorComponent | undefined;
@@ -1283,8 +1299,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       tui.setFocus(composerLayer);
       tui.requestRender();
     });
+    const selection = await untilExit(pendingSelection);
 
-    if (selection === undefined) {
+    if (selection === undefined || selection === EXIT_REQUESTED) {
       return;
     }
     try {
@@ -1314,7 +1331,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     showLoader("Loading sessions...");
     let sessions: readonly SessionIndexEntry[];
     try {
-      sessions = await selectorConfig.listSessions();
+      const result = await untilExit(selectorConfig.listSessions());
+      if (result === EXIT_REQUESTED) {
+        return;
+      }
+      sessions = result;
     } catch (error) {
       clearStatus();
       addSystemMessage(
@@ -1331,7 +1352,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
 
-    const selection = await new Promise<string | undefined>((resolve) => {
+    const pendingSelection = new Promise<string | undefined>((resolve) => {
       commandInputListenerActive = true;
       let selector: SessionSelectorComponent | undefined;
       const settle = (sessionKey: string | undefined): void => {
@@ -1359,9 +1380,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       tui.setFocus(composerLayer);
       tui.requestRender();
     });
+    const selection = await untilExit(pendingSelection);
 
     if (
       selection === undefined ||
+      selection === EXIT_REQUESTED ||
       selection === selectorConfig.currentSessionKey()
     ) {
       return;

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -1280,6 +1280,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           return;
         }
         settled = true;
+        extensionUiController.signal.removeEventListener("abort", abort);
         commandInputListenerActive = false;
         if (activeModelSelector === selector) {
           activeModelSelector = undefined;
@@ -1292,11 +1293,10 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       // Exit must settle the selector through the same idempotent path as
       // Escape; otherwise it stays mounted with input capture still active
       // after the TUI has stopped.
-      extensionUiController.signal.addEventListener(
-        "abort",
-        () => settle(undefined),
-        { once: true }
-      );
+      const abort = () => settle(undefined);
+      extensionUiController.signal.addEventListener("abort", abort, {
+        once: true,
+      });
       const layout = getModelSelectorLayout();
       selector = new ModelSelectorComponent({
         compact: layout.compact,
@@ -1374,6 +1374,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           return;
         }
         settled = true;
+        extensionUiController.signal.removeEventListener("abort", abort);
         commandInputListenerActive = false;
         if (activeSessionSelector === selector) {
           activeSessionSelector = undefined;
@@ -1386,11 +1387,10 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       // Exit must settle the selector through the same idempotent path as
       // Escape; otherwise it stays mounted with input capture still active
       // after the TUI has stopped.
-      extensionUiController.signal.addEventListener(
-        "abort",
-        () => settle(undefined),
-        { once: true }
-      );
+      const abort = () => settle(undefined);
+      extensionUiController.signal.addEventListener("abort", abort, {
+        once: true,
+      });
       const layout = getModelSelectorLayout();
       selector = new SessionSelectorComponent({
         compact: layout.compact,

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -1274,7 +1274,12 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       // Let the selector own ctrl+c/escape while it is mounted.
       commandInputListenerActive = true;
       let selector: ModelSelectorComponent | undefined;
+      let settled = false;
       const settle = (modelId: string | undefined): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
         commandInputListenerActive = false;
         if (activeModelSelector === selector) {
           activeModelSelector = undefined;
@@ -1284,6 +1289,14 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         tui.requestRender();
         resolve(modelId);
       };
+      // Exit must settle the selector through the same idempotent path as
+      // Escape; otherwise it stays mounted with input capture still active
+      // after the TUI has stopped.
+      extensionUiController.signal.addEventListener(
+        "abort",
+        () => settle(undefined),
+        { once: true }
+      );
       const layout = getModelSelectorLayout();
       selector = new ModelSelectorComponent({
         compact: layout.compact,
@@ -1355,7 +1368,12 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     const pendingSelection = new Promise<string | undefined>((resolve) => {
       commandInputListenerActive = true;
       let selector: SessionSelectorComponent | undefined;
+      let settled = false;
       const settle = (sessionKey: string | undefined): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
         commandInputListenerActive = false;
         if (activeSessionSelector === selector) {
           activeSessionSelector = undefined;
@@ -1365,6 +1383,14 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         tui.requestRender();
         resolve(sessionKey);
       };
+      // Exit must settle the selector through the same idempotent path as
+      // Escape; otherwise it stays mounted with input capture still active
+      // after the TUI has stopped.
+      extensionUiController.signal.addEventListener(
+        "abort",
+        () => settle(undefined),
+        { once: true }
+      );
       const layout = getModelSelectorLayout();
       selector = new SessionSelectorComponent({
         compact: layout.compact,


### PR DESCRIPTION
Fixes a HIGH finding confirmed by the 2026-09-03 full review of main (`.omo/reviews/main-2026-09-03/full-review.md`, claim-verified with file:line evidence).

## Evidence

- Failing-first regression: `.omo/evidence/tui-exit-hang-red.txt` (RED before the fix)
- Green after fix: `.omo/evidence/tui-exit-hang-green.txt`
- Full gates (package tests, typecheck, lint, build): see `.omo/evidence/` in the branch worktree
- Tegami entry included

Branch: `fix/2026-09-03-tui-exit-hang` (atomic commit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, pending model or session selectors could keep the TUI process alive after exit was requested. Exit now cancels pending loading and settles open selectors, releasing input capture and preventing stale selections.

- Covers model catalog loading, model selection, session loading, and session selection.
- Settles selectors through the same idempotent path as Escape so input capture is released exactly once, and detaches the abort listener after normal cancellation.
- Adds regression tests for exit during loading, while a picker is open, and for listener cleanup.

<sup>Written for commit abfe96480fb1dbc38c414d8002341f7c3f0b21c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

