### PR TITLE
test(compaction-score): raise the CLI artifact test budget for CI

### DIFF
--- a/.tegami/2026-09-04-ci-compaction-score-timeout.md
+++ b/.tegami/2026-09-04-ci-compaction-score-timeout.md
@@ -1,0 +1,10 @@
+---
+packages:
+    replay:
+      - exit-prerelease(npm:@minpeter/pss-runtime)
+---
+
+## Raise the production-overlap CLI test budget for CI
+
+The compaction-score CLI artifact test spawns real CLI subprocesses whose
+runtime exceeds the 30s budget on loaded CI runners; the budget is now 120s.

--- a/experimental/compaction-score/production-overlap-cli.test.ts
+++ b/experimental/compaction-score/production-overlap-cli.test.ts
@@ -8,7 +8,7 @@ import { validateProductionOverlapArtifact } from "./production-overlap-validati
 import { isRuntimeUserBlockZero } from "./runtime-block-time-metrics";
 
 const execFileAsync = promisify(execFile);
-const CLI_TEST_TIMEOUT_MS = 30_000;
+const CLI_TEST_TIMEOUT_MS = 120_000;
 
 describe("production-overlap CLI artifact", () => {
   it(


### PR DESCRIPTION
Unblocks CI on PRs #402/#405/#406 (and any cache-miss run): `production-overlap-cli.test.ts` spawns real CLI subprocesses that exceed the 30s budget on loaded CI runners. Verified locally: test passes (9s). Tooling-only change; Tegami replay entry included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the production-overlap CLI test timeout from 30s to 120s. The test spawns real CLI subprocesses that exceed the old budget on loaded CI runners, so this prevents CI failures on cache-miss runs.

<sup>Written for commit d24a5e108c7c21080320a18f6f4c34767f1f5410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

