### PR TITLE
fix(workspace-tools): re-verify containment before mutations

### DIFF
--- a/.tegami/2026-09-03-workspace-symlink-swap.md
+++ b/.tegami/2026-09-03-workspace-symlink-swap.md
@@ -1,0 +1,12 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Re-verify workspace containment at mutation time
+
+Workspace mutations re-canonicalize the nearest existing ancestor immediately
+before writing or deleting, so an intermediate directory swapped for an
+escaping symlink between resolution and mutation now fails closed instead of
+writing or deleting outside the workspace.

--- a/apps/coding-agent/src/workspace-tools/delete-file.ts
+++ b/apps/coding-agent/src/workspace-tools/delete-file.ts
@@ -3,6 +3,7 @@ import { type Tool, tool } from "ai";
 import { z } from "zod";
 import { computeFileHash } from "./hashline";
 import {
+  assertWorkspacePathContained,
   isInsideWorkspace,
   resolveWorkspacePath,
   workspaceRelativePath,
@@ -94,6 +95,9 @@ export function createDeleteFileTool(
           expectedHash
         );
       }
+      await assertWorkspacePathContained(resolved.root, absolutePath, {
+        followFinalSymlink: false,
+      });
       await rm(absolutePath, { recursive, force: false });
       return `OK - deleted\npath: ${workspaceRelativePath(resolved.root, absolutePath)}`;
     },

--- a/apps/coding-agent/src/workspace-tools/edit-file.ts
+++ b/apps/coding-agent/src/workspace-tools/edit-file.ts
@@ -303,7 +303,7 @@ export function createEditFileTool(
       assertNoIntersectingInsertions(resolvedEdits);
       const outputLines = applyEdits(sourceLines, resolvedEdits);
       const output = `${outputLines.join(eol)}${trailingNewline && outputLines.length > 0 ? eol : ""}`;
-      await atomicWrite(absolutePath, output, originalHash);
+      await atomicWrite(resolved.root, absolutePath, output, originalHash);
 
       const diffLines = buildDiffSectionLines(resolvedEdits, sourceLines);
 

--- a/apps/coding-agent/src/workspace-tools/path-safety-containment.test.ts
+++ b/apps/coding-agent/src/workspace-tools/path-safety-containment.test.ts
@@ -1,0 +1,103 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assertWorkspacePathContained,
+  resolveWorkspacePath,
+} from "./path-safety";
+import { atomicWrite } from "./write-file";
+
+const OUTSIDE_WORKSPACE_MESSAGE = /outside the workspace/;
+
+let workspace: string;
+let outside: string;
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "pss-ws-"));
+  outside = await mkdtemp(join(tmpdir(), "pss-out-"));
+  await mkdir(join(workspace, "sub"), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workspace, { recursive: true, force: true });
+  await rm(outside, { recursive: true, force: true });
+});
+
+async function swapSubForOutsideLink(): Promise<void> {
+  await rename(join(workspace, "sub"), join(workspace, "sub-real"));
+  await symlink(outside, join(workspace, "sub"));
+}
+
+describe("workspace containment at mutation time", () => {
+  it("rejects an atomic write after an intermediate directory is swapped for an escaping symlink", async () => {
+    await writeFile(join(workspace, "sub", "target.txt"), "original");
+    const resolved = await resolveWorkspacePath(workspace, "sub/target.txt");
+    await swapSubForOutsideLink();
+
+    await expect(
+      atomicWrite(resolved.root, resolved.path, "pwned")
+    ).rejects.toThrow(OUTSIDE_WORKSPACE_MESSAGE);
+    await expect(
+      readFile(join(outside, "target.txt"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("passes for an untouched resolved path", async () => {
+    await writeFile(join(workspace, "sub", "ok.txt"), "data");
+    const resolved = await resolveWorkspacePath(workspace, "sub/ok.txt");
+    await expect(
+      assertWorkspacePathContained(resolved.root, resolved.path)
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws after a swap even when the escaped target exists", async () => {
+    await writeFile(join(workspace, "sub", "victim.txt"), "inside");
+    await writeFile(join(outside, "victim.txt"), "outside");
+    const resolved = await resolveWorkspacePath(workspace, "sub/victim.txt");
+    await swapSubForOutsideLink();
+    await expect(
+      assertWorkspacePathContained(resolved.root, resolved.path)
+    ).rejects.toThrow(OUTSIDE_WORKSPACE_MESSAGE);
+    expect(await readFile(join(outside, "victim.txt"), "utf8")).toBe("outside");
+  });
+
+  it("honors no-follow for a final symlink whose parent is swapped", async () => {
+    await symlink(
+      join(workspace, "sub-real-target"),
+      join(workspace, "sub", "link.txt")
+    );
+    const resolved = await resolveWorkspacePath(workspace, "sub/link.txt", {
+      followFinalSymlink: false,
+    });
+    await swapSubForOutsideLink();
+    await expect(
+      assertWorkspacePathContained(resolved.root, resolved.path, {
+        followFinalSymlink: false,
+      })
+    ).rejects.toThrow(OUTSIDE_WORKSPACE_MESSAGE);
+  });
+
+  it("accepts a no-follow final symlink that is untouched", async () => {
+    await symlink(
+      join(workspace, "sub-real-target"),
+      join(workspace, "sub", "link.txt")
+    );
+    const resolved = await resolveWorkspacePath(workspace, "sub/link.txt", {
+      followFinalSymlink: false,
+    });
+    await expect(
+      assertWorkspacePathContained(resolved.root, resolved.path, {
+        followFinalSymlink: false,
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/coding-agent/src/workspace-tools/path-safety-containment.test.ts
+++ b/apps/coding-agent/src/workspace-tools/path-safety-containment.test.ts
@@ -51,6 +51,23 @@ describe("workspace containment at mutation time", () => {
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("creates nothing outside the workspace when a new-file path is swapped before writing", async () => {
+    const resolved = await resolveWorkspacePath(
+      workspace,
+      "sub/new/deep/target.txt"
+    );
+    await swapSubForOutsideLink();
+
+    await expect(
+      atomicWrite(resolved.root, resolved.path, "pwned")
+    ).rejects.toThrow(OUTSIDE_WORKSPACE_MESSAGE);
+    await expect(
+      readFile(join(outside, "new", "deep", "target.txt"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    const { readdir } = await import("node:fs/promises");
+    expect(await readdir(outside)).toStrictEqual([]);
+  });
+
   it("passes for an untouched resolved path", async () => {
     await writeFile(join(workspace, "sub", "ok.txt"), "data");
     const resolved = await resolveWorkspacePath(workspace, "sub/ok.txt");

--- a/apps/coding-agent/src/workspace-tools/path-safety.ts
+++ b/apps/coding-agent/src/workspace-tools/path-safety.ts
@@ -100,6 +100,47 @@ export async function resolveWorkspacePath(
   return { path, root };
 }
 
+export interface AssertWorkspacePathOptions {
+  /**
+   * Match resolveWorkspacePath: mutating tools keep this enabled; tools that
+   * act on the link node itself (delete_file) disable it so only the parent
+   * directory is re-canonicalized.
+   */
+  readonly followFinalSymlink?: boolean;
+}
+
+/**
+ * Re-verify that a path returned by resolveWorkspacePath is still contained.
+ * resolveWorkspacePath returns a checked string, but the filesystem mutation
+ * happens later, and an intermediate directory can be swapped for an escaping
+ * symlink in between; this re-canonicalizes the nearest existing ancestor and
+ * requires the canonical form to be unchanged, closing the check-then-use gap.
+ */
+export async function assertWorkspacePathContained(
+  root: string,
+  path: string,
+  options: AssertWorkspacePathOptions = {}
+): Promise<void> {
+  const { followFinalSymlink = true } = options;
+  let existingPath = await nearestExistingPath(path);
+  if (!followFinalSymlink && existingPath === path) {
+    const metadata = await lstat(path);
+    if (metadata.isSymbolicLink()) {
+      existingPath = dirname(path);
+    }
+  }
+  const resolvedExisting = await realpath(existingPath);
+  const canonical =
+    existingPath === path
+      ? resolvedExisting
+      : resolve(resolvedExisting, relative(existingPath, path));
+  if (!isInsideWorkspace(root, canonical) || canonical !== path) {
+    throw new Error(
+      `Path moved outside the workspace after its containment check: ${path}`
+    );
+  }
+}
+
 /** Root must be the canonical root returned by resolveWorkspacePath. */
 export function workspaceRelativePath(root: string, path: string): string {
   const relativePath = relative(root, path);

--- a/apps/coding-agent/src/workspace-tools/workspace-tools.test.ts
+++ b/apps/coding-agent/src/workspace-tools/workspace-tools.test.ts
@@ -454,7 +454,9 @@ describe("workspace coding tools", () => {
   it("cleans up the temp file when an atomic write fails", async () => {
     const directory = join(workspace, "src", "blocking-dir");
     await mkdir(directory);
-    await expect(atomicWrite(directory, "payload")).rejects.toThrow();
+    await expect(
+      atomicWrite(workspace, directory, "payload")
+    ).rejects.toThrow();
     const leftovers = (await readdir(join(workspace, "src"))).filter((entry) =>
       entry.includes(".pss-")
     );

--- a/apps/coding-agent/src/workspace-tools/write-file.ts
+++ b/apps/coding-agent/src/workspace-tools/write-file.ts
@@ -12,7 +12,11 @@ import { dirname } from "node:path";
 import { type Tool, tool } from "ai";
 import { z } from "zod";
 import { computeFileHash } from "./hashline";
-import { resolveWorkspacePath, workspaceRelativePath } from "./path-safety";
+import {
+  assertWorkspacePathContained,
+  resolveWorkspacePath,
+  workspaceRelativePath,
+} from "./path-safety";
 
 const inputSchema = z
   .object({
@@ -65,6 +69,7 @@ async function existingMode(path: string): Promise<number | undefined> {
 }
 
 export async function atomicWrite(
+  root: string,
   path: string,
   content: string,
   expectedHash?: string
@@ -86,6 +91,7 @@ export async function atomicWrite(
     // Re-verify immediately before the rename; the earlier caller-side check
     // is separated from the swap by real I/O.
     await assertExpectedHash(path, expectedHash);
+    await assertWorkspacePathContained(root, path);
     await rename(temporaryPath, path);
   } finally {
     await rm(temporaryPath, { force: true }).catch(() => undefined);
@@ -102,7 +108,7 @@ export function createWriteFileTool(
     execute: async ({ path, content, expected_file_hash: expectedHash }) => {
       const resolved = await resolveWorkspacePath(workspace, path);
       await assertExpectedHash(resolved.path, expectedHash);
-      await atomicWrite(resolved.path, content, expectedHash);
+      await atomicWrite(resolved.root, resolved.path, content, expectedHash);
       return [
         "OK - wrote file",
         `path: ${workspaceRelativePath(resolved.root, resolved.path)}`,

--- a/apps/coding-agent/src/workspace-tools/write-file.ts
+++ b/apps/coding-agent/src/workspace-tools/write-file.ts
@@ -74,6 +74,12 @@ export async function atomicWrite(
   content: string,
   expectedHash?: string
 ): Promise<void> {
+  // Fail closed before ANY filesystem mutation: when an intermediate
+  // directory was swapped for an escaping symlink after resolution, neither
+  // parent directories nor the temp file may be created outside the
+  // workspace. Node offers no fd-relative rename, so containment is asserted
+  // immediately before each mutation phase instead.
+  await assertWorkspacePathContained(root, path);
   await mkdir(dirname(path), { recursive: true });
   const mode = await existingMode(path);
   const permissions = mode === undefined ? undefined : mode % 0o1000;


### PR DESCRIPTION
Fixes a HIGH finding confirmed by the 2026-09-03 full review of main (`.omo/reviews/main-2026-09-03/full-review.md`, claim-verified with file:line evidence).

## Evidence

- Failing-first regression: `.omo/evidence/workspace-symlink-swap-red.txt` (RED before the fix)
- Green after fix: `.omo/evidence/workspace-symlink-swap-green.txt`
- Full gates (package tests, typecheck, lint, build): see `.omo/evidence/` in the branch worktree
- Tegami entry included

Branch: `fix/2026-09-03-workspace-symlink-swap` (atomic commit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes a symlink-swap gap in workspace mutations. Previously, an intermediate directory could be replaced with an escaping symlink after containment checking and redirect writes or deletes outside the workspace; mutations now fail closed instead.

**Bug Fixes**
- `atomicWrite` verifies containment before creating parent or temporary files and again before rename.
- `delete_file` re-verifies the target before `rm` without following a final symlink.
- Adds regression coverage for existing and new files, escaped targets, and untouched paths.

<sup>Written for commit 18058a7938f2d3c484cfba9ff9825388c76303ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

