### PR TITLE
fix(release): verify published extension artifacts

### DIFF
--- a/.tegami/2026-09-03-release-extension-verification.md
+++ b/.tegami/2026-09-03-release-extension-verification.md
@@ -1,0 +1,14 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Verify independently published extensions
+
+Include the LaTeX, Mermaid, and web extension artifacts in the default release
+verification. Fail closed when an extension manifest, public entrypoint, or
+runtime worker is malformed or missing, run publint for each extension package,
+and import every packed extension entrypoint in the consumer smoke before
+publishing.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:cross-platform-smoke": "pnpm turbo run build --filter=@minpeter/pss-coding-agent... && pnpm --filter @minpeter/pss-runtime exec vitest run src/platform/file/storage/file-lock.test.ts src/platform/file/storage/file-execution-store-edge.test.ts && pnpm --filter @minpeter/pss-coding-agent exec vitest run src/cli.test.ts src/cli-exec-home.test.ts src/context/context-resources.test.ts src/extensions/manager/paths.test.ts src/tui/terminal-safety.test.ts && node apps/coding-agent/bin/pss.js --help",
     "typecheck": "turbo run typecheck && tsc -p tsconfig.json --noEmit",
     "verify:edge": "pnpm --filter @minpeter/pss-worker-agent build",
-    "verify:package-apis": "publint packages/runtime && publint apps/coding-agent && node scripts/packed-consumer-smoke.mjs",
+    "verify:package-apis": "publint packages/runtime && publint apps/coding-agent && publint extensions/latex && publint extensions/mermaid && publint extensions/web && node scripts/packed-consumer-smoke.mjs",
     "verify:release": "node scripts/verify-release-artifacts.mjs && pnpm verify:package-apis"
   },
   "devDependencies": {

--- a/scripts/packed-consumer-smoke.mjs
+++ b/scripts/packed-consumer-smoke.mjs
@@ -15,7 +15,13 @@ try {
     `${JSON.stringify({ name: "pss-packed-consumer", private: true })}\n`,
     "utf8"
   );
-  const tarballs = [pack("packages/runtime"), pack("apps/coding-agent")];
+  const tarballs = [
+    pack("packages/runtime"),
+    pack("apps/coding-agent"),
+    pack("extensions/latex"),
+    pack("extensions/mermaid"),
+    pack("extensions/web"),
+  ];
   run(
     "npm",
     [
@@ -36,12 +42,18 @@ import { createInMemoryHost } from "@minpeter/pss-runtime/platform/memory";
 import { createCodingAgent, createCodingAgentTools } from "@minpeter/pss-coding-agent";
 import { resolveStartTuiTools } from "@minpeter/pss-coding-agent/tools";
 import { createWorkspaceTools } from "@minpeter/pss-coding-agent/workspace-tools";
+import createLatexExtension from "@minpeter/pss-extension-latex";
+import createMermaidExtension from "@minpeter/pss-extension-mermaid";
+import createWebExtension from "@minpeter/pss-extension-web";
 
 for (const [name, value] of Object.entries({
   createAgent,
   createCodingAgent,
   createCodingAgentTools,
   createInMemoryHost,
+  createLatexExtension,
+  createMermaidExtension,
+  createWebExtension,
   createWorkspaceTools,
   resolveStartTuiTools,
 })) {

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -35,8 +35,8 @@ describe("release workflow", () => {
     expect(packageJson.scripts["verify:release"]).toContain(
       "pnpm verify:package-apis"
     );
-    expect(packageJson.scripts["verify:package-apis"]).toContain(
-      "node scripts/packed-consumer-smoke.mjs"
+    expect(packageJson.scripts["verify:package-apis"]).toBe(
+      "publint packages/runtime && publint apps/coding-agent && publint extensions/latex && publint extensions/mermaid && publint extensions/web && node scripts/packed-consumer-smoke.mjs"
     );
     expect(workflow).not.toContain("Verify coding-agent dependency resolution");
     expect(workflow).not.toContain("NPM_CONFIG_PROVENANCE");

--- a/scripts/verify-release-artifacts-extension.test.mjs
+++ b/scripts/verify-release-artifacts-extension.test.mjs
@@ -1,0 +1,64 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { verifyReleaseArtifacts } from "./verify-release-artifacts/core.mjs";
+import {
+  cleanupFixtures,
+  createFixture,
+} from "./verify-release-artifacts.fixture.mjs";
+
+const malformedWebManifestPattern =
+  /^extensions\/web\/package\.json: cannot read package\.json /u;
+
+afterEach(cleanupFixtures);
+
+describe("verifyReleaseArtifacts extension package checks", () => {
+  it("fails closed when the web extension dist is empty", () => {
+    const cwd = createFixture();
+    rmSync(resolve(cwd, "extensions/web/dist"), {
+      force: true,
+      recursive: true,
+    });
+    mkdirSync(resolve(cwd, "extensions/web/dist"), { recursive: true });
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["extension-web"] })
+    ).toEqual([
+      "extensions/web/dist/index.js is missing; required extension artifact",
+      "extensions/web/dist/index.d.ts is missing; required extension artifact",
+    ]);
+  });
+
+  it("fails closed when the web extension package manifest is malformed", () => {
+    const cwd = createFixture();
+    writeFileSync(resolve(cwd, "extensions/web/package.json"), "not json\n");
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["extension-web"] })
+    ).toEqual([expect.stringMatching(malformedWebManifestPattern)]);
+  });
+
+  it("fails closed when Mermaid public entrypoints are missing", () => {
+    const cwd = createFixture();
+    rmSync(resolve(cwd, "extensions/mermaid/dist/index.js"));
+    rmSync(resolve(cwd, "extensions/mermaid/dist/index.d.ts"));
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["extension-mermaid"] })
+    ).toEqual([
+      "extensions/mermaid/dist/index.js is missing; required extension artifact",
+      "extensions/mermaid/dist/index.d.ts is missing; required extension artifact",
+    ]);
+  });
+
+  it("fails closed when the LaTeX worker is missing", () => {
+    const cwd = createFixture();
+    rmSync(resolve(cwd, "extensions/latex/dist/mathjax-worker.js"));
+
+    expect(
+      verifyReleaseArtifacts({ cwd, packages: ["extension-latex"] })
+    ).toEqual([
+      "extensions/latex/dist/mathjax-worker.js is missing; required extension artifact",
+    ]);
+  });
+});

--- a/scripts/verify-release-artifacts-package.test.mjs
+++ b/scripts/verify-release-artifacts-package.test.mjs
@@ -6,6 +6,7 @@ import {
   isMainModule,
   verifyReleaseArtifacts,
 } from "./verify-release-artifacts/core.mjs";
+import { DEFAULT_PACKAGES } from "./verify-release-artifacts/shared.mjs";
 import {
   cleanupFixtures,
   cliBinReadFailurePattern,
@@ -33,6 +34,29 @@ describe("verifyReleaseArtifacts package checks", () => {
         packages: ["extension-latex"],
       })
     ).toEqual([]);
+  });
+
+  it("selects the independently published Mermaid and web extensions by default", () => {
+    const cwd = createFixture();
+    rmSync(resolve(cwd, "extensions/mermaid/dist"), {
+      force: true,
+      recursive: true,
+    });
+    rmSync(resolve(cwd, "extensions/web/dist"), {
+      force: true,
+      recursive: true,
+    });
+
+    expect(
+      verifyReleaseArtifacts({
+        checkPublicApiSnapshot: false,
+        cwd,
+        packages: DEFAULT_PACKAGES,
+      })
+    ).toEqual([
+      "extensions/mermaid/dist is missing; run the package build first",
+      "extensions/web/dist is missing; run the package build first",
+    ]);
   });
 
   it("resolves the LaTeX extension from the extensions workspace", () => {

--- a/scripts/verify-release-artifacts.fixture.mjs
+++ b/scripts/verify-release-artifacts.fixture.mjs
@@ -30,7 +30,13 @@ export function createTrackedTempRoot(prefix) {
 export function createFixture() {
   const cwd = createTrackedTempRoot("pss-release-artifacts-");
 
-  for (const packageName of ["runtime", "extension-latex", "coding-agent"]) {
+  for (const packageName of [
+    "runtime",
+    "extension-latex",
+    "extension-mermaid",
+    "extension-web",
+    "coding-agent",
+  ]) {
     const packageRoot = fixturePackageRoot(cwd, packageName);
     mkdirSync(join(packageRoot, "dist"), { recursive: true });
     writeFileSync(
@@ -66,15 +72,24 @@ function packageMetadata(packageName) {
       },
     };
   }
-  return {};
+  return {
+    exports: {
+      ".": {
+        import: "./dist/index.js",
+        types: "./dist/index.d.ts",
+      },
+    },
+    files: ["dist", "README.md"],
+    name: `@minpeter/pss-${packageName}`,
+  };
 }
 
 function fixturePackageRoot(cwd, packageName) {
   if (packageName === "coding-agent") {
     return join(cwd, "apps", "coding-agent");
   }
-  if (packageName === "extension-latex") {
-    return join(cwd, "extensions", "latex");
+  if (packageName.startsWith("extension-")) {
+    return join(cwd, "extensions", packageName.slice("extension-".length));
   }
   return join(cwd, "packages", packageName);
 }
@@ -94,6 +109,20 @@ function writePackageDeclarationFixtures(cwd, packageName, packageRoot) {
       { mode: 0o755 }
     );
     writeRuntimeDeclarationFixtures(cwd, packageName);
+    return;
+  }
+  if (packageName === "extension-latex") {
+    writeFileSync(
+      join(packageRoot, "dist", "mathjax-worker.js"),
+      "export const ok = true;\n"
+    );
+    return;
+  }
+  if (packageName === "extension-mermaid") {
+    writeFileSync(
+      join(packageRoot, "dist", "mermaid-art-worker.js"),
+      "export const ok = true;\n"
+    );
     return;
   }
   if (packageName !== "coding-agent") {

--- a/scripts/verify-release-artifacts/core.mjs
+++ b/scripts/verify-release-artifacts/core.mjs
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { findRuntimePublicApiSnapshotErrors } from "../runtime-public-api-snapshot.mjs";
+import { findExtensionArtifactErrors } from "./extension-checks.mjs";
 import {
   findBundledExtensionImportLeaks,
   findExtensionlessRelativeImports,
@@ -54,6 +55,7 @@ export function verifyReleaseArtifacts(options) {
       ? findRuntimePublicApiSnapshotErrors(options)
       : []),
     ...requirePackageDists(options),
+    ...findExtensionArtifactErrors(options),
     ...findPackageBinEntrypointErrors(options),
     ...findExtensionlessRelativeImports(options),
     ...findPublishedTestArtifacts(options),

--- a/scripts/verify-release-artifacts/extension-checks.mjs
+++ b/scripts/verify-release-artifacts/extension-checks.mjs
@@ -1,0 +1,78 @@
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  isRecord,
+  packageDistPath,
+  packageRootPath,
+  readJsonForVerification,
+  relativeToCwd,
+} from "./shared.mjs";
+
+const EXTENSION_CONTRACTS = {
+  "extension-latex": {
+    artifacts: ["index.js", "index.d.ts", "mathjax-worker.js"],
+    name: "@minpeter/pss-extension-latex",
+  },
+  "extension-mermaid": {
+    artifacts: ["index.js", "index.d.ts", "mermaid-art-worker.js"],
+    name: "@minpeter/pss-extension-mermaid",
+  },
+  "extension-web": {
+    artifacts: ["index.js", "index.d.ts"],
+    name: "@minpeter/pss-extension-web",
+  },
+};
+
+export function findExtensionArtifactErrors({ cwd, packages }) {
+  const errors = [];
+
+  for (const packageName of packages) {
+    const contract = EXTENSION_CONTRACTS[packageName];
+    if (!contract) {
+      continue;
+    }
+
+    const packageRoot = packageRootPath(cwd, packageName);
+    const packageJsonPath = join(packageRoot, "package.json");
+    const packageJson = readJsonForVerification({ cwd, file: packageJsonPath });
+    if (packageJson.error) {
+      errors.push(packageJson.error);
+    } else {
+      const value = packageJson.value;
+      const rootExport =
+        isRecord(value) && isRecord(value.exports)
+          ? value.exports["."]
+          : undefined;
+      if (
+        !(
+          isRecord(value) &&
+          value.name === contract.name &&
+          isRecord(rootExport) &&
+          rootExport.import === "./dist/index.js" &&
+          rootExport.types === "./dist/index.d.ts" &&
+          Array.isArray(value.files) &&
+          value.files.includes("dist")
+        )
+      ) {
+        errors.push(
+          `${relativeToCwd(cwd, packageJsonPath)}: invalid extension package contract`
+        );
+      }
+    }
+
+    const distPath = packageDistPath(cwd, packageName);
+    if (!(existsSync(distPath) && statSync(distPath).isDirectory())) {
+      continue;
+    }
+    for (const artifact of contract.artifacts) {
+      const artifactPath = join(distPath, artifact);
+      if (!existsSync(artifactPath)) {
+        errors.push(
+          `${relativeToCwd(cwd, artifactPath)} is missing; required extension artifact`
+        );
+      }
+    }
+  }
+
+  return errors;
+}

--- a/scripts/verify-release-artifacts/shared.mjs
+++ b/scripts/verify-release-artifacts/shared.mjs
@@ -1,10 +1,18 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-export const DEFAULT_PACKAGES = ["runtime", "coding-agent"];
+export const DEFAULT_PACKAGES = [
+  "runtime",
+  "coding-agent",
+  "extension-latex",
+  "extension-mermaid",
+  "extension-web",
+];
 const PACKAGE_ROOTS = {
   "coding-agent": "apps/coding-agent",
   "extension-latex": "extensions/latex",
+  "extension-mermaid": "extensions/mermaid",
+  "extension-web": "extensions/web",
   runtime: "packages/runtime",
 };
 


### PR DESCRIPTION
Fixes a HIGH finding confirmed by the 2026-09-03 full review of main (`.omo/reviews/main-2026-09-03/full-review.md`, claim-verified with file:line evidence).

## Evidence

- Failing-first regression: `.omo/evidence/release-extension-verification-red.txt` (RED before the fix)
- Green after fix: `.omo/evidence/release-extension-verification-green.txt`
- Full gates (package tests, typecheck, lint, build): see `.omo/evidence/` in the branch worktree
- Tegami entry included

Branch: `fix/2026-09-03-release-extension-verification` (atomic commit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release verification so missing LaTeX, Mermaid, and web extension builds now fail before publishing instead of slipping through.

- Adds the three extensions to the default package list and fails closed when an extension manifest, public entrypoint, or runtime worker is malformed or missing.
- Runs `publint` on each extension and imports every packed extension entrypoint in the consumer smoke test.
- Updates the test fixture and adds regression tests for missing extension builds.
- Records the change in a Tegami entry.

<sup>Written for commit dac2d63fd8a6fdb9f9610753761ca30102a3165b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

