### PR TITLE
fix(build): prefer workspace source export conditions

### DIFF
--- a/.tegami/2026-09-05-workspace-source-exports.md
+++ b/.tegami/2026-09-05-workspace-source-exports.md
@@ -1,0 +1,12 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Workspace source exports
+
+Place the opt-in `@minpeter/pss-source` workspace source condition before `types` in package exports.
+Default published consumers continue to resolve declarations and JavaScript from `dist`.

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -11,63 +11,63 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "@minpeter/pss-source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./env": {
-      "types": "./dist/env.d.ts",
       "@minpeter/pss-source": "./src/env.ts",
+      "types": "./dist/env.d.ts",
       "import": "./dist/env.js"
     },
     "./model": {
-      "types": "./dist/model.d.ts",
       "@minpeter/pss-source": "./src/model.ts",
+      "types": "./dist/model.d.ts",
       "import": "./dist/model.js"
     },
     "./thread-config": {
-      "types": "./dist/thread-config.d.ts",
       "@minpeter/pss-source": "./src/thread-config.ts",
+      "types": "./dist/thread-config.d.ts",
       "import": "./dist/thread-config.js"
     },
     "./thread-inspect": {
-      "types": "./dist/thread-inspect.d.ts",
       "@minpeter/pss-source": "./src/thread-inspect.ts",
+      "types": "./dist/thread-inspect.d.ts",
       "import": "./dist/thread-inspect.js"
     },
     "./tools": {
-      "types": "./dist/tools.d.ts",
       "@minpeter/pss-source": "./src/tools.ts",
+      "types": "./dist/tools.d.ts",
       "import": "./dist/tools.js"
     },
     "./instructions": {
-      "types": "./dist/instructions.d.ts",
       "@minpeter/pss-source": "./src/instructions.ts",
+      "types": "./dist/instructions.d.ts",
       "import": "./dist/instructions.js"
     },
     "./workspace-tools": {
-      "types": "./dist/workspace-tools/index.d.ts",
       "@minpeter/pss-source": "./src/workspace-tools/index.ts",
+      "types": "./dist/workspace-tools/index.d.ts",
       "import": "./dist/workspace-tools/index.js"
     },
     "./tui": {
-      "types": "./dist/tui/app.d.ts",
       "@minpeter/pss-source": "./src/tui/app.ts",
+      "types": "./dist/tui/app.d.ts",
       "import": "./dist/tui/app.js"
     },
     "./extension": {
-      "types": "./dist/extensions/index.d.ts",
       "@minpeter/pss-source": "./src/extensions/index.ts",
+      "types": "./dist/extensions/index.d.ts",
       "import": "./dist/extensions/index.js"
     },
     "./providers": {
-      "types": "./dist/provider-registry.d.ts",
       "@minpeter/pss-source": "./src/provider-registry.ts",
+      "types": "./dist/provider-registry.d.ts",
       "import": "./dist/provider-registry.js"
     },
     "./extension/legacy": {
-      "types": "./dist/extensions/legacy.d.ts",
       "@minpeter/pss-source": "./src/extensions/legacy.ts",
+      "types": "./dist/extensions/legacy.d.ts",
       "import": "./dist/extensions/legacy.js"
     }
   },

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -8,7 +8,8 @@
   "assist": {
     "actions": {
       "source": {
-        "useSortedKeys": "off"
+        "useSortedKeys": "off",
+        "useSortedPackageJson": "off"
       }
     }
   },

--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -10,8 +10,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "@minpeter/pss-source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/extensions/mermaid/package.json
+++ b/extensions/mermaid/package.json
@@ -10,8 +10,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "@minpeter/pss-source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/extensions/web/package.json
+++ b/extensions/web/package.json
@@ -10,8 +10,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "@minpeter/pss-source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,88 +11,88 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "@minpeter/pss-source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./otel": {
-      "types": "./dist/otel/index.d.ts",
       "@minpeter/pss-source": "./src/otel/index.ts",
+      "types": "./dist/otel/index.d.ts",
       "import": "./dist/otel/index.js"
     },
     "./platform/memory": {
-      "types": "./dist/platform/memory/index.d.ts",
       "@minpeter/pss-source": "./src/platform/memory/index.ts",
+      "types": "./dist/platform/memory/index.d.ts",
       "import": "./dist/platform/memory/index.js"
     },
     "./platform/durable-object": {
-      "types": "./dist/platform/durable-object/host/storage-host.d.ts",
       "@minpeter/pss-source": "./src/platform/durable-object/host/storage-host.ts",
+      "types": "./dist/platform/durable-object/host/storage-host.d.ts",
       "import": "./dist/platform/durable-object/host/storage-host.js"
     },
     "./platform/durable-object/cloudflare": {
-      "types": "./dist/platform/durable-object/cloudflare/agents/index.d.ts",
       "@minpeter/pss-source": "./src/platform/durable-object/cloudflare/agents/index.ts",
+      "types": "./dist/platform/durable-object/cloudflare/agents/index.d.ts",
       "import": "./dist/platform/durable-object/cloudflare/agents/index.js"
     },
     "./platform/durable-object/cloudflare/image-codecs": {
-      "types": "./dist/platform/durable-object/cloudflare/image-codecs-edge.d.ts",
       "@minpeter/pss-source": "./src/platform/durable-object/cloudflare/image-codecs-edge.ts",
+      "types": "./dist/platform/durable-object/cloudflare/image-codecs-edge.d.ts",
       "import": "./dist/platform/durable-object/cloudflare/image-codecs-edge.js"
     },
     "./platform/durable-object/celld": {
-      "types": "./dist/platform/durable-object/celld/host.d.ts",
       "@minpeter/pss-source": "./src/platform/durable-object/celld/host.ts",
+      "types": "./dist/platform/durable-object/celld/host.d.ts",
       "import": "./dist/platform/durable-object/celld/host.js"
     },
     "./platform/file": {
-      "types": "./dist/platform/file/index.d.ts",
       "@minpeter/pss-source": "./src/platform/file/index.ts",
+      "types": "./dist/platform/file/index.d.ts",
       "import": "./dist/platform/file/index.js"
     },
     "./execution": {
-      "types": "./dist/execution/index.d.ts",
       "@minpeter/pss-source": "./src/execution/index.ts",
+      "types": "./dist/execution/index.d.ts",
       "import": "./dist/execution/index.js"
     },
     "./namespace": {
-      "types": "./dist/namespace.d.ts",
       "@minpeter/pss-source": "./src/namespace.ts",
+      "types": "./dist/namespace.d.ts",
       "import": "./dist/namespace.js"
     },
     "./evals": {
-      "types": "./dist/evals/index.d.ts",
       "@minpeter/pss-source": "./src/evals/index.ts",
+      "types": "./dist/evals/index.d.ts",
       "import": "./dist/evals/index.js"
     },
     "./fsm": {
-      "types": "./dist/fsm/index.d.ts",
       "@minpeter/pss-source": "./src/fsm/index.ts",
+      "types": "./dist/fsm/index.d.ts",
       "import": "./dist/fsm/index.js"
     },
     "./channel": {
-      "types": "./dist/channel/index.d.ts",
       "@minpeter/pss-source": "./src/channel/index.ts",
+      "types": "./dist/channel/index.d.ts",
       "import": "./dist/channel/index.js"
     },
     "./testing": {
-      "types": "./dist/testing/index.d.ts",
       "@minpeter/pss-source": "./src/testing/index.ts",
+      "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"
     },
     "./platform/sql-queue": {
-      "types": "./dist/platform/sql-queue/index.d.ts",
       "@minpeter/pss-source": "./src/platform/sql-queue/index.ts",
+      "types": "./dist/platform/sql-queue/index.d.ts",
       "import": "./dist/platform/sql-queue/index.js"
     },
     "./protocol": {
-      "types": "./dist/protocol/index.d.ts",
       "@minpeter/pss-source": "./src/protocol/index.ts",
+      "types": "./dist/protocol/index.d.ts",
       "import": "./dist/protocol/index.js"
     },
     "./protocol/node": {
-      "types": "./dist/protocol/node/index.d.ts",
       "@minpeter/pss-source": "./src/protocol/node/index.ts",
+      "types": "./dist/protocol/node/index.d.ts",
       "import": "./dist/protocol/node/index.js"
     }
   },

--- a/scripts/source-condition.test.mjs
+++ b/scripts/source-condition.test.mjs
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const DECLARATION_EXPORT_PATTERN = /^\.\/dist\/.+\.d\.ts$/;
+const JAVASCRIPT_EXPORT_PATTERN = /^\.\/dist\/.+\.js$/;
+const SOURCE_CONDITION = "@minpeter/pss-source";
+const packageDirectories = [
+  "apps/coding-agent",
+  "extensions/latex",
+  "extensions/mermaid",
+  "extensions/web",
+  "packages/runtime",
+];
+
+function readPackage(directory) {
+  return JSON.parse(readFileSync(`${directory}/package.json`, "utf8"));
+}
+
+describe("workspace source export condition", () => {
+  it("precedes the TypeScript types condition in every source-enabled export", () => {
+    for (const directory of packageDirectories) {
+      const packageJson = readPackage(directory);
+      for (const [subpath, conditions] of Object.entries(packageJson.exports)) {
+        expect(
+          Object.keys(conditions)[0],
+          `${packageJson.name}${subpath}`
+        ).toBe(SOURCE_CONDITION);
+      }
+    }
+  });
+
+  it("preserves declaration and JavaScript fallbacks for published consumers", () => {
+    for (const directory of packageDirectories) {
+      const packageJson = readPackage(directory);
+      for (const [subpath, conditions] of Object.entries(packageJson.exports)) {
+        expect(
+          Object.keys(conditions).indexOf("types"),
+          `${packageJson.name}${subpath}`
+        ).toBeLessThan(Object.keys(conditions).indexOf("import"));
+        expect(conditions.types).toMatch(DECLARATION_EXPORT_PATTERN);
+        expect(conditions.import).toMatch(JAVASCRIPT_EXPORT_PATTERN);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- prioritize `@minpeter/pss-source` before TypeScript's built-in `types` condition in every source-enabled workspace export
- prevent the package manifest organizer from undoing semantically significant conditional-export ordering
- add a repository invariant covering source priority and unchanged `dist` fallbacks

## Why

Conditional exports are matched in object order. Because `types` preceded the opt-in source condition, TypeScript workspace consumers resolved `packages/runtime/dist/*.d.ts` even with `customConditions: ["@minpeter/pss-source"]`. A stale or partially written runtime build could therefore produce unrelated coding-agent errors.

Failing-first with a runtime declaration made stale after build:

```text
@minpeter/pss-coding-agent:typecheck: src/thread-inspect.ts(44,26): error TS2339: Property 'threadKey' does not exist on type 'ThreadInspectionReport'.
@minpeter/pss-coding-agent:typecheck: src/thread-inspect.ts(45,28): error TS2339: Property 'storageFile' does not exist on type 'ThreadInspectionReport'.
@minpeter/pss-coding-agent:typecheck: src/thread-inspect.ts(46,24): error TS2339: Property 'version' does not exist on type 'ThreadInspectionReport'.
@minpeter/pss-coding-agent:typecheck: src/thread-inspect.ts(47,29): error TS2339: Property 'messageCount' does not exist on type 'ThreadInspectionReport'.
Tasks: 4 successful, 5 total
Failed: @minpeter/pss-coding-agent#typecheck
```

Before the change, resolution tracing selected `packages/runtime/dist/index.d.ts`; afterward the same coding-agent config selects `packages/runtime/src/index.ts`. Consumers without the custom condition still select `dist/index.d.ts` for types and `dist/index.js` at runtime.

No Tegami entry is included because this only repairs repository build/typecheck routing. Published consumers retain the same declaration and JavaScript fallbacks, and package runtime behavior does not change.

## Verification

- stale declaration reproduction: red before fix, green after fix (`5 successful, 5 total`)
- 5 uncached full-workspace typecheck runs with stale declaration injection: all `24 successful, 24 total`
- `PATH=/tmp/lane-bin:$PATH ./node_modules/.bin/turbo run typecheck`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `cd packages/runtime && ../../node_modules/.bin/vitest run` (281 files, 1704 passed, 5 skipped)
- `cd apps/coding-agent && ../../node_modules/.bin/vitest run` (126 files, 884 passed)
- `ultracite check .` in runtime and coding-agent
- `node_modules/.bin/vitest run --root . scripts/file-size.test.mjs`
- `node_modules/.bin/vitest run --root . scripts/source-condition.test.mjs`
- `cd packages/runtime && ./node_modules/.bin/tsdown && cd ../.. && node scripts/runtime-public-api.mjs check`
- `publint packages/runtime`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes the opt-in `@minpeter/pss-source` condition over TypeScript's `types` condition in every workspace export, so workspace typechecking resolves source files instead of potentially stale `dist` declarations. Previously, `types` was listed first, causing consumers with `customConditions: ["@minpeter/pss-source"]` to load `dist/*.d.ts` and fail on outdated builds. Published consumers still get `dist` types and runtime files; runtime behavior is unchanged.

- Reordered export conditions in `apps/coding-agent`, all `extensions/*`, and `packages/runtime`.
- Disabled Biome's `useSortedPackageJson` rule to preserve semantic condition order.
- Added `scripts/source-condition.test.mjs` to enforce source priority and keep `dist` fallbacks intact.
- Added a Tegami release note marking patch releases for `@minpeter/pss-runtime` and `@minpeter/pss-coding-agent`.

<sup>Written for commit 9e6b1157e49c9a4dc50d43deb8c05bfdd99dc98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

