### PR TITLE
feat: expose retries and stabilize coding-agent session UI

### DIFF
--- a/.tegami/2026-09-05-coding-agent-final-resume-block.md
+++ b/.tegami/2026-09-05-coding-agent-final-resume-block.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Reliable session resume output on exit
+
+Reuse the composer separator row for the current session's resume command after bounded turn finalization and runtime cleanup, without an extra rule or blank line. Keep shutdown failures above the final separator and command, including on narrow streaming exits.

--- a/.tegami/2026-09-05-coding-agent-retry-wait-status.md
+++ b/.tegami/2026-09-05-coding-agent-retry-wait-status.md
@@ -1,0 +1,12 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Show provider retry waits in the TUI footer
+
+Render an active `model-retry` schedule in the existing one-row footer status as
+a live countdown with the next attempt number and remaining retry budget. The
+wait clears on retry start, any stop reason, turn end, abort, error, and session
+switches, and is never written to the transcript.

--- a/.tegami/2026-09-05-runtime-model-retry-events.md
+++ b/.tegami/2026-09-05-runtime-model-retry-events.md
@@ -1,0 +1,13 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Expose authoritative provider retry scheduling
+
+Add live-only `model-retry` scheduled/started/stopped events with delay, deadline,
+remaining retries, and cancellation or terminal decisions. Runtime-owned provider
+retries preserve the SDK baseline; extensions and NDJSON receive the events without persisting them.

--- a/.tegami/2026-09-06-cold-hot-transcript-ownership.md
+++ b/.tegami/2026-09-06-cold-hot-transcript-ownership.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Freeze completed TUI output
+
+Keep the startup header and completed transcript immutable, with only the latest output block live. Interleaved tools and steering append continuations; extension prompts stay inline, and late renderer callbacks cannot rewrite history.

--- a/.tegami/2026-09-06-cold-resize-layout.md
+++ b/.tegami/2026-09-06-cold-resize-layout.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Re-layout sealed transcript content on terminal resize
+
+Keep COLD content immutable while text, Markdown tables/code, selected body tails, and startup information re-layout at new widths. Custom views can supply renderer-free snapshots; opaque graphics retain their captured asset and fixed geometry without restarting producers.

--- a/.tegami/2026-09-06-edit-file-anchor-omission.md
+++ b/.tegami/2026-09-06-edit-file-anchor-omission.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Clarify edit_file anchor selection
+
+Explicitly disable strict tool generation for edit_file, correct its anchor examples, and explain that unused anchor keys must be omitted entirely. Conflicting anchors still fail without writing, with actionable guidance for retrying.

--- a/.tegami/2026-09-06-final-answer-full-output.md
+++ b/.tegami/2026-09-06-final-answer-full-output.md
@@ -1,0 +1,13 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Change
+
+Assistant text still follows its latest eight rendered rows while streaming. On its committed text completion boundary, the active block expands to its full rendered text before becoming an immutable snapshot. Complete tables, code, and verification paragraphs remain in terminal scrollback.
+
+## Boundaries
+
+Reasoning and tool bodies remain bounded. Abort, errors, steering, and other handoffs preserve their current partial display rather than marking it complete. Continuations append separately and never reopen older snapshots. Late reasoning completion cannot seal a newer text block. Custom renderers retain their current output and are disposed once after capture.

--- a/.tegami/2026-09-06-hot-shrink-padding.md
+++ b/.tegami/2026-09-06-hot-shrink-padding.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Keep shrinking output cards from lifting the composer
+
+Keep the composer steady when HOT output shrinks by reserving blank rows at the transcript tail. Completed blocks contain only actual content, and subsequent output consumes the shared reserve. Width changes recompute it; canonical messages and files remain unchanged.

--- a/.tegami/2026-09-06-reusable-hot-padding.md
+++ b/.tegami/2026-09-06-reusable-hot-padding.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Reuse shrinking output's reserved space at the transcript tail
+
+Keep synthetic shrink padding separate from immutable completed output. Following blocks and their normal separators consume the shared trailing reserve before transcript height grows, without removing genuine blank lines, Markdown spacing or graphics reserved rows. Width changes recompute the reserve and transcript resets clear it.

--- a/.tegami/2026-09-06-stream-inner-scroll.md
+++ b/.tegami/2026-09-06-stream-inner-scroll.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Bounded streaming text bodies
+
+Streaming assistant text, reasoning, and tool text bodies follow the latest eight wrapped terminal rows. Completed assistant text expands fully before becoming immutable; full source content, headers, the composer, and atomic graphical output are preserved.

--- a/.tegami/2026-09-06-tool-input-preview.md
+++ b/.tegami/2026-09-06-tool-input-preview.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Progressive tool arguments
+
+Show streamed arguments for every tool in the pretty TUI, including decoded multiline source before execution. Keep raw I/O and completed result/error rendering unchanged.

--- a/.tegami/2026-09-06-write-file-hash-preconditions.md
+++ b/.tegami/2026-09-06-write-file-hash-preconditions.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Clarify write_file hash preconditions
+
+New files omit `expected_file_hash`; guarded overwrites copy the exact eight-character lowercase hash from the latest successful `read_file` for the same existing path, without placeholders or null.
+Reject malformed hashes (including uppercase, never normalized) as SDK invalid input; `00000000` remains syntactically valid, not a missing-file sentinel.
+Distinct `FILE_HASH_MISMATCH` and `FILE_HASH_TARGET_MISSING` execution errors explain how to proceed without weakening stale-overwrite checks.

--- a/.tegami/2026-09-07-cubic-cli-status-ownership.md
+++ b/.tegami/2026-09-07-cubic-cli-status-ownership.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Preserve CLI startup and status ownership
+
+Honor the selected workspace and startup output stream, clear retry-only labels when no base status exists, and keep detached callbacks from observing expired busy owners.

--- a/.tegami/2026-09-07-cubic-lifecycle-ownership.md
+++ b/.tegami/2026-09-07-cubic-lifecycle-ownership.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Preserve transcript and prompt ownership across lifecycle changes
+
+Stage session replay before replacing the transcript, finish hidden tool results,
+and stop consuming stale streams. Cancel mounted extension prompts when their
+host revokes interactive access, restoring composer focus without disturbing replacements.

--- a/.tegami/2026-09-07-cubic-render-capture.md
+++ b/.tegami/2026-09-07-cubic-render-capture.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Preserve tool graphics and sealed transcript presentation
+
+Keep multiline tool graphics and reserved rows intact, capture completed views and syntax highlighting once, and avoid reflowing ordinary box art as Markdown tables.

--- a/.tegami/2026-09-07-cubic-runtime-retry.md
+++ b/.tegami/2026-09-07-cubic-runtime-retry.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Correct provider retry lifecycle
+
+Classify a final non-retryable provider failure before retry exhaustion, and clean up pre-aborted model attempts through the normal finalization path.

--- a/.tegami/2026-09-07-invalid-tool-arguments.md
+++ b/.tegami/2026-09-07-invalid-tool-arguments.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Report rejected tool arguments without executing them
+
+Replace the SDK's source dump for tool calls rejected during input validation with a bounded `INVALID_TOOL_ARGUMENTS` result that states the tool was not executed and asks for smaller writes or edits, distinguishing malformed JSON from schema violations. In pretty mode the card keeps the streamed argument preview instead of the placeholder `{}` and is marked as not executed.

--- a/.tegami/2026-09-07-new-session-notice.md
+++ b/.tegami/2026-09-07-new-session-notice.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Compact new-session notice
+
+Show only the short session selector after `/new` or `/clear`, without repeating the current model and directory.

--- a/.tegami/2026-09-07-stream-error-propagation.md
+++ b/.tegami/2026-09-07-stream-error-propagation.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-runtime:
+    type: patch
+---
+
+## Preserve model stream failures
+
+Propagate recorded provider stream errors and missing finish events through the turn error path instead of persisting them as successful turns with only `finishReason: "error"`.

--- a/.tegami/2026-09-07-tool-block-spacing.md
+++ b/.tegami/2026-09-07-tool-block-spacing.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Separate tool cards from following output
+
+Keep one blank terminal row between tool cards, including empty directory reads, and the following assistant or reasoning block without adding gaps between streamed deltas.

--- a/.tegami/2026-09-07-write-streaming-header.md
+++ b/.tegami/2026-09-07-write-streaming-header.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Show write paths during argument streaming
+
+Show `write <path>` as soon as a streamed write argument exposes a nonempty path, while preserving the live input preview. Render paths literally and safely in both streaming and completed write headers.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -427,6 +427,48 @@ error rendering; it does not mean the tool has run or a file has been written.
 `showRawToolIo` keeps the JSON input/output view. Shell output still appears
 only when its result arrives, not as live stdout.
 
+Text bodies auto-follow their latest eight terminal rows, including wrapped
+lines, while streaming. On text completion, the current assistant block expands
+its full rendered text before freezing, including all table/code/prose rows.
+Long final answers remain available in terminal scrollback, not necessarily all
+on screen at once. Completed reasoning and interrupted partial text retain their
+displayed tail; later answer text cannot evict completed reasoning. Each
+pretty tool body and each raw Input/Output/Error body has its own window. Tool headers and raw section labels sit outside the
+budget. Earlier content remains stored but is not all visible at once; no new
+scrolling keys or mouse bindings are provided. The composer is unchanged.
+Text-only custom renderers use the same streaming bound and final-text expansion
+(a Markdown override is one body). Image-bearing renderer output, including Kitty/iTerm2 graphics and
+reserved image rows, remains intact and is exempt from the text-row cap.
+
+The startup header and transcript prefix are immutable rendered snapshots.
+Only the latest output block remains HOT; submitting input, a notice, or another
+stream/tool block freezes the previous block before appending. Late tool results
+and interleaved tool input use new continuation cards identified by call ID;
+canonical arguments and persisted messages remain complete. Completed views
+are detached, so late custom-renderer callbacks cannot rewrite history. Resize
+reflows the captured rows, not the old Markdown renderer or a newly selected
+tail; returning to the original width reproduces the snapshot. Ready graphics
+retain their payload and reserved geometry atomically (narrow terminals may clip).
+
+At a fixed terminal width, shrinking HOT output leaves synthetic blank rows at
+the transcript tail, above the composer, so the composer/footer does not jump
+upward. Completion freezes only actual rendered content, including genuine blank
+lines, Markdown spacing and graphic reserved rows. The next block starts after
+that content and its normal separator; new output consumes the shared trailing
+reserve before transcript height grows. Synthetic padding never becomes a
+permanent gap between COLD blocks or enters canonical messages/files. Width
+changes recompute the reservation without stale-width padding; transcript reset
+clears it. Streaming bodies remain capped, while full final-text expansion
+consumes or grows the reservation without rewriting older COLD blocks. Clearing
+multiline composer input is separate and unchanged.
+
+Extension input/select/confirm prompts share the HOT composer slot and retain
+the one-row footer rather than covering history. Model/title changes append
+current-state notices without rewriting startup information. `/reload` and
+compaction retain the transcript; explicit `/new` (`/clear`), `/resume`, `/fork`,
+and initial history replay start a new transcript epoch. Failed history loads
+retain old visible content and report the current-session mismatch.
+
 Provider failures use the runtime's structured `turn-error.error` metadata.
 The TUI maps stable categories to a concise title and action, shows only the
 safe summary, and renders bounded correlation IDs with their header source. It

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -440,15 +440,34 @@ Text-only custom renderers use the same streaming bound and final-text expansion
 (a Markdown override is one body). Image-bearing renderer output, including Kitty/iTerm2 graphics and
 reserved image rows, remains intact and is exempt from the text-row cap.
 
-The startup header and transcript prefix are immutable rendered snapshots.
-Only the latest output block remains HOT; submitting input, a notice, or another
-stream/tool block freezes the previous block before appending. Late tool results
-and interleaved tool input use new continuation cards identified by call ID;
-canonical arguments and persisted messages remain complete. Completed views
-are detached, so late custom-renderer callbacks cannot rewrite history. Resize
-reflows the captured rows, not the old Markdown renderer or a newly selected
-tail; returning to the original width reproduces the snapshot. Ready graphics
-retain their payload and reserved geometry atomically (narrow terminals may clip).
+The startup header and transcript prefix have immutable content, not immutable
+terminal wrapping. Only the latest output block remains HOT; submitting input,
+a notice, or another stream/tool block seals the previous block before appending.
+Late tool results and interleaved tool input use new continuation cards identified
+by call ID; canonical arguments and persisted messages remain complete. Completed
+views are detached, so late renderer callbacks cannot rewrite history.
+
+Width changes synchronously lay out copied text/Markdown and captured styles:
+soft wraps can join again, hard newlines remain, and tables/code re-layout.
+Completed answers retain their full content; capped reasoning/tool bodies select
+visible content once at sealing, including partial lines/cells. Resize never
+selects a fresh last-eight from the original source. Returning to the sealing
+width restores its exact presentation. Height-only changes affect the viewport
+and composer, not COLD content. Startup logo/model/cwd/help content stays fixed
+while its wrapping changes.
+
+Custom `AssistantTextView` implementations may provide synchronous
+`captureCold(width): ColdContent` (types exported from `/extension`). Return
+renderer-free presentation data: text with hard newlines, Markdown with captured
+style values, groups, or fixed rows. The host copies it before abort/disposal;
+never return callbacks, mutable view references, or fresh underlying content that
+was not displayed. Transparent composed fallbacks retain their delegated source.
+Opaque text renderers and non-wrapper theme transformations are explicit
+fixed-row-layout exceptions: rows may wrap narrower but cannot join old wraps.
+A graphical view without this contract is a fixed-size exception: its captured
+Kitty/iTerm2/DCS transmission and reserved rows remain atomic; narrower terminals
+may clip it. No image rescaling or producer rerun is claimed. A custom group can
+keep an image fixed while supplying independently reflowable adjacent text.
 
 At a fixed terminal width, shrinking HOT output leaves synthetic blank rows at
 the transcript tail, above the composer, so the composer/footer does not jump

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -419,6 +419,14 @@ The TUI renders the runtime's streaming deltas as live tokens while a step
 runs. Dedupe against the committed events is built in: committed
 `assistant-output` text renders only when a step produced no deltas.
 
+In pretty mode, every tool's streamed arguments use a shared input preview,
+including extension tools with custom result renderers. String values are
+shown decoded, so multiline source is readable before execution. The preview
+remains while execution is pending and is replaced by the normal result or
+error rendering; it does not mean the tool has run or a file has been written.
+`showRawToolIo` keeps the JSON input/output view. Shell output still appears
+only when its result arrives, not as live stdout.
+
 Provider failures use the runtime's structured `turn-error.error` metadata.
 The TUI maps stable categories to a concise title and action, shows only the
 safe summary, and renders bounded correlation IDs with their header source. It

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -185,10 +185,31 @@ and staged before one atomic publication; unknown capability kinds fail
 closed. Event handlers run serially in extension and registration order.
 Naming a stream event such as `assistant-output-delta` explicitly opts into
 ephemeral events. This also includes live-only `model-attempt` start/end pairs
-for physical provider calls and SDK retries. Object models and string ids backed
-by a configured `AI_SDK_DEFAULT_PROVIDER` are observed; implicit-gateway string
-ids emit no attempt events. Attempt events are excluded from durable replay and
-result payloads. Handler failures are attributed to the owning
+for physical provider calls and runtime retries, plus `pss.on("model-retry", ...)`
+for authoritative retry state. `scheduled` supplies `delayMs`, Unix-ms `retryAt`,
+and `remainingRetries` including the scheduled retry; `started` clears the wait
+and decrements that budget; `stopped` clears it permanently with zero remaining
+retries and a cancellation, exhaustion, non-retryable, or stream-ended reason.
+A schedule is cancellable, not a guarantee. See the runtime README for the full
+counting contract and countdown example. The TUI renders an active schedule in
+its existing one-row footer status as `Retrying in 4s · attempt 2 · 2 retries
+left`. When a retry starts or stops, the countdown returns to the ongoing
+operation's label; the wait never enters the transcript.
+
+The footer keeps one animated busy indicator throughout input preprocessing,
+streaming text, physical tool execution, provider/step waits, and cancellation
+cleanup. Reasoning and retry events change its label, not its lifetime. Tool
+execution may use the generic `Working` label because committed tool events
+arrive after physical execution. Commands, reloads, catalog/history loading,
+model/session switching, setup, compaction policies/summaries, and asynchronous
+turn-completion callbacks own independent busy lifetimes. Finishing one cannot
+hide another. User-only selectors and extension dialogs suspend their calling
+operation's indicator, but not concurrent background work. Status labels clip
+before the animated glyph, including with a custom right-side footer.
+Object models and string ids backed by a configured `AI_SDK_DEFAULT_PROVIDER`
+are observed; implicit-gateway string ids emit neither attempt nor retry events.
+Both event kinds are excluded from durable replay and result payloads.
+Handler failures are attributed to the owning
 extension and surfaced after the original events.
 
 Install an extension globally or for one project:
@@ -547,7 +568,7 @@ pss exec --workspace . --stdin --timeout-seconds 900 --result-file result.json
 `pss exec` streams JSONL events (`metadata`, `agent_event`, `result`) to stdout
 and exits 0 only when the task completes. Ephemeral events
 (`assistant-output-delta`, `assistant-reasoning-delta`, `tool-call-input-*`,
-`context-usage`, and `model-attempt`) appear as `agent_event` lines alongside
+`context-usage`, `model-attempt`, and `model-retry`) appear as `agent_event` lines alongside
 the committed events, but are excluded from the accumulated `result.events`
 payload, which stays committed-only. Structured `turn-error` metadata appears
 in both the live `agent_event` and committed result without raw provider
@@ -683,7 +704,14 @@ PSS_THREAD_KEY=workspace:demo pss inspect-thread
 
 ```sh
 pnpm dev:tui
+# From another workspace:
+pnpm -C /path/to/pss-runtime dev:tui
 ```
+
+`dev:tui` runs source code with the caller's directory as the workspace for
+file/shell tools, context, sessions, and file completion. Model settings still
+load from the runtime repository's `.env`, not the caller's `.env`. Installed
+`pss` and other commands keep their existing cwd and environment behavior.
 
 ## JSONL RPC mode
 

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -443,7 +443,9 @@ Text-only custom renderers use the same streaming bound and final-text expansion
 reserved image rows, remains intact and is exempt from the text-row cap.
 
 The startup header and transcript prefix have immutable content, not immutable
-terminal wrapping. Only the latest output block remains HOT; submitting input,
+terminal wrapping. HOT is the live output block still receiving updates; COLD
+blocks are detached snapshots with frozen content. Only the latest output block
+remains HOT; submitting input,
 a notice, or another stream/tool block seals the previous block before appending.
 Late tool results and interleaved tool input use new continuation cards identified
 by call ID; canonical arguments and persisted messages remain complete. Completed

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -421,7 +421,9 @@ runs. Dedupe against the committed events is built in: committed
 
 In pretty mode, every tool's streamed arguments use a shared input preview,
 including extension tools with custom result renderers. String values are
-shown decoded, so multiline source is readable before execution. The preview
+shown decoded, so multiline source is readable before execution. For
+`write_file`, the header changes to `write <path>` as soon as a nonempty path
+arrives, including partial paths, while the content continues streaming. The preview
 remains while execution is pending and is replaced by the normal result or
 error rendering; it does not mean the tool has run or a file has been written.
 `showRawToolIo` keeps the JSON input/output view. Shell output still appears

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -475,8 +475,10 @@ At a fixed terminal width, shrinking HOT output leaves synthetic blank rows at
 the transcript tail, above the composer, so the composer/footer does not jump
 upward. Completion freezes only actual rendered content, including genuine blank
 lines, Markdown spacing and graphic reserved rows. The next block starts after
-that content and its normal separator; new output consumes the shared trailing
-reserve before transcript height grows. Synthetic padding never becomes a
+that content and one blank separator row, including after header-only tool cards;
+this boundary is separate from spacing inside a tool body. Continued deltas in
+one block add no separator. New output consumes the shared trailing reserve
+before transcript height grows. Synthetic padding never becomes a
 permanent gap between COLD blocks or enters canonical messages/files. Width
 changes recompute the reservation without stale-width padding; transcript reset
 clears it. Streaming bodies remain capped, while full final-text expansion

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -88,6 +88,8 @@
     "lint": "ultracite check .",
     "preview:assistant": "tsx --conditions=@minpeter/pss-source scripts/preview-assistant-render.ts",
     "preview:edit": "tsx --conditions=@minpeter/pss-source scripts/preview-edit-render.ts",
+    "preview:retry-wait": "tsx --conditions=@minpeter/pss-source scripts/preview-retry-wait.ts",
+    "preview:retry-wait-tui": "tsx --conditions=@minpeter/pss-source scripts/preview-retry-wait-tui.ts",
     "start": "tsx --conditions=@minpeter/pss-source src/tui/app.ts",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
@@ -95,7 +97,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "4.0.36",
     "@ai-sdk/openai": "4.0.31",
-    "@ai-sdk/openai-compatible": "3.0.20",
+    "@ai-sdk/openai-compatible": "3.0.23",
     "@earendil-works/pi-tui": "^0.84.1",
     "@fontsource-variable/noto-sans": "5.3.0",
     "@fontsource-variable/noto-sans-arabic": "5.3.0",

--- a/apps/coding-agent/scripts/preview-retry-wait-tui.ts
+++ b/apps/coding-agent/scripts/preview-retry-wait-tui.ts
@@ -1,0 +1,247 @@
+// Real-surface capture of the retry-wait status through `createAgentTUI`:
+// `pnpm --filter @minpeter/pss-coding-agent preview:retry-wait-tui`
+// (set PSS_RETRY_PREVIEW=recovery|cancel|exhausted; default recovery).
+//
+// Unlike `preview-retry-wait.ts`, which composes the footer chain directly,
+// this drives the actual TUI: real `createAgentTUI`, real composer, real
+// header/chat/footer layout, real runtime turn against a local mock provider.
+//
+// The TUI paints to stdout continuously, so the last frame of a completed run
+// would never show a wait. The driver therefore records every byte the TUI
+// paints, marks the offset at which the countdown first appeared, lets the TUI
+// shut down cleanly, and finally replays only the prefix up to that offset.
+// The captured artifact is the TUI's own paint output at the wait moment.
+
+import type { AgentTurn } from "@minpeter/pss-runtime";
+import { createAgent } from "@minpeter/pss-runtime";
+import { createInMemoryHost } from "@minpeter/pss-runtime/platform/memory";
+import { APICallError } from "ai";
+import { convertArrayToReadableStream, MockLanguageModelV4 } from "ai/test";
+import { createAgentTUI } from "../src/tui/agent";
+
+const SCENARIOS = ["recovery", "cancel", "exhausted"] as const;
+type Scenario = (typeof SCENARIOS)[number];
+const requested = process.env.PSS_RETRY_PREVIEW ?? "recovery";
+if (!SCENARIOS.includes(requested as Scenario)) {
+  throw new Error(`PSS_RETRY_PREVIEW must be one of ${SCENARIOS.join(", ")}`);
+}
+const SCENARIO = requested as Scenario;
+const EXPECTED_CALLS = { cancel: 1, exhausted: 3, recovery: 2 } as const;
+const EXPECTED_TERMINAL = {
+  cancel: "turn-abort",
+  exhausted: "turn-error",
+  recovery: "turn-end",
+} as const;
+const EXPECTED_STOP = {
+  cancel: "cancelled",
+  exhausted: "exhausted",
+  recovery: undefined,
+} as const;
+
+const failure = () =>
+  new APICallError({
+    isRetryable: true,
+    message: "rate limited by fixture",
+    requestBodyValues: {},
+    responseHeaders: { "retry-after": "5" },
+    statusCode: 429,
+    url: "https://fixture.invalid/chat",
+  });
+
+let calls = 0;
+const model = new MockLanguageModelV4({
+  doStream: () => {
+    calls += 1;
+    if (calls === 1 || SCENARIO !== "recovery") {
+      return Promise.reject(failure());
+    }
+    return Promise.resolve({
+      stream: convertArrayToReadableStream([
+        { type: "stream-start", warnings: [] },
+        { id: "t", type: "text-start" },
+        {
+          delta: "Recovered after the retry.",
+          id: "t",
+          type: "text-delta",
+        },
+        { id: "t", type: "text-end" },
+        {
+          finishReason: { raw: "stop", unified: "stop" },
+          type: "finish",
+          usage: {
+            inputTokens: {
+              cacheRead: undefined,
+              cacheWrite: undefined,
+              noCache: 12,
+              total: 12,
+            },
+            outputTokens: {
+              reasoning: undefined,
+              text: 5,
+              total: 5,
+            },
+          },
+        },
+      ]),
+    });
+  },
+});
+
+const agent = await createAgent({ host: createInMemoryHost(), model });
+const thread = agent.thread("retry-wait-tui-preview");
+
+// Capture every byte the real TUI paints, suppressing live output so the
+// harness only receives the frame we deliberately replay at the end.
+const realWrite = process.stdout.write.bind(process.stdout);
+let painted = "";
+let countdownOffset: number | undefined;
+const RETRY_LABEL = "Retrying in";
+
+// Resolves the first time the real TUI paints a countdown, so every gate below
+// waits on an observed render instead of a wall-clock guess.
+let notifyCountdownPainted: (() => void) | undefined;
+const countdownPainted = new Promise<void>((resolve) => {
+  notifyCountdownPainted = resolve;
+});
+
+process.stdout.write = ((chunk: unknown, ...rest: unknown[]): boolean => {
+  painted += typeof chunk === "string" ? chunk : String(chunk);
+  if (countdownOffset === undefined && painted.includes(RETRY_LABEL)) {
+    // First frame that contains the countdown: this is the capture point.
+    countdownOffset = painted.length;
+    notifyCountdownPainted?.();
+    notifyCountdownPainted = undefined;
+  }
+  const callback = rest.at(-1);
+  if (typeof callback === "function") {
+    (callback as () => void)();
+  }
+  return true;
+}) as typeof process.stdout.write;
+
+// The TUI attaches its stdin handler during startup; defer a tick so the
+// injected keystrokes always land on a live listener.
+const inject = (data: string): void => {
+  setImmediate(() => process.stdin.emit("data", data));
+};
+const injectExit = (): void => {
+  inject("\u0003");
+  inject("\u0003");
+};
+
+let observedTerminal: string | undefined;
+let observedStop: string | undefined;
+let sawCountdownFrame = false;
+
+/**
+ * Mirrors the runtime turn so the driver can gate on real retry phases.
+ * `events` is a read-only own property, so the mirror is a fresh object rather
+ * than a prototype-chained copy.
+ */
+const observeTurn = (turn: AgentTurn): AgentTurn => {
+  const events = turn.events.bind(turn);
+  return {
+    ...turn,
+    events: () => {
+      const source = events();
+      return (async function* observed() {
+        try {
+          for await (const event of source) {
+            observedTerminal = event.type;
+            if (event.type === "model-retry" && event.phase === "stopped") {
+              observedStop = event.reason;
+            }
+            const isSchedule =
+              event.type === "model-retry" && event.phase === "scheduled";
+            // Yield first: the TUI only paints the wait once it has handled
+            // the event, so the paint gate below must run after the handoff.
+            yield event;
+            if (isSchedule) {
+              await countdownPainted;
+              sawCountdownFrame = true;
+              if (SCENARIO === "cancel") {
+                thread.interrupt();
+              }
+            }
+          }
+        } finally {
+          // Turn is over on every path, including the interrupted one that
+          // never reaches onTurnComplete. Drive the TUI's own exit keys.
+          injectExit();
+        }
+      })();
+    },
+  };
+};
+
+const tuiFinished = createAgentTUI({
+  footer: { text: "retry-wait QA" },
+  header: { subtitle: "retry-wait visual QA", title: "pss" },
+  thread: {
+    interrupt: () => thread.interrupt(),
+    send: async (input: string) => observeTurn(await thread.send(input)),
+    steer: async (input: string) => observeTurn(await thread.steer(input)),
+  },
+  onSetup: () => {
+    // The composer is live once setup completes; submit the prompt.
+    inject("go\r");
+  },
+});
+
+// Backstop only: the turn's own completion drives the exit above.
+const exitGuard = setTimeout(injectExit, 60_000);
+exitGuard.unref?.();
+
+await tuiFinished;
+clearTimeout(exitGuard);
+process.stdout.write = realWrite;
+await agent.dispose();
+
+const frame = painted.slice(0, countdownOffset ?? painted.length);
+realWrite(frame);
+realWrite("\r\n");
+
+const failures: string[] = [];
+if (countdownOffset === undefined) {
+  failures.push("the TUI never painted a retry countdown");
+}
+if (!sawCountdownFrame) {
+  failures.push("the countdown frame gate never resolved");
+}
+if (calls !== EXPECTED_CALLS[SCENARIO]) {
+  failures.push(
+    `physical calls: expected ${EXPECTED_CALLS[SCENARIO]}, observed ${calls}`
+  );
+}
+if (observedTerminal !== EXPECTED_TERMINAL[SCENARIO]) {
+  failures.push(
+    `terminal event: expected ${
+      EXPECTED_TERMINAL[SCENARIO]
+    }, observed ${observedTerminal}`
+  );
+}
+if (observedStop !== EXPECTED_STOP[SCENARIO]) {
+  failures.push(
+    `stop reason: expected ${EXPECTED_STOP[SCENARIO] ?? "none"}, observed ${
+      observedStop ?? "none"
+    }`
+  );
+}
+
+realWrite(
+  `__PSS_QA_META__${JSON.stringify({
+    calls,
+    capturedBytes: frame.length,
+    passed: failures.length === 0,
+    scenario: SCENARIO,
+    stopReason: observedStop ?? null,
+    terminal: observedTerminal ?? null,
+  })}\n`
+);
+
+if (failures.length > 0) {
+  process.stderr.write(
+    `${SCENARIO} TUI capture failed:\n- ${failures.join("\n- ")}\n`
+  );
+  process.exitCode = 1;
+}

--- a/apps/coding-agent/scripts/preview-retry-wait.ts
+++ b/apps/coding-agent/scripts/preview-retry-wait.ts
@@ -1,0 +1,279 @@
+// Visual preview of the retry-wait footer status against a real runtime turn:
+// `pnpm --filter @minpeter/pss-coding-agent preview:retry-wait`
+// (set PSS_RETRY_PREVIEW=recovery|cancel|exhausted; default recovery).
+//
+// A deterministic local mock provider raises a retryable 429 so the runtime's
+// own model-retry controller schedules a real wait; no provider is contacted.
+// Every scenario asserts its terminal turn state and physical call count, so a
+// fixture that silently stops streaming can never be captured as a success.
+import { createAgent } from "@minpeter/pss-runtime";
+import { createInMemoryHost } from "@minpeter/pss-runtime/platform/memory";
+import { APICallError } from "ai";
+import { convertArrayToReadableStream, MockLanguageModelV4 } from "ai/test";
+import { FooterStatusBar } from "../src/tui/agent";
+import { agentEventStreamParts } from "../src/tui/agent-event-stream";
+import { createRetryStatus } from "../src/tui/retry-status";
+import { createSpinnerOrchestrator } from "../src/tui/spinner-orchestrator";
+import {
+  type PiTuiStreamState,
+  STREAM_HANDLERS,
+} from "../src/tui/stream-handlers";
+
+const WIDTH = Math.min(process.stdout.columns || 100, 120);
+const SCENARIOS = ["recovery", "cancel", "exhausted"] as const;
+type Scenario = (typeof SCENARIOS)[number];
+
+const requestedScenario = process.env.PSS_RETRY_PREVIEW ?? "recovery";
+if (!SCENARIOS.includes(requestedScenario as Scenario)) {
+  throw new Error(
+    `PSS_RETRY_PREVIEW must be one of ${SCENARIOS.join(", ")}; got "${requestedScenario}"`
+  );
+}
+const SCENARIO = requestedScenario as Scenario;
+
+/** Terminal state each scenario must reach for the capture to count. */
+const EXPECTED = {
+  cancel: { calls: 1, stopReason: "cancelled", terminal: "turn-abort" },
+  exhausted: { calls: 3, stopReason: "exhausted", terminal: "turn-error" },
+  recovery: { calls: 2, stopReason: undefined, terminal: "turn-end" },
+} as const satisfies Record<
+  Scenario,
+  {
+    calls: number;
+    stopReason: string | undefined;
+    terminal: string;
+  }
+>;
+
+/** Collects every way a scenario failed to reach its documented end state. */
+const verifyOutcome = ({
+  calls,
+  frames,
+  stopReason,
+  terminal,
+}: {
+  calls: number;
+  frames: readonly string[];
+  stopReason: string | undefined;
+  terminal: string | undefined;
+}): string[] => {
+  const expected = EXPECTED[SCENARIO];
+  const failures: string[] = [];
+  if (terminal !== expected.terminal) {
+    failures.push(
+      `terminal event: expected ${expected.terminal}, observed ${terminal}`
+    );
+  }
+  if (calls !== expected.calls) {
+    failures.push(
+      `physical calls: expected ${expected.calls}, observed ${calls}`
+    );
+  }
+  if (stopReason !== expected.stopReason) {
+    failures.push(
+      `stop reason: expected ${expected.stopReason ?? "none"}, observed ${
+        stopReason ?? "none"
+      }`
+    );
+  }
+  if (!frames.some((frame) => frame.includes("Retrying"))) {
+    failures.push("no frame showed a retry countdown");
+  }
+  return failures;
+};
+
+const failure = () =>
+  new APICallError({
+    isRetryable: true,
+    message: "rate limited by fixture",
+    requestBodyValues: {},
+    responseHeaders: { "retry-after": "5" },
+    statusCode: 429,
+    url: "https://fixture.invalid/chat",
+  });
+
+const main = async (): Promise<void> => {
+  let calls = 0;
+  // Local deterministic provider; nothing leaves the machine. `recovery` fails
+  // only the first physical call, the other scenarios fail every call.
+  const model = new MockLanguageModelV4({
+    doStream: () => {
+      calls += 1;
+      if (calls === 1 || SCENARIO !== "recovery") {
+        return Promise.reject(failure());
+      }
+      return Promise.resolve({
+        stream: convertArrayToReadableStream([
+          { type: "stream-start", warnings: [] },
+          { id: "t", type: "text-start" },
+          { delta: "Recovered after the retry.", id: "t", type: "text-delta" },
+          { id: "t", type: "text-end" },
+          {
+            finishReason: { raw: "stop", unified: "stop" },
+            type: "finish",
+            usage: {
+              inputTokens: {
+                cacheRead: undefined,
+                cacheWrite: undefined,
+                noCache: 12,
+                total: 12,
+              },
+              outputTokens: {
+                reasoning: undefined,
+                text: 5,
+                total: 5,
+              },
+            },
+          },
+        ]),
+      });
+    },
+  });
+  const agent = await createAgent({ host: createInMemoryHost(), model });
+
+  const footer = new FooterStatusBar({ requestRender: () => undefined });
+  let foregroundMessage: string | null = null;
+  const setForeground = (message: string | null): void => {
+    foregroundMessage = message;
+    footer.setForegroundMessage(message);
+  };
+  const orchestrator = createSpinnerOrchestrator(
+    {
+      clearStatus: () => setForeground(null),
+      hasSpinner: () => foregroundMessage !== null,
+      setMessage: setForeground,
+      showLoader: setForeground,
+    },
+    "Working..."
+  );
+
+  // Explicit render gate: resolves on the next countdown label the status
+  // actually emits, so the capture never depends on a wall-clock sleep.
+  let awaitNextLabel: ((label: string) => void) | undefined;
+  const nextCountdownLabel = (): Promise<string> =>
+    new Promise((resolve) => {
+      awaitNextLabel = resolve;
+    });
+  const retryStatus = createRetryStatus({
+    now: () => Date.now(),
+    setMessage: (message) => {
+      if (message === null) {
+        orchestrator.onRetryWaitEnd();
+        return;
+      }
+      orchestrator.onRetryWaitMessage(message);
+      const notify = awaitNextLabel;
+      awaitNextLabel = undefined;
+      notify?.(message);
+    },
+  });
+
+  const state = {
+    activeToolInputs: new Map(),
+    ensureAssistantView: () => ({
+      appendReasoning: () => undefined,
+      appendText: () => undefined,
+    }),
+    flags: {
+      showFiles: false,
+      showFinishReason: false,
+      showRawToolIo: false,
+      showReasoning: true,
+      showSources: false,
+      showSteps: false,
+      showToolResults: true,
+    },
+    getToolView: () => undefined,
+    onRetryClear: retryStatus.clear,
+    onRetryWait: retryStatus.scheduled,
+    pendingToolCallIds: new Set<string>(),
+    resetAssistantView: () => undefined,
+    streamedToolCallIds: new Set<string>(),
+  } as unknown as PiTuiStreamState;
+
+  const frames: string[] = [];
+  const capture = (label: string): void => {
+    frames.push(`${label}\n${footer.render(WIDTH).join("\n")}`);
+  };
+
+  setForeground("Working...");
+  const thread = agent.thread("retry-wait-preview");
+  const turn = await thread.send("go");
+
+  const observed: string[] = [];
+  let stopReason: string | undefined;
+  let sawFirstSchedule = false;
+  let pendingTick: Promise<string> | undefined;
+
+  for await (const event of turn.events()) {
+    observed.push(event.type);
+    for await (const part of agentEventStreamParts(singleEvent(event))) {
+      await STREAM_HANDLERS[part.type]?.(part, state);
+    }
+    if (event.type !== "model-retry") {
+      continue;
+    }
+    if (event.phase === "scheduled" && !sawFirstSchedule) {
+      sawFirstSchedule = true;
+      capture("waiting (fresh schedule)");
+      // Gate on the countdown's own next render, not on elapsed time.
+      pendingTick = nextCountdownLabel();
+      await pendingTick;
+      capture("waiting (counting down)");
+      if (SCENARIO === "cancel") {
+        thread.interrupt();
+      }
+    }
+    if (event.phase === "started") {
+      capture("retry started (wait cleared)");
+    }
+    if (event.phase === "stopped") {
+      stopReason = event.reason;
+      capture(`stopped (${event.reason})`);
+    }
+  }
+
+  retryStatus.stop();
+  footer.stop();
+  await agent.dispose();
+
+  const terminal = observed.at(-1);
+  const failures = verifyOutcome({ calls, frames, stopReason, terminal });
+
+  process.stdout.write(
+    `\nretry-wait footer preview (${SCENARIO}) — width ${WIDTH}\n\n${frames.join(
+      "\n\n"
+    )}\n`
+  );
+  process.stdout.write(
+    `\nterminal event: ${terminal} · physical calls: ${calls} · stop reason: ${
+      stopReason ?? "none"
+    }\n`
+  );
+  process.stdout.write(
+    `__PSS_QA_META__${JSON.stringify({
+      calls,
+      frames: frames.length,
+      passed: failures.length === 0,
+      scenario: SCENARIO,
+      stopReason: stopReason ?? null,
+      terminal,
+    })}\n`
+  );
+
+  if (failures.length > 0) {
+    // Never let a broken fixture be captured as a passing scenario.
+    process.stderr.write(
+      `${SCENARIO} scenario did not reach its expected terminal state:\n- ${failures.join(
+        "\n- "
+      )}\n`
+    );
+    process.exitCode = 1;
+  }
+};
+
+async function* singleEvent<T>(event: T): AsyncGenerator<T> {
+  yield await Promise.resolve(event);
+}
+
+await main();

--- a/apps/coding-agent/src/cli-startup.test.ts
+++ b/apps/coding-agent/src/cli-startup.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runCodingAgentCli } from "./cli";
+import { startTui } from "./tui/app";
+import { PENDING_SPINNER_INTERVAL_MS } from "./tui/pending-spinner";
+
+vi.mock("./tui/app", () => ({ startTui: vi.fn(async () => 0) }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("CLI startup wiring", () => {
+  it("forwards the selected workspace to the TUI entry point", async () => {
+    const cwd = "/selected/workspace";
+    const stdout = { write: vi.fn() };
+    await runCodingAgentCli({
+      argv: [],
+      cwd,
+      loadExtensions: async () => ({ extensions: [], notices: [] }),
+      stdout,
+    });
+    expect(startTui).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd, startupOutput: stdout })
+    );
+  });
+
+  it.each([true, false, undefined])(
+    "uses the supplied stream's TTY capability (%s), not the process terminal",
+    async (isTTY) => {
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+      const tty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+      Object.defineProperty(process.stdout, "isTTY", {
+        configurable: true,
+        value: true,
+      });
+      const processWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockReturnValue(true);
+      const stdout = {
+        columns: 2,
+        ...(isTTY === undefined ? {} : { isTTY }),
+        write: vi.fn(),
+      };
+      try {
+        await runCodingAgentCli({
+          argv: [],
+          loadExtensions: () => {
+            const before = stdout.write.mock.calls.length;
+            vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
+            expect(stdout.write.mock.calls.length - before).toBe(isTTY ? 1 : 0);
+            return Promise.resolve({ extensions: [], notices: [] });
+          },
+          start: async () => 0,
+          stdout,
+        });
+        expect(processWrite).not.toHaveBeenCalled();
+        expect(stdout.write.mock.calls.length > 0).toBe(isTTY === true);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        if (tty) {
+          Object.defineProperty(process.stdout, "isTTY", tty);
+        } else {
+          Reflect.deleteProperty(process.stdout, "isTTY");
+        }
+      }
+    }
+  );
+});

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -33,6 +33,7 @@ import {
 } from "./thread-inspect";
 import { startTui } from "./tui/app";
 import { boundedReloadOperation } from "./tui/reload";
+import { withStartupStatus } from "./tui/startup-status";
 import { cliVersion } from "./update/cli-version";
 import { runUpdateCommand } from "./update/command";
 
@@ -174,24 +175,28 @@ async function runTuiCommand({
   }
   let cliTargets: Awaited<ReturnType<typeof resolveCliExtensionTargets>>;
   try {
-    cliTargets = await resolveCliExtensionTargets({
-      cwd,
-      paths: extensionPaths,
-    });
+    cliTargets = await withStartupStatus(() =>
+      resolveCliExtensionTargets({
+        cwd,
+        paths: extensionPaths,
+      })
+    );
   } catch (error) {
     stdout.write(`${errorMessage(error)}\n`);
     return 1;
   }
   const excludeIds = new Set(cliTargets.map((target) => target.id));
-  const configured =
-    (await loadExtensions?.()) ??
-    (start
-      ? { extensions: [], notices: [] }
-      : await loadConfiguredCodingAgentExtensions({
-          cwd,
-          ...(excludeIds.size === 0 ? {} : { excludeIds }),
-          home,
-        }));
+  const configured = await withStartupStatus(
+    async () =>
+      (await loadExtensions?.()) ??
+      (start
+        ? { extensions: [], notices: [] }
+        : await loadConfiguredCodingAgentExtensions({
+            cwd,
+            ...(excludeIds.size === 0 ? {} : { excludeIds }),
+            home,
+          }))
+  );
   for (const notice of configured.notices) {
     stdout.write(`${notice}\n`);
   }
@@ -200,7 +205,9 @@ async function runTuiCommand({
     try {
       extensions = mergeCliExtensions(
         configured.extensions,
-        await importCliExtensions({ targets: cliTargets })
+        await withStartupStatus(() =>
+          importCliExtensions({ targets: cliTargets })
+        )
       );
     } catch (error) {
       stdout.write(`${errorMessage(error)}\n`);

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -33,7 +33,10 @@ import {
 } from "./thread-inspect";
 import { startTui } from "./tui/app";
 import { boundedReloadOperation } from "./tui/reload";
-import { withStartupStatus } from "./tui/startup-status";
+import {
+  type StartupStatusOutput,
+  withStartupStatus,
+} from "./tui/startup-status";
 import { cliVersion } from "./update/cli-version";
 import { runUpdateCommand } from "./update/command";
 
@@ -56,7 +59,7 @@ interface RunCodingAgentCliOptions {
       readonly sessionName?: string;
     }
   ) => Promise<number>;
-  readonly stdout?: { write(text: string): void };
+  readonly stdout?: StartupStatusOutput;
   readonly update?: (args: readonly string[]) => Promise<number>;
 }
 
@@ -160,7 +163,7 @@ async function runTuiCommand({
       readonly sessionName?: string;
     }
   ) => Promise<number>;
-  readonly stdout: { write(text: string): void };
+  readonly stdout: StartupStatusOutput;
 }): Promise<number> {
   let extensionPaths: readonly string[];
   let selection: {
@@ -175,11 +178,9 @@ async function runTuiCommand({
   }
   let cliTargets: Awaited<ReturnType<typeof resolveCliExtensionTargets>>;
   try {
-    cliTargets = await withStartupStatus(() =>
-      resolveCliExtensionTargets({
-        cwd,
-        paths: extensionPaths,
-      })
+    cliTargets = await withStartupStatus(
+      () => resolveCliExtensionTargets({ cwd, paths: extensionPaths }),
+      stdout
     );
   } catch (error) {
     stdout.write(`${errorMessage(error)}\n`);
@@ -195,7 +196,8 @@ async function runTuiCommand({
             cwd,
             ...(excludeIds.size === 0 ? {} : { excludeIds }),
             home,
-          }))
+          })),
+    stdout
   );
   for (const notice of configured.notices) {
     stdout.write(`${notice}\n`);
@@ -205,8 +207,9 @@ async function runTuiCommand({
     try {
       extensions = mergeCliExtensions(
         configured.extensions,
-        await withStartupStatus(() =>
-          importCliExtensions({ targets: cliTargets })
+        await withStartupStatus(
+          () => importCliExtensions({ targets: cliTargets }),
+          stdout
         )
       );
     } catch (error) {
@@ -223,8 +226,10 @@ async function runTuiCommand({
     return await start(extensions, selection);
   }
   return await startTui({
+    cwd,
     extensions,
     reloadExtensions,
+    startupOutput: stdout,
     ...selection,
   });
 }

--- a/apps/coding-agent/src/edit-file-flow.test.ts
+++ b/apps/coding-agent/src/edit-file-flow.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { MarkdownTheme } from "@earendil-works/pi-tui";
 import type { ToolExecutionOptions } from "ai";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createToolRenderers } from "./tui/renderers/tool-renderers";
 import { BaseToolCallView } from "./tui/tool-call-view";
 import { computeFileHash } from "./workspace-tools/hashline";
@@ -454,9 +454,16 @@ const renderEditResult = (input: unknown, output: unknown): string => {
     false,
     createToolRenderers()
   );
+  const pretty = vi.spyOn(view, "setPrettyBlock");
   view.setFinalInput(input);
   view.setOutput(output);
-  return view.render(120).join("\n");
+  // Highlighting still receives the entire diff; only its visible tail is capped.
+  const body = pretty.mock.calls.at(-1)?.[1];
+  expect(body).toBeDefined();
+  expect(view.render(120).length).toBeLessThanOrEqual(10);
+  pretty.mockRestore();
+  view.dispose();
+  return body ?? "";
 };
 
 describe("edit_file hashline flow — input → file state → edit → highlight", () => {
@@ -505,7 +512,7 @@ describe("edit_file hashline flow — input → file state → edit → highligh
         `file_hash: ${computeFileHash(scenario.expectedFile)}`
       );
 
-      // and: the TUI renders the real tool output with the expected highlight
+      // and: the real tool output is fully highlighted before viewport selection
       const rendered = renderEditResult(input, editOutput);
       for (const expected of scenario.expectRender.contains) {
         expect(rendered).toContain(expected);

--- a/apps/coding-agent/src/exec.test.ts
+++ b/apps/coding-agent/src/exec.test.ts
@@ -132,6 +132,63 @@ describe("runCodingAgentExec", () => {
     expect(result.finalText).toBe("hello world");
   });
 
+  it("streams authoritative retries to NDJSON and extension subscribers but not results", async () => {
+    let calls = 0;
+    const observed: { phase: string; stream: boolean }[] = [];
+    const captured = createCapturedOutput();
+    const result = await runCodingAgentExec({
+      extensions: [
+        {
+          id: "retry-subscriber",
+          default(pss) {
+            pss.on("model-retry", (event, context) => {
+              observed.push({ phase: event.phase, stream: context.stream });
+            });
+          },
+        },
+      ],
+      model: new MockLanguageModelV4({
+        doStream: () => {
+          calls += 1;
+          if (calls === 1) {
+            throw new APICallError({
+              message: "private provider",
+              requestBodyValues: {},
+              responseHeaders: { "retry-after-ms": "0" },
+              statusCode: 429,
+              url: "https://fixture.test",
+            });
+          }
+          return Promise.resolve({
+            stream: convertArrayToReadableStream(streamChunks),
+          });
+        },
+      }),
+      prompt: "say hello",
+      stdout: captured.output,
+      workspace,
+    });
+    expect(calls).toBe(2);
+    expect(observed).toEqual([
+      { phase: "scheduled", stream: true },
+      { phase: "started", stream: true },
+    ]);
+    const lines = captured.lines();
+    expect(
+      lines.filter(
+        (line) =>
+          line.type === "agent_event" && line.event.type === "model-retry"
+      )
+    ).toHaveLength(2);
+    const resultLine = lines.find((line) => line.type === "result");
+    expect(resultLine?.result.events.some(isParsedStreamAgentEvent)).toBe(
+      false
+    );
+    expect(result.events.some(isStreamAgentEvent)).toBe(false);
+    expect(result.status).toBe("completed");
+    expect(result.finalText).toBe("hello world");
+  });
+
   it("rejects hostile extension ids without exposing their bytes", async () => {
     const hostileId = "extension-secret\u001b[2J\u0007\nSECOND_LINE\u2028";
 

--- a/apps/coding-agent/src/extensions/factory.ts
+++ b/apps/coding-agent/src/extensions/factory.ts
@@ -143,6 +143,9 @@ function createFactoryApi(
       case "model-attempt":
         registry.on(type, handler);
         return;
+      case "model-retry":
+        registry.on(type, handler);
+        return;
       case "model-usage":
         registry.on(type, handler);
         return;

--- a/apps/coding-agent/src/extensions/host-services.ts
+++ b/apps/coding-agent/src/extensions/host-services.ts
@@ -205,23 +205,60 @@ export class ExtensionHostServices {
     return Object.freeze({
       ...ui,
       confirm: async (
-        message: Parameters<CodingAgentExtensionUi["confirm"]>[0]
+        message: Parameters<CodingAgentExtensionUi["confirm"]>[0],
+        signal?: AbortSignal
       ) =>
         await this.#withInteractiveUi(extensionId, () =>
-          this.#raceUiRevocation(() => ui.confirm(message), false)
+          this.#raceUiRevocation(
+            () =>
+              ui.confirm(
+                message,
+                AbortSignal.any([
+                  this.#uiRevokedController.signal,
+                  ...(signal ? [signal] : []),
+                ])
+              ),
+            false
+          )
         ),
-      input: async (input: Parameters<CodingAgentExtensionUi["input"]>[0]) =>
+      input: async (
+        input: Parameters<CodingAgentExtensionUi["input"]>[0],
+        signal?: AbortSignal
+      ) =>
         await this.#withInteractiveUi(extensionId, () =>
-          this.#raceUiRevocation(() => ui.input(input), undefined)
+          this.#raceUiRevocation(
+            () =>
+              ui.input(
+                input,
+                AbortSignal.any([
+                  this.#uiRevokedController.signal,
+                  ...(signal ? [signal] : []),
+                ])
+              ),
+            undefined
+          )
         ),
       notify: (message: string) => {
         if (!this.#uiRevokedController.signal.aborted) {
           ui.notify(message);
         }
       },
-      select: async (input: Parameters<CodingAgentExtensionUi["select"]>[0]) =>
+      select: async (
+        input: Parameters<CodingAgentExtensionUi["select"]>[0],
+        signal?: AbortSignal
+      ) =>
         await this.#withInteractiveUi(extensionId, () =>
-          this.#raceUiRevocation(() => ui.select(input), undefined)
+          this.#raceUiRevocation(
+            () =>
+              ui.select(
+                input,
+                AbortSignal.any([
+                  this.#uiRevokedController.signal,
+                  ...(signal ? [signal] : []),
+                ])
+              ),
+            undefined
+          )
         ),
       status: (message: string) => {
         if (this.#uiRevokedController.signal.aborted) {

--- a/apps/coding-agent/src/extensions/index.ts
+++ b/apps/coding-agent/src/extensions/index.ts
@@ -19,6 +19,13 @@ export type {
   AssistantTextView,
 } from "../tui/assistant-renderer";
 export type {
+  ColdCapture,
+  ColdContent,
+  ColdStyle,
+  ColdTextStyle,
+  ColdTheme,
+} from "../tui/cold-content";
+export type {
   TuiCommand,
   TuiCommandAction,
   TuiCommandResult,

--- a/apps/coding-agent/src/extensions/registry.ts
+++ b/apps/coding-agent/src/extensions/registry.ts
@@ -34,6 +34,7 @@ const EXTENSION_EVENT_TYPES = Object.freeze({
   "assistant-reasoning-delta": true,
   "context-usage": true,
   "model-attempt": true,
+  "model-retry": true,
   "model-usage": true,
   "runtime-input": true,
   "step-end": true,

--- a/apps/coding-agent/src/extensions/runtime-services.ts
+++ b/apps/coding-agent/src/extensions/runtime-services.ts
@@ -40,9 +40,12 @@ export function createExtensionServiceScope(options: {
   readonly ui?: CodingAgentExtensionUi;
   readonly workspace?: string;
 }): ExtensionServiceScope {
-  const logger = createExtensionLogger(options.extensionId);
   const children: Agent[] = [];
   let stateWritesRevoked = false;
+  const logger = createExtensionLogger(
+    options.extensionId,
+    () => stateWritesRevoked
+  );
   const agents: CodingAgentExtensionAgents = {
     create: async (
       input: Parameters<CodingAgentExtensionAgents["create"]>[0]
@@ -84,13 +87,14 @@ export function createExtensionServiceScope(options: {
       // write that passed the revocation check before the flag was set.
       // The fence is bounded: a never-settling queued updater must not be
       // able to hang revocation (and with it the whole reload).
+      let timer: ReturnType<typeof setTimeout> | undefined;
       await Promise.race([
         services.state.get().catch(() => undefined),
         new Promise<void>((resolveFence) => {
-          const timer = setTimeout(resolveFence, STATE_WRITE_FENCE_TIMEOUT_MS);
+          timer = setTimeout(resolveFence, STATE_WRITE_FENCE_TIMEOUT_MS);
           timer.unref?.();
         }),
-      ]);
+      ]).finally(() => clearTimeout(timer));
     },
     dispose: async () => {
       stateWritesRevoked = true;
@@ -168,9 +172,15 @@ function freezeJson<Value extends ExtensionJsonValue>(value: Value): Value {
 }
 
 function createExtensionLogger(
-  extensionId: string
+  extensionId: string,
+  isRevoked: () => boolean
 ): CodingAgentExtensionLogger {
   const write = (level: string, message: string, data: unknown): void => {
+    // A detached cleanup may retain services after its deadline. Revoke only
+    // this host-owned sink, not console or the process output streams.
+    if (isRevoked()) {
+      throw new Error(`Extension "${extensionId}" logger is disposed`);
+    }
     try {
       process.stderr.write(
         `${JSON.stringify({

--- a/apps/coding-agent/src/extensions/types.ts
+++ b/apps/coding-agent/src/extensions/types.ts
@@ -32,20 +32,26 @@ export interface CodingAgentExtensionLogger {
 }
 
 export interface CodingAgentExtensionUi {
-  confirm(message: string): Promise<boolean>;
-  input(options: {
-    readonly initialValue?: string;
-    readonly label: string;
-  }): Promise<string | undefined>;
-  notify(message: string): void;
-  select(options: {
-    readonly label: string;
-    readonly options: readonly {
-      readonly description?: string;
+  confirm(message: string, signal?: AbortSignal): Promise<boolean>;
+  input(
+    options: {
+      readonly initialValue?: string;
       readonly label: string;
-      readonly value: string;
-    }[];
-  }): Promise<string | undefined>;
+    },
+    signal?: AbortSignal
+  ): Promise<string | undefined>;
+  notify(message: string): void;
+  select(
+    options: {
+      readonly label: string;
+      readonly options: readonly {
+        readonly description?: string;
+        readonly label: string;
+        readonly value: string;
+      }[];
+    },
+    signal?: AbortSignal
+  ): Promise<string | undefined>;
   status(message: string): () => void;
 }
 

--- a/apps/coding-agent/src/instructions.ts
+++ b/apps/coding-agent/src/instructions.ts
@@ -21,7 +21,7 @@ Use the dedicated tools instead of guessing:
 
 Follow this workflow:
 1. Inspect the smallest relevant file set with glob_files, grep_files, and read_file.
-2. Read a file before changing it. Preserve exact user-specified paths.
+2. Read an existing file before changing it. New files do not require a successful read; create them with write_file and omit expected_file_hash entirely. Preserve exact user-specified paths.
 3. Prefer edit_file with fresh LINE#ID anchors; use write_file for new files or complete rewrites.
 4. Run the relevant tests, typecheck, or build after behavioral changes.
 5. Stop when the requested outcome is complete. In the final response, state what changed and what verification ran.

--- a/apps/coding-agent/src/malformed-tool-input.test.ts
+++ b/apps/coding-agent/src/malformed-tool-input.test.ts
@@ -1,0 +1,251 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type AgentEvent, createAgent } from "@minpeter/pss-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { createOpenAICompatibleModelFromEnv } from "./model";
+import { agentEventStreamParts } from "./tui/agent-event-stream";
+import { BaseToolCallView } from "./tui/tool-call-view";
+import { createWriteFileTool } from "./workspace-tools/write-file";
+
+const theme = {
+  heading: String,
+  link: String,
+  linkUrl: String,
+  code: String,
+  codeBlock: String,
+  codeBlockBorder: String,
+  quote: String,
+  quoteBorder: String,
+  hr: String,
+  listBullet: String,
+  bold: String,
+  italic: String,
+  strikethrough: String,
+  underline: String,
+};
+const callId = "call_malformed_fixture";
+const secret = "SOURCE_MUST_NOT_APPEAR_IN_ERROR";
+const content = `preview-sentinel\n${'quote " slash \\ \uD83D\uDE80 \uD55C\n'.repeat(2500)}${secret}`;
+const validInput = JSON.stringify({ path: "index.html", content });
+
+function sse(input: string, finishReason: string | undefined): Response {
+  const chunk = (delta: unknown, reason: string | null = null) =>
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta, finish_reason: reason }] })}\n\n`;
+  let wire = chunk({
+    tool_calls: [
+      {
+        index: 0,
+        id: callId,
+        type: "function",
+        function: { name: "write_file", arguments: "" },
+      },
+    ],
+  });
+  // Individual UTF-16 code units split JSON escapes and surrogate pairs across deltas.
+  for (let offset = 0; offset < input.length; offset += 127) {
+    wire += chunk({
+      tool_calls: [
+        {
+          index: 0,
+          function: { arguments: input.slice(offset, offset + 127) },
+        },
+      ],
+    });
+  }
+  if (finishReason !== undefined) {
+    wire += chunk({}, finishReason);
+    wire += "data: [DONE]\n\n";
+  }
+  const bytes = new TextEncoder().encode(wire);
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        // Byte boundaries split UTF-8 as well as SSE records.
+        for (let offset = 0; offset < bytes.length; offset += 101) {
+          controller.enqueue(bytes.slice(offset, offset + 101));
+        }
+        controller.close();
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } }
+  );
+}
+
+async function run(
+  input: string,
+  finishReason: string | undefined,
+  executionError?: string
+) {
+  const workspace = await mkdtemp(join(tmpdir(), "pss-invalid-json-"));
+  await writeFile(join(workspace, "index.html"), "original");
+  const definition = createWriteFileTool(workspace);
+  const execute = vi.fn(definition.execute);
+  if (executionError !== undefined) {
+    execute.mockImplementation(() => {
+      const error = new Error(
+        executionError.replace("AI_InvalidToolInputError: ", "")
+      );
+      error.name = "AI_InvalidToolInputError";
+      throw error;
+    });
+  }
+  const fetch = vi.fn<typeof globalThis.fetch>();
+  fetch.mockResolvedValueOnce(sse(input, finishReason));
+  fetch.mockResolvedValueOnce(
+    new Response(
+      'data: {"choices":[{"index":0,"delta":{"content":"Done."},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+      { headers: { "content-type": "text/event-stream" } }
+    )
+  );
+  const agent = await createAgent({
+    model: createOpenAICompatibleModelFromEnv({
+      fetch,
+      runtimeEnv: {
+        AI_API_KEY: "fixture",
+        AI_BASE_URL: "https://fixture.invalid/v1",
+        AI_MODEL: "fixture-model",
+      },
+    }),
+    tools: { write_file: { ...definition, execute } },
+  });
+  try {
+    const turn = await agent.thread("invalid-json").send("Run the fixture.");
+    const events: AgentEvent[] = [];
+    for await (const event of turn.events()) {
+      events.push(event);
+    }
+    return {
+      events,
+      execute,
+      requests: fetch.mock.calls.map(([, init]) =>
+        JSON.parse(String(init?.body))
+      ),
+      bytes: await readFile(join(workspace, "index.html")),
+      files: await readdir(workspace),
+    };
+  } finally {
+    await agent.dispose();
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+async function render(events: AgentEvent[]) {
+  const view = new BaseToolCallView(callId, "write_file", theme);
+  try {
+    async function* stream() {
+      yield* events;
+    }
+    for await (const part of agentEventStreamParts(stream())) {
+      if (part.type === "tool-input-delta") {
+        await view.appendInputChunk(String(part.inputTextDelta));
+      }
+      if (part.type === "tool-call") {
+        view.setFinalInput(part.input);
+      }
+      if (part.type === "tool-error") {
+        view.setError(part.error);
+      }
+    }
+    return view.render(120).join("\n");
+  } finally {
+    view.dispose();
+  }
+}
+
+describe("malformed tool JSON through runtime and TUI", () => {
+  it.each([
+    { name: "truncated", input: validInput.slice(0, -2), finish: "length" },
+    {
+      name: "malformed quote",
+      input: validInput.replace("preview-sentinel", 'preview-sentinel"broken'),
+      finish: "tool_calls",
+    },
+  ])(
+    "rejects $name without writing and gives the next model bounded feedback",
+    async ({ input, finish }) => {
+      const result = await run(input, finish);
+      expect(result.execute).not.toHaveBeenCalled();
+      expect(result.bytes.toString()).toBe("original");
+      expect(result.files).toEqual(["index.html"]);
+      expect(result.requests).toHaveLength(2);
+      const toolMessage = result.requests[1].messages.find(
+        (message: { role: string }) => message.role === "tool"
+      );
+      const feedback = JSON.parse(toolMessage.content);
+      expect(feedback).toMatchObject({
+        code: "INVALID_TOOL_ARGUMENTS",
+        kind: "json-parse",
+        inputCharacters: input.length,
+      });
+      expect(feedback.finishReason).toBe(
+        finish === "length" ? "length" : undefined
+      );
+      expect(feedback.message.length).toBeGreaterThan(40);
+      expect(toolMessage.content.length).toBeLessThan(700);
+      expect(toolMessage.content).not.toContain(secret);
+      const event = result.events.find((event) => event.type === "tool-result");
+      expect(event).toMatchObject({
+        output: { type: "error-json", value: feedback },
+      });
+      expect(
+        result.events.filter((event) => event.type === "model-retry")
+      ).toEqual([]);
+      expect(result.events.at(-1)?.type).toBe("turn-end");
+      const output = await render(result.events);
+      expect(output).toContain("preview-sentinel");
+      expect(output).toContain("INVALID_TOOL_ARGUMENTS");
+      expect(output).toContain(secret);
+      expect(output.length).toBeLessThan(6000);
+    }
+  );
+
+  it("identifies schema rejection without claiming malformed JSON", async () => {
+    const input = JSON.stringify({ path: "index.html" });
+    const result = await run(input, "tool_calls");
+    expect(result.execute).not.toHaveBeenCalled();
+    expect(result.bytes.toString()).toBe("original");
+    const toolMessage = result.requests[1].messages.find(
+      (message: { role: string }) => message.role === "tool"
+    );
+    expect(JSON.parse(toolMessage.content)).toMatchObject({
+      code: "INVALID_TOOL_ARGUMENTS",
+      kind: "schema-validation",
+      inputCharacters: input.length,
+    });
+  });
+
+  it("preserves an executed tool error resembling SDK validation feedback", async () => {
+    const error = "AI_InvalidToolInputError: fixture executor failure";
+    const result = await run(validInput, "tool_calls", error);
+    expect(result.execute).toHaveBeenCalledOnce();
+    const toolMessage = result.requests[1].messages.find(
+      (message: { role: string }) => message.role === "tool"
+    );
+    expect(toolMessage.content).toBe(error);
+    expect(
+      result.events.find((event) => event.type === "tool-result")
+    ).toMatchObject({
+      output: { type: "error-text", value: error },
+    });
+  });
+
+  it("writes valid large JSON once with exact decoded bytes", async () => {
+    expect(validInput.length).toBeGreaterThan(30_000);
+    const result = await run(validInput, "tool_calls");
+    expect(result.execute).toHaveBeenCalledOnce();
+    expect(result.bytes).toEqual(Buffer.from(content));
+    expect(
+      result.events.filter((event) => event.type === "turn-error")
+    ).toEqual([]);
+  });
+
+  it("does not execute an incomplete call on abrupt stream closure", async () => {
+    const result = await run(validInput.slice(0, -2), undefined);
+    expect(result.execute).not.toHaveBeenCalled();
+    expect(result.bytes.toString()).toBe("original");
+    expect(
+      result.events.filter((event) => event.type === "model-retry")
+    ).toEqual([]);
+  });
+});

--- a/apps/coding-agent/src/model-output-schema.test.ts
+++ b/apps/coding-agent/src/model-output-schema.test.ts
@@ -1,0 +1,57 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText, Output } from "ai";
+import { expect, it } from "vitest";
+import { z } from "zod";
+import { createEditFileTool } from "./workspace-tools/edit-file";
+
+it("preserves structured output schema alongside non-strict tool generation", async () => {
+  const requests: unknown[] = [];
+  const provider = createOpenAICompatible({
+    name: "fixture",
+    apiKey: "fixture-key",
+    baseURL: "https://fixture.invalid/v1",
+    supportsStructuredOutputs: true,
+    fetch: (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return Promise.resolve(
+        Response.json({
+          id: "fixture-response",
+          object: "chat.completion",
+          created: 0,
+          model: "fixture-model",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: '{"ok":true}' },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        })
+      );
+    },
+  });
+  const result = await generateText({
+    model: provider("fixture-model"),
+    prompt: "Return the fixture output without calling a tool.",
+    output: Output.object({ schema: z.object({ ok: z.boolean() }) }),
+    tools: { edit_file: createEditFileTool("/unused-fixture-workspace") },
+  });
+  expect(result.output).toEqual({ ok: true });
+  expect(requests).toHaveLength(1);
+  expect(requests[0]).toMatchObject({
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        strict: true,
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+          additionalProperties: false,
+        },
+      },
+    },
+    tools: [{ function: { name: "edit_file", strict: false } }],
+  });
+});

--- a/apps/coding-agent/src/model-streaming-tools.test.ts
+++ b/apps/coding-agent/src/model-streaming-tools.test.ts
@@ -1,0 +1,151 @@
+import { type AgentEvent, createAgent } from "@minpeter/pss-runtime";
+import { jsonSchema, tool } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { createCodingModelSessionFromEnv } from "./model";
+
+// Captured from a live compatible-provider response: text precedes the first
+// tool delta, whose index is 2 (not 0), and arguments arrive separately.
+function toolStream(indices: readonly number[]): string {
+  const chunks: unknown[] = [
+    {
+      choices: [
+        {
+          index: 0,
+          delta: { role: "assistant", content: "Inspecting." },
+          finish_reason: null,
+        },
+      ],
+    },
+    ...indices.map((index) => ({
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index,
+                id: `call-${index}`,
+                type: "function",
+                function: { name: "read_file", arguments: "" },
+              },
+            ],
+            content: null,
+          },
+          finish_reason: null,
+        },
+      ],
+    })),
+    ...indices.map((index) => ({
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index,
+                function: {
+                  arguments: JSON.stringify({ path: `/fixture/${index}` }),
+                },
+              },
+            ],
+            content: null,
+          },
+          finish_reason: null,
+        },
+      ],
+    })),
+    {
+      choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+      usage: null,
+    },
+    {
+      choices: [],
+      usage: {
+        prompt_tokens: 4807,
+        completion_tokens: 116,
+        total_tokens: 4923,
+      },
+    },
+  ];
+  return encodeStream(chunks);
+}
+
+function encodeStream(chunks: readonly unknown[]): string {
+  return `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`;
+}
+
+const completedStream = encodeStream([
+  {
+    choices: [{ index: 0, delta: { content: "Done." }, finish_reason: "stop" }],
+  },
+]);
+
+describe("compatible provider streaming tool indexes", () => {
+  it.each([{ indices: [0] }, { indices: [2] }, { indices: [2, 7] }])(
+    "executes and commits tools with indexes $indices without retrying",
+    async ({ indices }) => {
+      const execute = vi.fn(({ path }: { path: string }) => path);
+      const fetch = vi.fn<typeof globalThis.fetch>();
+      fetch.mockResolvedValueOnce(
+        new Response(toolStream(indices), {
+          headers: { "content-type": "text/event-stream" },
+        })
+      );
+      fetch.mockResolvedValueOnce(
+        new Response(completedStream, {
+          headers: { "content-type": "text/event-stream" },
+        })
+      );
+      const session = createCodingModelSessionFromEnv({
+        fetch,
+        runtimeEnv: {
+          AI_API_KEY: "fixture",
+          AI_BASE_URL: "https://fixture.test/v1",
+          AI_MODEL: "fixture-model",
+        },
+      });
+      const agent = await createAgent({
+        model: session.model,
+        tools: {
+          read_file: tool({
+            inputSchema: jsonSchema<{ path: string }>({
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+              additionalProperties: false,
+            }),
+            execute,
+          }),
+        },
+      });
+      try {
+        const turn = await agent.thread("fixture").send("Inspect the files.");
+        const events: AgentEvent[] = [];
+        for await (const event of turn.events()) {
+          events.push(event);
+        }
+        expect(events.filter((event) => event.type === "turn-error")).toEqual(
+          []
+        );
+        expect(execute.mock.calls.map(([input]) => input)).toEqual(
+          indices.map((index) => ({ path: `/fixture/${index}` }))
+        );
+        expect(events.filter((event) => event.type === "tool-result")).toEqual(
+          indices.map((index) => ({
+            type: "tool-result",
+            toolCallId: `call-${index}`,
+            toolName: "read_file",
+            output: { type: "text", value: `/fixture/${index}` },
+          }))
+        );
+        expect(events.at(-1)?.type).toBe("turn-end");
+        expect(events.filter((event) => event.type === "model-retry")).toEqual(
+          []
+        );
+        expect(fetch).toHaveBeenCalledTimes(2);
+      } finally {
+        await agent.dispose();
+      }
+    }
+  );
+});

--- a/apps/coding-agent/src/sessions/session-auto-title.ts
+++ b/apps/coding-agent/src/sessions/session-auto-title.ts
@@ -21,6 +21,7 @@ export interface GenerateSessionTitleOptions {
   readonly history: readonly ModelMessage[];
   readonly instructions: string;
   readonly model: LanguageModel;
+  readonly signal?: AbortSignal;
 }
 
 /**
@@ -32,6 +33,7 @@ export async function generateSessionTitle({
   history,
   instructions,
   model,
+  signal,
 }: GenerateSessionTitleOptions): Promise<string | undefined> {
   const userMessages = history.filter((message) => message.role === "user");
   if (userMessages.length !== 1) {
@@ -44,6 +46,7 @@ export async function generateSessionTitle({
   }
   try {
     const result = await generateText({
+      abortSignal: signal,
       instructions,
       maxOutputTokens: 24,
       messages: [...history, TITLE_REQUEST],

--- a/apps/coding-agent/src/tui/agent-busy.test.ts
+++ b/apps/coding-agent/src/tui/agent-busy.test.ts
@@ -1,0 +1,818 @@
+import {
+  type Component,
+  Container,
+  type Editor,
+  type Terminal,
+  type TuiMainScreen,
+} from "@earendil-works/pi-tui";
+import {
+  type AgentTurn,
+  createAgent,
+  speculativeCompaction,
+} from "@minpeter/pss-runtime";
+import { createInMemoryHost } from "@minpeter/pss-runtime/platform/memory";
+import { jsonSchema, tool } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodingAgentExtensionUi } from "../extensions/types";
+
+const terminalHarness = vi.hoisted(() => ({
+  send: (_data: string): void => undefined,
+  surface: undefined as TuiMainScreen | undefined,
+}));
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  const noop = () => undefined;
+  class TestTerminal implements Terminal {
+    columns = 80;
+    rows = 24;
+    kittyProtocolActive = false;
+    clearFromCursor = noop;
+    clearLine = noop;
+    clearScreen = noop;
+    hideCursor = noop;
+    moveBy = noop;
+    setProgress = noop;
+    setTitle = noop;
+    showCursor = noop;
+    stop = noop;
+    write = noop;
+    drainInput() {
+      return Promise.resolve();
+    }
+    start(onInput: (data: string) => void) {
+      terminalHarness.send = onInput;
+    }
+  }
+  class TestScreen extends actual.TuiMainScreen {
+    override start() {
+      terminalHarness.surface = this;
+      super.start();
+    }
+  }
+  return {
+    ...actual,
+    ProcessTerminal: TestTerminal,
+    TuiMainScreen: TestScreen,
+  };
+});
+
+import { type AgentTUIConfig, createAgentTUI, FooterStatusBar } from "./agent";
+import { createCompactCommand } from "./compact-command";
+import { withCompactionStatus } from "./compaction-status";
+import { createToolRenderers } from "./renderers/tool-renderers";
+import { TuiSessionMachine } from "./session-state";
+
+const gate = <T = void>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+const bounded = async <T>(
+  promise: Promise<T>,
+  description = "Expected event was not observed"
+): Promise<T> => {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(description)), 1000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+const findFooter = (component: Component): FooterStatusBar | undefined => {
+  if (component instanceof FooterStatusBar) {
+    return component;
+  }
+  if (component instanceof Container) {
+    for (const child of component.children) {
+      const found = findFooter(child);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return;
+};
+const footer = () => {
+  const result = terminalHarness.surface && findFooter(terminalHarness.surface);
+  if (!result) {
+    throw new Error("No mounted footer");
+  }
+  return result;
+};
+const SPINNER_PATTERN = /[\u2800-\u28ff]/u;
+const frame = () => footer().render(80).join("").match(SPINNER_PATTERN)?.[0];
+const expectBusy = () => {
+  const first = frame();
+  expect.soft(first).toBeDefined();
+  vi.advanceTimersByTime(80);
+  expect.soft(frame()).toBeDefined();
+  expect.soft(frame()).not.toBe(first);
+};
+const input = (value: string) => {
+  for (const char of value) {
+    terminalHarness.send(char);
+  }
+};
+const idleGate = () => {
+  const idle = gate();
+  const original = TuiSessionMachine.prototype.awaitInput;
+  const spy = vi
+    .spyOn(TuiSessionMachine.prototype, "awaitInput")
+    .mockImplementation(function (this: TuiSessionMachine, resolve) {
+      original.call(this, resolve);
+      spy.mockRestore();
+      idle.resolve();
+    });
+  return idle.promise;
+};
+const exit = async (run: Promise<void>) => {
+  process.emit("SIGINT", "SIGINT");
+  process.emit("SIGINT", "SIGINT");
+  await run;
+  expect(vi.getTimerCount()).toBe(0);
+};
+const thread = () => ({
+  interrupt: vi.fn(),
+  send: vi.fn(() => {
+    throw new Error("Unexpected send");
+  }),
+  steer: vi.fn(() => {
+    throw new Error("Unexpected steer");
+  }),
+});
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe.sequential("real TUI busy lifetimes", () => {
+  it.each([
+    "activation",
+    "setup",
+    "command",
+    "reload",
+    "preprocess",
+    "history",
+  ] as const)(
+    "animates during %s until its promise settles",
+    async (boundary) => {
+      const entered = gate();
+      const release = gate();
+      const pending = () => {
+        entered.resolve();
+        return release.promise;
+      };
+      const idle = idleGate();
+      const config: AgentTUIConfig = {
+        thread: thread(),
+        commands: [
+          {
+            name: "slow",
+            description: "fixture",
+            execute: async () => {
+              if (boundary === "command") {
+                await pending();
+              }
+              return {
+                success: true,
+                ...(boundary === "reload"
+                  ? { action: { type: "reload" as const } }
+                  : {}),
+              };
+            },
+          },
+        ],
+        onExtensionUiReady: boundary === "activation" ? pending : undefined,
+        onSetup: boundary === "setup" ? pending : undefined,
+        onCommandAction: pending,
+        preprocessUserInput: async () => {
+          await pending();
+          return { success: false, error: "consumed" };
+        },
+        replayHistoryOnStartup: boundary === "history",
+        sessionSelector: {
+          currentSessionKey: () => "one",
+          listSessions: async () => [],
+          switchSession: async () => undefined,
+          loadCurrentHistory: async () => {
+            await pending();
+            return [];
+          },
+        },
+      };
+      const run = createAgentTUI(config);
+      let settled = idle;
+      try {
+        if (!["activation", "setup", "history"].includes(boundary)) {
+          await idle;
+          settled = idleGate();
+          input(boundary === "preprocess" ? "go\r" : "/slow\r");
+        }
+        await entered.promise;
+        expectBusy();
+      } finally {
+        release.resolve();
+        await settled;
+        expect(frame()).toBeUndefined();
+        await exit(run);
+      }
+    }
+  );
+
+  it("suspends a command for a user modal, resumes work after selection, and retains independent status owners", async () => {
+    let ui!: CodingAgentExtensionUi;
+    const mounted = gate();
+    const selected = gate();
+    const release = gate();
+    const idle = idleGate();
+    const run = createAgentTUI({
+      thread: thread(),
+      onExtensionUiReady: (createUi) => {
+        ui = createUi();
+      },
+      commands: [
+        {
+          name: "modal",
+          description: "fixture",
+          execute: async () => {
+            const selection = ui.select({
+              label: "Choose",
+              options: [{ label: "One", value: "one" }],
+            });
+            mounted.resolve();
+            await selection;
+            selected.resolve();
+            await release.promise;
+            return { success: true };
+          },
+        },
+      ],
+    });
+    await idle;
+    const settled = idleGate();
+    input("/modal\r");
+    try {
+      await mounted.promise;
+      expect(frame()).toBeUndefined();
+      const clearOne = ui.status("one");
+      const clearTwo = ui.status("two");
+      clearOne();
+      expectBusy();
+      clearTwo();
+      expect(frame()).toBeUndefined();
+      input("\r");
+      await selected.promise;
+      expectBusy();
+    } finally {
+      input("\u001b");
+      release.resolve();
+      await settled;
+      await exit(run);
+    }
+  });
+
+  it.each(["model", "session"] as const)(
+    "covers %s listing and switching but not selector user wait",
+    async (kind) => {
+      const listing = gate();
+      const releaseList = gate();
+      const mounted = gate();
+      const switching = gate();
+      const releaseSwitch = gate();
+      const loading = gate();
+      const releaseHistory = gate();
+      const idle = idleGate();
+      const run = createAgentTUI({
+        thread: thread(),
+        commands: [
+          {
+            name: "pick",
+            description: "fixture",
+            execute: () => ({
+              success: true,
+              action: {
+                type: kind === "model" ? "select-model" : "select-session",
+              },
+            }),
+          },
+        ],
+        modelSelector: {
+          currentModelId: () => {
+            mounted.resolve();
+            return "old";
+          },
+          listModelIds: async () => {
+            listing.resolve();
+            await releaseList.promise;
+            return ["next"];
+          },
+          switchModel: () => {
+            switching.resolve();
+            return releaseSwitch.promise;
+          },
+        },
+        sessionSelector: {
+          currentSessionKey: () => {
+            mounted.resolve();
+            return "old";
+          },
+          listSessions: async () => {
+            listing.resolve();
+            await releaseList.promise;
+            return [
+              {
+                key: "next",
+                cwd: "/fixture",
+                createdAt: "2026-09-05T00:00:00Z",
+                updatedAt: "2026-09-05T00:00:00Z",
+              },
+            ];
+          },
+          switchSession: () => {
+            switching.resolve();
+            return releaseSwitch.promise;
+          },
+          loadCurrentHistory: async () => {
+            loading.resolve();
+            await releaseHistory.promise;
+            return [];
+          },
+        },
+      });
+      await idle;
+      const settled = idleGate();
+      input("/pick\r");
+      try {
+        await listing.promise;
+        expectBusy();
+        releaseList.resolve();
+        await mounted.promise;
+        expect(frame()).toBeUndefined();
+        input("\r");
+        await switching.promise;
+        expectBusy();
+        releaseSwitch.resolve();
+        if (kind === "session") {
+          await loading.promise;
+          expectBusy();
+        }
+      } finally {
+        releaseList.resolve();
+        releaseSwitch.resolve();
+        releaseHistory.resolve();
+        await settled;
+        await exit(run);
+      }
+    }
+  );
+
+  it.each(["manual", "automatic"] as const)(
+    "animates during real %s compaction summary execution",
+    async (kind) => {
+      let ui: CodingAgentExtensionUi | undefined;
+      const summaryEntered = gate();
+      const releaseSummary = gate();
+      const compacted = gate();
+      const committing = gate();
+      const releaseCommit = gate();
+      const diagnostics: unknown[] = [];
+      const host = createInMemoryHost();
+      const commit = host.store.threads.commit.bind(host.store.threads);
+      vi.spyOn(host.store.threads, "commit").mockImplementation(
+        async (...args) => {
+          const state = args[1].state as { compactions?: unknown[] };
+          if ((state.compactions?.length ?? 0) > 0) {
+            committing.resolve();
+            await releaseCommit.promise;
+          }
+          return await commit(...args);
+        }
+      );
+      const summaryCall = kind === "manual" ? 2 : 3;
+      let calls = 0;
+      const model = new MockLanguageModelV4({
+        doStream: async () => {
+          const isSummary = ++calls === summaryCall;
+          if (isSummary) {
+            summaryEntered.resolve();
+            await releaseSummary.promise;
+          }
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: "text-start", id: "t" });
+                controller.enqueue({
+                  type: "text-delta",
+                  id: "t",
+                  delta: isSummary
+                    ? "summary"
+                    : "Long history content. ".repeat(200),
+                });
+                controller.enqueue({ type: "text-end", id: "t" });
+                controller.enqueue({
+                  type: "finish",
+                  finishReason: { raw: "stop", unified: "stop" },
+                  usage: {
+                    inputTokens: {
+                      noCache: 100,
+                      total: 100,
+                      cacheRead: undefined,
+                      cacheWrite: undefined,
+                    },
+                    outputTokens: {
+                      text: isSummary ? 2 : 1200,
+                      total: isSummary ? 2 : 1200,
+                      reasoning: undefined,
+                    },
+                  },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      });
+      const agent = await createAgent({
+        host: {
+          ...host,
+          diagnostics: {
+            report: (diagnostic) => {
+              diagnostics.push(diagnostic);
+              if ((diagnostic.compaction?.summaryCalls ?? 0) > 0) {
+                expect
+                  .soft(["committed", "skipped"])
+                  .toContain(diagnostic.compaction?.outcome);
+                compacted.resolve();
+              }
+            },
+          },
+        },
+        model,
+        ...(kind === "automatic"
+          ? {
+              compaction: withCompactionStatus(
+                speculativeCompaction({
+                  maxInputTokens: 10_000,
+                  prepareRatio: 0.1,
+                  promoteRatio: 0.2,
+                  retainRatio: 0.05,
+                }),
+                () => ui?.status("Compacting")
+              ),
+            }
+          : {}),
+      });
+      const realThread = agent.thread("compaction");
+      const idle = idleGate();
+      const run = createAgentTUI({
+        thread: realThread,
+        onExtensionUiReady: (createUi) => {
+          ui = createUi();
+        },
+        commands: [
+          createCompactCommand({
+            compact: async () => {
+              const result = await realThread.compact();
+              expect(result.status).toBe("compacted");
+              compacted.resolve();
+              return result;
+            },
+          }),
+        ],
+      });
+      await idle;
+      let settled = idleGate();
+      input("first\r");
+      await settled;
+      settled = idleGate();
+      input(kind === "manual" ? "/compact\r" : "second\r");
+      try {
+        await bounded(
+          summaryEntered.promise,
+          `Summary did not start: ${JSON.stringify(diagnostics)}`
+        );
+        expectBusy();
+        if (kind === "automatic") {
+          await settled;
+          expectBusy();
+        }
+        releaseSummary.resolve();
+        await bounded(
+          committing.promise,
+          "Compaction did not reach persistence"
+        );
+        expectBusy();
+        releaseCommit.resolve();
+        await bounded(
+          compacted.promise,
+          `Compaction did not commit: ${JSON.stringify(diagnostics)}`
+        );
+      } finally {
+        releaseSummary.resolve();
+        releaseCommit.resolve();
+        await settled;
+        await exit(run);
+        await agent.dispose();
+      }
+    }
+  );
+
+  it("keeps the original physical turn cancellable after steering settles, through Esc cleanup", async () => {
+    const text = gate();
+    const steeringEnded = gate();
+    const cancelled = gate();
+    const cleanup = gate();
+    const reloading = gate();
+    const releaseReload = gate();
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => ({
+        stream: new ReadableStream({
+          start(controller) {
+            options.abortSignal?.addEventListener(
+              "abort",
+              () => {
+                cancelled.resolve();
+                cleanup.promise.then(() =>
+                  controller.error(new DOMException("Cancelled", "AbortError"))
+                );
+              },
+              { once: true }
+            );
+            controller.enqueue({ type: "text-start", id: "t" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t",
+              delta: "Working",
+            });
+          },
+        }),
+      }),
+    });
+    const agent = await createAgent({ host: createInMemoryHost(), model });
+    const realThread = agent.thread("steering");
+    const idle = idleGate();
+    let steeringReturned = false;
+    let subscriptions = 0;
+    const observe = (turn: AgentTurn): AgentTurn => ({
+      ...turn,
+      events: () =>
+        (async function* () {
+          subscriptions += 1;
+          for await (const part of turn.events()) {
+            yield part;
+            if (part.type === "assistant-output-delta") {
+              text.resolve();
+            }
+          }
+        })(),
+    });
+    const run = createAgentTUI({
+      commands: [
+        {
+          name: "reload",
+          description: "fixture",
+          allowDuringActiveTurn: true,
+          execute: () => ({ success: true, action: { type: "reload" } }),
+        },
+      ],
+      onCommandAction: () => {
+        reloading.resolve();
+        return releaseReload.promise;
+      },
+      thread: {
+        send: async (value) => observe(await realThread.send(value)),
+        steer: async (value) => {
+          const steering = observe(await realThread.steer(value));
+          steeringReturned = true;
+          return steering;
+        },
+        interrupt: () => realThread.interrupt(),
+      },
+    });
+    await idle;
+    const settled = idleGate();
+    input("go\r");
+    await text.promise;
+    const surface = terminalHarness.surface;
+    if (!surface) {
+      throw new Error("No mounted surface");
+    }
+    const composer = surface.children.at(-1) as Container;
+    const editor = composer.children[0] as Editor;
+    const requestRender = surface.requestRender.bind(surface);
+    vi.spyOn(surface, "requestRender").mockImplementation((force) => {
+      requestRender(force);
+      if (steeringReturned && !editor.disableSubmit) {
+        steeringEnded.resolve();
+      }
+    });
+    try {
+      input("change direction\r");
+      await steeringEnded.promise;
+      expect.soft(subscriptions).toBe(1);
+      expectBusy();
+      input("/reload\r");
+      await reloading.promise;
+      expectBusy();
+      input("\u001b");
+      await bounded(cancelled.promise);
+      expectBusy();
+    } finally {
+      cleanup.resolve();
+      realThread.interrupt();
+      await settled;
+      expectBusy();
+      const noWork = gate();
+      const original = footer().setForegroundMessage.bind(footer());
+      vi.spyOn(footer(), "setForegroundMessage").mockImplementation(
+        (message) => {
+          original(message);
+          if (message === null) {
+            noWork.resolve();
+          }
+        }
+      );
+      releaseReload.resolve();
+      await bounded(noWork.promise);
+      expect(frame()).toBeUndefined();
+      await exit(run);
+      await agent.dispose();
+    }
+  });
+
+  it("keeps one ticker through real text, physical parallel tools, step waits, and async finalization", async () => {
+    const providers = [gate(), gate()];
+    const controllers = [
+      gate<ReadableStreamDefaultController>(),
+      gate<ReadableStreamDefaultController>(),
+    ];
+    const releaseProviders = [gate(), gate()];
+    const tools = [gate(), gate()];
+    const releaseTools = [gate(), gate()];
+    const completedTools = [gate(), gate()];
+    const events = new Map<string, ReturnType<typeof gate<void>>>();
+    const event = (name: string) => {
+      let value = events.get(name);
+      if (!value) {
+        value = gate();
+        events.set(name, value);
+      }
+      return value;
+    };
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        const index = calls++;
+        providers[index]?.resolve();
+        await releaseProviders[index]?.promise;
+        return {
+          stream: new ReadableStream({
+            start(controller) {
+              controllers[index]?.resolve(controller);
+            },
+          }),
+        };
+      },
+    });
+    const agent = await createAgent({
+      host: createInMemoryHost(),
+      model,
+      tools: {
+        read_file: tool({
+          inputSchema: jsonSchema<{ path: string }>({
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          }),
+          execute: async ({ path }) => {
+            const index = Number(path);
+            tools[index]?.resolve();
+            await releaseTools[index]?.promise;
+            completedTools[index]?.resolve();
+            return "file";
+          },
+        }),
+      },
+    });
+    const realThread = agent.thread("busy");
+    const finalizing = gate();
+    const releaseFinalizing = gate();
+    const observe = (turn: AgentTurn): AgentTurn => ({
+      ...turn,
+      events: () =>
+        (async function* () {
+          for await (const part of turn.events()) {
+            yield part;
+            event(
+              `${part.type}:${"toolCallId" in part ? part.toolCallId : ""}`
+            ).resolve();
+          }
+        })(),
+    });
+    const idle = idleGate();
+    const run = createAgentTUI({
+      toolRenderers: createToolRenderers(),
+      thread: {
+        interrupt: () => realThread.interrupt(),
+        send: async (text) => observe(await realThread.send(text)),
+        steer: (text) => realThread.steer(text),
+      },
+      onTurnComplete: () => {
+        finalizing.resolve();
+        return releaseFinalizing.promise;
+      },
+    });
+    await idle;
+    const settled = idleGate();
+    input("go\r");
+    const usage = {
+      inputTokens: { noCache: 1, total: 1 },
+      outputTokens: { text: 1, total: 1 },
+    };
+    try {
+      await providers[0]?.promise;
+      expectBusy();
+      const ticker = Reflect.get(footer(), "ticker");
+      releaseProviders[0]?.resolve();
+      const c = await controllers[0]?.promise;
+      c?.enqueue({ type: "text-start", id: "text" });
+      c?.enqueue({ type: "text-delta", id: "text", delta: "Still generating" });
+      await event("assistant-output-delta:").promise;
+      expectBusy();
+      c?.enqueue({ type: "text-end", id: "text" });
+      for (const index of [0, 1]) {
+        c?.enqueue({
+          type: "tool-input-start",
+          id: `call${index}`,
+          toolName: "read_file",
+        });
+        await event(`tool-call-input-start:call${index}`).promise;
+        expectBusy();
+        c?.enqueue({
+          type: "tool-input-delta",
+          id: `call${index}`,
+          delta: `{"path":"${index}"}`,
+        });
+        await event(`tool-call-input-delta:call${index}`).promise;
+        expectBusy();
+        c?.enqueue({ type: "tool-input-end", id: `call${index}` });
+        c?.enqueue({
+          type: "tool-call",
+          toolCallId: `call${index}`,
+          toolName: "read_file",
+          input: `{"path":"${index}"}`,
+        });
+      }
+      c?.enqueue({
+        type: "finish",
+        finishReason: { raw: "tool_calls", unified: "tool-calls" },
+        usage,
+      });
+      c?.close();
+      await Promise.all(tools.map((value) => value.promise));
+      expectBusy();
+      releaseTools[0]?.resolve();
+      await completedTools[0]?.promise;
+      expectBusy();
+      releaseTools[1]?.resolve();
+      await providers[1]?.promise;
+      expectBusy();
+      expect.soft(Reflect.get(footer(), "ticker")).toBe(ticker);
+      releaseProviders[1]?.resolve();
+      const c2 = await controllers[1]?.promise;
+      c2?.enqueue({ type: "text-start", id: "done" });
+      c2?.enqueue({ type: "text-delta", id: "done", delta: "Done" });
+      c2?.enqueue({ type: "text-end", id: "done" });
+      c2?.enqueue({
+        type: "finish",
+        finishReason: { raw: "stop", unified: "stop" },
+        usage,
+      });
+      c2?.close();
+      await finalizing.promise;
+      expectBusy();
+    } finally {
+      for (const value of [...releaseProviders, ...releaseTools]) {
+        value.resolve();
+      }
+      releaseFinalizing.resolve();
+      realThread.interrupt();
+      await settled;
+      await exit(run);
+      await agent.dispose();
+    }
+  });
+});

--- a/apps/coding-agent/src/tui/agent-event-stream.test.ts
+++ b/apps/coding-agent/src/tui/agent-event-stream.test.ts
@@ -408,6 +408,70 @@ describe("agentEventStreamParts", () => {
     ]);
   });
 
+  it("translates a scheduled retry into a retry-wait part carrying the deadline", async () => {
+    const parts = await collect([
+      {
+        attempt: 1,
+        attemptId: "step-1",
+        delayMs: 4000,
+        phase: "scheduled",
+        remainingRetries: 2,
+        retryAt: 1_700_000_004_000,
+        type: "model-retry",
+      } as AgentEvent,
+    ]);
+
+    expect(parts).toEqual([
+      {
+        attempt: 1,
+        attemptId: "step-1",
+        delayMs: 4000,
+        phase: "scheduled",
+        remainingRetries: 2,
+        retryAt: 1_700_000_004_000,
+        type: "retry-wait",
+      },
+    ]);
+  });
+
+  it("translates started and stopped retries into clearing retry-wait parts", async () => {
+    const parts = await collect([
+      {
+        attempt: 1,
+        attemptId: "step-1",
+        phase: "started",
+        remainingRetries: 1,
+        type: "model-retry",
+      } as AgentEvent,
+      {
+        attempt: 2,
+        attemptId: "step-1",
+        phase: "stopped",
+        reason: "exhausted",
+        remainingRetries: 0,
+        type: "model-retry",
+      } as AgentEvent,
+    ]);
+
+    expect(parts).toEqual([
+      {
+        attempt: 1,
+        attemptId: "step-1",
+        phase: "started",
+        remainingRetries: 1,
+        type: "retry-wait",
+      },
+      {
+        attempt: 2,
+        attemptId: "step-1",
+        phase: "stopped",
+        reason: "exhausted",
+        remainingRetries: 0,
+        type: "retry-wait",
+      },
+    ]);
+  });
+
   it("skips user-input and runtime-input echoes", async () => {
     const parts = await collect([
       { type: "user-input", text: "hi" } as AgentEvent,

--- a/apps/coding-agent/src/tui/agent-event-stream.ts
+++ b/apps/coding-agent/src/tui/agent-event-stream.ts
@@ -173,6 +173,12 @@ export async function* agentEventStreamParts(
           };
         }
         break;
+      case "model-retry":
+        // Live-only retry state. Forwarded as a stream part so the TUI's one
+        // dispatch table stays the sole renderer, but it never becomes a
+        // transcript row: the wait only drives the foreground status.
+        yield { ...event, type: "retry-wait" };
+        break;
       case "model-usage":
         lastFinishReason = event.finishReason;
         options.onModelUsage?.(event);

--- a/apps/coding-agent/src/tui/agent-exit.test.ts
+++ b/apps/coding-agent/src/tui/agent-exit.test.ts
@@ -37,6 +37,7 @@ vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
 });
 
 import { type AgentTUIConfig, createAgentTUI } from "./agent";
+import { TuiSessionMachine } from "./session-state";
 
 const deferred = <T>(): {
   promise: Promise<T>;
@@ -53,16 +54,17 @@ const deferred = <T>(): {
 };
 
 const submitModelCommandAfterSetup = (): void => {
-  // The outer microtask lets createAgentTUI continue past onSetup; the inner
-  // one runs after its input waiter has been installed.
-  queueMicrotask(() => {
-    queueMicrotask(() => {
+  const original = TuiSessionMachine.prototype.awaitInput;
+  const spy = vi
+    .spyOn(TuiSessionMachine.prototype, "awaitInput")
+    .mockImplementation(function (this: TuiSessionMachine, resolve) {
+      original.call(this, resolve);
+      spy.mockRestore();
       for (const input of "/model") {
         terminalHarness.send?.(input);
       }
       terminalHarness.send?.("\r");
     });
-  });
 };
 
 const requestExit = (): void => {

--- a/apps/coding-agent/src/tui/agent-ownership.test.ts
+++ b/apps/coding-agent/src/tui/agent-ownership.test.ts
@@ -1,0 +1,1260 @@
+import {
+  type Component,
+  type Container,
+  Markdown,
+  stripTerminalSequences,
+  type Terminal,
+  type TuiMainScreen,
+} from "@earendil-works/pi-tui";
+import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodingAgentExtensionUi } from "../extensions/types";
+import type { AssistantRendererContext } from "./assistant-renderer";
+import type { BaseToolCallView } from "./tool-call-view";
+import { ColdSnapshot, type TranscriptOwner } from "./transcript-owner";
+
+const terminal = vi.hoisted(() => ({
+  columns: 100,
+  send: (_data: string): void => undefined,
+  screen: undefined as TuiMainScreen | undefined,
+}));
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  const noop = () => undefined;
+  class LocalTerminal implements Terminal {
+    get columns() {
+      return terminal.columns;
+    }
+    rows = 40;
+    kittyProtocolActive = false;
+    clearFromCursor = noop;
+    clearLine = noop;
+    clearScreen = noop;
+    hideCursor = noop;
+    moveBy = noop;
+    setProgress = noop;
+    setTitle = noop;
+    showCursor = noop;
+    stop = noop;
+    write = noop;
+    drainInput() {
+      return Promise.resolve();
+    }
+    start(onInput: (data: string) => void) {
+      terminal.send = onInput;
+    }
+  }
+  class LocalScreen extends actual.TuiMainScreen {
+    override start() {
+      terminal.screen = this;
+      super.start();
+    }
+  }
+  return {
+    ...actual,
+    ProcessTerminal: LocalTerminal,
+    TuiMainScreen: LocalScreen,
+  };
+});
+
+import { type AgentTUIConfig, createAgentTUI } from "./agent";
+import { createModelCommand } from "./model-command";
+import { ModelSelectorComponent } from "./model-selector";
+import { TuiSessionMachine } from "./session-state";
+
+const gate = <T = void>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+const bounded = async <T>(promise: Promise<T>): Promise<T> => {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("Missing TUI event")),
+          2000
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+const idle = () => {
+  const signal = gate();
+  const original = TuiSessionMachine.prototype.awaitInput;
+  const spy = vi
+    .spyOn(TuiSessionMachine.prototype, "awaitInput")
+    .mockImplementation(function (this: TuiSessionMachine, resolve) {
+      original.call(this, resolve);
+      spy.mockRestore();
+      signal.resolve();
+    });
+  return bounded(signal.promise);
+};
+const send = (text: string) => {
+  for (const char of text) {
+    terminal.send(char);
+  }
+};
+const surface = () => {
+  if (!terminal.screen) {
+    throw new Error("TUI not mounted");
+  }
+  return terminal.screen;
+};
+const chat = () => surface().children[1] as Container;
+const rows = (component: Component = chat(), width = 100) => [
+  ...component.render(width),
+];
+const plain = () => stripTerminalSequences(rows().join("\n"));
+const onRender = async (matches: () => boolean, action: () => void) => {
+  const signal = gate();
+  const screen = surface();
+  const requestRender = screen.requestRender.bind(screen);
+  const spy = vi.spyOn(screen, "requestRender").mockImplementation((force) => {
+    requestRender(force);
+    if (matches()) {
+      signal.resolve();
+    }
+  });
+  try {
+    action();
+    await bounded(signal.promise);
+  } finally {
+    spy.mockRestore();
+  }
+};
+const prefix = () =>
+  chat().children.map((component) => ({ component, lines: rows(component) }));
+const unchanged = (snapshot: ReturnType<typeof prefix>) => {
+  for (const { component, lines } of snapshot) {
+    expect(rows(component)).toEqual(lines);
+    expect(chat().children).toContain(component);
+  }
+};
+function stream() {
+  let next = gate<
+    { event: AgentEvent; consumed: ReturnType<typeof gate<void>> } | undefined
+  >();
+  const run = {
+    runId: "local-run",
+    events: () =>
+      (async function* () {
+        for (;;) {
+          const slot = await next.promise;
+          next = gate();
+          if (!slot) {
+            return;
+          }
+          yield slot.event;
+          slot.consumed.resolve();
+        }
+      })(),
+  } as AgentTurn;
+  return {
+    run,
+    end: () => next.resolve(undefined),
+    emit: async (event: Record<string, unknown>) => {
+      const consumed = gate();
+      next.resolve({ event: event as AgentEvent, consumed });
+      await bounded(consumed.promise);
+    },
+  };
+}
+async function fixture(extra: Partial<AgentTUIConfig> = {}) {
+  const source = stream();
+  const started = gate();
+  const steered = gate();
+  const ready = idle();
+  const run = createAgentTUI({
+    ...extra,
+    thread: {
+      send: () => {
+        started.resolve();
+        return Promise.resolve(source.run);
+      },
+      steer: () => {
+        steered.resolve();
+        return Promise.resolve(source.run);
+      },
+      interrupt: source.end,
+    },
+  });
+  await ready;
+  let active = false;
+  return {
+    ...source,
+    async start() {
+      active = true;
+      send("USER\r");
+      await bounded(started.promise);
+    },
+    async steer() {
+      send("STEERING_USER\r");
+      await bounded(steered.promise);
+    },
+    async command(text: string) {
+      const ready = idle();
+      send(`${text}\r`);
+      await ready;
+    },
+    async finish() {
+      const ready = idle();
+      source.end();
+      await ready;
+      active = false;
+    },
+    async close() {
+      if (active) {
+        const ready = idle();
+        source.end();
+        await ready;
+      }
+      process.emit("SIGINT", "SIGINT");
+      process.emit("SIGINT", "SIGINT");
+      await bounded(run);
+    },
+  };
+}
+beforeEach(() => {
+  terminal.columns = 100;
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe.sequential("actual TUI transcript ownership", () => {
+  it.each(["direct", "picker"] as const)(
+    "appends only one model notice through %s and retains session notices and COLD header",
+    async (method) => {
+      let current = "MODEL_A";
+      const cwd = "/CWD_SENTINEL";
+      const header = { title: "LOGO", subtitle: `${current}\n${cwd}` };
+      const footer = { text: "FOOTER_A" };
+      const switchModel = vi.fn((id: string) => {
+        current = id;
+        header.subtitle = `${id}\n${cwd}`;
+        footer.text = "FOOTER_B";
+      });
+      const models = {
+        currentModelId: () => current,
+        listModelIds: async () => ["MODEL_A", "MODEL_B"],
+        switchModel,
+      };
+      const app = await fixture({
+        header,
+        footer,
+        modelSelector: models,
+        commands: [
+          createModelCommand(models),
+          {
+            name: "rename",
+            description: "fixture",
+            execute: () => {
+              header.subtitle = `${current}\n${cwd}\nSESSION_RENAMED`;
+              return { success: true, action: { type: "refresh-header" } };
+            },
+          },
+        ],
+      });
+      try {
+        const before = rows(surface().children[0]);
+        if (method === "direct") {
+          await app.command("/model MODEL_B");
+        } else {
+          await onRender(
+            () =>
+              (surface().children.at(-1) as Container).children[0] instanceof
+              ModelSelectorComponent,
+            () => send("/model\r")
+          );
+          const ready = idle();
+          send("MODEL_B\r");
+          await ready;
+        }
+        expect(current).toBe("MODEL_B");
+        expect(switchModel).toHaveBeenCalledExactlyOnceWith("MODEL_B");
+        expect(rows(surface().children[0])).toEqual(before);
+        const notice = plain()
+          .split("\n")
+          .filter((line) => line.trim());
+        expect(notice).toHaveLength(1);
+        expect(notice[0].match(/MODEL_B/g)).toHaveLength(1);
+        expect(plain()).not.toContain(cwd);
+        expect(
+          stripTerminalSequences(rows(surface().children.at(-1)).join("\n"))
+        ).toContain("FOOTER_B");
+        const noticeRows = rows();
+        await app.command("/rename");
+        expect(rows().slice(0, noticeRows.length)).toEqual(noticeRows);
+        expect(plain()).toContain("SESSION_RENAMED");
+        expect(rows(surface().children[0])).toEqual(before);
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it.each(["direct", "picker"] as const)(
+    "replaces only the current HOT model notice through %s",
+    async (method) => {
+      let current = "MODEL_A";
+      const models = {
+        currentModelId: () => current,
+        listModelIds: async () => [
+          "MODEL_A",
+          "MODEL_B",
+          "MODEL_C",
+          "MODEL_ERROR",
+        ],
+        switchModel: (id: string) => {
+          if (id === "MODEL_ERROR") {
+            throw new Error("SWITCH_SENTINEL");
+          }
+          current = id;
+        },
+      };
+      const app = await fixture({
+        commands: [createModelCommand(models)],
+        modelSelector: models,
+      });
+      const choose = async (id: string) => {
+        if (method === "direct") {
+          await app.command(`/model ${id}`);
+          return;
+        }
+        await onRender(
+          () =>
+            (surface().children.at(-1) as Container).children[0] instanceof
+            ModelSelectorComponent,
+          () => send("/model\r")
+        );
+        const ready = idle();
+        send(`${id}\r`);
+        await ready;
+      };
+      try {
+        await choose("MODEL_B");
+        await choose("MODEL_C");
+        expect(
+          plain()
+            .split("\n")
+            .filter((line) => line.trim())
+        ).toHaveLength(1);
+        expect(plain()).not.toContain("MODEL_B");
+        expect(plain()).toContain("MODEL_C");
+        expect(rows().join("\n")).toContain("\x1b[47m\x1b[30m");
+        await choose("MODEL_ERROR");
+        expect(plain()).toContain("MODEL_C");
+        expect(plain()).toContain("SWITCH_SENTINEL");
+        const cold = rows();
+        await choose("MODEL_B");
+        expect(rows().slice(0, cold.length)).toEqual(cold);
+        expect(plain()).toContain("MODEL_B");
+        expect(plain()).toContain("MODEL_C");
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it.each(["unchanged", "error", "cancel"] as const)(
+    "does not claim a picker model change on %s",
+    async (outcome) => {
+      const switchModel = vi.fn(() => {
+        if (outcome === "error") {
+          throw new Error("SWITCH_ERROR_SENTINEL");
+        }
+      });
+      const models = {
+        currentModelId: () => "MODEL_A",
+        listModelIds: async () => ["MODEL_A", "MODEL_B"],
+        switchModel,
+      };
+      const app = await fixture({
+        commands: [createModelCommand(models)],
+        modelSelector: models,
+      });
+      try {
+        await onRender(
+          () =>
+            (surface().children.at(-1) as Container).children[0] instanceof
+            ModelSelectorComponent,
+          () => send("/model\r")
+        );
+        const ready = idle();
+        send(outcome === "cancel" ? "\x1b" : "\r");
+        await ready;
+        if (outcome === "error") {
+          expect(plain()).toContain("SWITCH_ERROR_SENTINEL");
+          expect(plain()).not.toContain("MODEL_A");
+        } else {
+          expect(plain().trim()).toBe("");
+        }
+        expect(switchModel).toHaveBeenCalledTimes(outcome === "cancel" ? 0 : 1);
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it("does not rewrite the startup header when current model/session changes", async () => {
+    const header = { title: "LOGO", subtitle: "MODEL_A" };
+    const app = await fixture({
+      header,
+      commands: [
+        {
+          name: "change",
+          description: "fixture",
+          execute: () => {
+            header.subtitle = "MODEL_B_SESSION_B";
+            return {
+              success: true,
+              message: "MODEL_B_SESSION_B",
+              action: { type: "refresh-header" },
+            };
+          },
+        },
+      ],
+    });
+    try {
+      const before = rows(surface().children[0]);
+      await app.command("/change");
+      expect(rows(surface().children[0])).toEqual(before);
+      expect(plain()).toContain("MODEL_B_SESSION_B");
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("settles a pulsing notice before user append, not on its historical timeout", async () => {
+    const callbacks: (() => void)[] = [];
+    const original = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      fn: () => void,
+      ms?: number,
+      ...args: unknown[]
+    ) => {
+      if (ms === 140) {
+        callbacks.push(fn);
+        const handle = original(fn, ms, ...args);
+        clearTimeout(handle);
+        return handle;
+      }
+      return original(fn, ms, ...args);
+    }) as typeof setTimeout);
+    const app = await fixture();
+    try {
+      await app.command("");
+      const normal = rows();
+      await app.command("");
+      expect(rows()).not.toEqual(normal);
+      await app.start();
+      const cold = prefix();
+      expect(rows().slice(0, normal.length)).toEqual(normal);
+      for (const fn of callbacks) {
+        fn();
+      }
+      unchanged(cold);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("appends reverse A/B results below already completed content", async () => {
+    const app = await fixture();
+    try {
+      await app.start();
+      for (const toolCallId of ["A", "B"]) {
+        await app.emit({
+          type: "tool-call",
+          toolCallId,
+          toolName: "fixture",
+          input: { path: toolCallId },
+        });
+      }
+      await app.emit({
+        type: "tool-result",
+        toolCallId: "B",
+        toolName: "fixture",
+        output: { type: "text", value: "RESULT_B" },
+      });
+      const cold = prefix();
+      await app.emit({
+        type: "tool-result",
+        toolCallId: "A",
+        toolName: "fixture",
+        output: { type: "text", value: "RESULT_A" },
+      });
+      unchanged(cold);
+      expect(plain().indexOf("RESULT_A")).toBeGreaterThan(
+        plain().indexOf("RESULT_B")
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("isolates completed answers even when an old custom renderer ignores abort", async () => {
+    let late!: () => void;
+    let context!: AssistantRendererContext;
+    const app = await fixture({
+      assistantRenderer: (ctx) => {
+        context = ctx;
+        const view = new Markdown("", 1, 0, ctx.markdownTheme);
+        late = () => {
+          view.setText("BUGGY_LATE_RENDER");
+          ctx.requestRender();
+          ctx.notify("STALE_NOTICE");
+        };
+        return view;
+      },
+    });
+    try {
+      await app.start();
+      await app.emit({ type: "assistant-output-delta", text: "FIRST_ANSWER" });
+      await app.emit({ type: "assistant-output", text: "FIRST_ANSWER" });
+      const cold = prefix();
+      late();
+      unchanged(cold);
+      expect(plain()).not.toContain("STALE_NOTICE");
+      expect(context.signal.aborted).toBe(true);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("continues streaming below steering without changing its old answer", async () => {
+    const app = await fixture();
+    try {
+      await app.start();
+      await app.emit({
+        type: "assistant-output-delta",
+        text: "BEFORE_STEERING",
+      });
+      await app.steer();
+      const cold = prefix();
+      await app.emit({
+        type: "assistant-output-delta",
+        text: "AFTER_STEERING",
+      });
+      unchanged(cold);
+      expect(plain().indexOf("AFTER_STEERING")).toBeGreaterThan(
+        plain().indexOf("STEERING_USER")
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each([48, 100])(
+    "expands only completed text at width %i",
+    async (width) => {
+      const app = await fixture();
+      terminal.columns = width;
+      const markers = Array.from(
+        { length: 16 },
+        (_, i) => `CELL_${String(i).padStart(2, "0")}`
+      );
+      const answer = [
+        "| HEADER_ID | VALUE_ID |",
+        "| --- | --- |",
+        ...markers.map((m) => `| ${m} | OK |`),
+        "",
+        "VERIFY_A",
+        "",
+        "VERIFY_B",
+        "",
+        "VERIFY_C",
+      ].join("\n");
+      try {
+        await app.start();
+        await app.emit({
+          type: "tool-result",
+          toolCallId: "tool",
+          toolName: "fixture",
+          output: { type: "text", value: "TOOL_PREFIX" },
+        });
+        const cold = prefix();
+        await app.emit({ type: "assistant-output-delta", text: answer });
+        const active = chat().children.at(-1);
+        expect(rows(active, width)).toHaveLength(8);
+        expect(
+          stripTerminalSequences(rows(active, width).join("\n"))
+        ).not.toContain("HEADER_ID");
+        await app.emit({ type: "assistant-output", text: answer });
+        unchanged(cold);
+        const final = stripTerminalSequences(rows(chat(), width).join("\n"));
+        for (const marker of [
+          "HEADER_ID",
+          ...markers,
+          "VERIFY_A",
+          "VERIFY_B",
+          "VERIFY_C",
+        ]) {
+          expect(final.split(marker)).toHaveLength(2);
+        }
+        expect(chat().children.at(-1)).toBeInstanceOf(ColdSnapshot);
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it.each([
+    "fallback",
+    "short",
+    "code",
+    "late-reasoning",
+    "abort",
+    "error",
+    "steering",
+    "tools",
+  ] as const)("finalizes text only at its own boundary: %s", async (mode) => {
+    const app = await fixture();
+    const lines = Array.from(
+      { length: mode === "short" ? 2 : 24 },
+      (_, i) => `TEXT_${String(i).padStart(2, "0")}`
+    );
+    const text =
+      mode === "code"
+        ? `\`\`\`ts\n${lines.join("\n")}\n\`\`\``
+        : lines.join("\n");
+    const reasoning = Array.from(
+      { length: 20 },
+      (_, i) => `THINK_${String(i).padStart(2, "0")}`
+    ).join("\n");
+    try {
+      await app.start();
+      if (mode === "late-reasoning") {
+        await app.emit({ type: "assistant-reasoning-delta", text: reasoning });
+      }
+      if (mode !== "fallback") {
+        await app.emit({ type: "assistant-output-delta", text });
+      }
+      if (mode === "late-reasoning") {
+        await app.emit({ type: "assistant-reasoning", text: reasoning });
+        expect(chat().children.at(-1)).not.toBeInstanceOf(ColdSnapshot);
+      }
+      const streamed = rows();
+      if (mode === "abort" || mode === "error") {
+        await app.emit(
+          mode === "abort"
+            ? { type: "turn-abort" }
+            : { type: "turn-error", message: "FAIL_ID" }
+        );
+        await app.finish();
+        expect(plain()).not.toContain("TEXT_00");
+        expect(plain()).toContain("TEXT_23");
+      } else if (mode === "steering") {
+        await app.steer();
+        const cold = prefix();
+        const continuation = text.replaceAll("TEXT", "NEXT");
+        await app.emit({ type: "assistant-output-delta", text: continuation });
+        await app.emit({ type: "assistant-output", text: text + continuation });
+        unchanged(cold);
+        expect(plain()).not.toContain("TEXT_00");
+        for (const marker of lines) {
+          expect(plain().split(marker.replace("TEXT", "NEXT"))).toHaveLength(2);
+        }
+      } else {
+        await app.emit({ type: "assistant-output", text });
+        for (const marker of lines) {
+          expect(plain().split(marker)).toHaveLength(2);
+        }
+        if (mode === "short") {
+          expect(rows()).toEqual(streamed);
+        }
+        if (mode === "late-reasoning") {
+          expect(plain()).not.toContain("THINK_00");
+          expect(plain().match(/THINK_\d+/g)).toHaveLength(8);
+        }
+        if (mode === "tools") {
+          const cold = prefix();
+          await app.emit({
+            type: "tool-call",
+            toolCallId: "next",
+            toolName: "fixture",
+            input: {},
+          });
+          await app.emit({
+            type: "tool-result",
+            toolCallId: "next",
+            toolName: "fixture",
+            output: { type: "text", value: "RESULT_ID" },
+          });
+          await app.emit({ type: "step-start" });
+          await app.emit({ type: "assistant-output", text: "FINAL_ID" });
+          unchanged(cold);
+          expect(plain().split("TEXT_00")).toHaveLength(2);
+        }
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("captures the full current async renderer once, then revokes it", async () => {
+    const ready = gate();
+    const release = gate();
+    const dispose = vi.fn();
+    const setText = vi.fn();
+    let context!: AssistantRendererContext;
+    let display = ["PENDING_ID"];
+    const app = await fixture({
+      assistantRenderer: (ctx) => {
+        context = ctx;
+        release.promise.then(() => {
+          display = Array.from(
+            { length: 20 },
+            (_, i) => `CUSTOM_${String(i).padStart(2, "0")}`
+          );
+          ctx.requestRender();
+          ready.resolve();
+        });
+        return {
+          invalidate: () => undefined,
+          setText,
+          dispose,
+          render: () => display,
+        };
+      },
+    });
+    try {
+      await app.start();
+      await app.emit({ type: "assistant-output-delta", text: "SOURCE_ID" });
+      release.resolve();
+      await bounded(ready.promise);
+      expect(rows(chat().children.at(-1))).toHaveLength(8);
+      await app.emit({ type: "assistant-output", text: "SOURCE_ID" });
+      expect(plain().match(/CUSTOM_\d+/g)).toHaveLength(20);
+      expect(setText).toHaveBeenCalledTimes(1);
+      expect(dispose).toHaveBeenCalledTimes(1);
+      expect(context.signal.aborted).toBe(true);
+      const cold = prefix();
+      display = ["LATE_ID"];
+      context.requestRender();
+      context.notify("LATE_NOTICE_ID");
+      unchanged(cold);
+      expect(plain()).not.toContain("LATE_ID");
+    } finally {
+      await app.close();
+    }
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("freezes the chosen reasoning tail independently of a long answer and resize", async () => {
+    const app = await fixture();
+    const reasoning = Array.from(
+      { length: 12 },
+      (_, i) => `REASON_${i} 漢字🙂`
+    ).join("\n");
+    const answer = Array.from({ length: 20 }, (_, i) => `ANSWER_${i}`).join(
+      "\n"
+    );
+    try {
+      await app.start();
+      await app.emit({ type: "assistant-reasoning-delta", text: reasoning });
+      const shown = rows(chat().children[chat().children.length - 1]);
+      expect(shown).toHaveLength(8);
+      await app.emit({ type: "assistant-reasoning", text: reasoning });
+      const cold = prefix();
+      expect(rows(chat().children[chat().children.length - 1])).toEqual(shown);
+      await app.emit({ type: "assistant-output-delta", text: answer });
+      await app.emit({ type: "assistant-output", text: answer });
+      unchanged(cold);
+      const complete = rows();
+      rows(chat(), 31);
+      rows(chat(), 140);
+      expect(rows()).toEqual(complete);
+      expect(plain()).toContain("REASON_11");
+      expect(plain()).not.toContain("REASON_0");
+      expect(chat().children.every((c) => c instanceof ColdSnapshot)).toBe(
+        true
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("keeps exact canonical arguments across interleaved A/B/C continuations and isolates retained tool setters", async () => {
+    const calls: { input: unknown; output: unknown; view: BaseToolCallView }[] =
+      [];
+    const app = await fixture({
+      toolRenderers: {
+        fixture: (view, input, output) => {
+          calls.push({ input, output, view });
+          view.setPrettyBlock("fixture", String(output ?? "PENDING"));
+        },
+      },
+    });
+    const source = {
+      A: { path: "A", content: "one\ntwo\n漢字\n" },
+      B: { path: "B", content: "B source" },
+      C: { path: "C", content: "C source" },
+    };
+    const encoded = Object.fromEntries(
+      Object.entries(source).map(([id, input]) => [id, JSON.stringify(input)])
+    );
+    try {
+      await app.start();
+      for (const id of ["A", "B", "C"]) {
+        await app.emit({
+          type: "tool-call-input-start",
+          toolCallId: id,
+          toolName: "fixture",
+        });
+        await app.emit({
+          type: "tool-call-input-delta",
+          toolCallId: id,
+          inputTextDelta: encoded[id].slice(0, 12),
+        });
+      }
+      const old = prefix().slice(0, -1);
+      for (const id of ["A", "C", "B"] as const) {
+        await app.emit({
+          type: "tool-call-input-delta",
+          toolCallId: id,
+          inputTextDelta: encoded[id].slice(12),
+        });
+        await app.emit({
+          type: "tool-call",
+          toolCallId: id,
+          toolName: "fixture",
+          input: source[id],
+        });
+      }
+      unchanged(old);
+      for (const id of ["C", "A", "B"] as const) {
+        const before = prefix().filter(
+          (entry) => entry.component instanceof ColdSnapshot
+        );
+        await app.emit({
+          type: "tool-result",
+          toolCallId: id,
+          toolName: "fixture",
+          output: { type: "text", value: `RESULT_${id}` },
+        });
+        unchanged(before);
+        expect(
+          [...calls].reverse().find((call) => call.output === `RESULT_${id}`)
+            ?.input
+        ).toEqual(source[id]);
+      }
+      const cold = prefix();
+      for (const { view } of calls) {
+        view.setPrettyBlock("STALE", "BUGGY_TOOL");
+        view.clear();
+      }
+      unchanged(cold);
+      expect(plain()).not.toContain("BUGGY_TOOL");
+      expect(plain().indexOf("RESULT_C")).toBeLessThan(
+        plain().indexOf("RESULT_A")
+      );
+      expect(plain().indexOf("RESULT_A")).toBeLessThan(
+        plain().indexOf("RESULT_B")
+      );
+      expect(JSON.parse(encoded.A)).toEqual(source.A);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each(["empty", "error", "abort"] as const)(
+    "seals partial output on %s terminal completion",
+    async (ending) => {
+      const app = await fixture();
+      try {
+        await app.start();
+        if (ending !== "empty") {
+          await app.emit({ type: "assistant-output-delta", text: "PARTIAL" });
+        }
+        if (ending === "error") {
+          await app.emit({ type: "turn-error", message: "ERROR_SENTINEL" });
+        }
+        if (ending === "abort") {
+          await app.emit({ type: "turn-abort" });
+        }
+        await app.finish();
+        expect(chat().children.every((c) => c instanceof ColdSnapshot)).toBe(
+          true
+        );
+        if (ending !== "empty") {
+          expect(plain()).toContain("PARTIAL");
+        }
+        if (ending === "error") {
+          expect(plain()).toContain("ERROR_SENTINEL");
+        }
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it("retains old output on failed replacement load and revokes callbacks across explicit reset", async () => {
+    const callbacks: (() => void)[] = [];
+    let fail = true;
+    const app = await fixture({
+      assistantRenderer: (ctx) => {
+        const view = new Markdown("", 1, 0, ctx.markdownTheme);
+        callbacks.push(() => {
+          view.setText("STALE_AFTER_RESET");
+          ctx.notify("STALE_NOTICE");
+          ctx.requestRender();
+        });
+        return view;
+      },
+      commands: [
+        {
+          name: "replace",
+          description: "fixture",
+          execute: () => ({
+            success: true,
+            action: { type: "session", clear: true },
+          }),
+        },
+      ],
+      sessionSelector: {
+        currentSessionKey: () => "new-session",
+        listSessions: async () => [],
+        switchSession: async () => undefined,
+        loadCurrentHistory: () =>
+          fail
+            ? Promise.reject(new Error("LOAD_FAILED"))
+            : Promise.resolve([{ role: "assistant", content: "REPLAY" }]),
+      },
+    });
+    try {
+      await app.start();
+      await app.emit({ type: "assistant-output-delta", text: "OLD_ANSWER" });
+      await app.finish();
+      const before = prefix();
+      const epoch = (chat() as TranscriptOwner).epoch;
+      await app.command("/replace");
+      unchanged(before);
+      expect(plain()).toContain("LOAD_FAILED");
+      expect((chat() as TranscriptOwner).epoch).toBe(epoch);
+      fail = false;
+      await app.command("/replace");
+      expect((chat() as TranscriptOwner).epoch).toBe(epoch + 1);
+      const cold = prefix();
+      for (const callback of callbacks) {
+        callback();
+      }
+      unchanged(cold);
+      expect(plain()).toContain("REPLAY");
+      expect(plain()).not.toContain("OLD_ANSWER");
+      expect(plain()).not.toContain("STALE");
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("allows enrichment only while HOT and seals before reload without clearing history", async () => {
+    let complete!: () => void;
+    const host = new AbortController();
+    const app = await fixture({
+      assistantRendererSignal: host.signal,
+      assistantRenderer: (ctx) => {
+        const view = new Markdown("", 1, 0, ctx.markdownTheme);
+        complete = () => {
+          view.setText("READY_ENRICHMENT");
+          ctx.requestRender();
+        };
+        return view;
+      },
+      commands: [
+        {
+          name: "reload",
+          description: "fixture",
+          execute: () => ({
+            success: true,
+            action: { type: "reload" },
+            message: "RELOADED",
+          }),
+        },
+      ],
+      onCommandAction: () => {
+        host.abort();
+        complete();
+      },
+    });
+    try {
+      await app.start();
+      await app.emit({ type: "assistant-output-delta", text: "FALLBACK" });
+      complete();
+      expect(plain()).toContain("READY_ENRICHMENT");
+      await app.finish();
+      const cold = prefix();
+      const epoch = (chat() as TranscriptOwner).epoch;
+      await app.command("/reload");
+      unchanged(cold);
+      expect((chat() as TranscriptOwner).epoch).toBe(epoch);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each([false, true])(
+    "freezes the %s-ready graphic or fallback without invoking its renderer on resize",
+    async (readyAtSeal) => {
+      let ready = false;
+      let renderCount = 0;
+      let context!: AssistantRendererContext;
+      const asset = "\x1b_Ga=T,f=100;ASSET\x1b\\";
+      const graphicRows = [asset, ...Array.from({ length: 12 }, () => "")];
+      const app = await fixture({
+        assistantRenderer: (ctx) => {
+          context = ctx;
+          const view = new Markdown("", 1, 0, ctx.markdownTheme);
+          const render = view.render.bind(view);
+          view.render = (width) => {
+            renderCount += 1;
+            return ready ? [...graphicRows] : render(width);
+          };
+          return view;
+        },
+      });
+      try {
+        await app.start();
+        await app.emit({
+          type: "assistant-output-delta",
+          text: "GRAPHIC_FALLBACK",
+        });
+        ready = readyAtSeal;
+        await app.emit({ type: "assistant-output", text: "GRAPHIC_FALLBACK" });
+        const cold = prefix();
+        const count = renderCount;
+        ready = true;
+        context.requestRender();
+        rows(chat(), 12);
+        unchanged(cold);
+        expect(renderCount).toBe(count);
+        const frozen = chat().children[chat().children.length - 1];
+        if (readyAtSeal) {
+          expect(frozen.render(12)).toEqual(graphicRows);
+        } else {
+          expect(plain()).toContain("GRAPHIC_FALLBACK");
+          expect(rows().join("\n")).not.toContain(asset);
+        }
+        expect(context.signal.aborted).toBe(true);
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it("ignores an old stream after an explicit active-turn reset and cancels old prompts/status", async () => {
+    let ui!: CodingAgentExtensionUi;
+    const app = await fixture({
+      onExtensionUiReady: (create) => {
+        ui = create();
+      },
+      commands: [
+        {
+          name: "new",
+          description: "fixture",
+          allowDuringActiveTurn: true,
+          execute: () => ({
+            success: true,
+            message: "RESET_DONE",
+            action: { type: "session", clear: true },
+          }),
+        },
+      ],
+      sessionSelector: {
+        currentSessionKey: () => "new",
+        listSessions: async () => [],
+        switchSession: async () => undefined,
+        loadCurrentHistory: async () => [
+          { role: "assistant", content: "NEW_EPOCH" },
+        ],
+      },
+    });
+    try {
+      await app.start();
+      await app.emit({ type: "assistant-output-delta", text: "OLD_STREAM" });
+      const epoch = (chat() as TranscriptOwner).epoch;
+      await onRender(
+        () => plain().includes("RESET_DONE"),
+        () => send("/new\r")
+      );
+      expect((chat() as TranscriptOwner).epoch).toBe(epoch + 1);
+      const afterReset = rows();
+      await app.emit({ type: "assistant-output-delta", text: "STALE_DELTA" });
+      await app.emit({
+        type: "tool-call",
+        toolCallId: "reused",
+        toolName: "fixture",
+        input: { stale: true },
+      });
+      expect(rows()).toEqual(afterReset);
+      const prompt = ui.input({ label: "OLD_EPOCH_PROMPT" });
+      ui.status("OLD_EPOCH_STATUS");
+      (chat() as TranscriptOwner).reset("session-navigation");
+      await expect(prompt).resolves.toBeUndefined();
+      expect(
+        stripTerminalSequences(surface().render(100).join("\n"))
+      ).not.toContain("OLD_EPOCH_STATUS");
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("freezes before multiline rejected steering and resumes below the rejection", async () => {
+    const app = await fixture({
+      preprocessUserInput: async (input) =>
+        input === "STEERING_USER"
+          ? { success: false, error: "REJECT_ONE\nREJECT_TWO" }
+          : undefined,
+    });
+    try {
+      await app.start();
+      await app.emit({
+        type: "assistant-output-delta",
+        text: "BEFORE_REJECTION",
+      });
+      await onRender(
+        () => plain().includes("REJECT_TWO"),
+        () => send("STEERING_USER\r")
+      );
+      const cold = prefix().filter(
+        (entry) => entry.component instanceof ColdSnapshot
+      );
+      await app.emit({
+        type: "assistant-output-delta",
+        text: "AFTER_REJECTION",
+      });
+      unchanged(cold);
+      expect(plain().indexOf("AFTER_REJECTION")).toBeGreaterThan(
+        plain().indexOf("REJECT_TWO")
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("hands off even empty tool input and freezes the pending card on abort", async () => {
+    const app = await fixture();
+    try {
+      await app.start();
+      await app.emit({
+        type: "assistant-output-delta",
+        text: "PARTIAL_REASON",
+      });
+      await app.emit({
+        type: "tool-call-input-start",
+        toolCallId: "EMPTY_A",
+        toolName: "fixture",
+      });
+      const cold = prefix().filter(
+        (entry) => entry.component instanceof ColdSnapshot
+      );
+      await app.emit({
+        type: "tool-call-input-start",
+        toolCallId: "EMPTY_B",
+        toolName: "fixture",
+      });
+      unchanged(cold);
+      await app.emit({ type: "turn-abort" });
+      expect(chat().children.every((c) => c instanceof ColdSnapshot)).toBe(
+        true
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each(["error-text", "execution-denied"] as const)(
+    "appends a late %s result without changing the old tool",
+    async (type) => {
+      const app = await fixture();
+      try {
+        await app.start();
+        await app.emit({
+          type: "tool-call",
+          toolCallId: "A",
+          toolName: "fixture",
+          input: {},
+        });
+        await app.emit({ type: "assistant-output", text: "LATER_ANSWER" });
+        const cold = prefix();
+        await app.emit({
+          type: "tool-result",
+          toolCallId: "A",
+          toolName: "fixture",
+          output: { type, value: "ERROR_RESULT", reason: "DENIED_RESULT" },
+        });
+        unchanged(cold);
+        expect(chat().children.every((c) => c instanceof ColdSnapshot)).toBe(
+          true
+        );
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it("keeps concurrent extension prompts in the HOT composer, restores focus and preserves COLD", async () => {
+    let ui!: CodingAgentExtensionUi;
+    let secondUi!: CodingAgentExtensionUi;
+    const firstHost = new AbortController();
+    const secondHost = new AbortController();
+    const app = await fixture({
+      onExtensionUiReady: (create) => {
+        ui = create(firstHost.signal);
+        secondUi = create(secondHost.signal);
+      },
+    });
+    try {
+      await app.start();
+      await app.emit({ type: "assistant-output-delta", text: "ANSWER" });
+      await app.finish();
+      const cold = prefix();
+      const overlay = vi.spyOn(surface(), "showOverlay");
+      const one = ui.input({ label: "FIRST_PROMPT", initialValue: "draft" });
+      const two = secondUi.select({
+        label: "SECOND_PROMPT",
+        options: [
+          { label: "ONE", value: "one" },
+          { label: "TWO", value: "two" },
+        ],
+      });
+      const composer = surface().children.at(-1) as Container;
+      expect(stripTerminalSequences(rows(composer).join("\n"))).toContain(
+        "SECOND_PROMPT"
+      );
+      firstHost.abort();
+      await expect(one).resolves.toBeUndefined();
+      expect(stripTerminalSequences(rows(composer).join("\n"))).toContain(
+        "SECOND_PROMPT"
+      );
+      terminal.send("\x1b[13;1:3u");
+      expect(composer.children[0]).not.toBeUndefined();
+      terminal.send("\x1b[B");
+      send("\r");
+      await expect(two).resolves.toBe("two");
+      unchanged(cold);
+      expect(overlay).not.toHaveBeenCalled();
+      expect(composer.children.at(-1)?.render(100)).toHaveLength(1);
+      const confirm = ui.confirm("ABORTED");
+      await expect(confirm).resolves.toBe(false);
+      const input = secondUi.input({ label: "CANCEL_PROMPT" });
+      send("\x03");
+      await expect(input).resolves.toBeUndefined();
+    } finally {
+      firstHost.abort();
+      secondHost.abort();
+      await app.close();
+    }
+  });
+});

--- a/apps/coding-agent/src/tui/agent-ownership.test.ts
+++ b/apps/coding-agent/src/tui/agent-ownership.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   type Component,
   type Container,
@@ -9,7 +12,9 @@ import {
 import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodingAgentExtensionUi } from "../extensions/types";
+import { createReadFileTool } from "../workspace-tools/read-file";
 import type { AssistantRendererContext } from "./assistant-renderer";
+import { createToolRenderers } from "./renderers/tool-renderers";
 import type { BaseToolCallView } from "./tool-call-view";
 import { ColdSnapshot, type TranscriptOwner } from "./transcript-owner";
 
@@ -464,6 +469,225 @@ describe.sequential("actual TUI transcript ownership", () => {
       for (const fn of callbacks) {
         fn();
       }
+      unchanged(cold);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each([48, 100])(
+    "separates an actual empty directory read from assistant deltas at width %i",
+    async (width) => {
+      terminal.columns = width;
+      const workspace = await mkdtemp(join(tmpdir(), "pss-spacing-"));
+      const app = await fixture({ toolRenderers: createToolRenderers() });
+      try {
+        await app.start();
+        const input = { path: ".", offset: 1, limit: 100 };
+        const tool = createReadFileTool(workspace);
+        const output = await tool.execute?.(input, {
+          toolCallId: "empty-directory",
+          messages: [],
+          context: undefined,
+        });
+        expect(typeof output).toBe("string");
+        await app.emit({
+          type: "tool-call",
+          toolCallId: "empty-directory",
+          toolName: "read_file",
+          input,
+        });
+        await app.emit({
+          type: "tool-result",
+          toolCallId: "empty-directory",
+          toolName: "read_file",
+          output: { type: "text", value: output },
+        });
+        const toolBlock = chat().children.at(-1);
+        expect(toolBlock?.render(width)).toHaveLength(1);
+        const cold = prefix();
+        await app.emit({ type: "assistant-output-delta", text: "AFTER" });
+        const rendered = rows(chat(), width).map(stripTerminalSequences);
+        const assistantRow = rendered.findIndex((row) => row.includes("AFTER"));
+        expect(rendered.slice(assistantRow - 2, assistantRow)).toEqual([
+          stripTerminalSequences(toolBlock?.render(width)[0] ?? ""),
+          "",
+        ]);
+        const count = chat().children.length;
+        await app.emit({ type: "assistant-output-delta", text: " CONTINUED" });
+        expect(chat().children).toHaveLength(count);
+        expect(rows(chat(), width).map(stripTerminalSequences)).toContainEqual(
+          expect.stringContaining("AFTER CONTINUED")
+        );
+        unchanged(cold);
+      } finally {
+        await app.close();
+        await rm(workspace, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it.each([
+    ["populated", { type: "text", value: "OK - directory\npath: .\nENTRY" }],
+    ["error", { type: "error-text", value: "READ_FAILURE" }],
+  ])(
+    "separates %s tools from the next assistant block",
+    async (_label, output) => {
+      const app = await fixture({ toolRenderers: createToolRenderers() });
+      try {
+        await app.start();
+        await app.emit({
+          type: "tool-call",
+          toolCallId: "read",
+          toolName: "read_file",
+          input: { path: "." },
+        });
+        await app.emit({
+          type: "tool-result",
+          toolCallId: "read",
+          toolName: "read_file",
+          output,
+        });
+        const content = rows(chat().children.at(-1));
+        const cold = prefix();
+        await app.emit({ type: "assistant-output-delta", text: "AFTER" });
+        const rendered = rows().map(stripTerminalSequences);
+        const index = rendered.findIndex((row) => row.includes("AFTER"));
+        expect(rendered.slice(index - 2, index)).toEqual([
+          stripTerminalSequences(content.at(-1) ?? ""),
+          "",
+        ]);
+        unchanged(cold);
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it.each(["reasoning", "tool", "system", "user", "late"])(
+    "keeps one boundary row from a tool to %s without rewriting COLD",
+    async (next) => {
+      const app = await fixture({ toolRenderers: createToolRenderers() });
+      try {
+        await app.start();
+        await app.emit({
+          type: "tool-call",
+          toolCallId: "first",
+          toolName: "read_file",
+          input: { path: "." },
+        });
+        if (next !== "late") {
+          await app.emit({
+            type: "tool-result",
+            toolCallId: "first",
+            toolName: "read_file",
+            output: { type: "text", value: "OK - directory\npath: .\n" },
+          });
+        }
+        const before = chat().children.length;
+        const last = chat().children.at(-1);
+        if (next === "reasoning") {
+          await app.emit({
+            type: "assistant-reasoning-delta",
+            text: "THINKING",
+          });
+        } else if (next === "tool") {
+          await app.emit({
+            type: "tool-call",
+            toolCallId: "second",
+            toolName: "read_file",
+            input: { path: "second" },
+          });
+        } else if (next === "user") {
+          await app.steer();
+        } else if (next === "system") {
+          await app.emit({ type: "turn-error", error: "SYSTEM_FAILURE" });
+        } else {
+          await app.emit({
+            type: "assistant-output-delta",
+            text: "INTERLEAVED",
+          });
+        }
+        expect(chat().children[before]?.render(100)).toEqual([""]);
+        expect(chat().children[before + 1]?.render(100).length).toBeGreaterThan(
+          0
+        );
+        // The preceding block's content is unchanged; its immutable replacement
+        // may be new only when a pending tool is handed off.
+        expect(chat().children[before - 1]?.render(100)).toEqual(
+          last?.render(100)
+        );
+        const cold = prefix().slice(0, before);
+        if (next === "late") {
+          await app.emit({
+            type: "tool-result",
+            toolCallId: "first",
+            toolName: "read_file",
+            output: { type: "text", value: "OK - directory\npath: .\n" },
+          });
+          const continuation = chat().children.at(-1);
+          expect(
+            stripTerminalSequences(rows(continuation).join("\n"))
+          ).toContain("Continuation (first)");
+          const boundary = chat().children.length;
+          await app.emit({
+            type: "assistant-output-delta",
+            text: "AFTER_LATE",
+          });
+          expect(chat().children[boundary]?.render(100)).toEqual([""]);
+          expect(
+            chat().children[boundary + 1]?.render(100).length
+          ).toBeGreaterThan(0);
+        }
+        unchanged(cold);
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
+  it("consumes reserved tail for the tool boundary without trimming real body blanks", async () => {
+    const app = await fixture({
+      toolRenderers: {
+        fixture: (view, _input, output) =>
+          view.setPrettyBlock(
+            "HEADER",
+            output === undefined ? "LONG\n".repeat(12) : "BODY\n\n"
+          ),
+      },
+    });
+    try {
+      await app.start();
+      await app.emit({
+        type: "tool-call",
+        toolCallId: "shrink",
+        toolName: "fixture",
+        input: {},
+      });
+      const height = rows().length;
+      await app.emit({
+        type: "tool-result",
+        toolCallId: "shrink",
+        toolName: "fixture",
+        output: { type: "text", value: "done" },
+      });
+      const cold = prefix();
+      const toolRows = rows(chat().children.at(-1));
+      expect(
+        toolRows.slice(-2).map((row) => stripTerminalSequences(row).trim())
+      ).toEqual(["", ""]);
+      const before = chat().children.length;
+      await app.emit({ type: "assistant-output-delta", text: "NEXT" });
+      expect(chat().children[before]?.render(100)).toEqual([""]);
+      expect(chat().children[before + 1]?.render(100)).toHaveLength(1);
+      expect(rows()).toHaveLength(height);
+      const content = chat().children.flatMap((child) => child.render(100));
+      expect(rows().slice(0, content.length)).toEqual(content);
+      expect(
+        rows()
+          .slice(content.length)
+          .every((row) => row === "")
+      ).toBe(true);
       unchanged(cold);
     } finally {
       await app.close();

--- a/apps/coding-agent/src/tui/agent-ownership.test.ts
+++ b/apps/coding-agent/src/tui/agent-ownership.test.ts
@@ -11,6 +11,8 @@ import {
 } from "@earendil-works/pi-tui";
 import type { AgentEvent, AgentTurn } from "@minpeter/pss-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExtensionHostEventBus } from "../extensions/event-bus";
+import { ExtensionHostServices } from "../extensions/host-services";
 import type { CodingAgentExtensionUi } from "../extensions/types";
 import { createReadFileTool } from "../workspace-tools/read-file";
 import type { AssistantRendererContext } from "./assistant-renderer";
@@ -148,23 +150,32 @@ function stream() {
   let next = gate<
     { event: AgentEvent; consumed: ReturnType<typeof gate<void>> } | undefined
   >();
+  const returned = vi.fn();
   const run = {
     runId: "local-run",
     events: () =>
       (async function* () {
-        for (;;) {
-          const slot = await next.promise;
-          next = gate();
-          if (!slot) {
-            return;
+        try {
+          for (;;) {
+            const slot = await next.promise;
+            next = gate();
+            if (!slot) {
+              return;
+            }
+            try {
+              yield slot.event;
+            } finally {
+              slot.consumed.resolve();
+            }
           }
-          yield slot.event;
-          slot.consumed.resolve();
+        } finally {
+          returned();
         }
       })(),
   } as AgentTurn;
   return {
     run,
+    returned,
     end: () => next.resolve(undefined),
     emit: async (event: Record<string, unknown>) => {
       const consumed = gate();
@@ -217,7 +228,7 @@ async function fixture(extra: Partial<AgentTUIConfig> = {}) {
       active = false;
     },
     async close() {
-      if (active) {
+      if (active && !source.returned.mock.calls.length) {
         const ready = idle();
         source.end();
         await ready;
@@ -238,6 +249,160 @@ afterEach(() => {
 });
 
 describe.sequential("actual TUI transcript ownership", () => {
+  it.each(["input", "select", "confirm"] as const)(
+    "unmounts revoked host %s without cancelling a replacement prompt",
+    async (kind) => {
+      const controller = new AbortController();
+      const services = new ExtensionHostServices(
+        {},
+        new ExtensionHostEventBus({
+          signal: controller.signal,
+          timeoutMs: 2000,
+        })
+      );
+      let replacement!: CodingAgentExtensionUi;
+      const app = await fixture({
+        onExtensionUiReady: (create) => {
+          services.bindUi(create(), "tui");
+          replacement = create();
+        },
+      });
+      try {
+        const ui = services.getServices("fixture", {
+          mode: "tui",
+          providers: new Map(),
+          signal: controller.signal,
+        }).ui;
+        const composer = surface().children.at(-1) as Container;
+        const editor = composer.children[0];
+        const prompts = {
+          input: () => ui.input({ label: "OLD_PROMPT" }),
+          confirm: () => ui.confirm("OLD_PROMPT"),
+          select: () =>
+            ui.select({
+              label: "OLD_PROMPT",
+              options: [{ label: "VALUE", value: "value" }],
+            }),
+        };
+        const request = new AbortController();
+        const cancelled = ui.input({ label: "REQUEST_PROMPT" }, request.signal);
+        request.abort();
+        await expect(cancelled).resolves.toBeUndefined();
+        expect(composer.children[0] === editor).toBe(true);
+        const pending = prompts[kind]();
+        expect(composer.children[0]).not.toBe(editor);
+        const next = replacement.input({ label: "NEW_PROMPT" });
+        const replacementView = composer.children[0];
+        services.revokeInteractiveUi();
+        await expect(pending).resolves.toBe(
+          kind === "confirm" ? false : undefined
+        );
+        expect(composer.children[0]).toBe(replacementView);
+        send("\x1b");
+        await expect(next).resolves.toBeUndefined();
+        expect(composer.children[0] === editor).toBe(true);
+        send("FOCUS_RESTORED");
+        expect(stripTerminalSequences(rows(composer).join("\n"))).toContain(
+          "FOCUS_RESTORED"
+        );
+      } finally {
+        controller.abort();
+        await services.dispose();
+        await app.close();
+      }
+    }
+  );
+
+  it("appends a fresh renderer notice after intervening assistant deltas", async () => {
+    const contexts: AssistantRendererContext[] = [];
+    const app = await fixture({
+      assistantRenderer: (ctx) => {
+        contexts.push(ctx);
+        return new Markdown("", 1, 0, ctx.markdownTheme);
+      },
+    });
+    try {
+      await app.start();
+      await app.emit({ type: "assistant-output-delta", text: "BEFORE_NOTICE" });
+      contexts.at(-1)?.notify("NOTICE_ID");
+      const first = rows();
+      await app.emit({ type: "assistant-output-delta", text: "AFTER_NOTICE" });
+      contexts.at(-1)?.notify("NOTICE_ID");
+      expect(rows().slice(0, first.length)).toEqual(first);
+      expect(plain().split("NOTICE_ID")).toHaveLength(3);
+      expect(plain().indexOf("AFTER_NOTICE")).toBeGreaterThan(
+        plain().indexOf("NOTICE_ID")
+      );
+      expect(rows().join("\n")).not.toContain("\x1b[47m\x1b[30m");
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each(["setText", "render"] as const)(
+    "retains the old transcript when replay %s fails after a valid prefix",
+    async (failure) => {
+      const disposed = vi.fn();
+      const app = await fixture({
+        assistantRenderer: (ctx) => {
+          const view = new Markdown("", 1, 0, ctx.markdownTheme);
+          let source = "";
+          return {
+            setText: (text) => {
+              source = text;
+              if (failure === "setText" && text === "BAD_REPLAY") {
+                throw new Error("REPLAY_FAILURE");
+              }
+              view.setText(text);
+            },
+            invalidate: () => view.invalidate(),
+            render: (width) => {
+              if (failure === "render" && source === "BAD_REPLAY") {
+                throw new Error("REPLAY_FAILURE");
+              }
+              return view.render(width);
+            },
+            dispose: disposed,
+          };
+        },
+        commands: [
+          {
+            name: "replace",
+            description: "fixture",
+            execute: () => ({
+              success: true,
+              action: { type: "session", clear: true },
+            }),
+          },
+        ],
+        sessionSelector: {
+          currentSessionKey: () => "new-session",
+          listSessions: async () => [],
+          switchSession: async () => undefined,
+          loadCurrentHistory: async () => [
+            { role: "user", content: "REPLAY_PREFIX" },
+            { role: "assistant", content: "BAD_REPLAY" },
+          ],
+        },
+      });
+      try {
+        await app.start();
+        await app.emit({ type: "assistant-output", text: "OLD_ANSWER" });
+        await app.finish();
+        const before = prefix();
+        const epoch = (chat() as TranscriptOwner).epoch;
+        await app.command("/replace");
+        unchanged(before);
+        expect((chat() as TranscriptOwner).epoch).toBe(epoch);
+        expect(plain()).toContain("REPLAY_FAILURE");
+        expect(plain()).not.toContain("REPLAY_PREFIX");
+        expect(disposed).toHaveBeenCalledTimes(2);
+      } finally {
+        await app.close();
+      }
+    }
+  );
+
   it.each(["direct", "picker"] as const)(
     "appends only one model notice through %s and retains session notices and COLD header",
     async (method) => {
@@ -1314,13 +1479,17 @@ describe.sequential("actual TUI transcript ownership", () => {
       );
       expect((chat() as TranscriptOwner).epoch).toBe(epoch + 1);
       const afterReset = rows();
+      const endTurn = TuiSessionMachine.prototype.endTurn;
+      const ended = gate();
+      vi.spyOn(TuiSessionMachine.prototype, "endTurn").mockImplementationOnce(
+        function (this: TuiSessionMachine, run) {
+          endTurn.call(this, run);
+          ended.resolve();
+        }
+      );
       await app.emit({ type: "assistant-output-delta", text: "STALE_DELTA" });
-      await app.emit({
-        type: "tool-call",
-        toolCallId: "reused",
-        toolName: "fixture",
-        input: { stale: true },
-      });
+      expect(app.returned).toHaveBeenCalledTimes(1);
+      await bounded(ended.promise);
       expect(rows()).toEqual(afterReset);
       const prompt = ui.input({ label: "OLD_EPOCH_PROMPT" });
       ui.status("OLD_EPOCH_STATUS");

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -49,6 +49,7 @@ import {
 import { ModelSelectorComponent } from "./model-selector";
 import { createSpinnerTicker, type SpinnerTicker } from "./pending-spinner";
 import { boundedReloadOperation } from "./reload";
+import { type AppendedNotice, createRepeatedNotice } from "./repeated-notice";
 import { createRetryStatus } from "./retry-status";
 import {
   resumeSessionReplayParts,
@@ -80,6 +81,7 @@ const ANSI_BOLD = "\x1b[1m";
 const ANSI_DIM = "\x1b[2m";
 const ANSI_BG_SOFT_LIGHT = "\x1b[48;5;249m";
 const ANSI_BG_GRAY = "\x1b[100m";
+const ANSI_BG_WHITE = "\x1b[47m";
 const ANSI_CYAN = "\x1b[36m";
 const ANSI_BRIGHT_CYAN = "\x1b[96m";
 const ANSI_GRAY = "\x1b[38;5;245m";
@@ -432,13 +434,23 @@ const addTranslatedMessage = (
   );
 };
 
-const addSystemMessage = (chatContainer: Container, message: string): void => {
-  const cleaned = sanitizeTerminalText(message).trimEnd();
-  if (cleaned.length === 0) {
+/**
+ * Appends a sanitized gray system notice row. Returns the mounted row and exact
+ * string it was created with, so a repeated notice can restore that style
+ * byte-for-byte after pulsing; `undefined` when nothing was appended.
+ */
+const appendSystemNotice = (
+  chatContainer: Container,
+  message: string
+): AppendedNotice | undefined => {
+  if (message.length === 0) {
     return;
   }
 
-  addChatComponent(chatContainer, new Text(style(ANSI_GRAY, cleaned), 1, 0));
+  const normalText = style(ANSI_GRAY, message);
+  const row = new Text(normalText, 1, 0);
+  addChatComponent(chatContainer, row);
+  return { normalText, row };
 };
 
 const addErrorMessage = (chatContainer: Container, error: unknown): void => {
@@ -701,17 +713,27 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     }
     assistantViews.clear();
   };
+  // Immediately repeated identical notices pulse the one visible row instead
+  // of appending duplicates. Scope is the current notice instance only; see
+  // `repeated-notice.ts`.
+  const repeatedNotice = createRepeatedNotice({
+    appendNotice: (message) => appendSystemNotice(chatContainer, message),
+    chatContainer,
+    pulseStyle: (message) => style(`${ANSI_BG_WHITE}${ANSI_BLACK}`, message),
+    requestRender: () => tui.requestRender(),
+  });
+  const showSystemMessage = (message: string): void => {
+    // Sanitize before either style is applied, including repeated custom notices.
+    repeatedNotice.show(sanitizeTerminalText(message).trimEnd());
+  };
   const clearChat = (): void => {
     disposeAssistantViews();
     chatContainer.clear();
+    repeatedNotice.reset();
   };
 
-  const assistantRendererNotifications = createAssistantRendererNotifications(
-    (message) => {
-      addSystemMessage(chatContainer, message);
-      tui.requestRender();
-    }
-  );
+  const assistantRendererNotifications =
+    createAssistantRendererNotifications(showSystemMessage);
 
   const title = new Text("", 1, 0);
   const help = new Text(
@@ -1230,8 +1252,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         editorTheme,
         isCtrlCInput,
         handleCtrlCPress,
-        showMessage: (message: string) =>
-          addSystemMessage(chatContainer, message),
+        showMessage: showSystemMessage,
         updateHeader,
       })
     );
@@ -1246,7 +1267,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   const showModelSelector = async (initialQuery?: string): Promise<void> => {
     const selectorConfig = config.modelSelector;
     if (selectorConfig === undefined) {
-      addSystemMessage(chatContainer, "Model selection is not available.");
+      showSystemMessage("Model selection is not available.");
       tui.requestRender();
       return;
     }
@@ -1264,8 +1285,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       modelIds = result;
     } catch (error) {
       clearStatus();
-      addSystemMessage(
-        chatContainer,
+      showSystemMessage(
         `Could not list models: ${
           error instanceof Error ? error.message : String(error)
         }. Switch directly with /model <model-id>.`
@@ -1275,8 +1295,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     }
     clearStatus();
     if (modelIds.length === 0) {
-      addSystemMessage(
-        chatContainer,
+      showSystemMessage(
         "The provider returned an empty model catalog. Switch directly with /model <model-id>."
       );
       tui.requestRender();
@@ -1337,13 +1356,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         selectorConfig.switchModel(selection)
       );
       updateHeader();
-      addSystemMessage(
-        chatContainer,
+      showSystemMessage(
         `Model switched to ${selection}. New steps use it immediately.`
       );
     } catch (error) {
-      addSystemMessage(
-        chatContainer,
+      showSystemMessage(
         `Model switch failed: ${
           error instanceof Error ? error.message : String(error)
         }`
@@ -1355,7 +1372,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   const showSessionSelector = async (initialQuery?: string): Promise<void> => {
     const selectorConfig = config.sessionSelector;
     if (selectorConfig === undefined) {
-      addSystemMessage(chatContainer, "Session selection is not available.");
+      showSystemMessage("Session selection is not available.");
       tui.requestRender();
       return;
     }
@@ -1371,8 +1388,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       sessions = result;
     } catch (error) {
       clearStatus();
-      addSystemMessage(
-        chatContainer,
+      showSystemMessage(
         `Could not list sessions: ${
           error instanceof Error ? error.message : String(error)
         }`
@@ -1382,7 +1398,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     }
     clearStatus();
     if (sessions.length === 0) {
-      addSystemMessage(chatContainer, "No sessions recorded yet.");
+      showSystemMessage("No sessions recorded yet.");
       tui.requestRender();
       return;
     }
@@ -1447,8 +1463,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       });
       updateHeader();
     } catch (error) {
-      addSystemMessage(
-        chatContainer,
+      showSystemMessage(
         `Session switch failed: ${
           error instanceof Error ? error.message : String(error)
         }`
@@ -1461,9 +1476,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     commandResult: TuiCommandResult | null
   ): void => {
     if (commandResult?.message) {
-      addSystemMessage(chatContainer, commandResult.message);
+      showSystemMessage(commandResult.message);
     } else if (commandResult === null) {
-      addSystemMessage(chatContainer, "Unknown command.");
+      showSystemMessage("Unknown command.");
     }
     tui.requestRender();
   };
@@ -1514,7 +1529,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     }
 
     if (commandResult.message) {
-      addSystemMessage(chatContainer, commandResult.message);
+      showSystemMessage(commandResult.message);
     }
     tui.requestRender();
   };
@@ -1529,7 +1544,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     }
     updateHeader();
     if (commandResult.message) {
-      addSystemMessage(chatContainer, commandResult.message);
+      showSystemMessage(commandResult.message);
     }
     tui.requestRender();
   };
@@ -1545,8 +1560,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       await busy.run("Reloading...", () => config.onCommandAction?.(action));
     } catch (error) {
       refreshCommandSet();
-      addSystemMessage(
-        chatContainer,
+      showSystemMessage(
         `Reload failed: ${
           error instanceof Error ? error.message : String(error)
         }`
@@ -1557,7 +1571,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     refreshCommandSet();
     updateHeader();
     if (commandResult.message) {
-      addSystemMessage(chatContainer, commandResult.message);
+      showSystemMessage(commandResult.message);
     }
     tui.requestRender();
   };
@@ -1611,7 +1625,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
         if (result.type === "rejected") {
           clearStatus();
-          addSystemMessage(chatContainer, result.error);
+          showSystemMessage(result.error);
           tui.requestRender();
           return;
         }
@@ -1644,7 +1658,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   const processInput = async (input: string): Promise<boolean> => {
     const trimmed = input.trim();
     if (trimmed.length === 0) {
-      addSystemMessage(chatContainer, "Please enter a message.");
+      showSystemMessage("Please enter a message.");
       tui.requestRender();
       return true;
     }
@@ -1664,7 +1678,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       clearStatus();
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      addSystemMessage(chatContainer, `Error: ${errorMessage}`);
+      showSystemMessage(`Error: ${errorMessage}`);
       tui.requestRender();
       return true;
     } finally {
@@ -1706,7 +1720,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           clearStatus();
           const errorMessage =
             error instanceof Error ? error.message : String(error);
-          addSystemMessage(chatContainer, `Error: ${errorMessage}`);
+          showSystemMessage(`Error: ${errorMessage}`);
           tui.requestRender();
         });
       }
@@ -1724,7 +1738,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       config.onExtensionUiReady?.((hostSignal) =>
         createExtensionUi({
           restoreFocus: clearPromptInput,
-          showMessage: (message) => addSystemMessage(chatContainer, message),
+          showMessage: showSystemMessage,
           showStatus: (message) => {
             const clear = busy.status(message);
             const signal = hostSignal ?? extensionUiController.signal;
@@ -1751,7 +1765,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       )
     );
     for (const message of config.setupMessages ?? []) {
-      addSystemMessage(chatContainer, message);
+      showSystemMessage(message);
     }
     await busy.run("Setting up...", () => config.onSetup?.());
     if (config.replayHistoryOnStartup === true) {
@@ -1790,6 +1804,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         // Flush the final interruption/status frame while its views still
         // exist. Normal stop adds a clamped cursor move and newline, losing
         // the composer's position when the transcript fills the viewport.
+        // Ending a pulse first keeps an exit mid-blink from freezing the
+        // notice inverted in that preserved frame.
+        repeatedNotice.settle();
         tui.renderNow();
         const renderState = tui.captureRenderState();
         const composerRows = composerLayer.render(terminal.columns).length;
@@ -1797,6 +1814,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         terminal.write(terminalExitCursorSequence(renderState, composerRows));
         disposeAssistantViews();
       } finally {
+        repeatedNotice.stop();
         await Promise.all(turnCompletions);
         for (const error of completionFailures) {
           console.error("onTurnComplete callback failed in TUI:", error);

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -8,12 +8,10 @@ import {
   isKeyRelease,
   isKeyRepeat,
   Key,
-  Markdown,
   type MarkdownTheme,
   matchesKey,
   ProcessTerminal,
   Spacer,
-  Text,
   type TUI,
   TuiMainScreen,
   visibleWidth,
@@ -58,6 +56,10 @@ import {
 } from "./session-history-replay";
 import { SessionSelectorComponent } from "./session-selector";
 import { TuiSessionMachine } from "./session-state";
+import {
+  SnapshotMarkdown as Markdown,
+  SnapshotText as Text,
+} from "./snapshot-views";
 import { createSpinnerOrchestrator } from "./spinner-orchestrator";
 import {
   addChatComponent,
@@ -851,10 +853,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     title.setText(
       subtitle ? `${headerTitle}\n${style(ANSI_DIM, subtitle)}` : headerTitle
     );
-    const snapshot = new ColdSnapshot(
-      headerContainer.render(terminal.columns),
-      terminal.columns
-    );
+    const snapshot = ColdSnapshot.capture(headerContainer, terminal.columns);
     headerContainer.clear();
     headerContainer.addChild(snapshot);
   };

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -28,6 +28,7 @@ import {
   createAssistantRendererNotifications,
 } from "./assistant-renderer";
 import { createAliasAwareAutocompleteProvider } from "./autocomplete";
+import { BusyStatus } from "./busy-status";
 import {
   isCommand,
   parseCommand,
@@ -47,6 +48,8 @@ import {
 } from "./input-routing";
 import { ModelSelectorComponent } from "./model-selector";
 import { createSpinnerTicker, type SpinnerTicker } from "./pending-spinner";
+import { boundedReloadOperation } from "./reload";
+import { createRetryStatus } from "./retry-status";
 import {
   resumeSessionReplayParts,
   type SessionHistoryReplayPart,
@@ -201,7 +204,8 @@ export class FooterStatusBar extends Text {
       return [this.padLine("", width)];
     }
 
-    const contentWidth = Math.max(0, width - 1);
+    // At one column the glyph takes precedence over the usual left padding.
+    const contentWidth = width === 1 ? 1 : width - 1;
     const lines: string[] = [];
     const leadingEntry = this.resolveLeadingEntry();
     const leadingLine = this.renderLeadingLine(
@@ -251,7 +255,7 @@ export class FooterStatusBar extends Text {
       ? style(ANSI_DIM, rightTextPlain)
       : "";
     return this.padLine(
-      ` ${left?.styled ?? ""}${" ".repeat(gap)}${rightTextStyled}`,
+      `${width === 1 ? "" : " "}${left?.styled ?? ""}${" ".repeat(gap)}${rightTextStyled}`,
       width
     );
   }
@@ -619,6 +623,7 @@ export interface AgentTUIConfig {
   assistantRenderer?: AssistantRenderer;
   assistantRendererSignal?: AbortSignal;
   commands?: TuiCommand[];
+  cwd?: string;
   footer?: { text?: string };
   header?: { title: string; subtitle?: string };
   /**
@@ -640,7 +645,8 @@ export interface AgentTUIConfig {
   onSetup?: () => void | Promise<void>;
   onTurnComplete?: (
     usage: TurnUsage | undefined,
-    finishReason?: string
+    finishReason?: string,
+    signal?: AbortSignal
   ) => Promise<void> | void;
   preprocessCommand?: (
     commandInput: string,
@@ -669,13 +675,15 @@ export interface AgentTUIConfig {
 }
 
 export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
+  const turnCompletions = new Set<Promise<void>>();
+  const completionFailures: unknown[] = [];
   const markdownTheme =
     config.theme?.markdownTheme ?? createDefaultMarkdownTheme();
   const editorTheme = config.theme?.editorTheme ?? createDefaultEditorTheme();
   let commandSet = buildTuiCommandSet(config.commands);
 
   const terminal = new ProcessTerminal();
-  const tui: TUI = new TuiMainScreen(terminal);
+  const tui = new TuiMainScreen(terminal);
   tui.setClearOnShrink(false);
 
   const headerContainer = new Container();
@@ -739,13 +747,13 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   });
   let autocompleteProvider = createAliasAwareAutocompleteProvider({
     commands: commandSet.commands,
-    basePath: process.cwd(),
+    basePath: config.cwd ?? process.cwd(),
   });
   const refreshCommandSet = (): void => {
     commandSet = buildTuiCommandSet(config.commands);
     autocompleteProvider = createAliasAwareAutocompleteProvider({
       commands: commandSet.commands,
-      basePath: process.cwd(),
+      basePath: config.cwd ?? process.cwd(),
     });
     editor.setAutocompleteProvider(autocompleteProvider);
   };
@@ -769,7 +777,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
   const session = new TuiSessionMachine();
   let lastCtrlCPressAt = 0;
-  let foregroundStatusMessage: string | null = null;
+  const busy = new BusyStatus((message) =>
+    footerStatusBar.setForegroundMessage(message)
+  );
   let activeModelSelector: ModelSelectorComponent | undefined;
   let activeSessionSelector: SessionSelectorComponent | undefined;
   let commandInputListenerActive = false;
@@ -786,16 +796,10 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   ): Promise<T | typeof EXIT_REQUESTED> =>
     Promise.race([operation, exitRequested]);
 
-  const clearStatus = (): void => {
-    foregroundStatusMessage = null;
-    footerStatusBar.setForegroundMessage(null);
-  };
-
-  const showLoader = (message: string): void => {
-    const sanitized = sanitizeTerminalText(message);
-    foregroundStatusMessage = sanitized;
-    footerStatusBar.setForegroundMessage(sanitized);
-  };
+  // Compatibility hooks reset this operation's label, not its busy lifetime.
+  const clearStatus = (): void => busy.setMessage(null);
+  const showLoader = (message: string): void =>
+    busy.setMessage(sanitizeTerminalText(message));
 
   const clearPromptInput = (): void => {
     editor.setText("");
@@ -815,7 +819,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   const requestExit = (): void => {
     extensionUiController.abort();
     cancelActiveTurn();
-    clearStatus();
+    busy.dispose();
     session.close();
   };
 
@@ -970,19 +974,27 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       firstVisiblePartSeen: false,
     };
 
-    const baseLoaderMessage = loaderMessage ?? foregroundStatusMessage;
+    const baseLoaderMessage = loaderMessage ?? busy.getMessage();
     const orchestrator = createSpinnerOrchestrator(
       {
         clearStatus,
-        hasSpinner: () => foregroundStatusMessage !== null,
-        setMessage: (message) => {
-          foregroundStatusMessage = message;
-          footerStatusBar.setForegroundMessage(message);
-        },
+        hasSpinner: () => busy.getMessage() !== undefined,
+        setMessage: showLoader,
         showLoader,
       },
       baseLoaderMessage
     );
+    const retryStatus = createRetryStatus({
+      now: () => Date.now(),
+      setMessage: (message) => {
+        if (message === null) {
+          orchestrator.onRetryWaitEnd();
+        } else {
+          orchestrator.onRetryWaitMessage(message);
+        }
+        tui.requestRender();
+      },
+    });
 
     const state: PiTuiStreamState = {
       flags,
@@ -996,8 +1008,10 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       chatContainer,
       onReasoningStart: orchestrator.onReasoningStart,
       onReasoningEnd: orchestrator.onReasoningEnd,
-      onToolPendingStart: orchestrator.onToolPendingStart,
-      onToolPendingEnd: orchestrator.onToolPendingEnd,
+      // Runtime tool-call/result events are committed after execution. They
+      // must not claim physical execution; the turn's Working lease covers it.
+      onRetryWait: retryStatus.scheduled,
+      onRetryClear: retryStatus.clear,
     };
 
     try {
@@ -1012,6 +1026,10 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         tui.requestRender();
       }
     } finally {
+      // Turn end, abort, and error all land here: never leave a countdown
+      // ticking or a stale wait banner behind for the next step or thread.
+      retryStatus.clear();
+      retryStatus.stop();
       for (const view of toolViews.values()) {
         view.dispose();
       }
@@ -1020,64 +1038,53 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     return { finishReason: tracker.finishReason };
   };
 
-  const renderSessionHistory = async (
+  const renderSessionHistory = (
     replay?: readonly SessionHistoryReplayPart[]
-  ): Promise<void> => {
-    const selectorConfig = config.sessionSelector;
-    if (selectorConfig === undefined) {
-      return;
-    }
-    const parts =
-      replay ??
-      sessionHistoryReplayParts(await selectorConfig.loadCurrentHistory());
-    let streamParts: TuiStreamPart[] = [];
-    const flushStreamParts = async (): Promise<void> => {
-      if (streamParts.length === 0) {
+  ): Promise<void> =>
+    busy.run("Loading session history...", async () => {
+      const selectorConfig = config.sessionSelector;
+      if (selectorConfig === undefined) {
         return;
       }
-      const pending = streamParts;
-      streamParts = [];
-      await renderAgentStream(
-        (async function* () {
-          yield* pending;
-        })(),
-        {
-          showReasoning: true,
-          showSteps: false,
-          showFinishReason: false,
-          showRawToolIo: config.showRawToolIo ?? false,
-          showToolResults: true,
-          showSources: false,
-          showFiles: false,
+      const parts =
+        replay ??
+        sessionHistoryReplayParts(await selectorConfig.loadCurrentHistory());
+      let streamParts: TuiStreamPart[] = [];
+      const flushStreamParts = async (): Promise<void> => {
+        if (streamParts.length === 0) {
+          return;
         }
-      );
-    };
-    for (const part of parts) {
-      if (part.type === "stream") {
-        streamParts.push(part.part);
-        continue;
+        const pending = streamParts;
+        streamParts = [];
+        await renderAgentStream(
+          (async function* () {
+            yield* pending;
+          })(),
+          {
+            showReasoning: true,
+            showSteps: false,
+            showFinishReason: false,
+            showRawToolIo: config.showRawToolIo ?? false,
+            showToolResults: true,
+            showSources: false,
+            showFiles: false,
+          }
+        );
+      };
+      for (const part of parts) {
+        if (part.type === "stream") {
+          streamParts.push(part.part);
+          continue;
+        }
+        await flushStreamParts();
+        if (part.type === "clear") {
+          clearChat();
+        } else {
+          addUserMessage(chatContainer, markdownTheme, part.text);
+        }
       }
       await flushStreamParts();
-      if (part.type === "clear") {
-        clearChat();
-      } else {
-        addUserMessage(chatContainer, markdownTheme, part.text);
-      }
-    }
-    await flushStreamParts();
-  };
-
-  const createStreamingLoaderClearer = (): (() => void) => {
-    let hasClearedStreamingLoader = false;
-
-    return () => {
-      if (hasClearedStreamingLoader) {
-        return;
-      }
-      hasClearedStreamingLoader = true;
-      clearStatus();
-    };
-  };
+    });
 
   const accumulateUsage = (
     total: { inputTokens: number; outputTokens: number; totalTokens: number },
@@ -1103,7 +1110,6 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
     try {
       showLoader("Working...");
-      const clearStreamingLoader = createStreamingLoaderClearer();
 
       const { finishReason } = await renderAgentStream(
         agentEventStreamParts(run.events(), {
@@ -1126,29 +1132,39 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           showSources: false,
           showFiles: false,
         },
-        clearStreamingLoader,
+        undefined,
         "Working..."
       );
-
-      clearStreamingLoader();
 
       if (session.wasInterrupted(run)) {
         addInterruptedMessage();
         return;
       }
 
-      Promise.resolve(
-        config.onTurnComplete?.(
-          sawModelUsage ? { ...turnUsage } : undefined,
-          finishReason
+      const completion = busy
+        .run("Finalizing...", () =>
+          boundedReloadOperation(
+            Promise.resolve(
+              config.onTurnComplete?.(
+                sawModelUsage ? { ...turnUsage } : undefined,
+                finishReason,
+                extensionUiController.signal
+              )
+            ),
+            10_000,
+            "Turn completion"
+          )
         )
-      )
         .then(() => {
-          updateHeader();
+          if (!session.closed) {
+            updateHeader();
+          }
         })
         .catch((error) => {
-          console.error("onTurnComplete callback failed in TUI:", error);
+          completionFailures.push(error);
         });
+      turnCompletions.add(completion);
+      completion.then(() => turnCompletions.delete(completion));
 
       if (finishReason !== undefined) {
         addAbnormalFinishReasonMessage(finishReason);
@@ -1172,7 +1188,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return null;
     }
 
-    return await command.execute({ args: parsed.args });
+    return await busy.run("Working...", () =>
+      command.execute({ args: parsed.args })
+    );
   };
 
   const preprocessCommandInput = async (
@@ -1182,25 +1200,30 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return input;
     }
 
-    return await config.preprocessCommand(input, {
-      addInputListener: (listener) => {
-        commandInputListenerActive = true;
-        const remove = tui.addInputListener(listener);
-        return () => {
-          remove();
-          commandInputListenerActive = false;
-        };
-      },
-      clearStatus,
-      tui,
-      overlayContainer,
-      editorTheme,
-      isCtrlCInput,
-      handleCtrlCPress,
-      showMessage: (message: string) =>
-        addSystemMessage(chatContainer, message),
-      updateHeader,
-    });
+    const preprocess = config.preprocessCommand;
+    return await busy.run("Processing command...", () =>
+      preprocess(input, {
+        addInputListener: (listener) => {
+          commandInputListenerActive = true;
+          const resume = busy.suspend();
+          const remove = tui.addInputListener(listener);
+          return () => {
+            remove();
+            resume();
+            commandInputListenerActive = false;
+          };
+        },
+        clearStatus,
+        tui,
+        overlayContainer,
+        editorTheme,
+        isCtrlCInput,
+        handleCtrlCPress,
+        showMessage: (message: string) =>
+          addSystemMessage(chatContainer, message),
+        updateHeader,
+      })
+    );
   };
 
   /**
@@ -1217,10 +1240,13 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
 
-    showLoader("Loading model catalog...");
     let modelIds: string[];
     try {
-      const result = await untilExit(selectorConfig.listModelIds());
+      const result = await untilExit(
+        busy.run("Loading model catalog...", () =>
+          selectorConfig.listModelIds()
+        )
+      );
       if (result === EXIT_REQUESTED) {
         return;
       }
@@ -1244,6 +1270,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
 
+    const resumeBusy = busy.suspend();
     const pendingSelection = new Promise<string | undefined>((resolve) => {
       // Let the selector own ctrl+c/escape while it is mounted.
       commandInputListenerActive = true;
@@ -1262,6 +1289,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         composerLayer.setContent(editor);
         tui.setFocus(composerLayer);
         tui.requestRender();
+        resumeBusy();
         resolve(modelId);
       };
       // Exit must settle the selector through the same idempotent path as
@@ -1292,7 +1320,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
     try {
-      await selectorConfig.switchModel(selection);
+      await busy.run("Switching model...", () =>
+        selectorConfig.switchModel(selection)
+      );
       updateHeader();
       addSystemMessage(
         chatContainer,
@@ -1315,10 +1345,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
 
-    showLoader("Loading sessions...");
     let sessions: readonly SessionIndexEntry[];
     try {
-      const result = await untilExit(selectorConfig.listSessions());
+      const result = await untilExit(
+        busy.run("Loading sessions...", () => selectorConfig.listSessions())
+      );
       if (result === EXIT_REQUESTED) {
         return;
       }
@@ -1339,6 +1370,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
 
+    const resumeBusy = busy.suspend();
     const pendingSelection = new Promise<string | undefined>((resolve) => {
       commandInputListenerActive = true;
       let selector: SessionSelectorComponent | undefined;
@@ -1356,6 +1388,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         composerLayer.setContent(editor);
         tui.setFocus(composerLayer);
         tui.requestRender();
+        resumeBusy();
         resolve(sessionKey);
       };
       // Exit must settle the selector through the same idempotent path as
@@ -1390,9 +1423,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
     try {
-      await renderSessionHistory(
-        await resumeSessionReplayParts(selectorConfig, selection)
-      );
+      await busy.run("Switching session...", async () => {
+        await renderSessionHistory(
+          await resumeSessionReplayParts(selectorConfig, selection)
+        );
+      });
       updateHeader();
     } catch (error) {
       addSystemMessage(
@@ -1454,7 +1489,8 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     }
 
     if (commandResult.action.type === "refresh-header") {
-      await config.onCommandAction?.(commandResult.action);
+      const action = commandResult.action;
+      await busy.run("Working...", () => config.onCommandAction?.(action));
       updateHeader();
     }
 
@@ -1485,8 +1521,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     if (!commandResult.action) {
       return;
     }
+    const action = commandResult.action;
     try {
-      await config.onCommandAction?.(commandResult.action);
+      await busy.run("Reloading...", () => config.onCommandAction?.(action));
     } catch (error) {
       refreshCommandSet();
       addSystemMessage(
@@ -1504,61 +1541,68 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     tui.requestRender();
   };
 
-  const processCommandInput = async (trimmed: string): Promise<boolean> => {
-    const commandInput = await preprocessCommandInput(trimmed);
-    if (commandInput === null) {
-      tui.requestRender();
-      return true;
-    }
-
-    const commandResult = await executeLocalCommand(commandInput);
-    await handleCommandResult(commandResult);
-    return true;
-  };
-
-  const processUserInputMessage = async (
-    trimmed: string,
-    steeringRun?: AgentTurn
-  ): Promise<void> => {
-    addUserMessage(chatContainer, markdownTheme, trimmed);
-    tui.requestRender();
-
-    const result = await dispatchUserInput({
-      activeRun: steeringRun,
-      hooks: {
-        showStatus: (text: string) => showLoader(text),
-        clearStatus: () => clearStatus(),
-      },
-      input: trimmed,
-      onPrepared: (prepared) => {
-        if (prepared.translatedDisplay) {
-          addTranslatedMessage(
-            chatContainer,
-            markdownTheme,
-            prepared.translatedDisplay
-          );
-        }
-        showLoader(steeringRun === undefined ? "Processing..." : "Steering...");
+  const processCommandInput = (trimmed: string): Promise<boolean> =>
+    busy.run("Working...", async () => {
+      const commandInput = await preprocessCommandInput(trimmed);
+      if (commandInput === null) {
         tui.requestRender();
-      },
-      preprocess: config.preprocessUserInput,
-      thread: config.thread,
+        return true;
+      }
+
+      const commandResult = await executeLocalCommand(commandInput);
+      await handleCommandResult(commandResult);
+      return true;
     });
 
-    if (result.type === "rejected") {
-      clearStatus();
-      addSystemMessage(chatContainer, result.error);
-      tui.requestRender();
-      return;
-    }
+  const processUserInputMessage = (
+    trimmed: string,
+    steeringRun?: AgentTurn
+  ): Promise<void> =>
+    busy.run(
+      steeringRun === undefined ? "Processing..." : "Steering...",
+      async () => {
+        addUserMessage(chatContainer, markdownTheme, trimmed);
+        tui.requestRender();
 
-    if (!result.consumeRun) {
-      clearStatus();
-      return;
-    }
+        const result = await dispatchUserInput({
+          activeRun: steeringRun,
+          hooks: {
+            showStatus: (text: string) => showLoader(text),
+            clearStatus: () => clearStatus(),
+          },
+          input: trimmed,
+          onPrepared: (prepared) => {
+            if (prepared.translatedDisplay) {
+              addTranslatedMessage(
+                chatContainer,
+                markdownTheme,
+                prepared.translatedDisplay
+              );
+            }
+            showLoader(
+              steeringRun === undefined ? "Processing..." : "Steering..."
+            );
+            tui.requestRender();
+          },
+          preprocess: config.preprocessUserInput,
+          thread: config.thread,
+        });
 
-    await runSingleTurn(result.run);
-  };
+        if (result.type === "rejected") {
+          clearStatus();
+          addSystemMessage(chatContainer, result.error);
+          tui.requestRender();
+          return;
+        }
+
+        if (!result.consumeRun) {
+          clearStatus();
+          return;
+        }
+
+        await runSingleTurn(result.run);
+      }
+    );
 
   const processSteeringInput = async (
     trimmed: string,
@@ -1655,27 +1699,38 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   tui.start();
 
   try {
-    await config.onExtensionUiReady?.((hostSignal) =>
-      createExtensionUi({
-        restoreFocus: clearPromptInput,
-        showMessage: (message) => addSystemMessage(chatContainer, message),
-        showStatus: (message) => {
-          showLoader(message);
-          return clearStatus;
-        },
-        // Host-scoped signals let a runtime swap cancel prompts that a
-        // detached previous host still has on screen.
-        signal:
-          hostSignal === undefined
-            ? extensionUiController.signal
-            : AbortSignal.any([extensionUiController.signal, hostSignal]),
-        tui,
-      })
+    await busy.run("Activating extensions...", () =>
+      config.onExtensionUiReady?.((hostSignal) =>
+        createExtensionUi({
+          restoreFocus: clearPromptInput,
+          showMessage: (message) => addSystemMessage(chatContainer, message),
+          showStatus: (message) => {
+            const clear = busy.status(message);
+            const signal = hostSignal ?? extensionUiController.signal;
+            signal.addEventListener("abort", clear, { once: true });
+            if (signal.aborted) {
+              clear();
+            }
+            return () => {
+              signal.removeEventListener("abort", clear);
+              clear();
+            };
+          },
+          onUserWait: () => busy.suspend(),
+          // Host-scoped signals let a runtime swap cancel prompts that a
+          // detached previous host still has on screen.
+          signal:
+            hostSignal === undefined
+              ? extensionUiController.signal
+              : AbortSignal.any([extensionUiController.signal, hostSignal]),
+          tui,
+        })
+      )
     );
     for (const message of config.setupMessages ?? []) {
       addSystemMessage(chatContainer, message);
     }
-    await config.onSetup?.();
+    await busy.run("Setting up...", () => config.onSetup?.());
     if (config.replayHistoryOnStartup === true) {
       await renderSessionHistory();
     }
@@ -1693,9 +1748,8 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       }
     }
   } finally {
-    const composerRows = composerLayer.render(terminal.columns).length;
     extensionUiController.abort();
-    clearStatus();
+    busy.dispose();
     footerStatusBar.stop();
     session.close();
 
@@ -1709,9 +1763,22 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       // Rendering must stop before the streamed assistant views are disposed:
       // disposal empties their children, so a later render would blank the
       // reply that is already on screen.
-      tui.stop();
-      terminal.write(terminalExitCursorSequence(composerRows));
-      disposeAssistantViews();
+      try {
+        // Flush the final interruption/status frame while its views still
+        // exist. Normal stop adds a clamped cursor move and newline, losing
+        // the composer's position when the transcript fills the viewport.
+        tui.renderNow();
+        const renderState = tui.captureRenderState();
+        const composerRows = composerLayer.render(terminal.columns).length;
+        tui.stop({ preserveScreen: true });
+        terminal.write(terminalExitCursorSequence(renderState, composerRows));
+        disposeAssistantViews();
+      } finally {
+        await Promise.all(turnCompletions);
+        for (const error of completionFailures) {
+          console.error("onTurnComplete callback failed in TUI:", error);
+        }
+      }
     }
   }
 }

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -49,7 +49,7 @@ import {
 import { ModelSelectorComponent } from "./model-selector";
 import { createSpinnerTicker, type SpinnerTicker } from "./pending-spinner";
 import { boundedReloadOperation } from "./reload";
-import { type AppendedNotice, createRepeatedNotice } from "./repeated-notice";
+import { createRepeatedNotice } from "./repeated-notice";
 import { createRetryStatus } from "./retry-status";
 import {
   resumeSessionReplayParts,
@@ -74,6 +74,11 @@ import { AssistantStreamView } from "./stream-views";
 import { terminalExitCursorSequence } from "./terminal-exit";
 import { sanitizeTerminalText } from "./terminal-safety";
 import { BaseToolCallView, type ToolRendererMap } from "./tool-call-view";
+import {
+  ColdSnapshot,
+  type TranscriptLease,
+  TranscriptOwner,
+} from "./transcript-owner";
 
 const ANSI_RESET = "\x1b[0m";
 const ANSI_BLACK = "\x1b[30m";
@@ -323,17 +328,13 @@ export class FooterStatusBar extends Text {
   }
 }
 
-/**
- * Bottom-pinned, focus-owning composer. The chat is normal-flow content but
- * this component is rendered as an overlay, so a streaming Markdown reflow
- * can never alter the editor's screen row. It forwards focus and input to
- * whichever component currently occupies the editor slot.
- */
+/** Normal-flow HOT composer and one-row footer, including inline prompts. */
 class ComposerLayer extends Container {
   #content: Component;
   readonly #footer: Component;
   readonly #afterInput: ((data: string) => void) | undefined;
   #focused = false;
+  readonly #prompts: Component[] = [];
 
   constructor(
     content: Component,
@@ -353,13 +354,14 @@ class ComposerLayer extends Container {
 
   set focused(value: boolean) {
     this.#focused = value;
-    if (isFocusable(this.#content)) {
-      this.#content.focused = value;
+    const content = this.#prompts.at(-1) ?? this.#content;
+    if (isFocusable(content)) {
+      content.focused = value;
     }
   }
 
   handleInput(data: string): void {
-    this.#content.handleInput?.(data);
+    (this.#prompts.at(-1) ?? this.#content).handleInput?.(data);
     this.#afterInput?.(data);
   }
 
@@ -371,9 +373,35 @@ class ComposerLayer extends Container {
     this.#rebuild();
   }
 
+  get hasPrompt(): boolean {
+    return this.#prompts.length > 0;
+  }
+
+  mountPrompt(component: Component): () => void {
+    const previous = this.#prompts.at(-1) ?? this.#content;
+    if (isFocusable(previous)) {
+      previous.focused = false;
+    }
+    this.#prompts.push(component);
+    this.#rebuild();
+    this.focused = this.#focused;
+    return () => {
+      const index = this.#prompts.indexOf(component);
+      if (index < 0) {
+        return;
+      }
+      if (isFocusable(component)) {
+        component.focused = false;
+      }
+      this.#prompts.splice(index, 1);
+      this.#rebuild();
+      this.focused = this.#focused;
+    };
+  }
+
   #rebuild(): void {
     this.clear();
-    this.addChild(this.#content);
+    this.addChild(this.#prompts.at(-1) ?? this.#content);
     this.addChild(this.#footer);
   }
 }
@@ -426,31 +454,12 @@ const addTranslatedMessage = (
   markdownTheme: MarkdownTheme,
   message: string
 ): void => {
-  chatContainer.addChild(new Spacer(1));
-  chatContainer.addChild(
+  addChatComponent(
+    chatContainer,
     new Markdown(sanitizeTerminalText(message), 1, 1, markdownTheme, {
       bgColor: (text: string) => style(ANSI_BG_GRAY, text),
     })
   );
-};
-
-/**
- * Appends a sanitized gray system notice row. Returns the mounted row and exact
- * string it was created with, so a repeated notice can restore that style
- * byte-for-byte after pulsing; `undefined` when nothing was appended.
- */
-const appendSystemNotice = (
-  chatContainer: Container,
-  message: string
-): AppendedNotice | undefined => {
-  if (message.length === 0) {
-    return;
-  }
-
-  const normalText = style(ANSI_GRAY, message);
-  const row = new Text(normalText, 1, 0);
-  addChatComponent(chatContainer, row);
-  return { normalText, row };
 };
 
 const addErrorMessage = (chatContainer: Container, error: unknown): void => {
@@ -471,8 +480,12 @@ const addErrorMessage = (chatContainer: Container, error: unknown): void => {
 
 interface StreamViewFactories {
   activeToolInputs: Map<string, ToolInputRenderState>;
+  endAssistantView: (kind: "reasoning" | "text") => void;
   ensureAssistantView: () => AssistantStreamView;
   ensureToolView: (toolCallId: string, toolName: string) => BaseToolCallView;
+  finish: () => void;
+  finishToolView: (id: string) => void;
+  getToolView: (id: string) => BaseToolCallView | undefined;
   pendingToolCallIds: Set<string>;
   resetAssistantView: (suppressLeadingSpacer?: boolean) => void;
   streamedToolCallIds: Set<string>;
@@ -483,7 +496,7 @@ const createStreamViewFactories = (options: {
   assistantRenderer?: AssistantRenderer;
   assistantRendererSignal?: AbortSignal;
   assistantViews: Set<AssistantStreamView>;
-  chatContainer: Container;
+  chatContainer: TranscriptOwner;
   flags: PiTuiRenderFlags;
   foregroundColor?: string;
   markdownTheme: MarkdownTheme;
@@ -496,57 +509,106 @@ const createStreamViewFactories = (options: {
   const streamedToolCallIds = new Set<string>();
   const pendingToolCallIds = new Set<string>();
   const toolViews = new Map<string, BaseToolCallView>();
-  let assistantView: AssistantStreamView | null = null;
+  let assistantLease: TranscriptLease<AssistantStreamView> | undefined;
+  const toolLeases = new Map<string, TranscriptLease<BaseToolCallView>>();
   let suppressAssistantLeadingSpacer = false;
 
   const resetAssistantView = (suppressLeadingSpacer = false): void => {
     if (suppressLeadingSpacer) {
       suppressAssistantLeadingSpacer = true;
     }
-    assistantView = null;
+    if (assistantLease) {
+      options.chatContainer.finish(assistantLease);
+      assistantLease = undefined;
+    }
   };
 
   const ensureAssistantView = (): AssistantStreamView => {
-    if (!assistantView) {
-      assistantView = new AssistantStreamView(options.markdownTheme, {
-        assistantRenderer: options.assistantRenderer,
-        foregroundColor: options.foregroundColor,
-        notify: options.notifyAssistantRenderer,
-        notifyOnce: options.notifyAssistantRendererOnce,
-        requestRender: options.requestRender,
-        signal: options.assistantRendererSignal,
-      });
-      options.assistantViews.add(assistantView);
-      addChatComponent(options.chatContainer, assistantView, {
-        addLeadingSpacer: !suppressAssistantLeadingSpacer,
-      });
+    if (!assistantLease?.active) {
+      assistantLease = options.chatContainer.acquire(
+        (permission) => {
+          const view = new AssistantStreamView(options.markdownTheme, {
+            assistantRenderer: options.assistantRenderer,
+            foregroundColor: options.foregroundColor,
+            notify: (message) => {
+              if (permission.active) {
+                options.notifyAssistantRenderer(message);
+              }
+            },
+            notifyOnce: (key, message) => {
+              if (permission.active) {
+                options.notifyAssistantRendererOnce(key, message);
+              }
+            },
+            requestRender: () => {
+              if (permission.active) {
+                options.requestRender();
+              }
+            },
+            signal:
+              options.assistantRendererSignal === undefined
+                ? permission.signal
+                : AbortSignal.any([
+                    permission.signal,
+                    options.assistantRendererSignal,
+                  ]),
+          });
+          options.assistantViews.add(view);
+          return view;
+        },
+        {
+          leadingSpacer: !suppressAssistantLeadingSpacer,
+          dispose: (view) => {
+            options.assistantViews.delete(view);
+            view.dispose();
+          },
+        }
+      );
       suppressAssistantLeadingSpacer = false;
     }
 
-    return assistantView;
+    return assistantLease.view;
   };
 
   const ensureToolView = (
     toolCallId: string,
     toolName: string
   ): BaseToolCallView => {
-    const existing = toolViews.get(toolCallId);
-    if (existing) {
-      existing.setToolName(toolName);
-      return existing;
+    const existing = toolLeases.get(toolCallId);
+    if (existing?.active) {
+      existing.view.setToolName(toolName);
+      return existing.view;
     }
 
-    const view = new BaseToolCallView(
-      toolCallId,
-      toolName,
-      options.markdownTheme,
-      options.requestRender,
-      options.flags.showRawToolIo,
-      options.toolRenderers
+    const lease = options.chatContainer.acquire(
+      (permission) =>
+        new BaseToolCallView(
+          toolCallId,
+          toolName,
+          options.markdownTheme,
+          () => {
+            if (permission.active) {
+              options.requestRender();
+            }
+          },
+          options.flags.showRawToolIo,
+          options.toolRenderers
+        ),
+      {
+        label: existing
+          ? `Continuation (${sanitizeTerminalText(toolCallId)})`
+          : undefined,
+        settle: (view) => view.settle(),
+        dispose: (view) => view.dispose(),
+      }
     );
-    toolViews.set(toolCallId, view);
-    addChatComponent(options.chatContainer, view);
-    return view;
+    const input = activeToolInputs.get(toolCallId);
+    if (input?.finalInput !== undefined) {
+      lease.view.setFinalInput(input.finalInput);
+    }
+    toolLeases.set(toolCallId, lease);
+    toolViews.set(toolCallId, lease.view);
+    return lease.view;
   };
 
   return {
@@ -554,9 +616,33 @@ const createStreamViewFactories = (options: {
     streamedToolCallIds,
     pendingToolCallIds,
     toolViews,
+    endAssistantView: (kind) => {
+      // Committed reasoning can arrive after text deltas. Never seal that
+      // newer text lease, or reopen a lease handed off to steering/tools.
+      if (assistantLease?.active && assistantLease.view.contentKind === kind) {
+        if (kind === "text") {
+          assistantLease.view.completeText();
+        }
+        resetAssistantView();
+      }
+    },
     resetAssistantView,
     ensureAssistantView,
     ensureToolView,
+    getToolView: (id: string) =>
+      toolLeases.get(id)?.active ? toolViews.get(id) : undefined,
+    finishToolView: (id: string) => {
+      const lease = toolLeases.get(id);
+      if (lease) {
+        options.chatContainer.finish(lease);
+      }
+    },
+    finish: () => {
+      resetAssistantView();
+      for (const lease of toolLeases.values()) {
+        options.chatContainer.finish(lease);
+      }
+    },
   };
 };
 
@@ -639,6 +725,8 @@ export interface AgentTUIConfig {
   assistantRenderer?: AssistantRenderer;
   assistantRendererSignal?: AbortSignal;
   commands?: TuiCommand[];
+  /** Structured current metadata; titles must never be parsed from subtitles. */
+  currentSession?: () => Pick<SessionIndexEntry, "key" | "name">;
   cwd?: string;
   footer?: { text?: string };
   header?: { title: string; subtitle?: string };
@@ -703,7 +791,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   tui.setClearOnShrink(false);
 
   const headerContainer = new Container();
-  const chatContainer = new Container();
+  const chatContainer = new TranscriptOwner(() => terminal.columns);
   const overlayContainer = new Container();
   const footerStatusBar = new FooterStatusBar(tui);
   const assistantViews = new Set<AssistantStreamView>();
@@ -717,19 +805,28 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   // of appending duplicates. Scope is the current notice instance only; see
   // `repeated-notice.ts`.
   const repeatedNotice = createRepeatedNotice({
-    appendNotice: (message) => appendSystemNotice(chatContainer, message),
-    chatContainer,
+    appendNotice: (message) => {
+      if (!message) {
+        return;
+      }
+      const normalText = style(ANSI_GRAY, message);
+      const lease = chatContainer.acquire(() => new Text(normalText, 1, 0), {
+        settle: () => repeatedNotice.settle(),
+      });
+      return { normalText, row: lease.view, isActive: () => lease.active };
+    },
+    normalStyle: (message) => style(ANSI_GRAY, message),
     pulseStyle: (message) => style(`${ANSI_BG_WHITE}${ANSI_BLACK}`, message),
     requestRender: () => tui.requestRender(),
   });
-  const showSystemMessage = (message: string): void => {
+  const showSystemMessage = (message: string, key?: "model-change"): void => {
     // Sanitize before either style is applied, including repeated custom notices.
-    repeatedNotice.show(sanitizeTerminalText(message).trimEnd());
+    repeatedNotice.show(sanitizeTerminalText(message).trimEnd(), key);
   };
-  const clearChat = (): void => {
-    disposeAssistantViews();
-    chatContainer.clear();
+  const clearChat = (reason: "initial-replay" | "session-navigation"): void => {
     repeatedNotice.reset();
+    chatContainer.reset(reason);
+    disposeAssistantViews();
   };
 
   const assistantRendererNotifications =
@@ -745,24 +842,50 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     0
   );
 
-  const updateHeader = (): void => {
-    const headerTitle = sanitizeTerminalText(
-      config.header?.title ?? "Agent TUI"
+  const initializeStartupHeader = (): void => {
+    const headerTitle = style(
+      `${ANSI_BOLD}${ANSI_ORANGE}`,
+      sanitizeTerminalText(config.header?.title ?? "Agent TUI")
     );
-    const subtitle =
-      config.header?.subtitle === undefined
-        ? undefined
-        : sanitizeTerminalText(config.header.subtitle);
-    const footer = sanitizeTerminalText(config.footer?.text ?? "").trim();
+    const subtitle = sanitizeTerminalText(config.header?.subtitle ?? "");
     title.setText(
-      subtitle
-        ? `${style(`${ANSI_BOLD}${ANSI_ORANGE}`, headerTitle)}\n${style(
-            ANSI_DIM,
-            subtitle
-          )}`
-        : style(`${ANSI_BOLD}${ANSI_ORANGE}`, headerTitle)
+      subtitle ? `${headerTitle}\n${style(ANSI_DIM, subtitle)}` : headerTitle
     );
-    footerStatusBar.setRightText(footer);
+    const snapshot = new ColdSnapshot(
+      headerContainer.render(terminal.columns),
+      terminal.columns
+    );
+    headerContainer.clear();
+    headerContainer.addChild(snapshot);
+  };
+
+  let currentSubtitle = config.header?.subtitle;
+  let currentSession = config.currentSession?.();
+  const refreshCurrentStatus = (reason?: "model-change"): void => {
+    const nextSession = config.currentSession?.();
+    const sessionChanged = nextSession?.key !== currentSession?.key;
+    const titleChanged =
+      !sessionChanged && nextSession?.name !== currentSession?.name;
+    if (titleChanged && nextSession?.name !== undefined) {
+      const name = sanitizeTerminalText(
+        nextSession.name,
+        nextSession.name.length
+      );
+      showSystemMessage(`Session title updated to "${name}".`);
+    } else if (
+      (sessionChanged || config.header?.subtitle !== currentSubtitle) &&
+      reason !== "model-change"
+    ) {
+      const subtitle = sanitizeTerminalText(config.header?.subtitle ?? "");
+      if (subtitle) {
+        showSystemMessage(`Current session/model:\n${subtitle}`);
+      }
+    }
+    currentSubtitle = config.header?.subtitle;
+    currentSession = nextSession === undefined ? undefined : { ...nextSession };
+    footerStatusBar.setRightText(
+      sanitizeTerminalText(config.footer?.text ?? "").trim()
+    );
     tui.requestRender();
   };
 
@@ -908,6 +1031,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   };
 
   const removeInputListener = tui.addInputListener((data) => {
+    if (composerLayer.hasPrompt) {
+      return;
+    }
     if (isCtrlCInput(data) && !commandInputListenerActive) {
       handleCtrlCPress();
       return { consume: true };
@@ -982,9 +1108,13 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       streamedToolCallIds,
       pendingToolCallIds,
       toolViews,
+      endAssistantView,
       resetAssistantView,
       ensureAssistantView,
       ensureToolView,
+      getToolView,
+      finishToolView,
+      finish,
     } = createStreamViewFactories({
       assistantRenderer: config.assistantRenderer,
       assistantRendererSignal: config.assistantRendererSignal,
@@ -998,6 +1128,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       requestRender: () => tui.requestRender(),
       toolRenderers: config.toolRenderers,
     });
+    const epoch = chatContainer.epoch;
     const tracker: StreamPartTracker = {
       finishReason: undefined,
       firstVisiblePartSeen: false,
@@ -1030,10 +1161,13 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       activeToolInputs,
       streamedToolCallIds,
       pendingToolCallIds,
+      endAssistantView,
       resetAssistantView,
       ensureAssistantView,
       ensureToolView,
-      getToolView: (toolCallId: string) => toolViews.get(toolCallId),
+      getToolView,
+      finishToolView,
+      finishOutput: finish,
       chatContainer,
       onReasoningStart: orchestrator.onReasoningStart,
       onReasoningEnd: orchestrator.onReasoningEnd,
@@ -1045,6 +1179,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
     try {
       for await (const part of stream) {
+        if (epoch !== chatContainer.epoch || session.closed) {
+          continue;
+        }
         await dispatchStreamPart(part, {
           chatContainer,
           flags,
@@ -1059,6 +1196,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       // ticking or a stale wait banner behind for the next step or thread.
       retryStatus.clear();
       retryStatus.stop();
+      finish();
       for (const view of toolViews.values()) {
         view.dispose();
       }
@@ -1068,7 +1206,8 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   };
 
   const renderSessionHistory = (
-    replay?: readonly SessionHistoryReplayPart[]
+    replay?: readonly SessionHistoryReplayPart[],
+    resetReason: "initial-replay" | "session-navigation" = "session-navigation"
   ): Promise<void> =>
     busy.run("Loading session history...", async () => {
       const selectorConfig = config.sessionSelector;
@@ -1107,7 +1246,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         }
         await flushStreamParts();
         if (part.type === "clear") {
-          clearChat();
+          clearChat(resetReason);
         } else {
           addUserMessage(chatContainer, markdownTheme, part.text);
         }
@@ -1130,6 +1269,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   };
 
   const runSingleTurn = async (run: AgentTurn): Promise<void> => {
+    const turnEpoch = chatContainer.epoch;
+    const turnSignal = AbortSignal.any([
+      chatContainer.signal,
+      extensionUiController.signal,
+    ]);
     session.beginTurn(run);
     editor.disableSubmit = false;
     tui.setFocus(composerLayer);
@@ -1147,13 +1291,19 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       const { finishReason } = await renderAgentStream(
         agentEventStreamParts(run.events(), {
           onContextUsage: (snapshot) => {
+            if (turnSignal.aborted) {
+              return;
+            }
             config.onContextUsage?.(snapshot);
-            updateHeader();
+            refreshCurrentStatus();
           },
           onModelUsage: (usage) => {
+            if (turnSignal.aborted) {
+              return;
+            }
             sawModelUsage = true;
             accumulateUsage(turnUsage, usage);
-            updateHeader();
+            refreshCurrentStatus();
           },
         }),
         {
@@ -1169,6 +1319,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         "Working..."
       );
 
+      if (turnEpoch !== chatContainer.epoch || session.closed) {
+        return;
+      }
       if (session.wasInterrupted(run)) {
         addInterruptedMessage();
         return;
@@ -1181,7 +1334,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
               config.onTurnComplete?.(
                 sawModelUsage ? { ...turnUsage } : undefined,
                 finishReason,
-                extensionUiController.signal
+                turnSignal
               )
             ),
             10_000,
@@ -1189,8 +1342,8 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           )
         )
         .then(() => {
-          if (!session.closed) {
-            updateHeader();
+          if (!session.closed && turnEpoch === chatContainer.epoch) {
+            refreshCurrentStatus();
           }
         })
         .catch((error) => {
@@ -1253,7 +1406,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         isCtrlCInput,
         handleCtrlCPress,
         showMessage: showSystemMessage,
-        updateHeader,
+        updateHeader: refreshCurrentStatus,
       })
     );
   };
@@ -1348,17 +1501,22 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     });
     const selection = await untilExit(pendingSelection);
 
-    if (selection === undefined || selection === EXIT_REQUESTED) {
+    if (typeof selection !== "string") {
       return;
     }
     try {
+      const previousModelId = selectorConfig.currentModelId();
       await busy.run("Switching model...", () =>
         selectorConfig.switchModel(selection)
       );
-      updateHeader();
-      showSystemMessage(
-        `Model switched to ${selection}. New steps use it immediately.`
-      );
+      refreshCurrentStatus("model-change");
+      const currentModelId = selectorConfig.currentModelId();
+      if (currentModelId !== previousModelId) {
+        showSystemMessage(
+          `Model changed to ${currentModelId}.`,
+          "model-change"
+        );
+      }
     } catch (error) {
       showSystemMessage(
         `Model switch failed: ${
@@ -1461,10 +1619,10 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           await resumeSessionReplayParts(selectorConfig, selection)
         );
       });
-      updateHeader();
+      refreshCurrentStatus();
     } catch (error) {
       showSystemMessage(
-        `Session switch failed: ${
+        `Session switch failed (current session: ${selectorConfig.currentSessionKey()}; previous transcript retained): ${
           error instanceof Error ? error.message : String(error)
         }`
       );
@@ -1525,11 +1683,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     if (commandResult.action.type === "refresh-header") {
       const action = commandResult.action;
       await busy.run("Working...", () => config.onCommandAction?.(action));
-      updateHeader();
+      refreshCurrentStatus(action.reason);
     }
 
     if (commandResult.message) {
-      showSystemMessage(commandResult.message);
+      showSystemMessage(commandResult.message, commandResult.action.reason);
     }
     tui.requestRender();
   };
@@ -1540,9 +1698,17 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   ): Promise<void> => {
     if (clear) {
       clearStatus();
-      await renderSessionHistory();
+      try {
+        await renderSessionHistory();
+      } catch (error) {
+        showSystemMessage(
+          `History load failed for current session ${config.sessionSelector?.currentSessionKey() ?? "unknown"}; previous transcript retained: ${error instanceof Error ? error.message : String(error)}`
+        );
+        tui.requestRender();
+        return;
+      }
     }
-    updateHeader();
+    refreshCurrentStatus();
     if (commandResult.message) {
       showSystemMessage(commandResult.message);
     }
@@ -1556,6 +1722,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
     const action = commandResult.action;
+    chatContainer.finish();
     try {
       await busy.run("Reloading...", () => config.onCommandAction?.(action));
     } catch (error) {
@@ -1569,7 +1736,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       return;
     }
     refreshCommandSet();
-    updateHeader();
+    refreshCurrentStatus();
     if (commandResult.message) {
       showSystemMessage(commandResult.message);
     }
@@ -1730,18 +1897,40 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     session.submitInput(text);
   };
 
-  updateHeader();
+  initializeStartupHeader();
+  refreshCurrentStatus();
   tui.start();
 
   try {
     await busy.run("Activating extensions...", () =>
       config.onExtensionUiReady?.((hostSignal) =>
         createExtensionUi({
-          restoreFocus: clearPromptInput,
+          promptSignal: () =>
+            AbortSignal.any([
+              chatContainer.signal,
+              extensionUiController.signal,
+              ...(hostSignal ? [hostSignal] : []),
+            ]),
+          promptHost: {
+            mount: (component) => {
+              const unmount = composerLayer.mountPrompt(component);
+              tui.setFocus(composerLayer);
+              tui.requestRender();
+              return () => {
+                unmount();
+                tui.setFocus(composerLayer);
+                tui.requestRender();
+              };
+            },
+          },
           showMessage: showSystemMessage,
           showStatus: (message) => {
             const clear = busy.status(message);
-            const signal = hostSignal ?? extensionUiController.signal;
+            const signal = AbortSignal.any([
+              chatContainer.signal,
+              extensionUiController.signal,
+              ...(hostSignal ? [hostSignal] : []),
+            ]);
             signal.addEventListener("abort", clear, {
               once: true,
             });
@@ -1760,7 +1949,6 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
             hostSignal === undefined
               ? extensionUiController.signal
               : AbortSignal.any([extensionUiController.signal, hostSignal]),
-          tui,
         })
       )
     );
@@ -1769,9 +1957,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     }
     await busy.run("Setting up...", () => config.onSetup?.());
     if (config.replayHistoryOnStartup === true) {
-      await renderSessionHistory();
+      await renderSessionHistory(undefined, "initial-replay");
     }
-    updateHeader();
+    refreshCurrentStatus();
 
     while (!session.closed) {
       const input = await waitForInput();
@@ -1806,6 +1994,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         // the composer's position when the transcript fills the viewport.
         // Ending a pulse first keeps an exit mid-blink from freezing the
         // notice inverted in that preserved frame.
+        chatContainer.finish();
         repeatedNotice.settle();
         tui.renderNow();
         const renderState = tui.captureRenderState();

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -255,7 +255,9 @@ export class FooterStatusBar extends Text {
       ? style(ANSI_DIM, rightTextPlain)
       : "";
     return this.padLine(
-      `${width === 1 ? "" : " "}${left?.styled ?? ""}${" ".repeat(gap)}${rightTextStyled}`,
+      `${width === 1 ? "" : " "}${left?.styled ?? ""}${" ".repeat(
+        gap
+      )}${rightTextStyled}`,
       width
     );
   }
@@ -279,7 +281,9 @@ export class FooterStatusBar extends Text {
     return {
       plain: prefix ? `${prefix}${message ? ` ${message}` : ""}` : message,
       styled: prefix
-        ? `${prefixStyle}${message ? ` ${style(messageStylePrefix, message)}` : ""}`
+        ? `${prefixStyle}${
+            message ? ` ${style(messageStylePrefix, message)}` : ""
+          }`
         : style(messageStylePrefix, message),
     };
   }
@@ -730,7 +734,10 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     const footer = sanitizeTerminalText(config.footer?.text ?? "").trim();
     title.setText(
       subtitle
-        ? `${style(`${ANSI_BOLD}${ANSI_ORANGE}`, headerTitle)}\n${style(ANSI_DIM, subtitle)}`
+        ? `${style(`${ANSI_BOLD}${ANSI_ORANGE}`, headerTitle)}\n${style(
+            ANSI_DIM,
+            subtitle
+          )}`
         : style(`${ANSI_BOLD}${ANSI_ORANGE}`, headerTitle)
     );
     footerStatusBar.setRightText(footer);
@@ -1087,7 +1094,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     });
 
   const accumulateUsage = (
-    total: { inputTokens: number; outputTokens: number; totalTokens: number },
+    total: {
+      inputTokens: number;
+      outputTokens: number;
+      totalTokens: number;
+    },
     usage: ModelUsage
   ): void => {
     total.inputTokens += usage.inputTokens ?? 0;
@@ -1255,7 +1266,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       clearStatus();
       addSystemMessage(
         chatContainer,
-        `Could not list models: ${error instanceof Error ? error.message : String(error)}. Switch directly with /model <model-id>.`
+        `Could not list models: ${
+          error instanceof Error ? error.message : String(error)
+        }. Switch directly with /model <model-id>.`
       );
       tui.requestRender();
       return;
@@ -1331,7 +1344,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     } catch (error) {
       addSystemMessage(
         chatContainer,
-        `Model switch failed: ${error instanceof Error ? error.message : String(error)}`
+        `Model switch failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
     }
     tui.requestRender();
@@ -1358,7 +1373,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       clearStatus();
       addSystemMessage(
         chatContainer,
-        `Could not list sessions: ${error instanceof Error ? error.message : String(error)}`
+        `Could not list sessions: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
       tui.requestRender();
       return;
@@ -1432,7 +1449,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     } catch (error) {
       addSystemMessage(
         chatContainer,
-        `Session switch failed: ${error instanceof Error ? error.message : String(error)}`
+        `Session switch failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
     }
     tui.requestRender();
@@ -1528,7 +1547,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       refreshCommandSet();
       addSystemMessage(
         chatContainer,
-        `Reload failed: ${error instanceof Error ? error.message : String(error)}`
+        `Reload failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
       tui.requestRender();
       return;
@@ -1623,7 +1644,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
   const processInput = async (input: string): Promise<boolean> => {
     const trimmed = input.trim();
     if (trimmed.length === 0) {
-      addSystemMessage(chatContainer, "메시지를 입력해주세요");
+      addSystemMessage(chatContainer, "Please enter a message.");
       tui.requestRender();
       return true;
     }
@@ -1707,7 +1728,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
           showStatus: (message) => {
             const clear = busy.status(message);
             const signal = hostSignal ?? extensionUiController.signal;
-            signal.addEventListener("abort", clear, { once: true });
+            signal.addEventListener("abort", clear, {
+              once: true,
+            });
             if (signal.aborted) {
               clear();
             }

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -489,7 +489,7 @@ interface StreamViewFactories {
   finishToolView: (id: string) => void;
   getToolView: (id: string) => BaseToolCallView | undefined;
   pendingToolCallIds: Set<string>;
-  resetAssistantView: (suppressLeadingSpacer?: boolean) => void;
+  resetAssistantView: () => void;
   streamedToolCallIds: Set<string>;
   toolViews: Map<string, BaseToolCallView>;
 }
@@ -513,12 +513,8 @@ const createStreamViewFactories = (options: {
   const toolViews = new Map<string, BaseToolCallView>();
   let assistantLease: TranscriptLease<AssistantStreamView> | undefined;
   const toolLeases = new Map<string, TranscriptLease<BaseToolCallView>>();
-  let suppressAssistantLeadingSpacer = false;
 
-  const resetAssistantView = (suppressLeadingSpacer = false): void => {
-    if (suppressLeadingSpacer) {
-      suppressAssistantLeadingSpacer = true;
-    }
+  const resetAssistantView = (): void => {
     if (assistantLease) {
       options.chatContainer.finish(assistantLease);
       assistantLease = undefined;
@@ -559,14 +555,12 @@ const createStreamViewFactories = (options: {
           return view;
         },
         {
-          leadingSpacer: !suppressAssistantLeadingSpacer,
           dispose: (view) => {
             options.assistantViews.delete(view);
             view.dispose();
           },
         }
       );
-      suppressAssistantLeadingSpacer = false;
     }
 
     return assistantLease.view;

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -860,7 +860,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
   let currentSubtitle = config.header?.subtitle;
   let currentSession = config.currentSession?.();
-  const refreshCurrentStatus = (reason?: "model-change"): void => {
+  const refreshCurrentStatus = (reason?: "model-change" | "new"): void => {
     const nextSession = config.currentSession?.();
     const sessionChanged = nextSession?.key !== currentSession?.key;
     const titleChanged =
@@ -873,7 +873,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       showSystemMessage(`Session title updated to "${name}".`);
     } else if (
       (sessionChanged || config.header?.subtitle !== currentSubtitle) &&
-      reason !== "model-change"
+      reason === undefined
     ) {
       const subtitle = sanitizeTerminalText(config.header?.subtitle ?? "");
       if (subtitle) {
@@ -1675,7 +1675,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     }
 
     if (commandResult.action.type === "session") {
-      await handleSessionAction(commandResult, commandResult.action.clear);
+      await handleSessionAction(commandResult, commandResult.action);
       return;
     }
 
@@ -1693,9 +1693,9 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
   const handleSessionAction = async (
     commandResult: TuiCommandResult,
-    clear: boolean
+    action: Extract<TuiCommandAction, { type: "session" }>
   ): Promise<void> => {
-    if (clear) {
+    if (action.clear) {
       clearStatus();
       try {
         await renderSessionHistory();
@@ -1707,7 +1707,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         return;
       }
     }
-    refreshCurrentStatus();
+    refreshCurrentStatus(action.reason);
     if (commandResult.message) {
       showSystemMessage(commandResult.message);
     }

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -1094,8 +1094,19 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     stream: AsyncIterable<TuiStreamPart>,
     flags: PiTuiRenderFlags,
     onFirstVisiblePart?: () => void,
-    loaderMessage?: string
+    loaderMessage?: string,
+    transcript = chatContainer
   ): Promise<{ finishReason: string | undefined }> => {
+    const replaying = transcript !== chatContainer;
+    const views = replaying ? new Set<AssistantStreamView>() : assistantViews;
+    const notifications = replaying
+      ? createAssistantRendererNotifications((message) => {
+          addChatComponent(
+            transcript,
+            new Text(sanitizeTerminalText(message), 1, 0)
+          );
+        })
+      : assistantRendererNotifications;
     const {
       activeToolInputs,
       streamedToolCallIds,
@@ -1111,17 +1122,17 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
     } = createStreamViewFactories({
       assistantRenderer: config.assistantRenderer,
       assistantRendererSignal: config.assistantRendererSignal,
-      assistantViews,
-      chatContainer,
+      assistantViews: views,
+      chatContainer: transcript,
       flags,
       foregroundColor: config.theme?.foregroundColor,
       markdownTheme,
-      notifyAssistantRenderer: assistantRendererNotifications.notify,
-      notifyAssistantRendererOnce: assistantRendererNotifications.notifyOnce,
+      notifyAssistantRenderer: notifications.notify,
+      notifyAssistantRendererOnce: notifications.notifyOnce,
       requestRender: () => tui.requestRender(),
       toolRenderers: config.toolRenderers,
     });
-    const epoch = chatContainer.epoch;
+    const epoch = transcript.epoch;
     const tracker: StreamPartTracker = {
       finishReason: undefined,
       firstVisiblePartSeen: false,
@@ -1161,7 +1172,7 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       getToolView,
       finishToolView,
       finishOutput: finish,
-      chatContainer,
+      chatContainer: transcript,
       onReasoningStart: orchestrator.onReasoningStart,
       onReasoningEnd: orchestrator.onReasoningEnd,
       // Runtime tool-call/result events are committed after execution. They
@@ -1172,11 +1183,11 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
 
     try {
       for await (const part of stream) {
-        if (epoch !== chatContainer.epoch || session.closed) {
-          continue;
+        if (epoch !== transcript.epoch || session.closed) {
+          break;
         }
         await dispatchStreamPart(part, {
-          chatContainer,
+          chatContainer: transcript,
           flags,
           onFirstVisiblePart,
           state,
@@ -1189,9 +1200,17 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       // ticking or a stale wait banner behind for the next step or thread.
       retryStatus.clear();
       retryStatus.stop();
-      finish();
-      for (const view of toolViews.values()) {
-        view.dispose();
+      try {
+        finish();
+      } finally {
+        for (const view of toolViews.values()) {
+          view.dispose();
+        }
+        if (replaying) {
+          for (const view of views) {
+            view.dispose();
+          }
+        }
       }
     }
 
@@ -1210,6 +1229,8 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
       const parts =
         replay ??
         sessionHistoryReplayParts(await selectorConfig.loadCurrentHistory());
+      // Render and seal the replacement off-screen before revoking the old epoch.
+      const staged = new TranscriptOwner(() => terminal.columns);
       let streamParts: TuiStreamPart[] = [];
       const flushStreamParts = async (): Promise<void> => {
         if (streamParts.length === 0) {
@@ -1229,7 +1250,10 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
             showToolResults: true,
             showSources: false,
             showFiles: false,
-          }
+          },
+          undefined,
+          undefined,
+          staged
         );
       };
       for (const part of parts) {
@@ -1239,12 +1263,17 @@ export async function createAgentTUI(config: AgentTUIConfig): Promise<void> {
         }
         await flushStreamParts();
         if (part.type === "clear") {
-          clearChat(resetReason);
+          staged.reset(resetReason);
         } else {
-          addUserMessage(chatContainer, markdownTheme, part.text);
+          addUserMessage(staged, markdownTheme, part.text);
         }
       }
       await flushStreamParts();
+      staged.finish();
+      clearChat(resetReason);
+      for (const component of staged.children) {
+        chatContainer.addChild(component);
+      }
     });
 
   const accumulateUsage = (

--- a/apps/coding-agent/src/tui/app-shutdown.test.ts
+++ b/apps/coding-agent/src/tui/app-shutdown.test.ts
@@ -282,7 +282,7 @@ describe.sequential("startTui final output", () => {
     expect(output.join("").split(hint)).toHaveLength(2);
   });
 
-  it("retains the streamed transcript and one composer border after narrow scrolling", async () => {
+  it("retains the streamed viewport tail and one composer border after narrow scrolling", async () => {
     const marker = "STREAM_SENTINEL";
     let hint = "";
     terminal.painted = (data) => {
@@ -299,7 +299,10 @@ describe.sequential("startTui final output", () => {
             controller.enqueue({
               type: "text-delta",
               id: "answer",
-              delta: `${marker}\n\n`.repeat(35),
+              delta: Array.from(
+                { length: 35 },
+                (_, i) => `${marker}_${i + 1}`
+              ).join("\n\n"),
             });
             abortSignal?.addEventListener(
               "abort",
@@ -329,7 +332,9 @@ describe.sequential("startTui final output", () => {
     );
     expect(await run).toBe(0);
     const rows = await expectFinalScreen(output.join(""), hint);
-    expect(rows.filter((row) => row?.includes(marker))).toHaveLength(35);
+    expect(rows.filter((row) => row?.includes(marker))).toHaveLength(4);
+    expect(rows.some((row) => row?.includes(`${marker}_35`))).toBe(true);
+    expect(rows.some((row) => row?.includes(`${marker}_1`))).toBe(false);
     expect(output.join("").split(hint)).toHaveLength(2);
   });
 

--- a/apps/coding-agent/src/tui/app-shutdown.test.ts
+++ b/apps/coding-agent/src/tui/app-shutdown.test.ts
@@ -1,0 +1,686 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { inspect } from "node:util";
+import { type Terminal, TuiMainScreen } from "@earendil-works/pi-tui";
+import { MockLanguageModelV4 } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSessionManager } from "../sessions/session-manager";
+import { resolveSessionSelector } from "../sessions/session-resume";
+
+const terminal = vi.hoisted(() => ({
+  columns: 48,
+  rows: 10,
+  input: (_data: string): void => undefined,
+  render: (): void => undefined,
+  painted: (_data: string): void => undefined,
+  stopped: (): void => undefined,
+}));
+const update = vi.hoisted(() => ({
+  enabled: false,
+  install: async () => 0,
+}));
+
+vi.mock("../update/cli-version", () => ({ cliVersion: "0.0.14" }));
+vi.mock("../update/auto-update", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../update/auto-update")>();
+  return {
+    ...actual,
+    planAutoUpdate: (...args: Parameters<typeof actual.planAutoUpdate>) =>
+      update.enabled
+        ? {
+            channel: "latest",
+            currentVersion: "0.0.14",
+            manager: "pnpm",
+            target: "0.0.15",
+          }
+        : actual.planAutoUpdate(...args),
+    runAutoUpdate: (
+      plan: Parameters<typeof actual.runAutoUpdate>[0],
+      options: Parameters<typeof actual.runAutoUpdate>[1]
+    ) =>
+      actual.runAutoUpdate(plan, {
+        ...options,
+        fetchTags: async () => ({ latest: "0.0.15" }),
+        spawnInstall: () => update.install(),
+      }),
+  };
+});
+
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  const noop = () => undefined;
+  class TestTerminal implements Terminal {
+    get columns() {
+      return terminal.columns;
+    }
+    get rows() {
+      return terminal.rows;
+    }
+    readonly kittyProtocolActive = false;
+    readonly clearFromCursor = noop;
+    readonly clearLine = noop;
+    readonly clearScreen = noop;
+    readonly hideCursor = noop;
+    readonly moveBy = noop;
+    readonly setProgress = noop;
+    readonly setTitle = noop;
+    readonly showCursor = noop;
+    write(data: string) {
+      process.stdout.write(data);
+      terminal.painted(data);
+    }
+    drainInput() {
+      return Promise.resolve();
+    }
+    stop() {
+      terminal.stopped();
+    }
+    start(input: (data: string) => void) {
+      terminal.input = input;
+    }
+  }
+  return { ...actual, ProcessTerminal: TestTerminal };
+});
+
+import { createAgentTUI } from "./agent";
+import { startTui } from "./app";
+import { TuiSessionMachine } from "./session-state";
+import { formatSessionResumeHint } from "./terminal-exit";
+
+const model = new MockLanguageModelV4({
+  doStream: async () => ({
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-start", id: "answer" });
+        controller.enqueue({
+          type: "text-delta",
+          id: "answer",
+          delta: "answer",
+        });
+        controller.enqueue({ type: "text-end", id: "answer" });
+        controller.enqueue({
+          type: "finish",
+          finishReason: { raw: "stop", unified: "stop" },
+          usage: {
+            inputTokens: {
+              total: 1,
+              noCache: 1,
+              cacheRead: undefined,
+              cacheWrite: undefined,
+            },
+            outputTokens: { total: 1, text: 1, reasoning: undefined },
+          },
+        });
+        controller.close();
+      },
+    }),
+  }),
+});
+
+const { Terminal: Xterm } = createRequire(import.meta.url)(
+  "@xterm/xterm"
+) as typeof import("@xterm/xterm");
+
+async function screen(output: string) {
+  const emulator = new Xterm({
+    cols: terminal.columns,
+    rows: terminal.rows,
+    allowProposedApi: true,
+    convertEol: true,
+  });
+  try {
+    await new Promise<void>((resolve) => emulator.write(output, resolve));
+    const buffer = emulator.buffer.active;
+    return Array.from({ length: buffer.length }, (_, row) =>
+      buffer.getLine(row)?.translateToString(true).trimEnd()
+    );
+  } finally {
+    emulator.dispose();
+  }
+}
+
+async function expectFinalScreen(output: string, hint: string) {
+  const rows = await screen(output);
+  const rule = "─".repeat(terminal.columns);
+  const hintRows = Array.from(
+    { length: Math.ceil(hint.length / terminal.columns) },
+    (_, index) =>
+      hint.slice(index * terminal.columns, (index + 1) * terminal.columns)
+  );
+  const border = rows.indexOf(rule);
+  expect(rows.filter((row) => row === rule)).toHaveLength(1);
+  expect(rows.slice(border, border + hintRows.length + 1)).toEqual([
+    rule,
+    ...hintRows,
+  ]);
+  expect(rows.slice(border + hintRows.length + 1).every((row) => !row)).toBe(
+    true
+  );
+  return rows;
+}
+
+function gate() {
+  let resolve: () => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<void>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function onInputReady(action: () => void) {
+  const original = TuiSessionMachine.prototype.awaitInput;
+  const spy = vi
+    .spyOn(TuiSessionMachine.prototype, "awaitInput")
+    .mockImplementation(function (this: TuiSessionMachine, resolve) {
+      original.call(this, resolve);
+      spy.mockRestore();
+      action();
+    });
+}
+
+function exit() {
+  const now = Date.now();
+  const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+  terminal.input("\x03");
+  clock.mockReturnValue(now + 100);
+  terminal.input("\x03");
+  clock.mockRestore();
+}
+
+describe.sequential("startTui final output", () => {
+  let directory: string;
+  let output: string[];
+  const columns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), "pss-shutdown-"));
+    output = [];
+    terminal.columns = 48;
+    terminal.rows = 10;
+    const start = TuiMainScreen.prototype.start;
+    vi.spyOn(TuiMainScreen.prototype, "start").mockImplementation(function (
+      this: TuiMainScreen
+    ) {
+      start.call(this);
+      terminal.render = () => this.renderNow();
+    });
+    vi.stubEnv("HOME", directory);
+    vi.stubEnv("PSS_THREAD_DIR", join(directory, "threads"));
+    vi.stubEnv("PSS_THREAD_KEY", "");
+    vi.stubEnv("PSS_DISABLE_UPDATE_CHECK", "1");
+    Object.defineProperty(process.stdout, "columns", {
+      configurable: true,
+      value: 48,
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      output.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      output.push(String(chunk));
+      return true;
+    });
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    if (columns) {
+      Object.defineProperty(process.stdout, "columns", columns);
+    } else {
+      Reflect.deleteProperty(process.stdout, "columns");
+    }
+    terminal.stopped = () => undefined;
+    terminal.painted = () => undefined;
+    update.enabled = false;
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it.each([
+    { columns: 100, rows: 32 },
+    { columns: 48, rows: 10 },
+  ])("reuses the idle composer border at $columns x $rows", async (size) => {
+    Object.assign(terminal, size);
+    Object.defineProperty(process.stdout, "columns", { value: size.columns });
+    let painted = "";
+    let hint = "";
+    const run = startTui(
+      { cwd: directory, model, tools: {}, sessionName: "named" },
+      {
+        createTui(config) {
+          hint = formatSessionResumeHint(
+            config.sessionSelector?.currentSessionKey() ?? ""
+          );
+          config.onSetup = () =>
+            onInputReady(() => {
+              terminal.render();
+              painted = output.join("");
+              exit();
+            });
+          return createAgentTUI(config);
+        },
+      }
+    );
+    expect(await run).toBe(0);
+    const before = await screen(painted);
+    const after = await screen(output.join(""));
+    const border = before.indexOf("─".repeat(size.columns));
+    const hintRow = after.findIndex((row) =>
+      row?.startsWith(hint.slice(0, size.columns))
+    );
+    expect(border).toBeGreaterThanOrEqual(0);
+    expect(hintRow).toBe(border + 1);
+    expect(after[hintRow - 1]).toBe("─".repeat(size.columns));
+    expect(
+      after.filter((row) => row === "─".repeat(size.columns))
+    ).toHaveLength(1);
+    expect(after.slice(0, border)).toEqual(before.slice(0, border));
+    expect(output.join("").split(hint)).toHaveLength(2);
+  });
+
+  it("retains the streamed transcript and one composer border after narrow scrolling", async () => {
+    const marker = "STREAM_SENTINEL";
+    let hint = "";
+    terminal.painted = (data) => {
+      if (data.includes(marker)) {
+        terminal.painted = () => undefined;
+        queueMicrotask(exit);
+      }
+    };
+    const streaming = new MockLanguageModelV4({
+      doStream: async ({ abortSignal }) => ({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "text-start", id: "answer" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "answer",
+              delta: `${marker}\n\n`.repeat(35),
+            });
+            abortSignal?.addEventListener(
+              "abort",
+              () => controller.error(abortSignal.reason),
+              { once: true }
+            );
+          },
+        }),
+      }),
+    });
+    const run = startTui(
+      { cwd: directory, model: streaming, tools: {}, sessionName: "named" },
+      {
+        createTui(config) {
+          hint = formatSessionResumeHint(
+            config.sessionSelector?.currentSessionKey() ?? ""
+          );
+          config.onSetup = () =>
+            onInputReady(() => {
+              for (const key of "go\r") {
+                terminal.input(key);
+              }
+            });
+          return createAgentTUI(config);
+        },
+      }
+    );
+    expect(await run).toBe(0);
+    const rows = await expectFinalScreen(output.join(""), hint);
+    expect(rows.filter((row) => row?.includes(marker))).toHaveLength(35);
+    expect(output.join("").split(hint)).toHaveLength(2);
+  });
+
+  it("restores one narrow composer rule and exactly one real current selector after owned extension logging", async () => {
+    // Given: real session storage, host, TUI and bounded asynchronous observer.
+    const shutdown = gate();
+    const release = gate();
+    const run = startTui(
+      {
+        cwd: directory,
+        model,
+        tools: {},
+        extensions: [
+          {
+            id: "shutdown-log",
+            configure() {
+              /* Lifecycle-only fixture. */
+            },
+            activate({ services }) {
+              services.events.on("host:session-shutdown", async () => {
+                shutdown.resolve();
+                await release.promise;
+                process.stdout.write("OBSERVER_SENTINEL\n");
+              });
+              return () => {
+                services.logger.info("DISPOSE_SENTINEL");
+              };
+            },
+          },
+        ],
+      },
+      {
+        createTui(config) {
+          config.onSetup = () => onInputReady(exit);
+          return createAgentTUI(config);
+        },
+      }
+    );
+    // When
+    await shutdown.promise;
+    release.resolve();
+    expect(await run).toBe(0);
+    // Then: resolve the printed selector against the actual final disk index.
+    const manager = createSessionManager({
+      cwd: directory,
+      directory: join(directory, "threads"),
+    });
+    const [session] = await manager.listSessions();
+    if (!session) {
+      throw new Error("No persisted session");
+    }
+    const hint = formatSessionResumeHint(session.key);
+    const text = output.join("");
+    const selector = hint.split("--session ")[1];
+    expect(await resolveSessionSelector(manager, selector ?? "")).toBe(
+      session.key
+    );
+    expect(text.split(hint)).toHaveLength(2);
+    expect(text.endsWith(`${"─".repeat(48)}\n${hint}\n`)).toBe(true);
+    expect(text.indexOf("OBSERVER_SENTINEL")).toBeLessThan(text.indexOf(hint));
+    expect(text.indexOf("DISPOSE_SENTINEL")).toBeLessThan(text.indexOf(hint));
+    const rows = await expectFinalScreen(text, hint);
+    expect(rows.some((row) => row?.includes("OBSERVER_SENTINEL"))).toBe(true);
+    expect(rows.some((row) => row?.includes("DISPOSE_SENTINEL"))).toBe(true);
+  });
+
+  it("settles detached completion errors before the final block", async () => {
+    // Given: a completion callback released by the real terminal stop event.
+    const stopped = gate();
+    const logged = gate();
+    terminal.stopped = stopped.resolve;
+    let hint = "";
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      output.push(`${args.map((value) => inspect(value)).join(" ")}\n`);
+      logged.resolve();
+    });
+    const run = startTui(
+      { cwd: directory, model, tools: {}, sessionName: "named" },
+      {
+        createTui(config) {
+          config.onSetup = () =>
+            onInputReady(() => {
+              for (const key of "go\r") {
+                terminal.input(key);
+              }
+            });
+          hint = formatSessionResumeHint(
+            config.sessionSelector?.currentSessionKey() ?? ""
+          );
+          config.onTurnComplete = async () => {
+            onInputReady(exit);
+            await stopped.promise;
+            throw new Error("CALLBACK_SENTINEL");
+          };
+          return createAgentTUI(config);
+        },
+      }
+    );
+    // When
+    await Promise.all([run, logged.promise]);
+    // Then
+    const text = output.join("");
+    expect(text.indexOf("CALLBACK_SENTINEL")).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf("CALLBACK_SENTINEL")).toBeLessThan(
+      text.indexOf("To resume this session:")
+    );
+    const rows = await expectFinalScreen(text, hint);
+    expect(rows.some((row) => row?.includes("CALLBACK_SENTINEL"))).toBe(true);
+  });
+
+  it("reports setup and cleanup failures before the only final block", async () => {
+    // Given: two independent failures; cleanup must still execute.
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      output.push(inspect(args));
+    });
+    // When
+    const code = await startTui(
+      {
+        cwd: directory,
+        model,
+        tools: {},
+        extensions: [
+          {
+            id: "failing-cleanup",
+            configure() {
+              /* Lifecycle-only fixture. */
+            },
+            activate() {
+              return () => {
+                throw new Error("CLEANUP_FAILURE_SENTINEL");
+              };
+            },
+          },
+        ],
+      },
+      {
+        createTui(config) {
+          config.onSetup = () => {
+            throw new Error("SETUP_FAILURE_SENTINEL");
+          };
+          return createAgentTUI(config);
+        },
+      }
+    );
+    // Then
+    const text = output.join("");
+    expect(code).toBe(1);
+    for (const sentinel of [
+      "SETUP_FAILURE_SENTINEL",
+      "CLEANUP_FAILURE_SENTINEL",
+    ]) {
+      expect(text.indexOf(sentinel), text).toBeGreaterThanOrEqual(0);
+      expect(text.indexOf(sentinel)).toBeLessThan(
+        text.indexOf("To resume this session:")
+      );
+    }
+    expect(text.split("To resume this session:")).toHaveLength(2);
+    expect(text.endsWith("\n")).toBe(true);
+  });
+
+  it("cancels and bounds an uncooperative completion without a late owned error logger", async () => {
+    // Given: fake only the deadline after startup; no filesystem or TUI state polling.
+    const stopped = gate();
+    const callback = gate();
+    let signal: AbortSignal | undefined;
+    terminal.stopped = stopped.resolve;
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation((...args: unknown[]) => {
+        output.push(inspect(args));
+      });
+    const run = startTui(
+      { cwd: directory, model, tools: {}, sessionName: "named" },
+      {
+        createTui(config) {
+          config.onSetup = () =>
+            onInputReady(() => {
+              for (const key of "go\r") {
+                terminal.input(key);
+              }
+            });
+          config.onTurnComplete = (_usage, _reason, callbackSignal) => {
+            signal = callbackSignal;
+            vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+            onInputReady(exit);
+            return callback.promise;
+          };
+          return createAgentTUI(config);
+        },
+      }
+    );
+    // When: advance the actual bounded callback deadline after terminal teardown.
+    await stopped.promise;
+    expect(signal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await run;
+    const beforeLateRejection = output.join("");
+    const rejected = expect(callback.promise).rejects.toThrow("LATE_SENTINEL");
+    callback.reject(new Error("LATE_SENTINEL"));
+    await rejected;
+    // Then: the timeout was reported once before the block; late rejection is observed, not re-logged.
+    expect(errorLog).toHaveBeenCalledOnce();
+    expect(beforeLateRejection.indexOf("10000ms")).toBeLessThan(
+      beforeLateRejection.indexOf("To resume this session:")
+    );
+    expect(output.join("")).toBe(beforeLateRejection);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts the built-in title provider before printing the resume block", async () => {
+    // Given: title generation is real app-owned completion work, not an injected callback.
+    const generating = gate();
+    const aborted = gate();
+    const titleModel = new MockLanguageModelV4({
+      doStream: model.doStream,
+      doGenerate: (options) =>
+        new Promise((_resolve, reject) => {
+          options.abortSignal?.addEventListener(
+            "abort",
+            () => {
+              aborted.resolve();
+              reject(options.abortSignal?.reason);
+            },
+            { once: true }
+          );
+          generating.resolve();
+        }),
+    });
+    const run = startTui(
+      { cwd: directory, model: titleModel, tools: {} },
+      {
+        createTui(config) {
+          config.onSetup = () =>
+            onInputReady(() => {
+              for (const key of "go\r") {
+                terminal.input(key);
+              }
+            });
+          return createAgentTUI(config);
+        },
+      }
+    );
+    // When
+    await generating.promise;
+    exit();
+    await aborted.promise;
+    expect(await run).toBe(0);
+    // Then: cancelled title work does not rename the current session afterward.
+    const manager = createSessionManager({
+      cwd: directory,
+      directory: join(directory, "threads"),
+    });
+    const [session] = await manager.listSessions();
+    expect(session?.name).toBeUndefined();
+    expect(output.join("").split("To resume this session:")).toHaveLength(2);
+  });
+
+  it("bounds uncooperative host cleanup and reports its deadline before the final block", async () => {
+    // Given: host cancellation is observed but this cleanup refuses to settle.
+    const cleaning = gate();
+    const cleanup = gate();
+    let signal: AbortSignal | undefined;
+    let log: ((message: string) => void) | undefined;
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      output.push(inspect(args));
+    });
+    const run = startTui(
+      {
+        cwd: directory,
+        model,
+        tools: {},
+        extensions: [
+          {
+            id: "uncooperative-cleanup",
+            configure() {
+              /* Lifecycle-only fixture. */
+            },
+            activate(context) {
+              signal = context.signal;
+              log = context.services.logger.info;
+              return () => {
+                cleaning.resolve();
+                return cleanup.promise;
+              };
+            },
+          },
+        ],
+      },
+      {
+        createTui(config) {
+          config.onSetup = () =>
+            onInputReady(() => {
+              vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+              exit();
+            });
+          return createAgentTUI(config);
+        },
+      }
+    );
+    // When
+    await cleaning.promise;
+    expect(signal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(await run).toBe(1);
+    // Then
+    const text = output.join("");
+    expect(text.indexOf("10000ms")).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf("10000ms")).toBeLessThan(
+      text.indexOf("To resume this session:")
+    );
+    expect(() => log?.("LATE_LOG_SENTINEL")).toThrow();
+    expect(output.join("")).toBe(text);
+    cleanup.resolve();
+    await cleanup.promise;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([0, 1])(
+    "settles optional auto-update exit %s before the final block",
+    async (code) => {
+      // Given: the real updater with local tags and an event-gated installer.
+      const started = gate();
+      const release = gate();
+      update.enabled = true;
+      update.install = async () => {
+        started.resolve();
+        await release.promise;
+        process.stdout.write("INSTALL_SENTINEL\n");
+        return code;
+      };
+      const run = startTui(
+        { cwd: directory, model, tools: {} },
+        {
+          createTui(config) {
+            config.onSetup = () => onInputReady(exit);
+            return createAgentTUI(config);
+          },
+        }
+      );
+      // When
+      await started.promise;
+      expect(output.join("").includes("To resume this session:")).toBe(false);
+      release.resolve();
+      expect(await run).toBe(code);
+      // Then
+      const text = output.join("");
+      expect(text.indexOf("INSTALL_SENTINEL")).toBeLessThan(
+        text.indexOf("To resume this session:")
+      );
+      expect(text.split("To resume this session:")).toHaveLength(2);
+      expect(text.endsWith("\n")).toBe(true);
+    }
+  );
+});

--- a/apps/coding-agent/src/tui/app-startup-output.test.ts
+++ b/apps/coding-agent/src/tui/app-startup-output.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, expect, it, vi } from "vitest";
 import { startTui } from "./app";
-import { PENDING_SPINNER_INTERVAL_MS } from "./pending-spinner";
 
 // Observe the real pre-mount renderer without constructing a terminal session.
 // Extension initialization rejects after the startup status has acquired its row.
@@ -27,7 +26,6 @@ it("clears the supplied startup stream when TUI initialization rejects", async (
   try {
     await expect(startTui(options)).rejects.toBe(failure);
     expect(vi.getTimerCount()).toBe(0);
-    vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
     expect(processWrite).not.toHaveBeenCalled();
     expect(startupOutput.write).toHaveBeenCalledTimes(2);
     expect(startupOutput.write).toHaveBeenLastCalledWith("\r\x1b[2K");

--- a/apps/coding-agent/src/tui/app-startup-output.test.ts
+++ b/apps/coding-agent/src/tui/app-startup-output.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { startTui } from "./app";
+
+// Observe the real pre-mount renderer without constructing a terminal session.
+// Extension initialization rejects after the startup status has acquired its row.
+vi.mock("../extensions/defaults", () => ({
+  createCodingAgentExtensionHostWithDefaults: () => Promise.reject(failure),
+}));
+const { failure } = vi.hoisted(() => ({ failure: new Error("fixture") }));
+
+afterEach(() => vi.restoreAllMocks());
+
+it("clears the supplied startup stream when TUI initialization rejects", async () => {
+  const tty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: true,
+  });
+  const processWrite = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  const startupOutput = { columns: 2, isTTY: true, write: vi.fn() };
+  const options = { startupOutput, tools: {} };
+  try {
+    await expect(startTui(options)).rejects.toBe(failure);
+    expect(processWrite).not.toHaveBeenCalled();
+    expect(startupOutput.write).toHaveBeenCalledTimes(2);
+    expect(startupOutput.write).toHaveBeenLastCalledWith("\r\x1b[2K");
+  } finally {
+    if (tty) {
+      Object.defineProperty(process.stdout, "isTTY", tty);
+    } else {
+      Reflect.deleteProperty(process.stdout, "isTTY");
+    }
+  }
+});

--- a/apps/coding-agent/src/tui/app-startup-output.test.ts
+++ b/apps/coding-agent/src/tui/app-startup-output.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, it, vi } from "vitest";
 import { startTui } from "./app";
+import { PENDING_SPINNER_INTERVAL_MS } from "./pending-spinner";
 
 // Observe the real pre-mount renderer without constructing a terminal session.
 // Extension initialization rejects after the startup status has acquired its row.
@@ -8,9 +9,13 @@ vi.mock("../extensions/defaults", () => ({
 }));
 const { failure } = vi.hoisted(() => ({ failure: new Error("fixture") }));
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 it("clears the supplied startup stream when TUI initialization rejects", async () => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
   const tty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
   Object.defineProperty(process.stdout, "isTTY", {
     configurable: true,
@@ -21,6 +26,8 @@ it("clears the supplied startup stream when TUI initialization rejects", async (
   const options = { startupOutput, tools: {} };
   try {
     await expect(startTui(options)).rejects.toBe(failure);
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
     expect(processWrite).not.toHaveBeenCalled();
     expect(startupOutput.write).toHaveBeenCalledTimes(2);
     expect(startupOutput.write).toHaveBeenLastCalledWith("\r\x1b[2K");

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { inspect } from "node:util";
 import {
   type AgentOptions,
   type ContextUsageSnapshot,
@@ -54,6 +55,7 @@ import { type AgentTUIConfig, createAgentTUI } from "./agent";
 import type { TuiCommand } from "./command";
 import { createReloadCommand } from "./command-set";
 import { createCompactCommand } from "./compact-command";
+import { withCompactionStatus } from "./compaction-status";
 import { parseDirectStartArguments } from "./direct-start";
 import { createModelCommand } from "./model-command";
 import {
@@ -65,10 +67,13 @@ import {
 import { createToolRenderers } from "./renderers/tool-renderers";
 import { createSessionCommands } from "./session-commands";
 import { shouldReplayOnStartup } from "./session-startup-replay";
+import { showStartupStatus } from "./startup-status";
 import { formatSessionResumeHint } from "./terminal-exit";
 import { contextUsageFooter } from "./usage-footer";
 
 export interface StartTuiOptions {
+  /** Workspace for tools, context, sessions, and completion; not dotenv loading. */
+  readonly cwd?: string;
   readonly extensions?: readonly CodingAgentExtensionInput[];
   /** Overrides the language model (tests and scripted QA). */
   readonly model?: AgentOptions["model"];
@@ -123,10 +128,10 @@ async function resolveStartupSessionEntry(
     return {
       entry: {
         createdAt: at,
-        cwd: process.cwd(),
+        cwd: sessionManager.cwd,
         key: threadConfig.keyFromEnv
           ? threadConfig.key
-          : `cwd:${process.cwd()}#${randomUUID().slice(0, 8)}`,
+          : `cwd:${sessionManager.cwd}#${randomUUID().slice(0, 8)}`,
         updatedAt: at,
       },
       notice: `Session index unavailable: ${
@@ -179,7 +184,53 @@ export async function startTui(
   options: StartTuiOptions = {},
   dependencies: StartTuiDependencies = { createTui: createAgentTUI }
 ): Promise<number> {
-  const resolvedThreadConfig = resolveCodingAgentThreadConfig();
+  const stopStatus = showStartupStatus();
+  let currentSessionKey: (() => string) | undefined;
+  try {
+    return await startTuiSession(
+      options,
+      {
+        createTui: (config) => {
+          stopStatus();
+          return dependencies.createTui(config);
+        },
+      },
+      (getKey) => {
+        currentSessionKey = getKey;
+      }
+    );
+  } catch (error) {
+    if (currentSessionKey === undefined) {
+      throw error;
+    }
+    stopStatus();
+    console.error("TUI session failed:", inspect(error, { depth: null }));
+    return 1;
+  } finally {
+    stopStatus();
+    if (currentSessionKey !== undefined) {
+      // Teardown reclaimed the composer border's row. Restore it in place
+      // (or below shutdown logs), without adding a blank row or second rule.
+      // No owned shutdown work or logging follows this block.
+      process.stdout.write(
+        `${"─".repeat(process.stdout.columns ?? 80)}\n${formatSessionResumeHint(currentSessionKey())}\n`
+      );
+    }
+  }
+}
+
+async function startTuiSession(
+  options: StartTuiOptions,
+  dependencies: StartTuiDependencies,
+  onSessionReady: (currentSessionKey: () => string) => void
+): Promise<number> {
+  const { cwd = process.cwd() } = options;
+  const resolvedThreadConfig = resolveCodingAgentThreadConfig(process.env, cwd);
+  let activityUi: CodingAgentExtensionUi | undefined;
+  const tuiCompaction = withCompactionStatus(
+    resolvedThreadConfig.compaction,
+    () => activityUi?.status("Compacting session context...")
+  );
   const providerEmitter: ProviderObservationEmitter = {};
   let model: AgentOptions["model"];
   let modelSession: CodingModelSession | undefined;
@@ -197,13 +248,13 @@ export async function startTui(
   let contextResources: ContextResources;
   try {
     contextResources = await loadContextResources({
-      cwd: process.cwd(),
+      cwd,
       home: homedir(),
       resourceRoots: extensionHost.resourceRoots,
     });
     ({ model, modelSession } = resolveTuiModel(options.model, providerEmitter));
     agent = await createCodingAgent({
-      compaction: resolvedThreadConfig.compaction,
+      compaction: tuiCompaction,
       extensionHost,
       host: createFileHost({ directory: resolvedThreadConfig.directory }),
       instructions: composeCodingAgentInstructions(
@@ -211,7 +262,7 @@ export async function startTui(
       ),
       model,
       tools: options.tools,
-      workspace: process.cwd(),
+      workspace: cwd,
     });
   } catch (error) {
     await extensionHost.dispose();
@@ -222,9 +273,10 @@ export async function startTui(
     throw error;
   }
   let exitCode = 0;
+  const cleanupFailures: unknown[] = [];
   try {
     const sessionManager = createSessionManager({
-      cwd: process.cwd(),
+      cwd,
       directory: resolvedThreadConfig.directory,
       threads: createFileHost({ directory: resolvedThreadConfig.directory })
         .store.threads,
@@ -240,6 +292,7 @@ export async function startTui(
       options.sessionName
     );
     let currentSession = startupSession.entry;
+    onSessionReady(() => currentSession.key);
     const sessionIndexNotice = startupSession.notice;
     let thread = agent.thread(currentSession.key);
     let createExtensionUiForHost:
@@ -361,7 +414,7 @@ export async function startTui(
     };
 
     const buildSubtitle = (): string => {
-      const base = `${modelSubtitleLabel(modelSession)}\n${process.cwd()}`;
+      const base = `${modelSubtitleLabel(modelSession)}\n${cwd}`;
       return currentSession.name === undefined
         ? base
         : `${base}\nsession: ${currentSession.name}`;
@@ -375,7 +428,8 @@ export async function startTui(
       ].join("\n\n");
 
     const generateTitleForSession = async (
-      session: SessionIndexEntry
+      session: SessionIndexEntry,
+      signal?: AbortSignal
     ): Promise<void> => {
       if (
         session.name !== undefined ||
@@ -386,11 +440,12 @@ export async function startTui(
       titleGenerationInFlight.add(session.key);
       try {
         const title = await generateSessionTitle({
+          signal,
           history: await sessionManager.loadSessionHistory(session.key),
           instructions: currentInstructions(),
           model,
         });
-        if (title === undefined) {
+        if (title === undefined || signal?.aborted) {
           return;
         }
         const renamed = await sessionManager.renameSessionIfUnnamed(
@@ -469,6 +524,7 @@ export async function startTui(
         steer: (input) => thread.steer(input),
       },
       commands: initialCommandMerge.commands,
+      cwd,
       header,
       footer,
       ...(activeModelSession === undefined
@@ -502,7 +558,7 @@ export async function startTui(
           await switchThread(entry, "resume");
         },
       },
-      onTurnComplete: () => {
+      onTurnComplete: (_usage, _finishReason, signal) => {
         const completedSession = currentSession;
         // Keep /resume recency meaningful: every completed turn bumps the
         // session's updatedAt (best-effort; never surfaces to the user).
@@ -510,10 +566,13 @@ export async function startTui(
           sessionManager
             .touchSession(completedSession.key)
             .catch(() => undefined),
-          generateTitleForSession(completedSession).catch(() => undefined),
+          generateTitleForSession(completedSession, signal).catch(
+            () => undefined
+          ),
         ]).then(() => undefined);
       },
       onExtensionUiReady: async (createUi) => {
+        activityUi = createUi();
         createExtensionUiForHost = createUi;
         extensionUiAbort = new AbortController();
         extensionUi = createUi(extensionUiAbort.signal);
@@ -529,7 +588,10 @@ export async function startTui(
       },
       onSetup: () => {
         for (const refresh of deferredRefreshes) {
-          refresh().catch(() => undefined);
+          const clear = extensionUi?.status("Checking for updates...");
+          refresh()
+            .catch(() => undefined)
+            .finally(() => clear?.());
         }
       },
       replayHistoryOnStartup: shouldReplayOnStartup({
@@ -619,7 +681,7 @@ export async function startTui(
 
     const createReplacementAgent = (host: CodingAgentExtensionHost) =>
       createCodingAgent({
-        compaction: threadConfig.compaction,
+        compaction: tuiCompaction,
         extensionHost: host,
         host: createFileHost({ directory: threadConfig.directory }),
         instructions: composeCodingAgentInstructions(
@@ -627,7 +689,7 @@ export async function startTui(
         ),
         model,
         tools: options.tools,
-        workspace: process.cwd(),
+        workspace: cwd,
       });
 
     const installRuntime = (
@@ -686,7 +748,7 @@ export async function startTui(
             // reload restores the previous resources with the previous
             // runtime.
             contextResources = await loadContextResources({
-              cwd: process.cwd(),
+              cwd,
               home: homedir(),
               resourceRoots: host.resourceRoots,
             });
@@ -824,10 +886,13 @@ export async function startTui(
     try {
       await dependencies.createTui(tuiConfig);
     } finally {
-      process.stdout.write(`${formatSessionResumeHint(currentSession.key)}\n`);
       emitSessionEvent("host:session-shutdown", { key: currentSession.key });
       thread.interrupt();
-      await thread.dispose().catch(() => undefined);
+      await collectCleanupFailure(
+        () => thread.dispose(),
+        cleanupFailures,
+        extensionHost.timeoutMs
+      );
     }
 
     if (autoUpdate !== undefined) {
@@ -837,22 +902,42 @@ export async function startTui(
       });
     }
   } finally {
-    const cleanupFailures: unknown[] = [];
     for (const cleanup of [
       () => agent.dispose(),
       () => extensionHost.dispose(),
     ]) {
-      try {
-        await cleanup();
-      } catch (error) {
-        cleanupFailures.push(error);
-      }
+      await collectCleanupFailure(
+        cleanup,
+        cleanupFailures,
+        extensionHost.timeoutMs
+      );
     }
     if (cleanupFailures.length > 0) {
+      await collectCleanupFailure(
+        () => extensionHost.revokeExtensionState(),
+        cleanupFailures,
+        extensionHost.timeoutMs
+      );
       exitCode = 1;
+      console.error(
+        "TUI cleanup failed:",
+        inspect(cleanupFailures, { depth: null })
+      );
     }
   }
   return exitCode;
+}
+
+async function collectCleanupFailure(
+  cleanup: () => Promise<void>,
+  failures: unknown[],
+  timeoutMs: number
+): Promise<void> {
+  try {
+    await boundedReloadOperation(cleanup(), timeoutMs, "TUI shutdown");
+  } catch (error) {
+    failures.push(error);
+  }
 }
 
 export function mergeToolRenderers(

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -524,6 +524,7 @@ async function startTuiSession(
         steer: (input) => thread.steer(input),
       },
       commands: initialCommandMerge.commands,
+      currentSession: () => currentSession,
       cwd,
       header,
       footer,

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -67,7 +67,7 @@ import {
 import { createToolRenderers } from "./renderers/tool-renderers";
 import { createSessionCommands } from "./session-commands";
 import { shouldReplayOnStartup } from "./session-startup-replay";
-import { showStartupStatus } from "./startup-status";
+import { type StartupStatusOutput, showStartupStatus } from "./startup-status";
 import { formatSessionResumeHint } from "./terminal-exit";
 import { contextUsageFooter } from "./usage-footer";
 
@@ -82,6 +82,8 @@ export interface StartTuiOptions {
   readonly sessionKey?: string;
   /** Display name recorded for the startup session (`--name`). */
   readonly sessionName?: string;
+  /** Pre-mount status output only; pi-tui owns the interactive terminal. */
+  readonly startupOutput?: StartupStatusOutput;
   /** Replaces the TUI's default optional OpenSearch tools. */
   readonly tools?: ToolSet;
 }
@@ -184,7 +186,7 @@ export async function startTui(
   options: StartTuiOptions = {},
   dependencies: StartTuiDependencies = { createTui: createAgentTUI }
 ): Promise<number> {
-  const stopStatus = showStartupStatus();
+  const stopStatus = showStartupStatus(options.startupOutput);
   let currentSessionKey: (() => string) | undefined;
   try {
     return await startTuiSession(

--- a/apps/coding-agent/src/tui/assistant-renderer.ts
+++ b/apps/coding-agent/src/tui/assistant-renderer.ts
@@ -1,10 +1,15 @@
+import type { Component, MarkdownTheme } from "@earendil-works/pi-tui";
+
 import {
-  type Component,
-  Markdown,
-  type MarkdownTheme,
-} from "@earendil-works/pi-tui";
+  type ColdContent,
+  captureComponent,
+  hasGraphics,
+} from "./cold-content";
+import { SnapshotMarkdown as Markdown } from "./snapshot-views";
 
 export interface AssistantTextView extends Component {
+  /** Synchronous immutable presentation data; omitted views are fixed-size captures. */
+  captureCold?(width: number): ColdContent;
   dispose?(): void;
   setText(text: string): void;
 }
@@ -55,6 +60,7 @@ export const composeAssistantRenderers = (
         return createView(index - 1, notifyOutward);
       }
       let self: AssistantTextView | undefined;
+      const delegates = new Set<AssistantTextView>();
       // An async inner render (image ready) must drop every outer cached
       // frame before the TUI repaints, or the update never becomes visible.
       const requestRender = (): void => {
@@ -66,12 +72,43 @@ export const composeAssistantRenderers = (
         delegate: (text) => {
           const inner = createView(index - 1, requestRender);
           inner.setText(text);
+          delegates.add(inner);
           return inner;
         },
         requestRender,
       });
       self = view;
-      return view;
+      return {
+        setText(text) {
+          delegates.clear();
+          view.setText(text);
+        },
+        render: (width) => view.render(width),
+        invalidate: () => view.invalidate(),
+        dispose: () => view.dispose?.(),
+        captureCold(width) {
+          if (view.captureCold) {
+            return view.captureCold(width);
+          }
+          const rows = view.render(width);
+          // A transparent fallback already rendered an inner source view. Use
+          // that exact committed presentation, never reconstruct its raw input.
+          for (const delegate of delegates) {
+            const innerRows = delegate.render(width);
+            if (
+              rows.length === innerRows.length &&
+              rows.every((row, i) => row === innerRows[i])
+            ) {
+              return captureComponent(delegate, width);
+            }
+          }
+          return {
+            kind: "fixed",
+            rows: [...rows],
+            reason: hasGraphics(rows) ? "graphics" : "opaque-renderer",
+          };
+        },
+      };
     };
     return createView(renderers.length - 1, context.requestRender);
   };

--- a/apps/coding-agent/src/tui/body-viewport.test.ts
+++ b/apps/coding-agent/src/tui/body-viewport.test.ts
@@ -1,0 +1,207 @@
+import {
+  getOsc8LinkAtColumn,
+  type MarkdownTheme,
+  stripTerminalSequences,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { AssistantStreamView } from "./stream-views";
+import { BaseToolCallView } from "./tool-call-view";
+
+const identity = (text: string): string => text;
+const theme: MarkdownTheme = {
+  heading: identity,
+  link: identity,
+  linkUrl: identity,
+  code: identity,
+  codeBlock: identity,
+  codeBlockBorder: identity,
+  quote: identity,
+  quoteBorder: identity,
+  hr: identity,
+  listBullet: identity,
+  bold: identity,
+  italic: identity,
+  strikethrough: identity,
+  underline: identity,
+};
+const source = (count: number): string =>
+  Array.from(
+    { length: count },
+    (_, i) => `ROW_${String(i + 1).padStart(2, "0")}`
+  ).join("\n");
+const plain = (rows: string[]): string[] => rows.map(stripTerminalSequences);
+
+describe("auto-following body rows", () => {
+  it.each([0, 1, 8, 9, 30])(
+    "bounds %i pretty rows and follows the tail",
+    (count) => {
+      const view = new BaseToolCallView("call", "custom", theme);
+      view.setPrettyBlock("HEADER", source(count));
+      const rows = plain(view.render(100));
+      expect(rows).toHaveLength(count === 0 ? 1 : 2 + Math.min(8, count));
+      if (count > 0) {
+        expect(rows.at(-1)).toContain(`ROW_${String(count).padStart(2, "0")}`);
+      }
+      if (count > 8) {
+        expect(rows.join("\n")).not.toContain("ROW_01");
+      }
+      view.dispose();
+    }
+  );
+
+  it.each([9, 30])("bounds %i reasoning rows", (count) => {
+    const view = new AssistantStreamView(theme);
+    view.appendReasoning(source(count));
+    const rows = plain(view.render(100));
+    expect(rows.length).toBeLessThanOrEqual(8);
+    expect(rows.join("\n")).toContain(`ROW_${String(count).padStart(2, "0")}`);
+    expect(rows.join("\n")).not.toContain("ROW_01");
+    view.dispose();
+  });
+
+  it("follows text after reasoning without accumulating segment budgets", () => {
+    const view = new AssistantStreamView(theme);
+    view.appendReasoning(source(30));
+    view.appendText(source(30).replaceAll("ROW", "TEXT"));
+    expect(view.render(48)).toHaveLength(8);
+    expect(plain(view.render(48)).join("\n")).toContain("TEXT_30");
+    expect(plain(view.render(48)).join("\n")).not.toContain("ROW_");
+    expect(view).toMatchObject({
+      segments: [
+        { content: source(30) },
+        { content: source(30).replaceAll("ROW", "TEXT") },
+      ],
+    });
+    view.dispose();
+  });
+
+  it("shows the latest suffix beyond the ninth wrapped input row", () => {
+    const view = new BaseToolCallView("call", "custom", theme);
+    view.setPrettyBlock("HEADER", `${"x".repeat(48 * 30)}LATEST_TAIL`);
+    expect(plain(view.render(48)).join("")).toContain("LATEST_TAIL");
+    view.dispose();
+  });
+
+  it("wraps a single long line before following, including after resize", () => {
+    const view = new BaseToolCallView("call", "custom", theme);
+    const body = `${"漢字😀é".repeat(150)}TAIL`;
+    view.setPrettyBlock("HEADER", body);
+    for (const width of [100, 48, 12, 100]) {
+      const rows = view.render(width);
+      expect(rows).toHaveLength(10);
+      expect(rows.every((row) => visibleWidth(row) <= width)).toBe(true);
+      expect(plain(rows).join("")).toContain("TAIL");
+    }
+    expect(view).toMatchObject({ readBody: { text: body } });
+    view.dispose();
+  });
+
+  it.each([false, true])(
+    "keeps streamed input and final result/error bounded (raw=%s)",
+    async (raw) => {
+      const view = new BaseToolCallView(
+        "call",
+        "write_file",
+        theme,
+        undefined,
+        raw
+      );
+      const input = { path: "sample", content: source(30) };
+      const json = JSON.stringify(input);
+      await view.appendInputChunk(json);
+      expect(view.render(48).length).toBeLessThanOrEqual(raw ? 12 : 10);
+      view.setFinalInput(input);
+      view.setOutput(source(30));
+      expect(view.render(48).length).toBeLessThanOrEqual(24);
+      expect(plain(view.render(48)).join("\n")).toContain("ROW_30");
+      view.setError(source(30).replaceAll("ROW", "ERR"));
+      expect(view.render(48).length).toBeLessThanOrEqual(36);
+      expect(plain(view.render(48)).join("\n")).toContain("ERR_30");
+      expect(view).toMatchObject({
+        inputBuffer: json,
+        finalInput: input,
+        output: source(30),
+      });
+      expect(view.getError()).toBe(source(30).replaceAll("ROW", "ERR"));
+      view.dispose();
+    }
+  );
+
+  it("retains ANSI styling from rows above the viewport", () => {
+    const view = new BaseToolCallView("call", "custom", theme);
+    view.setPrettyBlock("HEADER", `\x1b[31m${source(30)}\x1b[0m`, {
+      allowAnsi: true,
+      useBackground: false,
+    });
+    const body = view.render(100).slice(2);
+    expect(body).toHaveLength(8);
+    expect(body[0]).toContain("\x1b[31m");
+    expect(plain(body)[0]).toContain("ROW_23");
+    view.dispose();
+  });
+
+  it.each([
+    "\x1b_Ga=T,f=100;AAAA\x1b\\",
+    "\x1b]1337;File=inline=1:AAAA\x07",
+    "\x1bPqAAAA\x1b\\",
+  ])("preserves atomic graphical renderer output %s", (transmission) => {
+    const rows = [transmission, ...Array.from({ length: 12 }, () => "")];
+    const view = new AssistantStreamView(theme, {
+      assistantRenderer: () => ({
+        invalidate: () => undefined,
+        setText: () => undefined,
+        render: () => rows,
+      }),
+    });
+    view.appendText("image source");
+    expect(view.render(48)).toEqual(rows);
+    view.dispose();
+  });
+
+  it("preserves inherited OSC8 links in the tail", () => {
+    const view = new BaseToolCallView("call", "custom", theme);
+    view.setPrettyBlock(
+      "HEADER",
+      `\x1b]8;;https://example.test\x07${source(30)}\x1b]8;;\x07`,
+      { allowAnsi: true, useBackground: false }
+    );
+    expect(getOsc8LinkAtColumn(view.render(48)[2] ?? "", 1)).toBe(
+      "https://example.test"
+    );
+    view.dispose();
+  });
+
+  it("keeps simultaneous tools independent and preserves input on abort", async () => {
+    const first = new BaseToolCallView("one", "write_file", theme);
+    const second = new BaseToolCallView("two", "write_file", theme);
+    const firstInput = JSON.stringify({ content: source(30) });
+    await first.appendInputChunk(firstInput);
+    await second.appendInputChunk(
+      JSON.stringify({ content: source(9).replaceAll("ROW", "OTHER") })
+    );
+    first.dispose();
+    expect(first).toMatchObject({ inputBuffer: firstInput, output: undefined });
+    expect(first.render(48)).toHaveLength(10);
+    expect(plain(first.render(48)).join("\n")).toContain("ROW_30");
+    expect(plain(second.render(48)).join("\n")).toContain("OTHER_09");
+    second.dispose();
+  });
+
+  it("bounds custom Markdown overrides and preserves code fences in source", () => {
+    const markdown = `\`\`\`ts\n${source(30)}\n\`\`\``;
+    const view = new BaseToolCallView(
+      "call",
+      "custom",
+      theme,
+      undefined,
+      false,
+      { custom: (target) => target.setRenderedOverride(markdown) }
+    );
+    view.setOutput("result");
+    expect(view.render(48)).toHaveLength(8);
+    expect(plain(view.render(48)).join("\n")).toContain("ROW_30");
+    expect(view).toMatchObject({ renderedOverride: markdown });
+    view.dispose();
+  });
+});

--- a/apps/coding-agent/src/tui/body-viewport.ts
+++ b/apps/coding-agent/src/tui/body-viewport.ts
@@ -4,6 +4,12 @@ import {
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 
+import {
+  type ColdContent,
+  captureComponent,
+  selectColdTail,
+} from "./cold-content";
+
 const BODY_ROWS = 8;
 
 /** Render-only tail window; never shorten the component's underlying source. */
@@ -33,6 +39,14 @@ export class BodyViewport implements Component {
 
   constructor(child: Component) {
     this.child = child;
+  }
+
+  captureCold(width: number): ColdContent {
+    return selectColdTail(
+      captureComponent(this.child, width),
+      width,
+      BODY_ROWS
+    );
   }
 
   invalidate(): void {

--- a/apps/coding-agent/src/tui/body-viewport.ts
+++ b/apps/coding-agent/src/tui/body-viewport.ts
@@ -1,0 +1,45 @@
+import {
+  type Component,
+  truncateToWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+
+const BODY_ROWS = 8;
+
+/** Render-only tail window; never shorten the component's underlying source. */
+export const renderBodyTail = (lines: string[], width: number): string[] => {
+  // Graphics transmissions and their reserved rows are atomic. The text viewport
+  // does not support clipping Kitty, iTerm2, or DCS (including sixel) graphics.
+  if (
+    lines.some(
+      (line) =>
+        line.includes("\x1b_G") ||
+        line.includes("\x1b]1337;File=") ||
+        line.includes("\x1bP")
+    )
+  ) {
+    return lines;
+  }
+  if (lines.length === 0) {
+    return [];
+  }
+  return wrapTextWithAnsi(lines.join("\n"), Math.max(1, width))
+    .slice(-BODY_ROWS)
+    .map((line) => truncateToWidth(line, width, ""));
+};
+
+export class BodyViewport implements Component {
+  private readonly child: Component;
+
+  constructor(child: Component) {
+    this.child = child;
+  }
+
+  invalidate(): void {
+    this.child.invalidate();
+  }
+
+  render(width: number): string[] {
+    return renderBodyTail(this.child.render(width), width);
+  }
+}

--- a/apps/coding-agent/src/tui/busy-status.test.ts
+++ b/apps/coding-agent/src/tui/busy-status.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { BusyStatus } from "./busy-status";
+
+describe("BusyStatus contextual ownership", () => {
+  it.each(["settled", "disposed"] as const)(
+    "does not expose a %s owner to a detached callback",
+    async (lifecycle) => {
+      const render = vi.fn();
+      const busy = new BusyStatus(render);
+      let release!: () => void;
+      const released = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      let detached!: Promise<string | undefined>;
+      await busy.run("owner", () => {
+        expect(busy.getMessage()).toBe("owner");
+        detached = released.then(() => {
+          busy.setMessage("detached");
+          return busy.getMessage();
+        });
+        if (lifecycle === "disposed") {
+          busy.dispose();
+        }
+      });
+      render.mockClear();
+      release();
+      expect(await detached).toBeUndefined();
+      expect(render).not.toHaveBeenCalled();
+    }
+  );
+
+  it("restores the live parent context after a nested operation", async () => {
+    const busy = new BusyStatus(vi.fn());
+    await busy.run("parent", async () => {
+      await busy.run("child", () => {
+        busy.setMessage("updated");
+        expect(busy.getMessage()).toBe("updated");
+      });
+      expect(busy.getMessage()).toBe("parent");
+    });
+    expect(busy.getMessage()).toBeUndefined();
+    busy.dispose();
+    await busy.run("after-disposal", () => {
+      expect(busy.getMessage()).toBeUndefined();
+    });
+  });
+});

--- a/apps/coding-agent/src/tui/busy-status.ts
+++ b/apps/coding-agent/src/tui/busy-status.ts
@@ -1,0 +1,98 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface BusyEntry {
+  base: string;
+  message: string;
+  suspended: number;
+}
+
+/** Operation lifetimes own visibility; streaming events only change labels. */
+export class BusyStatus {
+  private readonly context = new AsyncLocalStorage<readonly BusyEntry[]>();
+  private readonly entries = new Set<BusyEntry>();
+  private disposed = false;
+
+  private readonly render: (message: string | null) => void;
+
+  constructor(render: (message: string | null) => void) {
+    this.render = render;
+  }
+
+  private publish(): void {
+    if (this.disposed) {
+      return;
+    }
+    const visible = [...this.entries].filter((entry) => entry.suspended === 0);
+    this.render(visible.at(-1)?.message ?? null);
+  }
+
+  async run<T>(message: string, operation: () => T | Promise<T>): Promise<T> {
+    const entry = { base: message, message, suspended: 0 };
+    if (!this.disposed) {
+      this.entries.add(entry);
+    }
+    this.publish();
+    try {
+      return await this.context.run(
+        [...(this.context.getStore() ?? []), entry],
+        operation
+      );
+    } finally {
+      this.entries.delete(entry);
+      this.publish();
+    }
+  }
+
+  /** An extension status is an independent lease, not a global clear switch. */
+  status(message: string): () => void {
+    const entry = { base: message, message, suspended: 0 };
+    if (!this.disposed) {
+      this.entries.add(entry);
+    }
+    this.publish();
+    return () => {
+      this.entries.delete(entry);
+      this.publish();
+    };
+  }
+
+  setMessage(message: string | null): void {
+    const entry = this.context.getStore()?.at(-1);
+    if (entry && this.entries.has(entry)) {
+      entry.message = message ?? entry.base;
+      this.publish();
+    }
+  }
+
+  getMessage(): string | undefined {
+    return this.context.getStore()?.at(-1)?.message;
+  }
+
+  /** Suspend only the calling operation chain, never independent background work. */
+  suspend(): () => void {
+    const entries = this.context.getStore() ?? [];
+    for (const entry of entries) {
+      entry.suspended += 1;
+    }
+    this.publish();
+    let resumed = false;
+    return () => {
+      if (resumed) {
+        return;
+      }
+      resumed = true;
+      for (const entry of entries) {
+        entry.suspended -= 1;
+      }
+      this.publish();
+    };
+  }
+
+  dispose(): void {
+    this.entries.clear();
+    this.render(null);
+    this.disposed = true;
+    // Keep async context available for detached callbacks, which must remain
+    // inert rather than acquiring a fresh owner after terminal teardown.
+  }
+}

--- a/apps/coding-agent/src/tui/busy-status.ts
+++ b/apps/coding-agent/src/tui/busy-status.ts
@@ -65,7 +65,8 @@ export class BusyStatus {
   }
 
   getMessage(): string | undefined {
-    return this.context.getStore()?.at(-1)?.message;
+    const entry = this.context.getStore()?.at(-1);
+    return entry && this.entries.has(entry) ? entry.message : undefined;
   }
 
   /** Suspend only the calling operation chain, never independent background work. */

--- a/apps/coding-agent/src/tui/cold-content.ts
+++ b/apps/coding-agent/src/tui/cold-content.ts
@@ -1,0 +1,355 @@
+import {
+  type Component,
+  Container,
+  Markdown,
+  type MarkdownTheme,
+  Spacer,
+  stripTerminalSequences,
+  Text,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+
+import {
+  type ColdTable,
+  renderColdTable,
+  selectMarkdownTables,
+} from "./cold-table";
+
+const HARD_BREAK = /\r\n|\r|\n/;
+
+/** Renderer-free values. A snapshot must describe the presentation, not new input. */
+export type ColdContent =
+  | ColdTable
+  | { readonly kind: "group"; readonly children: readonly ColdContent[] }
+  | { readonly kind: "spacer"; readonly rows: number }
+  | {
+      readonly kind: "text";
+      readonly text: string;
+      readonly paddingX: number;
+      readonly paddingY: number;
+      readonly background?: ColdStyle;
+    }
+  | {
+      readonly kind: "markdown";
+      readonly text: string;
+      readonly paddingX: number;
+      readonly paddingY: number;
+      readonly theme: ColdTheme;
+      readonly defaultStyle?: ColdTextStyle;
+      readonly trimEnd?: boolean;
+    }
+  | {
+      readonly kind: "fixed";
+      readonly rows: readonly string[];
+      readonly reason: "graphics" | "opaque-renderer";
+    }
+  | {
+      readonly kind: "selected";
+      readonly content: ColdContent;
+      readonly width: number;
+      readonly rows: readonly string[];
+    };
+
+export interface ColdCapture {
+  /** Called once at handoff. Return data only; no callbacks, views or producers. */
+  captureCold(width: number): ColdContent;
+}
+
+export interface ColdStyle {
+  readonly after: string;
+  readonly before: string;
+}
+type StyleKey = Exclude<
+  keyof MarkdownTheme,
+  "highlightCode" | "codeBlockIndent"
+>;
+export type ColdTheme = Readonly<Record<StyleKey, ColdStyle>> & {
+  readonly codeBlockIndent?: string;
+  readonly highlighted?: Readonly<Record<string, readonly string[]>>;
+};
+export interface ColdTextStyle {
+  readonly bgColor?: ColdStyle;
+  readonly bold?: boolean;
+  readonly color?: ColdStyle;
+  readonly italic?: boolean;
+  readonly strikethrough?: boolean;
+  readonly underline?: boolean;
+}
+
+export const hasGraphics = (lines: readonly string[]): boolean =>
+  lines.some(
+    (line) =>
+      line.includes("\x1b_G") ||
+      line.includes("\x1b]1337;File=") ||
+      line.includes("\x1bP")
+  );
+
+export const captureComponent = (
+  component: Component,
+  width: number
+): ColdContent => {
+  if (
+    "captureCold" in component &&
+    typeof component.captureCold === "function"
+  ) {
+    return component.captureCold(width);
+  }
+  if (component instanceof Spacer) {
+    return { kind: "spacer", rows: component.render(width).length };
+  }
+  if (component instanceof Container) {
+    return {
+      kind: "group",
+      children: component.children.map((child) =>
+        captureComponent(child, width)
+      ),
+    };
+  }
+  const rows = component.render(width);
+  return {
+    kind: "fixed",
+    rows: [...rows],
+    reason: hasGraphics(rows) ? "graphics" : "opaque-renderer",
+  };
+};
+
+export const captureStyle = (style: (text: string) => string): ColdStyle => {
+  const marker = "\u0000";
+  const styled = style(marker);
+  const index = styled.indexOf(marker);
+  // A non-wrapper theme is detected by the presentation equality check at capture.
+  return index < 0
+    ? { before: styled, after: "" }
+    : { before: styled.slice(0, index), after: styled.slice(index + 1) };
+};
+const styleFunction =
+  (style: ColdStyle) =>
+  (text: string): string =>
+    `${style.before}${text}${style.after}`;
+export const restoreTheme = (theme: ColdTheme): MarkdownTheme => {
+  const { highlighted, codeBlockIndent, ...styles } = theme;
+  return {
+    ...(Object.fromEntries(
+      Object.entries(styles).map(([key, value]) => [key, styleFunction(value)])
+    ) as Record<StyleKey, (text: string) => string>),
+    codeBlockIndent,
+    ...(highlighted
+      ? {
+          highlightCode: (code: string, language?: string) => {
+            const rows = highlighted[JSON.stringify([code, language])];
+            if (!rows) {
+              throw new Error("Uncaptured COLD code highlighting");
+            }
+            return [...rows];
+          },
+        }
+      : {}),
+  };
+};
+
+export const renderColdContent = (
+  content: ColdContent,
+  width: number
+): string[] => {
+  switch (content.kind) {
+    case "group":
+      return content.children.flatMap((child) =>
+        renderColdContent(child, width)
+      );
+    case "spacer":
+      return Array.from({ length: content.rows }, () => "");
+    case "table":
+      return renderColdTable(content, width);
+    case "fixed":
+      return content.reason === "graphics"
+        ? [...content.rows]
+        : content.rows.flatMap((row) => wrapTextWithAnsi(row, width));
+    case "selected":
+      return width === content.width
+        ? [...content.rows]
+        : renderColdContent(content.content, width);
+    case "text":
+      return new Text(
+        content.text,
+        content.paddingX,
+        content.paddingY,
+        content.background && styleFunction(content.background)
+      ).render(width);
+    case "markdown": {
+      const { color, bgColor, ...flags } = content.defaultStyle ?? {};
+      const style = content.defaultStyle && {
+        ...flags,
+        color: color && styleFunction(color),
+        bgColor: bgColor && styleFunction(bgColor),
+      };
+      const rows = new Markdown(
+        content.text,
+        content.paddingX,
+        content.paddingY,
+        restoreTheme(content.theme),
+        style
+      ).render(width);
+      if (content.trimEnd) {
+        while (rows.length && !rows.at(-1)?.trim()) {
+          rows.pop();
+        }
+      }
+      return rows;
+    }
+    default: {
+      const unsupported: never = content;
+      throw new Error(`Unsupported COLD content: ${String(unsupported)}`);
+    }
+  }
+};
+
+export const preservePresentation = (
+  content: ColdContent,
+  rows: string[],
+  width: number
+): ColdContent => {
+  const captured = renderColdContent(content, width);
+  return captured.length === rows.length &&
+    captured.every((row, i) => row === rows[i])
+    ? content
+    : {
+        kind: "fixed",
+        rows: [...rows],
+        reason: hasGraphics(rows) ? "graphics" : "opaque-renderer",
+      };
+};
+
+/** Select once from logical text, retaining the hard/soft break distinction. */
+export const selectTextTail = (
+  content: Extract<ColdContent, { kind: "text" }>,
+  width: number,
+  count: number
+): ColdContent => {
+  const padding = Math.min(
+    content.paddingX,
+    Math.max(0, Math.floor((width - 1) / 2))
+  );
+  const available = Math.max(1, width - padding * 2);
+  const text = content.text.replace(/\t/g, "   ");
+  const wrapped = wrapTextWithAnsi(text, available);
+  if (wrapped.length <= count) {
+    return content;
+  }
+  const discarded = wrapped.length - count;
+  // Re-wrap logical lines separately only to locate the selected boundary. The
+  // actual suffix comes from the ANSI-aware full wrap, including inherited SGR/OSC8.
+  let row = 0;
+  let lineIndex = 0;
+  const logical = text.split(HARD_BREAK);
+  for (; lineIndex < logical.length; lineIndex += 1) {
+    const length = wrapTextWithAnsi(logical[lineIndex], available).length;
+    if (row + length > discarded) {
+      break;
+    }
+    row += length;
+  }
+  const end = row + wrapTextWithAnsi(logical[lineIndex], available).length;
+  const fragments = wrapped.slice(row, end);
+  // wrapTextWithAnsi consumes whitespace at word boundaries. Keep those soft
+  // separators, but do not insert spaces into split long words/CJK graphemes.
+  const source = stripLayout(logical[lineIndex]);
+  let offset = 0;
+  let suffix = "";
+  for (const [index, fragment] of fragments.entries()) {
+    const plain = stripLayout(fragment);
+    const start = source.indexOf(plain, offset);
+    if (row + index >= discarded) {
+      const separator =
+        suffix && start > offset ? source.slice(offset, start) : "";
+      suffix += separator + fragment;
+    }
+    offset = start < 0 ? offset : start + plain.length;
+  }
+  const remaining = wrapped.slice(end);
+  // Use each following true source newline; carry ANSI state from the wrapped
+  // first row, while retaining the following unwrapped logical line content.
+  const following = logical.slice(lineIndex + 1);
+  if (following.length && remaining.length) {
+    suffix += `\n${following.join("\n")}`;
+  }
+  return {
+    kind: "selected",
+    width,
+    rows: renderColdContent(content, width).slice(-count),
+    content: { ...content, text: suffix, paddingY: 0 },
+  };
+};
+
+// Only used to locate text within its known logical source, never to recover Markdown.
+const stripLayout = (text: string): string => stripTerminalSequences(text);
+
+/** Tail capture for source-backed Markdown uses its unwrapped styled logical lines.
+ * Full Markdown keeps its source and table/code layout; no ANSI-to-Markdown recovery.
+ */
+export const selectColdTail = (
+  content: ColdContent,
+  width: number,
+  count = 8
+): ColdContent => {
+  const rows = renderColdContent(content, width);
+  if (rows.length <= count || hasGraphics(rows)) {
+    return content;
+  }
+  if (content.kind === "spacer") {
+    return { ...content, rows: count };
+  }
+  if (content.kind === "text") {
+    return selectTextTail(content, width, count);
+  }
+  if (content.kind === "group") {
+    let remaining = count;
+    const children: ColdContent[] = [];
+    for (const child of [...content.children].reverse()) {
+      if (remaining <= 0) {
+        break;
+      }
+      const size = renderColdContent(child, width).length;
+      children.unshift(selectColdTail(child, width, remaining));
+      remaining -= size;
+    }
+    return { kind: "group", children };
+  }
+  if (content.kind === "markdown") {
+    const naturalWidth = content.text
+      .split(HARD_BREAK)
+      .reduce(
+        (maximum, line) =>
+          Math.max(maximum, visibleWidth(line.replaceAll("\t", "   ")) + 16),
+        width
+      );
+    const logical = renderColdContent(
+      { ...content, paddingX: 0, paddingY: 0 },
+      naturalWidth
+    ).map((line) => line.trimEnd());
+    const tableSelection = selectMarkdownTables(
+      logical,
+      rows,
+      width,
+      count,
+      content.paddingX
+    );
+    if (tableSelection) {
+      return tableSelection;
+    }
+    const flow: Extract<ColdContent, { kind: "text" }> = {
+      kind: "text",
+      text: logical.join("\n"),
+      paddingX: content.paddingX,
+      paddingY: 0,
+      background: content.defaultStyle?.bgColor,
+    };
+    return {
+      kind: "selected",
+      width,
+      rows: rows.slice(-count),
+      content: selectTextTail(flow, width, count),
+    };
+  }
+  return { kind: "fixed", rows: rows.slice(-count), reason: "opaque-renderer" };
+};

--- a/apps/coding-agent/src/tui/cold-content.ts
+++ b/apps/coding-agent/src/tui/cold-content.ts
@@ -98,7 +98,12 @@ export const captureComponent = (
   if (component instanceof Spacer) {
     return { kind: "spacer", rows: component.render(width).length };
   }
-  if (component instanceof Container) {
+  // Only inherited Container layout is transparent. Custom render overrides
+  // without an explicit capture contract must keep their real rendered frame.
+  if (
+    component instanceof Container &&
+    component.render === Container.prototype.render
+  ) {
     return {
       kind: "group",
       children: component.children.map((child) =>

--- a/apps/coding-agent/src/tui/cold-resize.test.ts
+++ b/apps/coding-agent/src/tui/cold-resize.test.ts
@@ -1,0 +1,273 @@
+import {
+  getOsc8LinkAtColumn,
+  Markdown,
+  type MarkdownTheme,
+  stripTerminalSequences,
+  Text,
+} from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { composeAssistantRenderers } from "./assistant-renderer";
+import { SnapshotMarkdown, SnapshotText } from "./snapshot-views";
+import { AssistantStreamView } from "./stream-views";
+import { BaseToolCallView } from "./tool-call-view";
+import { ColdSnapshot, TranscriptOwner } from "./transcript-owner";
+
+const identity = (text: string) => text;
+const theme: MarkdownTheme = {
+  heading: identity,
+  link: identity,
+  linkUrl: identity,
+  code: identity,
+  codeBlock: identity,
+  codeBlockBorder: identity,
+  quote: identity,
+  quoteBorder: identity,
+  hr: identity,
+  listBullet: identity,
+  bold: identity,
+  italic: identity,
+  strikethrough: identity,
+  underline: identity,
+};
+const paragraph = Array.from({ length: 40 }, (_, i) => `word${i}`).join(" ");
+const plain = (rows: string[]) =>
+  rows.map(stripTerminalSequences).map((row) => row.trimEnd());
+
+describe("COLD resize layout", () => {
+  it.each([
+    paragraph,
+    `${paragraph}\nHARD_BREAK\n\nAFTER_BLANK`,
+    "| Name | Description |\n| --- | --- |\n| FIRST | many words in the first table cell that wrap narrowly |\n| SECOND | second cell has a longer description too |",
+    `\`\`\`ts\nconst value = '${paragraph}';\n  secondLine();\n\`\`\``,
+    `漢字é🙂 ${paragraph} 漢字é🙂`,
+  ])("re-lays out completed Markdown from the sealed source: %s", (source) => {
+    let width = 24;
+    const owner = new TranscriptOwner(() => width);
+    const lease = owner.acquire(() => new AssistantStreamView(theme), {
+      leadingSpacer: false,
+      dispose: (view) => view.dispose(),
+    });
+    lease.view.appendText(source);
+    lease.view.completeText();
+    owner.finish(lease);
+    const original = owner.render(width);
+    for (width of [100, 48, 120, 24]) {
+      expect(owner.render(width)).toEqual(
+        new Markdown(source, 1, 0, theme).render(width)
+      );
+    }
+    expect(owner.render(width)).toEqual(original);
+  });
+
+  it("selects the pretty tool tail once, then joins its soft wraps without revealing discarded text", () => {
+    let width = 24;
+    const owner = new TranscriptOwner(() => width);
+    const lease = owner.acquire(
+      () => new BaseToolCallView("call", "test", theme),
+      { leadingSpacer: false, dispose: (view) => view.dispose() }
+    );
+    lease.view.setPrettyBlock("HEADER", `DISCARDED\n${paragraph}`, {
+      useBackground: false,
+    });
+    owner.finish(lease);
+    const original = plain(owner.render(width));
+    const selected = original.slice(2).join(" ").replace(/\s+/g, " ").trim();
+    width = 120;
+    const wide = plain(owner.render(width));
+    expect(wide.length).toBeLessThan(original.length);
+    expect(wide.slice(2).join(" ").replace(/\s+/g, " ").trim()).toBe(selected);
+    expect(wide.join("\n")).not.toContain("DISCARDED");
+    width = 24;
+    expect(plain(owner.render(width))).toEqual(original);
+  });
+
+  it.each([
+    `${paragraph}\n\nLAST\nLINE`,
+    "漢字é🙂".repeat(120),
+    `\x1b[31m${"repeat repeat ".repeat(100)}\nLAST\x1b[0m`,
+    Array.from({ length: 20 }, (_, i) => `LINE_${i}`).join("\n"),
+  ])("keeps only selected tool glyphs and inherited ANSI: %s", (source) => {
+    const owner = new TranscriptOwner(() => 24);
+    const lease = owner.acquire(
+      () => new BaseToolCallView("call", "test", theme),
+      { leadingSpacer: false, dispose: (view) => view.dispose() }
+    );
+    lease.view.setPrettyBlock("HEADER", source, {
+      allowAnsi: true,
+      useBackground: false,
+    });
+    owner.finish();
+    const snapshot = owner.children[0];
+    const glyphs = (width: number) =>
+      plain(snapshot.render(width)).join("").replace(/\s/g, "");
+    for (const width of [12, 48, 120, 24]) {
+      expect(glyphs(width)).toBe(glyphs(24));
+    }
+  });
+
+  it.each([paragraph, `\`\`\`ts\n${paragraph}\n\`\`\``])(
+    "selects reasoning and raw tool bodies only once: %s",
+    (source) => {
+      const owner = new TranscriptOwner(() => 24);
+      const lease = owner.acquire(() => new AssistantStreamView(theme), {
+        leadingSpacer: false,
+        dispose: (view) => view.dispose(),
+      });
+      lease.view.appendReasoning(source);
+      owner.finish();
+      const snapshot = owner.children[0];
+      const glyphs = (width: number) =>
+        plain(snapshot.render(width)).join("").replace(/\s/g, "");
+      for (const width of [12, 48, 120, 24]) {
+        expect(glyphs(width)).toBe(glyphs(24));
+      }
+    }
+  );
+
+  it.each([
+    "| Name | Description |\n| --- | --- |\n| FIRST | many words in the first table cell that wrap narrowly |\n| SECOND | second cell has a longer description too |",
+    `- ${paragraph}\n- ${paragraph.replaceAll("word", "item")}`,
+    `> ${paragraph}`,
+  ])(
+    "preserves selected structured Markdown tokens on resize: %s",
+    (source) => {
+      const owner = new TranscriptOwner(() => 24);
+      const lease = owner.acquire(() => new AssistantStreamView(theme), {
+        leadingSpacer: false,
+        dispose: (view) => view.dispose(),
+      });
+      lease.view.appendReasoning(source);
+      owner.finish();
+      const snapshot = owner.children[0];
+      const tokens = (width: number) =>
+        plain(snapshot.render(width))
+          .join("")
+          .match(/[A-Za-z0-9]/g)
+          ?.sort();
+      for (const width of [48, 120, 24]) {
+        expect(tokens(width)).toEqual(tokens(24));
+      }
+    }
+  );
+
+  it("uses a transparent fallback's captured transformed source", () => {
+    const renderer = composeAssistantRenderers([
+      (context) => {
+        const delegate = context.delegate;
+        if (!delegate) {
+          throw new Error("Expected a composed delegate");
+        }
+        let inner: ReturnType<typeof delegate>;
+        return {
+          setText: (text) => {
+            inner = delegate(`PREFIX ${text}`);
+          },
+          render: (width) => inner.render(width),
+          invalidate: () => inner.invalidate(),
+        };
+      },
+    ]);
+    const view = new AssistantStreamView(theme, {
+      assistantRenderer: renderer,
+    });
+    view.appendText(paragraph);
+    view.completeText();
+    const snapshot = ColdSnapshot.capture(view, 24);
+    view.dispose();
+    expect(snapshot.render(120)).toEqual(
+      new Markdown(`PREFIX ${paragraph}`, 1, 0, theme).render(120)
+    );
+  });
+
+  it("copies custom snapshot data and never re-enters an abort-ignoring renderer", () => {
+    const data = {
+      kind: "text" as const,
+      text: paragraph,
+      paddingX: 1,
+      paddingY: 0,
+    };
+    const render = vi.fn((width: number) =>
+      new Text(data.text, 1, 0).render(width)
+    );
+    const capture = vi.fn(() => data);
+    const owner = new TranscriptOwner(() => 24);
+    const lease = owner.acquire(
+      (permission) => {
+        permission.signal.addEventListener("abort", () => {
+          data.text = "LATE";
+        });
+        return { render, invalidate: vi.fn(), captureCold: capture };
+      },
+      { leadingSpacer: false }
+    );
+    owner.finish(lease);
+    const calls = render.mock.calls.length;
+    for (const width of [100, 48, 120, 24]) {
+      expect(owner.render(width)).toEqual(
+        new Text(paragraph, 1, 0).render(width)
+      );
+    }
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(calls);
+  });
+
+  it("retains selected ANSI and OSC8 styles across widths", () => {
+    const view = new BaseToolCallView("call", "test", theme);
+    view.setPrettyBlock(
+      "HEADER",
+      `\x1b]8;;https://fixture.invalid\x07\x1b[31m${paragraph.repeat(8)}\x1b[0m\x1b]8;;\x07`,
+      { allowAnsi: true, useBackground: false }
+    );
+    const snapshot = ColdSnapshot.capture(view, 24);
+    view.dispose();
+    for (const width of [12, 48, 120, 24]) {
+      const row = snapshot.render(width)[2];
+      expect(getOsc8LinkAtColumn(row, 1)).toBe("https://fixture.invalid");
+      expect(row).toContain("\x1b[31m");
+    }
+  });
+
+  it("captures highlighting once and does not retain theme callbacks", () => {
+    const highlightCode = vi.fn((code: string) =>
+      code.split("\n").map((line) => `\x1b[31m${line}\x1b[0m`)
+    );
+    const source = `\`\`\`ts\n${paragraph}\n\`\`\``;
+    const mutableTheme = { ...theme, highlightCode };
+    const view = new SnapshotMarkdown(source, 1, 0, mutableTheme);
+    const snapshot = ColdSnapshot.capture(view, 24);
+    const calls = highlightCode.mock.calls.length;
+    mutableTheme.codeBlock = () => "CHANGED_STYLE";
+    for (const width of [48, 120, 24]) {
+      expect(snapshot.render(width).join("")).toContain("\x1b[31m");
+    }
+    expect(highlightCode).toHaveBeenCalledTimes(calls);
+  });
+
+  it("preserves non-wrapper custom theme output as an explicit opaque layout", () => {
+    const view = new SnapshotMarkdown("`lower_case`", 1, 0, {
+      ...theme,
+      code: (text) => text.toUpperCase(),
+    });
+    const snapshot = ColdSnapshot.capture(view, 24);
+    const data = snapshot.captureCold();
+    expect(data.kind).toBe("selected");
+    if (data.kind !== "selected") {
+      throw new Error("Expected original-width layout cache");
+    }
+    expect(data.content).toMatchObject({
+      kind: "fixed",
+      reason: "opaque-renderer",
+    });
+    expect(plain(snapshot.render(120)).join("")).toContain("LOWER_CASE");
+  });
+
+  it("keeps genuine blank lines and hard breaks in a sealed startup-like Text", () => {
+    let width = 24;
+    const owner = new TranscriptOwner(() => width);
+    owner.addChild(new SnapshotText(`${paragraph}\nMODEL\n\nHELP`, 1, 0));
+    width = 120;
+    expect(owner.render(width)).toEqual(
+      new Text(`${paragraph}\nMODEL\n\nHELP`, 1, 0).render(width)
+    );
+  });
+});

--- a/apps/coding-agent/src/tui/cold-table.ts
+++ b/apps/coding-agent/src/tui/cold-table.ts
@@ -1,0 +1,280 @@
+import {
+  sliceByColumn,
+  stripTerminalSequences,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { type ColdContent, selectTextTail } from "./cold-content";
+
+export interface ColdTable {
+  readonly bottom: boolean;
+  readonly kind: "table";
+  readonly paddingX: number;
+  readonly rows: readonly {
+    readonly cells: readonly string[];
+    readonly before?: "top" | "separator";
+  }[];
+}
+
+const TABLE_TOP = /^┌[─┬]+┐$/;
+const TABLE_BOTTOM = /^└[─┴]+┘$/;
+const TABLE_SEPARATOR = /^├[─┼]+┤$/;
+const plain = (line: string) => stripTerminalSequences(line).trim();
+const bottom = (line: string) => TABLE_BOTTOM.test(plain(line));
+const separator = (line: string) => TABLE_SEPARATOR.test(plain(line));
+const trimCell = (line: string): string =>
+  sliceByColumn(line, 0, visibleWidth(stripTerminalSequences(line).trimEnd()));
+
+/** Decode only pi-tui's table layout, generated from a known Markdown source.
+ * Column offsets come from its border, not pipes in user text. This is a styled
+ * cell snapshot, never an attempt to recover Markdown from arbitrary ANSI rows.
+ */
+const tableCells = (
+  lines: readonly string[],
+  paddingX: number
+): { cells: string[][]; heights: number[] } => {
+  const border = plain(lines[0]);
+  const widths = border
+    .slice(2, -2)
+    .split("─┬─")
+    .map((part) => part.length);
+  const cells: string[][] = [];
+  const heights: number[] = [];
+  let current: string[][] = [];
+  const flush = () => {
+    if (!current.length) {
+      return;
+    }
+    cells.push(
+      widths.map((_, column) => current.map((row) => row[column]).join("\n"))
+    );
+    heights.push(current.length);
+    current = [];
+  };
+  for (const line of lines.slice(1)) {
+    if (separator(line) || bottom(line)) {
+      flush();
+      continue;
+    }
+    let offset = paddingX + 2;
+    current.push(
+      widths.map((width) => {
+        const cell = trimCell(sliceByColumn(line, offset, width));
+        offset += width + 3;
+        return cell;
+      })
+    );
+  }
+  flush();
+  return { cells, heights };
+};
+
+const borderLine = (
+  widths: readonly number[],
+  kind: "top" | "separator" | "bottom"
+): string => {
+  const [left, middle, right] = {
+    top: ["┌", "┬", "┐"],
+    bottom: ["└", "┴", "┘"],
+    separator: ["├", "┼", "┤"],
+  }[kind];
+  return `${left}─${widths.map((width) => "─".repeat(width)).join(`─${middle}─`)}─${right}`;
+};
+
+export const renderColdTable = (table: ColdTable, width: number): string[] => {
+  const columns = table.rows[0]?.cells.length ?? 0;
+  if (!columns) {
+    return [];
+  }
+  const available = Math.max(1, width - table.paddingX * 2);
+  if (available < 4 * columns + 1) {
+    return table.rows.flatMap((row) =>
+      row.cells.flatMap((cell) => wrapTextWithAnsi(cell, available))
+    );
+  }
+  const widths = Array.from({ length: columns }, () => 1);
+  const natural = widths.map((_, column) =>
+    Math.max(1, ...table.rows.map((row) => visibleWidth(row.cells[column])))
+  );
+  let remaining = available - (3 * columns + 1) - columns;
+  while (remaining > 0 && widths.some((value, i) => value < natural[i])) {
+    for (let i = 0; i < columns && remaining > 0; i += 1) {
+      if (widths[i] < natural[i]) {
+        widths[i] += 1;
+        remaining -= 1;
+      }
+    }
+  }
+  const lines: string[] = [];
+  for (const row of table.rows) {
+    if (row.before) {
+      lines.push(borderLine(widths, row.before));
+    }
+    const cells = row.cells.map((cell, i) => wrapTextWithAnsi(cell, widths[i]));
+    const height = Math.max(...cells.map((cell) => cell.length));
+    for (let y = 0; y < height; y += 1) {
+      lines.push(
+        `│ ${cells
+          .map((cell, i) => {
+            const text = cell[y] ?? "";
+            return (
+              text + " ".repeat(Math.max(0, widths[i] - visibleWidth(text)))
+            );
+          })
+          .join(" │ ")} │`
+      );
+    }
+  }
+  if (table.bottom) {
+    lines.push(borderLine(widths, "bottom"));
+  }
+  return lines.map(
+    (line) =>
+      `${" ".repeat(table.paddingX)}${line}${" ".repeat(Math.max(0, width - table.paddingX - visibleWidth(line)))}`
+  );
+};
+
+const ranges = (
+  rows: readonly string[],
+  paddingX = 0
+): { start: number; end: number; table: boolean }[] => {
+  // Only unindented table borders emitted at Markdown's content margin count.
+  // Fenced code's indentation and quote/list prefixes are not table metadata.
+  const lines = rows.map((line) =>
+    stripTerminalSequences(line).slice(paddingX).trimEnd()
+  );
+  const result: { start: number; end: number; table: boolean }[] = [];
+  let start = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!TABLE_TOP.test(lines[index])) {
+      continue;
+    }
+    const end = lines.findIndex(
+      (line, i) => i > index && TABLE_BOTTOM.test(line)
+    );
+    if (end < 0) {
+      continue;
+    }
+    if (index > start) {
+      result.push({ start, end: index, table: false });
+    }
+    result.push({ start: index, end: end + 1, table: true });
+    index = end;
+    start = end + 1;
+  }
+  if (start < lines.length) {
+    result.push({ start, end: lines.length, table: false });
+  }
+  return result;
+};
+
+const selectedCell = (
+  cell: string,
+  width: number,
+  discarded: number
+): string => {
+  const length = wrapTextWithAnsi(cell, width).length;
+  if (discarded >= length) {
+    return "";
+  }
+  const selected = selectTextTail(
+    { kind: "text", text: cell, paddingX: 0, paddingY: 0 },
+    width,
+    length - discarded
+  );
+  if (selected.kind === "text") {
+    return selected.text;
+  }
+  if (selected.kind === "selected" && selected.content.kind === "text") {
+    return selected.content.text;
+  }
+  throw new Error("Expected a selected table text cell");
+};
+
+const selectTable = (
+  logical: readonly string[],
+  actual: readonly string[],
+  start: number,
+  paddingX: number
+): ColdContent => {
+  const source = tableCells(logical, 0);
+  const displayed = tableCells(actual, paddingX);
+  const widths = plain(actual[0])
+    .slice(2, -2)
+    .split("─┬─")
+    .map((part) => part.length);
+  const rows: { cells: string[]; before?: "top" | "separator" }[] = [];
+  let position = 1;
+  for (const [rowIndex, cells] of source.cells.entries()) {
+    const height = displayed.heights[rowIndex];
+    const discarded = Math.max(0, start - position);
+    if (discarded < height) {
+      const before = rowIndex === 0 ? "top" : "separator";
+      rows.push({
+        before: start <= position - 1 ? before : undefined,
+        cells: cells.map((cell, column) =>
+          selectedCell(cell, widths[column], discarded)
+        ),
+      });
+    }
+    position += height + 1;
+  }
+  return rows.length
+    ? { kind: "table", rows, paddingX, bottom: true }
+    : {
+        kind: "fixed",
+        rows: actual.slice(Math.max(start, 0)),
+        reason: "opaque-renderer",
+      };
+};
+
+/** Select the committed physical suffix, but retain cell-local soft-wrap origins. */
+export const selectMarkdownTables = (
+  natural: readonly string[],
+  actual: readonly string[],
+  width: number,
+  count: number,
+  paddingX: number
+): ColdContent | undefined => {
+  const sourceRanges = ranges(natural);
+  if (!sourceRanges.some((range) => range.table)) {
+    return;
+  }
+  const actualRanges = ranges(actual, paddingX);
+  if (sourceRanges.length !== actualRanges.length) {
+    return;
+  }
+  const start = actual.length - count;
+  const children: ColdContent[] = [];
+  for (const [index, range] of actualRanges.entries()) {
+    if (range.end <= start) {
+      continue;
+    }
+    const sourceRange = sourceRanges[index];
+    const logical = natural.slice(sourceRange.start, sourceRange.end);
+    if (!range.table) {
+      children.push(
+        selectTextTail(
+          { kind: "text", text: logical.join("\n"), paddingX, paddingY: 0 },
+          width,
+          range.end - Math.max(start, range.start)
+        )
+      );
+      continue;
+    }
+    children.push(
+      selectTable(
+        logical,
+        actual.slice(range.start, range.end),
+        start - range.start,
+        paddingX
+      )
+    );
+  }
+  return {
+    kind: "selected",
+    width,
+    rows: actual.slice(-count),
+    content: { kind: "group", children },
+  };
+};

--- a/apps/coding-agent/src/tui/cold-table.ts
+++ b/apps/coding-agent/src/tui/cold-table.ts
@@ -134,6 +134,44 @@ export const renderColdTable = (table: ColdTable, width: number): string[] => {
   );
 };
 
+const validTableGeometry = (lines: readonly string[]): boolean => {
+  const top = lines[0];
+  const segments = top.slice(1, -1).split("┬");
+  if (segments.some((segment) => segment.length < 3)) {
+    return false;
+  }
+  const rule = `├${segments.join("┼")}┤`;
+  if (lines.at(-1) !== `└${segments.join("┴")}┘`) {
+    return false;
+  }
+  const boundaries = [0];
+  let column = 0;
+  for (const segment of segments) {
+    column += segment.length + 1;
+    boundaries.push(column);
+  }
+  let hasSeparator = false;
+  let hasInterior = false;
+  for (const line of lines.slice(1, -1)) {
+    if (line === rule) {
+      if (!hasInterior) {
+        return false;
+      }
+      hasSeparator = true;
+      hasInterior = false;
+      continue;
+    }
+    if (
+      visibleWidth(line) !== top.length ||
+      boundaries.some((column) => sliceByColumn(line, column, 1) !== "│")
+    ) {
+      return false;
+    }
+    hasInterior = true;
+  }
+  return hasSeparator && hasInterior;
+};
+
 const ranges = (
   rows: readonly string[],
   paddingX = 0
@@ -152,7 +190,7 @@ const ranges = (
     const end = lines.findIndex(
       (line, i) => i > index && TABLE_BOTTOM.test(line)
     );
-    if (end < 0) {
+    if (end < 0 || !validTableGeometry(lines.slice(index, end + 1))) {
       continue;
     }
     if (index > start) {

--- a/apps/coding-agent/src/tui/command.ts
+++ b/apps/coding-agent/src/tui/command.ts
@@ -13,7 +13,7 @@ export type TuiCommandAction =
       /** @deprecated Legacy action ignored by current hosts. */
       type: "new-session";
     }
-  | { type: "refresh-header" }
+  | { type: "refresh-header"; reason?: "model-change" }
   | { type: "reload" }
   | { clear: boolean; type: "session" }
   | { query?: string; type: "select-session" }

--- a/apps/coding-agent/src/tui/command.ts
+++ b/apps/coding-agent/src/tui/command.ts
@@ -15,7 +15,7 @@ export type TuiCommandAction =
     }
   | { type: "refresh-header"; reason?: "model-change" }
   | { type: "reload" }
-  | { clear: boolean; type: "session" }
+  | { clear: boolean; reason?: "new"; type: "session" }
   | { query?: string; type: "select-session" }
   | { prompt: string; type: "submit-prompt" }
   | { type: "select-model"; query?: string };

--- a/apps/coding-agent/src/tui/compaction-status.ts
+++ b/apps/coding-agent/src/tui/compaction-status.ts
@@ -1,0 +1,44 @@
+import type {
+  AgentCompaction,
+  AgentCompactionContext,
+} from "@minpeter/pss-runtime";
+
+/** Track speculative policy work too: its summary may outlive the sending turn. */
+export function withCompactionStatus(
+  policy: AgentCompaction | undefined,
+  showStatus: () => (() => void) | undefined
+): AgentCompaction | undefined {
+  if (policy === undefined) {
+    return;
+  }
+  return Object.assign(async (context: Readonly<AgentCompactionContext>) => {
+    // The runtime aborts the episode signal on normal settlement as well as
+    // cancellation/deadline. It includes persistence after the policy returns.
+    const clearEpisode = showStatus();
+    if (clearEpisode) {
+      if (context.signal.aborted) {
+        clearEpisode();
+      } else {
+        context.signal.addEventListener("abort", clearEpisode, { once: true });
+      }
+    }
+    // A detached policy/summary can outlive that signal. Keep its own lease
+    // until its actual promise settles, even after the episode times out.
+    const clear = showStatus();
+    try {
+      return await policy({
+        ...context,
+        summarize: async (range, options) => {
+          const clearSummary = showStatus();
+          try {
+            return await context.summarize(range, options);
+          } finally {
+            clearSummary?.();
+          }
+        },
+      });
+    } finally {
+      clear?.();
+    }
+  }, policy);
+}

--- a/apps/coding-agent/src/tui/cubic-render-ownership.test.ts
+++ b/apps/coding-agent/src/tui/cubic-render-ownership.test.ts
@@ -1,0 +1,90 @@
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type AssistantRendererContext,
+  type AssistantTextView,
+  composeAssistantRenderers,
+} from "./assistant-renderer";
+
+const identity = (text: string) => text;
+const markdownTheme: MarkdownTheme = {
+  heading: identity,
+  link: identity,
+  linkUrl: identity,
+  code: identity,
+  codeBlock: identity,
+  codeBlockBorder: identity,
+  quote: identity,
+  quoteBorder: identity,
+  hr: identity,
+  listBullet: identity,
+  bold: identity,
+  italic: identity,
+  strikethrough: identity,
+  underline: identity,
+};
+
+describe("delegated renderer ownership", () => {
+  it("leaves cached delegates alive until their real Mermaid owner replaces or disposes them", async () => {
+    // Load real extension source only through Vitest, outside the declaration graph.
+    const { MermaidMarkdown } = await vi.importActual<{
+      MermaidMarkdown: new (
+        text: string,
+        paddingX: number,
+        paddingY: number,
+        theme: MarkdownTheme,
+        context: AssistantRendererContext
+      ) => AssistantTextView;
+    }>("../../../../extensions/mermaid/src/mermaid-markdown.ts");
+    const disposed: string[] = [];
+    const composed = composeAssistantRenderers([
+      () => {
+        let text = "";
+        let closed = false;
+        return {
+          invalidate() {
+            return;
+          },
+          setText(value) {
+            text = value;
+          },
+          render() {
+            if (closed) {
+              throw new Error("Rendered disposed delegate");
+            }
+            return [text];
+          },
+          dispose() {
+            if (closed) {
+              throw new Error("Delegate disposed twice");
+            }
+            closed = true;
+            disposed.push(text);
+          },
+        };
+      },
+      (context) => new MermaidMarkdown("", 0, 0, markdownTheme, context),
+    ]);
+    if (!composed) {
+      throw new Error("Missing composed renderer");
+    }
+    const view = composed({
+      markdownTheme,
+      notify: () => undefined,
+      notifyOnce: () => undefined,
+      requestRender: () => undefined,
+      signal: new AbortController().signal,
+    });
+    view.setText("FIRST");
+    expect(view.render(24)).toEqual(["FIRST"]);
+    view.setText("FIRST");
+    view.invalidate();
+    expect(view.render(48)).toEqual(["FIRST"]);
+    expect(disposed).toEqual([]);
+    view.setText("SECOND");
+    expect(view.render(24)).toEqual(["SECOND"]);
+    expect(disposed).toEqual(["FIRST"]);
+    view.dispose?.();
+    expect(disposed).toEqual(["FIRST", "SECOND"]);
+  });
+});

--- a/apps/coding-agent/src/tui/cubic-render-ownership.test.ts
+++ b/apps/coding-agent/src/tui/cubic-render-ownership.test.ts
@@ -1,10 +1,10 @@
 import type { MarkdownTheme } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
-import {
-  type AssistantRendererContext,
-  type AssistantTextView,
-  composeAssistantRenderers,
-} from "./assistant-renderer";
+import type {
+  CodingAgentExtensionFactory,
+  ExtensionCapability,
+} from "../extensions/index";
+import { composeAssistantRenderers } from "./assistant-renderer";
 
 const identity = (text: string) => text;
 const markdownTheme: MarkdownTheme = {
@@ -26,16 +26,23 @@ const markdownTheme: MarkdownTheme = {
 
 describe("delegated renderer ownership", () => {
   it("leaves cached delegates alive until their real Mermaid owner replaces or disposes them", async () => {
-    // Load real extension source only through Vitest, outside the declaration graph.
-    const { MermaidMarkdown } = await vi.importActual<{
-      MermaidMarkdown: new (
-        text: string,
-        paddingX: number,
-        paddingY: number,
-        theme: MarkdownTheme,
-        context: AssistantRendererContext
-      ) => AssistantTextView;
-    }>("../../../../extensions/mermaid/src/mermaid-markdown.ts");
+    // Vitest's source condition loads the public factory outside the declaration
+    // graph; its renderer capability avoids coupling to Mermaid's internal files.
+    const { createMermaidExtension } = await vi.importActual<{
+      createMermaidExtension: CodingAgentExtensionFactory;
+    }>("@minpeter/pss-extension-mermaid");
+    const capabilities: ExtensionCapability[] = [];
+    await createMermaidExtension({
+      on: () => undefined,
+      provide: (capability) => capabilities.push(capability),
+      use: () => undefined,
+    });
+    const mermaid = capabilities.find(
+      (capability) => capability.kind === "assistant-renderer"
+    );
+    if (mermaid?.kind !== "assistant-renderer") {
+      throw new Error("Missing Mermaid renderer capability");
+    }
     const disposed: string[] = [];
     const composed = composeAssistantRenderers([
       () => {
@@ -63,7 +70,7 @@ describe("delegated renderer ownership", () => {
           },
         };
       },
-      (context) => new MermaidMarkdown("", 0, 0, markdownTheme, context),
+      mermaid.renderer,
     ]);
     if (!composed) {
       throw new Error("Missing composed renderer");

--- a/apps/coding-agent/src/tui/cubic-render.test.ts
+++ b/apps/coding-agent/src/tui/cubic-render.test.ts
@@ -1,0 +1,157 @@
+import {
+  Container,
+  Markdown,
+  type MarkdownTheme,
+  stripTerminalSequences,
+  Text,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { selectMarkdownTables } from "./cold-table";
+import { SnapshotMarkdown } from "./snapshot-views";
+import { AssistantStreamView } from "./stream-views";
+import { BaseToolCallView } from "./tool-call-view";
+import { ColdSnapshot } from "./transcript-owner";
+
+const identity = (text: string) => text;
+const theme: MarkdownTheme = {
+  heading: identity,
+  link: identity,
+  linkUrl: identity,
+  code: identity,
+  codeBlock: identity,
+  codeBlockBorder: identity,
+  quote: identity,
+  quoteBorder: identity,
+  hr: identity,
+  listBullet: identity,
+  bold: identity,
+  italic: identity,
+  strikethrough: identity,
+  underline: identity,
+};
+
+describe("Cubic render regressions", () => {
+  it.each([
+    "\x1b_Ga=T,f=100;ASSET\x1b\\",
+    "\x1b]1337;File=inline=1:ASSET\x07",
+    "\x1bPqASSET\x1b\\",
+  ])(
+    "keeps custom graphics and reserved rows separate and atomic: %j",
+    (payload) => {
+      const view = new BaseToolCallView("graphics", "custom", theme);
+      try {
+        const body = [
+          payload,
+          ...Array.from({ length: 12 }, () => ""),
+          "AFTER",
+        ];
+        view.setPrettyBlock("HEADER", body.join("\n"), { allowAnsi: true });
+        const rows = view.render(24);
+        expect(rows).toHaveLength(body.length + 2);
+        expect(rows.every((row) => !row.includes("\n"))).toBe(true);
+        expect(rows.slice(2).map(visibleWidth)).toEqual(body.map(() => 24));
+        expect(rows[2]).toContain(payload);
+        expect(stripTerminalSequences(rows.at(-1) ?? "").trim()).toBe("AFTER");
+        const snapshot = ColdSnapshot.capture(view, 24);
+        for (const width of [12, 24, 48]) {
+          expect(snapshot.render(width).slice(2)).toEqual(rows.slice(2));
+        }
+      } finally {
+        view.dispose();
+      }
+    }
+  );
+
+  it("captures opaque descendants once and commits the same frame at every width", () => {
+    let frame = 0;
+    const render = vi.fn(() => [`FRAME_${++frame}`]);
+    const group = new Container();
+    group.addChild({ render, invalidate: vi.fn() });
+    const snapshot = ColdSnapshot.capture(group, 24);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(snapshot.render(24)).toEqual(["FRAME_1"]);
+    expect(snapshot.render(48)).toEqual(["FRAME_1"]);
+  });
+
+  it.each(["CUSTOM_HEADER", "\x1b_Ga=T,f=100;ASSET\x1b\\"])(
+    "preserves opaque Container render overrides through assistant sealing: %j",
+    (header) => {
+      class CustomAssistant extends Container {
+        readonly body = new Text("", 0, 0);
+        constructor() {
+          super();
+          this.addChild(this.body);
+        }
+        setText(text: string): void {
+          this.body.setText(text);
+        }
+        override render(width: number): string[] {
+          return [header, ...super.render(width)];
+        }
+      }
+      const custom = new CustomAssistant();
+      const render = vi.spyOn(custom, "render");
+      const view = new AssistantStreamView(theme, {
+        assistantRenderer: () => custom,
+      });
+      view.appendText("BODY");
+      view.completeText();
+      const hot = view.render(24);
+      expect(hot[0]).toBe(header);
+      render.mockClear();
+      const snapshot = ColdSnapshot.capture(view, 24);
+      expect(snapshot.render(24)).toEqual(hot);
+      expect(render).toHaveBeenCalledTimes(1);
+      view.dispose();
+      custom.body.setText("LATE_MUTATION");
+      for (const width of [48, 80, 24]) {
+        expect(snapshot.render(width)).toEqual(hot);
+      }
+      expect(render).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("captures syntax highlighting once per block, including committed rows", () => {
+    const highlightCode = vi.fn((code: string) =>
+      code.split("\n").map((line) => `\x1b[31m${line}\x1b[0m`)
+    );
+    const view = new SnapshotMarkdown("```ts\nconst value = 1;\n```", 1, 0, {
+      ...theme,
+      highlightCode,
+    });
+    const snapshot = ColdSnapshot.capture(view, 24);
+    expect(highlightCode).toHaveBeenCalledTimes(1);
+    for (const width of [12, 24, 48]) {
+      expect(snapshot.render(width).join("")).toContain("\x1b[31m");
+    }
+    expect(highlightCode).toHaveBeenCalledTimes(1);
+  });
+
+  it("still selects real styled Markdown table cells with wide glyphs and literal pipes", () => {
+    const source = "| Name | Value |\n| --- | --- |\n| 漢字 | a\\|b |";
+    const styled = {
+      ...theme,
+      bold: (text: string) => `\x1b[1m${text}\x1b[0m`,
+    };
+    const natural = new Markdown(source, 0, 0, styled).render(80);
+    const actual = new Markdown(source, 1, 0, styled).render(24);
+    const selected = selectMarkdownTables(natural, actual, 24, 3, 1);
+    expect(selected).toMatchObject({
+      kind: "selected",
+      content: {
+        kind: "group",
+        children: [{ kind: "table", rows: [{ cells: ["漢字", "a|b"] }] }],
+      },
+    });
+  });
+
+  it.each([
+    { rows: ["┌─────┐", "│ ART │", "└─────┘"] },
+    { rows: ["┌─────┐", "│ ART │", "├────┤", "│ END │", "└─────┘"] },
+    { rows: ["┌─────┐", "│ ART │", "├─────┤", "│ END", "└─────┘"] },
+    { rows: ["┌─────┐", "│ ART │", "├─────┤", "│ END │", "└────┘"] },
+  ])("does not decode non-table box art as cell data: $rows", ({ rows }) => {
+    expect(selectMarkdownTables(rows, rows, 24, 2, 0)).toBeUndefined();
+  });
+});

--- a/apps/coding-agent/src/tui/extension-ui.test.ts
+++ b/apps/coding-agent/src/tui/extension-ui.test.ts
@@ -90,13 +90,8 @@ describe("extension TUI service", () => {
     // that submitted the command right after the overlay opens. It must be
     // swallowed instead of confirming the first item.
     expect(listener?.("\x1b[13;1:3u")).toEqual({ consume: true });
-    const pending = await Promise.race([
-      result,
-      new Promise<string>((resolve) => {
-        setTimeout(() => resolve("pending"), 0);
-      }),
-    ]);
-    expect(pending).toBe("pending");
+    expect(fixture.hidden()).toBe(0);
+    expect(fixture.listeners).toHaveLength(1);
 
     // A real Enter press still confirms the selection.
     listener?.("\r");
@@ -125,12 +120,7 @@ describe("extension TUI service", () => {
     const fixture = createFakeTui();
     fixture.controller.abort();
 
-    const result = await Promise.race([
-      fixture.ui.input({ label: "Aborted" }),
-      new Promise<string>((resolve) => {
-        setTimeout(() => resolve("pending"), 0);
-      }),
-    ]);
+    const result = await fixture.ui.input({ label: "Aborted" });
 
     expect(result).toBeUndefined();
     expect(fixture.overlays).toHaveLength(0);

--- a/apps/coding-agent/src/tui/extension-ui.test.ts
+++ b/apps/coding-agent/src/tui/extension-ui.test.ts
@@ -1,128 +1,84 @@
-import type { Container, Input, SelectList, TUI } from "@earendil-works/pi-tui";
-import { describe, expect, it } from "vitest";
+import type {
+  Component,
+  Container,
+  Input,
+  SelectList,
+} from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
 import { createExtensionUi } from "./extension-ui";
 
-interface FakeTui {
-  readonly addInputListener: (
-    listener: (input: string) => unknown
-  ) => () => void;
-  readonly requestRender: () => void;
-  readonly setFocus: (component: unknown) => void;
-  readonly showOverlay: (component: Container) => {
-    focus(): void;
-    hide(): void;
-  };
-}
-
-const createFakeTui = () => {
-  const overlays: Container[] = [];
-  const listeners: ((input: string) => unknown)[] = [];
-  let hidden = 0;
-  let restored = 0;
-  const tui: FakeTui = {
-    addInputListener: (listener) => {
-      listeners.push(listener);
-      return () => {
-        const index = listeners.indexOf(listener);
-        if (index >= 0) {
-          listeners.splice(index, 1);
-        }
-      };
-    },
-    requestRender: () => undefined,
-    setFocus: () => undefined,
-    showOverlay: (component) => {
-      overlays.push(component);
-      return {
-        focus: () => undefined,
-        hide: () => {
-          hidden += 1;
-        },
-      };
-    },
-  };
+const fixture = () => {
+  const mounted: Component[] = [];
   const controller = new AbortController();
+  const showMessage = vi.fn();
+  const showStatus = vi.fn(() => () => undefined);
+  const unmounted = vi.fn();
   const ui = createExtensionUi({
-    restoreFocus: () => {
-      restored += 1;
+    promptHost: {
+      mount: (component) => {
+        mounted.push(component);
+        return unmounted;
+      },
     },
-    showMessage: () => undefined,
-    showStatus: () => () => undefined,
+    showMessage,
+    showStatus,
     signal: controller.signal,
-    tui: tui as unknown as TUI,
   });
-  return {
-    controller,
-    hidden: () => hidden,
-    listeners,
-    overlays,
-    restored: () => restored,
-    ui,
-  };
+  return { controller, mounted, showMessage, showStatus, ui, unmounted };
 };
 
-describe("extension TUI service", () => {
-  it("settles input once and restores focus", async () => {
-    const fixture = createFakeTui();
-    const result = fixture.ui.input({ initialValue: "draft", label: "Name" });
-    const input = fixture.overlays[0]?.children[1] as Input;
-
+describe("extension inline TUI service", () => {
+  it("settles input once and releases its composer slot", async () => {
+    const f = fixture();
+    const result = f.ui.input({ initialValue: "draft", label: "Name" });
+    const input = (f.mounted[0] as Container).children[1] as Input;
     input.onSubmit?.("chosen");
     input.onEscape?.();
-
     await expect(result).resolves.toBe("chosen");
-    expect(fixture.hidden()).toBe(1);
-    expect(fixture.restored()).toBe(1);
+    expect(f.unmounted).toHaveBeenCalledTimes(1);
   });
-
-  it("ignores key releases so the Enter that opened the picker cannot confirm", async () => {
-    const fixture = createFakeTui();
-    const result = fixture.ui.select({
+  it("ignores key releases before choosing the selected value", async () => {
+    const f = fixture();
+    const result = f.ui.select({
       label: "Model",
       options: [
         { label: "Fast", value: "fast" },
         { label: "Slow", value: "slow" },
       ],
     });
-    const listener = fixture.listeners[0];
-
-    // Kitty keyboard protocol delivers the *release* of the Enter keypress
-    // that submitted the command right after the overlay opens. It must be
-    // swallowed instead of confirming the first item.
-    expect(listener?.("\x1b[13;1:3u")).toEqual({ consume: true });
-    expect(fixture.hidden()).toBe(0);
-    expect(fixture.listeners).toHaveLength(1);
-
-    // A real Enter press still confirms the selection.
-    listener?.("\r");
-    await expect(result).resolves.toBe("fast");
+    const prompt = f.mounted[0];
+    prompt.handleInput?.("\x1b[13;1:3u");
+    expect(f.unmounted).not.toHaveBeenCalled();
+    prompt.handleInput?.("\x1b[B");
+    prompt.handleInput?.("\r");
+    await expect(result).resolves.toBe("slow");
   });
-
-  it("settles select cancellation on lifecycle abort and removes input routing", async () => {
-    const fixture = createFakeTui();
-    const result = fixture.ui.select({
+  it("settles cancellation on lifecycle abort and ignores retained selection callbacks", async () => {
+    const f = fixture();
+    const result = f.ui.select({
       label: "Model",
       options: [{ label: "Fast", value: "fast" }],
     });
-    const list = fixture.overlays[0]?.children[1] as SelectList;
-
-    expect(fixture.listeners).toHaveLength(1);
-    fixture.controller.abort();
+    const list = (f.mounted[0] as Container).children[1] as SelectList;
+    f.controller.abort();
     list.onSelect?.({ label: "Fast", value: "fast" });
-
     await expect(result).resolves.toBeUndefined();
-    expect(fixture.listeners).toHaveLength(0);
-    expect(fixture.hidden()).toBe(1);
-    expect(fixture.restored()).toBe(1);
+    expect(f.unmounted).toHaveBeenCalledTimes(1);
   });
-
-  it("does not open a dialog after the TUI lifecycle is already aborted", async () => {
-    const fixture = createFakeTui();
-    fixture.controller.abort();
-
-    const result = await fixture.ui.input({ label: "Aborted" });
-
-    expect(result).toBeUndefined();
-    expect(fixture.overlays).toHaveLength(0);
+  it("does not open prompts or publish notices/status after host abort", async () => {
+    const f = fixture();
+    f.controller.abort();
+    await expect(f.ui.input({ label: "Aborted" })).resolves.toBeUndefined();
+    f.ui.notify("stale");
+    f.ui.status("stale")();
+    expect(f.mounted).toHaveLength(0);
+    expect(f.showMessage).not.toHaveBeenCalled();
+    expect(f.showStatus).not.toHaveBeenCalled();
+  });
+  it.each(["\x1b", "\x03"])("cancels with %j", async (key) => {
+    const f = fixture();
+    const result = f.ui.confirm("Confirm?");
+    f.mounted[0].handleInput?.(key);
+    await expect(result).resolves.toBe(false);
   });
 });

--- a/apps/coding-agent/src/tui/extension-ui.ts
+++ b/apps/coding-agent/src/tui/extension-ui.ts
@@ -20,6 +20,7 @@ const selectTheme = {
 };
 
 export function createExtensionUi(options: {
+  readonly onUserWait?: () => () => void;
   readonly restoreFocus: () => void;
   readonly showMessage: (message: string) => void;
   readonly showStatus: (message: string) => () => void;
@@ -70,32 +71,40 @@ async function inputValue(
     return;
   }
   const sanitizedLabel = requiredLabel(label);
-  return await new Promise<string | undefined>((resolve) => {
-    const container = new Container();
-    const input = new Input();
-    let settled = false;
-    let handle: ReturnType<typeof options.tui.showOverlay>;
-    const settle = (value: string | undefined) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      options.signal.removeEventListener("abort", abort);
-      handle.hide();
-      options.restoreFocus();
-      resolve(value);
-    };
-    const abort = () => settle(undefined);
-    container.addChild(new Text(sanitizedLabel, 1, 0));
-    container.addChild(input);
-    input.setValue(initialValue ?? "");
-    input.onEscape = () => settle(undefined);
-    input.onSubmit = (value) => settle(value);
-    handle = options.tui.showOverlay(container, { minWidth: 32, width: "60%" });
-    options.signal.addEventListener("abort", abort, { once: true });
-    options.tui.setFocus(input);
-    options.tui.requestRender();
-  });
+  const resume = options.onUserWait?.();
+  try {
+    return await new Promise<string | undefined>((resolve) => {
+      const container = new Container();
+      const input = new Input();
+      let settled = false;
+      let handle: ReturnType<typeof options.tui.showOverlay>;
+      const settle = (value: string | undefined) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        options.signal.removeEventListener("abort", abort);
+        handle.hide();
+        options.restoreFocus();
+        resolve(value);
+      };
+      const abort = () => settle(undefined);
+      container.addChild(new Text(sanitizedLabel, 1, 0));
+      container.addChild(input);
+      input.setValue(initialValue ?? "");
+      input.onEscape = () => settle(undefined);
+      input.onSubmit = (value) => settle(value);
+      handle = options.tui.showOverlay(container, {
+        minWidth: 32,
+        width: "60%",
+      });
+      options.signal.addEventListener("abort", abort, { once: true });
+      options.tui.setFocus(input);
+      options.tui.requestRender();
+    });
+  } finally {
+    resume?.();
+  }
 }
 
 async function selectValue(
@@ -139,52 +148,60 @@ async function selectValue(
       value: option.value,
     };
   });
-  return await new Promise<string | undefined>((resolve) => {
-    const container = new Container();
-    const list = new SelectList(items, 8, selectTheme);
-    let settled = false;
-    let handle: ReturnType<typeof options.tui.showOverlay>;
-    let removeInput: () => void = () => undefined;
-    const settle = (value: string | undefined) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      options.signal.removeEventListener("abort", abort);
-      removeInput();
-      handle.hide();
-      options.restoreFocus();
-      resolve(value);
-    };
-    const abort = () => settle(undefined);
-    container.addChild(new Text(label, 1, 0));
-    container.addChild(list);
-    list.onCancel = () => settle(undefined);
-    list.onSelect = (selected) => settle(selected.value);
-    handle = options.tui.showOverlay(container, { minWidth: 32, width: "60%" });
-    removeInput = options.tui.addInputListener((data) => {
-      // Drop Kitty-protocol key *release* events (the TUI's focused-component
-      // path filters them too). Without this, the release of the Enter that
-      // submitted the command opening this picker arrives a moment later and
-      // instantly confirms the first item.
-      if (isKeyRelease(data)) {
+  const resume = options.onUserWait?.();
+  try {
+    return await new Promise<string | undefined>((resolve) => {
+      const container = new Container();
+      const list = new SelectList(items, 8, selectTheme);
+      let settled = false;
+      let handle: ReturnType<typeof options.tui.showOverlay>;
+      let removeInput: () => void = () => undefined;
+      const settle = (value: string | undefined) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        options.signal.removeEventListener("abort", abort);
+        removeInput();
+        handle.hide();
+        options.restoreFocus();
+        resolve(value);
+      };
+      const abort = () => settle(undefined);
+      container.addChild(new Text(label, 1, 0));
+      container.addChild(list);
+      list.onCancel = () => settle(undefined);
+      list.onSelect = (selected) => settle(selected.value);
+      handle = options.tui.showOverlay(container, {
+        minWidth: 32,
+        width: "60%",
+      });
+      removeInput = options.tui.addInputListener((data) => {
+        // Drop Kitty-protocol key *release* events (the TUI's focused-component
+        // path filters them too). Without this, the release of the Enter that
+        // submitted the command opening this picker arrives a moment later and
+        // instantly confirms the first item.
+        if (isKeyRelease(data)) {
+          return { consume: true };
+        }
+        if (matchesKey(data, Key.escape)) {
+          settle(undefined);
+        } else {
+          list.handleInput(data);
+        }
+        // Listener-consumed input bypasses the TUI's focused-component path,
+        // which is what normally schedules a render; request one explicitly so
+        // arrow-key selection is actually visible.
+        options.tui.requestRender();
         return { consume: true };
-      }
-      if (matchesKey(data, Key.escape)) {
-        settle(undefined);
-      } else {
-        list.handleInput(data);
-      }
-      // Listener-consumed input bypasses the TUI's focused-component path,
-      // which is what normally schedules a render; request one explicitly so
-      // arrow-key selection is actually visible.
+      });
+      options.signal.addEventListener("abort", abort, { once: true });
+      handle.focus();
       options.tui.requestRender();
-      return { consume: true };
     });
-    options.signal.addEventListener("abort", abort, { once: true });
-    handle.focus();
-    options.tui.requestRender();
-  });
+  } finally {
+    resume?.();
+  }
 }
 
 function requiredLabel(value: string): string {

--- a/apps/coding-agent/src/tui/extension-ui.ts
+++ b/apps/coding-agent/src/tui/extension-ui.ts
@@ -1,12 +1,13 @@
 import {
+  type Component,
   Container,
   Input,
+  isFocusable,
   isKeyRelease,
   Key,
   matchesKey,
   SelectList,
   Text,
-  type TUI,
 } from "@earendil-works/pi-tui";
 import type { CodingAgentExtensionUi } from "../extensions/types";
 import { sanitizeTerminalText } from "./terminal-safety";
@@ -19,16 +20,58 @@ const selectTheme = {
   selectedText: (text: string) => text,
 };
 
-export function createExtensionUi(options: {
+/** Prompts share the HOT composer slot, never a screen overlay. */
+export interface ExtensionPromptHost {
+  mount(component: Component): () => void;
+}
+
+class InlinePrompt extends Container {
+  readonly #input: Component;
+  readonly #cancel: () => void;
+  #focused = false;
+
+  constructor(label: string, input: Component, cancel: () => void) {
+    super();
+    this.#input = input;
+    this.#cancel = cancel;
+    this.addChild(new Text(label, 1, 0));
+    this.addChild(input);
+  }
+
+  get focused(): boolean {
+    return this.#focused;
+  }
+  set focused(value: boolean) {
+    this.#focused = value;
+    if (isFocusable(this.#input)) {
+      this.#input.focused = value;
+    }
+  }
+
+  handleInput(data: string): void {
+    if (isKeyRelease(data)) {
+      return;
+    }
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+      this.#cancel();
+    } else {
+      this.#input.handleInput?.(data);
+    }
+  }
+}
+
+interface UiOptions {
   readonly onUserWait?: () => () => void;
-  readonly restoreFocus: () => void;
+  readonly promptHost: ExtensionPromptHost;
+  readonly promptSignal?: () => AbortSignal;
   readonly showMessage: (message: string) => void;
   readonly showStatus: (message: string) => () => void;
   readonly signal: AbortSignal;
-  readonly tui: TUI;
-}): CodingAgentExtensionUi {
+}
+
+export function createExtensionUi(options: UiOptions): CodingAgentExtensionUi {
   const ui: CodingAgentExtensionUi = {
-    confirm: async (message: string) =>
+    confirm: async (message) =>
       (await selectValue(options, {
         label: message,
         options: [
@@ -36,71 +79,59 @@ export function createExtensionUi(options: {
           { label: "Cancel", value: "cancel" },
         ],
       })) === "confirm",
-    input: async ({
-      initialValue,
-      label,
-    }: {
-      readonly initialValue?: string;
-      readonly label: string;
-    }) => await inputValue(options, label, initialValue),
-    notify: (message: string) =>
-      options.showMessage(sanitizeTerminalText(message)),
-    select: async ({
-      label,
-      options: values,
-    }: {
-      readonly label: string;
-      readonly options: readonly {
-        readonly description?: string;
-        readonly label: string;
-        readonly value: string;
-      }[];
-    }) => await selectValue(options, { label, options: values }),
-    status: (message: string) =>
-      options.showStatus(sanitizeTerminalText(message)),
+    input: async ({ initialValue, label }) => {
+      if (options.signal.aborted) {
+        return;
+      }
+      const input = new Input();
+      input.setValue(initialValue ?? "");
+      return await prompt(options, requiredLabel(label), input, (settle) => {
+        input.onEscape = () => settle(undefined);
+        input.onSubmit = settle;
+      });
+    },
+    notify: (message) => {
+      if (!options.signal.aborted) {
+        options.showMessage(sanitizeTerminalText(message));
+      }
+    },
+    select: async (input) => await selectValue(options, input),
+    status: (message) =>
+      options.signal.aborted
+        ? () => undefined
+        : options.showStatus(sanitizeTerminalText(message)),
   };
   return Object.freeze(ui);
 }
 
-async function inputValue(
-  options: Parameters<typeof createExtensionUi>[0],
+async function prompt(
+  options: UiOptions,
   label: string,
-  initialValue: string | undefined
+  input: Component,
+  configure: (settle: (value: string | undefined) => void) => void
 ): Promise<string | undefined> {
-  if (options.signal.aborted) {
+  const signal = options.promptSignal?.() ?? options.signal;
+  if (signal.aborted) {
     return;
   }
-  const sanitizedLabel = requiredLabel(label);
   const resume = options.onUserWait?.();
   try {
     return await new Promise<string | undefined>((resolve) => {
-      const container = new Container();
-      const input = new Input();
       let settled = false;
-      let handle: ReturnType<typeof options.tui.showOverlay>;
+      let unmount: () => void = () => undefined;
       const settle = (value: string | undefined) => {
         if (settled) {
           return;
         }
         settled = true;
-        options.signal.removeEventListener("abort", abort);
-        handle.hide();
-        options.restoreFocus();
+        signal.removeEventListener("abort", abort);
+        unmount();
         resolve(value);
       };
       const abort = () => settle(undefined);
-      container.addChild(new Text(sanitizedLabel, 1, 0));
-      container.addChild(input);
-      input.setValue(initialValue ?? "");
-      input.onEscape = () => settle(undefined);
-      input.onSubmit = (value) => settle(value);
-      handle = options.tui.showOverlay(container, {
-        minWidth: 32,
-        width: "60%",
-      });
-      options.signal.addEventListener("abort", abort, { once: true });
-      options.tui.setFocus(input);
-      options.tui.requestRender();
+      configure(settle);
+      unmount = options.promptHost.mount(new InlinePrompt(label, input, abort));
+      signal.addEventListener("abort", abort, { once: true });
     });
   } finally {
     resume?.();
@@ -108,15 +139,8 @@ async function inputValue(
 }
 
 async function selectValue(
-  options: Parameters<typeof createExtensionUi>[0],
-  input: {
-    readonly label: string;
-    readonly options: readonly {
-      readonly description?: string;
-      readonly label: string;
-      readonly value: string;
-    }[];
-  }
+  options: UiOptions,
+  input: Parameters<CodingAgentExtensionUi["select"]>[0]
 ): Promise<string | undefined> {
   if (options.signal.aborted) {
     return;
@@ -148,60 +172,11 @@ async function selectValue(
       value: option.value,
     };
   });
-  const resume = options.onUserWait?.();
-  try {
-    return await new Promise<string | undefined>((resolve) => {
-      const container = new Container();
-      const list = new SelectList(items, 8, selectTheme);
-      let settled = false;
-      let handle: ReturnType<typeof options.tui.showOverlay>;
-      let removeInput: () => void = () => undefined;
-      const settle = (value: string | undefined) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        options.signal.removeEventListener("abort", abort);
-        removeInput();
-        handle.hide();
-        options.restoreFocus();
-        resolve(value);
-      };
-      const abort = () => settle(undefined);
-      container.addChild(new Text(label, 1, 0));
-      container.addChild(list);
-      list.onCancel = () => settle(undefined);
-      list.onSelect = (selected) => settle(selected.value);
-      handle = options.tui.showOverlay(container, {
-        minWidth: 32,
-        width: "60%",
-      });
-      removeInput = options.tui.addInputListener((data) => {
-        // Drop Kitty-protocol key *release* events (the TUI's focused-component
-        // path filters them too). Without this, the release of the Enter that
-        // submitted the command opening this picker arrives a moment later and
-        // instantly confirms the first item.
-        if (isKeyRelease(data)) {
-          return { consume: true };
-        }
-        if (matchesKey(data, Key.escape)) {
-          settle(undefined);
-        } else {
-          list.handleInput(data);
-        }
-        // Listener-consumed input bypasses the TUI's focused-component path,
-        // which is what normally schedules a render; request one explicitly so
-        // arrow-key selection is actually visible.
-        options.tui.requestRender();
-        return { consume: true };
-      });
-      options.signal.addEventListener("abort", abort, { once: true });
-      handle.focus();
-      options.tui.requestRender();
-    });
-  } finally {
-    resume?.();
-  }
+  const list = new SelectList(items, 8, selectTheme);
+  return await prompt(options, label, list, (settle) => {
+    list.onCancel = () => settle(undefined);
+    list.onSelect = (selected) => settle(selected.value);
+  });
 }
 
 function requiredLabel(value: string): string {

--- a/apps/coding-agent/src/tui/extension-ui.ts
+++ b/apps/coding-agent/src/tui/extension-ui.ts
@@ -71,31 +71,41 @@ interface UiOptions {
 
 export function createExtensionUi(options: UiOptions): CodingAgentExtensionUi {
   const ui: CodingAgentExtensionUi = {
-    confirm: async (message) =>
-      (await selectValue(options, {
-        label: message,
-        options: [
-          { label: "Confirm", value: "confirm" },
-          { label: "Cancel", value: "cancel" },
-        ],
-      })) === "confirm",
-    input: async ({ initialValue, label }) => {
+    confirm: async (message, signal) =>
+      (await selectValue(
+        options,
+        {
+          label: message,
+          options: [
+            { label: "Confirm", value: "confirm" },
+            { label: "Cancel", value: "cancel" },
+          ],
+        },
+        signal
+      )) === "confirm",
+    input: async ({ initialValue, label }, signal) => {
       if (options.signal.aborted) {
         return;
       }
       const input = new Input();
       input.setValue(initialValue ?? "");
-      return await prompt(options, requiredLabel(label), input, (settle) => {
-        input.onEscape = () => settle(undefined);
-        input.onSubmit = settle;
-      });
+      return await prompt(
+        options,
+        requiredLabel(label),
+        input,
+        (settle) => {
+          input.onEscape = () => settle(undefined);
+          input.onSubmit = settle;
+        },
+        signal
+      );
     },
     notify: (message) => {
       if (!options.signal.aborted) {
         options.showMessage(sanitizeTerminalText(message));
       }
     },
-    select: async (input) => await selectValue(options, input),
+    select: async (input, signal) => await selectValue(options, input, signal),
     status: (message) =>
       options.signal.aborted
         ? () => undefined
@@ -108,9 +118,14 @@ async function prompt(
   options: UiOptions,
   label: string,
   input: Component,
-  configure: (settle: (value: string | undefined) => void) => void
+  configure: (settle: (value: string | undefined) => void) => void,
+  requestSignal?: AbortSignal
 ): Promise<string | undefined> {
-  const signal = options.promptSignal?.() ?? options.signal;
+  const signal = AbortSignal.any([
+    options.signal,
+    ...(options.promptSignal ? [options.promptSignal()] : []),
+    ...(requestSignal ? [requestSignal] : []),
+  ]);
   if (signal.aborted) {
     return;
   }
@@ -140,7 +155,8 @@ async function prompt(
 
 async function selectValue(
   options: UiOptions,
-  input: Parameters<CodingAgentExtensionUi["select"]>[0]
+  input: Parameters<CodingAgentExtensionUi["select"]>[0],
+  signal?: AbortSignal
 ): Promise<string | undefined> {
   if (options.signal.aborted) {
     return;
@@ -173,10 +189,16 @@ async function selectValue(
     };
   });
   const list = new SelectList(items, 8, selectTheme);
-  return await prompt(options, label, list, (settle) => {
-    list.onCancel = () => settle(undefined);
-    list.onSelect = (selected) => settle(selected.value);
-  });
+  return await prompt(
+    options,
+    label,
+    list,
+    (settle) => {
+      list.onCancel = () => settle(undefined);
+      list.onSelect = (selected) => settle(selected.value);
+    },
+    signal
+  );
 }
 
 function requiredLabel(value: string): string {

--- a/apps/coding-agent/src/tui/footer-status.test.ts
+++ b/apps/coding-agent/src/tui/footer-status.test.ts
@@ -3,6 +3,7 @@ import { FooterStatusBar } from "./agent";
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: test helper strips ANSI emitted by the footer
 const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+const SPINNER_PATTERN = /[\u2800-\u28ff]/u;
 
 describe("FooterStatusBar", () => {
   it("reserves one blank row while idle so the editor cannot jump", () => {
@@ -55,6 +56,33 @@ describe("FooterStatusBar", () => {
     }
     footer.stop();
   });
+
+  it.each([1, 2, 3, 8, 18, 80])(
+    "keeps an animated glyph at width %i despite long right status",
+    (width) => {
+      vi.useFakeTimers();
+      const footer = new FooterStatusBar({ requestRender: vi.fn() });
+      try {
+        footer.setForegroundMessage("A long operation label");
+        footer.setRightText("Custom footer status ".repeat(30));
+        const before = footer.render(width)[0]?.replace(ANSI_PATTERN, "") ?? "";
+        vi.advanceTimersByTime(80);
+        footer.setForegroundMessage("Another label");
+        const after = footer.render(width)[0]?.replace(ANSI_PATTERN, "") ?? "";
+        expect(before).toMatch(SPINNER_PATTERN);
+        expect(after).toMatch(SPINNER_PATTERN);
+        expect(after.match(SPINNER_PATTERN)?.[0]).not.toBe(
+          before.match(SPINNER_PATTERN)?.[0]
+        );
+        expect(before.length).toBeLessThanOrEqual(width);
+        expect(after.length).toBeLessThanOrEqual(width);
+      } finally {
+        footer.stop();
+        expect(vi.getTimerCount()).toBe(0);
+        vi.useRealTimers();
+      }
+    }
+  );
 
   it("shares narrow widths between running and right-side status", () => {
     const footer = new FooterStatusBar({ requestRender: vi.fn() });

--- a/apps/coding-agent/src/tui/footer-status.test.ts
+++ b/apps/coding-agent/src/tui/footer-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { FooterStatusBar } from "./agent";
+import { PENDING_SPINNER_INTERVAL_MS } from "./pending-spinner";
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: test helper strips ANSI emitted by the footer
 const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
@@ -62,11 +63,12 @@ describe("FooterStatusBar", () => {
     (width) => {
       vi.useFakeTimers();
       const footer = new FooterStatusBar({ requestRender: vi.fn() });
+      let remainingTimers = 0;
       try {
         footer.setForegroundMessage("A long operation label");
         footer.setRightText("Custom footer status ".repeat(30));
         const before = footer.render(width)[0]?.replace(ANSI_PATTERN, "") ?? "";
-        vi.advanceTimersByTime(80);
+        vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
         footer.setForegroundMessage("Another label");
         const after = footer.render(width)[0]?.replace(ANSI_PATTERN, "") ?? "";
         expect(before).toMatch(SPINNER_PATTERN);
@@ -78,9 +80,10 @@ describe("FooterStatusBar", () => {
         expect(after.length).toBeLessThanOrEqual(width);
       } finally {
         footer.stop();
-        expect(vi.getTimerCount()).toBe(0);
+        remainingTimers = vi.getTimerCount();
         vi.useRealTimers();
       }
+      expect(remainingTimers).toBe(0);
     }
   );
 

--- a/apps/coding-agent/src/tui/hot-shrink-padding.test.ts
+++ b/apps/coding-agent/src/tui/hot-shrink-padding.test.ts
@@ -1,0 +1,380 @@
+import {
+  type Component,
+  type MarkdownTheme,
+  stripTerminalSequences,
+  Text,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PENDING_SPINNER_INTERVAL_MS } from "./pending-spinner";
+import { addChatComponent } from "./stream-handlers";
+import { BaseToolCallView } from "./tool-call-view";
+import { ColdSnapshot, TranscriptOwner } from "./transcript-owner";
+
+const identity = (text: string): string => text;
+const theme: MarkdownTheme = {
+  heading: identity,
+  link: identity,
+  linkUrl: identity,
+  code: identity,
+  codeBlock: identity,
+  codeBlockBorder: identity,
+  quote: identity,
+  quoteBorder: identity,
+  hr: identity,
+  listBullet: identity,
+  bold: identity,
+  italic: identity,
+  strikethrough: identity,
+  underline: identity,
+};
+const long = Array.from({ length: 30 }, (_, i) => `ROW_${i}`).join("\n");
+const blanks = (count: number) => Array.from({ length: count }, () => "");
+const mount = (owner: TranscriptOwner) =>
+  owner.acquire(() => new BaseToolCallView("call", "custom", theme), {
+    leadingSpacer: false,
+    settle: (view) => view.settle(),
+    dispose: (view) => view.dispose(),
+  });
+
+function expectReservation(
+  owner: TranscriptOwner,
+  view: Component,
+  width: number,
+  height: number
+): void {
+  const real = view.render(width);
+  expect(owner.render(width)).toEqual([
+    ...real,
+    ...blanks(height - real.length),
+  ]);
+}
+
+describe("HOT block height reservation", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("keeps the pending spinner live and settles it when sealing", () => {
+    const owner = new TranscriptOwner(() => 100);
+    const lease = mount(owner);
+    const initial = owner.render(100);
+    vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
+    const tick = owner.render(100);
+    expect(tick).not.toEqual(initial);
+    expect(tick).toHaveLength(initial.length);
+    owner.finish(lease);
+    const cold = owner.render(100);
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
+    expect(owner.render(100)).toEqual(cold);
+  });
+
+  it("retains same-view total height below a shrinking eight-row body", () => {
+    const owner = new TranscriptOwner(() => 100);
+    const lease = mount(owner);
+    lease.view.setPrettyBlock("HEADER", long);
+    expect(owner.render(100)).toHaveLength(10);
+    lease.view.setPrettyBlock("HEADER", "SHORT");
+    expect(lease.view.render(100)).toHaveLength(3);
+    expectReservation(owner, lease.view, 100, 10);
+    lease.view.setPrettyBlock("HEADER", long);
+    expectReservation(owner, lease.view, 100, 10);
+    owner.finish();
+  });
+
+  it("includes header wrapping and continuation labels outside the body cap", () => {
+    const owner = new TranscriptOwner(() => 48);
+    const lease = owner.acquire(
+      () => new BaseToolCallView("call", "custom", theme),
+      {
+        label: "Continuation",
+        leadingSpacer: false,
+        dispose: (v) => v.dispose(),
+      }
+    );
+    lease.view.setPrettyBlock("HEADER ".repeat(30), long);
+    const before = owner.render(48);
+    expect(before.length).toBeGreaterThan(11);
+    lease.view.setPrettyBlock("SHORT", long);
+    const after = owner.render(48);
+    expect(after).toHaveLength(before.length);
+    expect(after.slice(1, 11)).toEqual(lease.view.render(48));
+    expect(after.slice(11)).toEqual(blanks(before.length - 11));
+    owner.finish();
+  });
+
+  it("seals a custom empty result with padding and preserves full input/output", async () => {
+    const owner = new TranscriptOwner(() => 100);
+    const lease = owner.acquire(
+      () =>
+        new BaseToolCallView("call", "custom", theme, undefined, false, {
+          custom: (view, _input, output) => {
+            if (output !== undefined) {
+              view.setPrettyBlock("DONE", "");
+            }
+          },
+        }),
+      { leadingSpacer: false, dispose: (v) => v.dispose() }
+    );
+    const input = { message: long };
+    const buffer = JSON.stringify(input);
+    await lease.view.appendInputChunk(buffer);
+    expect(owner.render(100)).toHaveLength(10);
+    lease.view.setFinalInput(input);
+    lease.view.setOutput("original result");
+    expect(lease.view.render(100)).toHaveLength(1);
+    // Result delivery seals without an intervening HOT render.
+    owner.finish(lease);
+    const snapshot = owner.render(100);
+    expect(snapshot).toEqual([...lease.view.render(100), ...blanks(9)]);
+    expect(owner.children[0]).toBeInstanceOf(ColdSnapshot);
+    expect(owner.children[0]?.render(100)).toEqual(lease.view.render(100));
+    expect(lease).toMatchObject({ active: false });
+    expect(lease.view).toMatchObject({
+      inputBuffer: buffer,
+      finalInput: input,
+      output: "original result",
+    });
+    lease.view.setOutput("late mutation");
+    owner.invalidate();
+    expect(owner.render(100)).toEqual(snapshot);
+  });
+
+  it.each([false, true])(
+    "retains actual partial-parser replacement height (raw=%s)",
+    async (raw) => {
+      const owner = new TranscriptOwner(() => 100);
+      const lease = owner.acquire(
+        () => new BaseToolCallView("call", "custom", theme, undefined, raw),
+        { leadingSpacer: false, dispose: (v) => v.dispose() }
+      );
+      const prefix = JSON.stringify({ message: long }).slice(0, -1);
+      await lease.view.appendInputChunk(prefix);
+      const height = owner.render(100).length;
+      const suffix = ',"message":"SHORT"}';
+      await lease.view.appendInputChunk(suffix);
+      expect(lease.view.render(100).length).toBeLessThan(height);
+      expectReservation(owner, lease.view, 100, height);
+      expect(lease.active).toBe(true);
+      expect(lease.view).toMatchObject({
+        inputBuffer: prefix + suffix,
+        parsedInput: { message: "SHORT" },
+      });
+      owner.finish();
+    }
+  );
+
+  it("transfers only synthetic reservation to the shared tail", () => {
+    const owner = new TranscriptOwner(() => 100);
+    const first = mount(owner);
+    first.view.setPrettyBlock("HEADER", long);
+    owner.render(100);
+    first.view.setPrettyBlock("HEADER", "SHORT");
+    const second = owner.acquire(() => new Text("NEXT", 0, 0), {
+      leadingSpacer: false,
+    });
+    expect(owner.children[0]?.render(100)).toEqual(first.view.render(100));
+    expect(owner.children[0]?.render(100)).toHaveLength(3);
+    expect(owner.children[1]?.render(100)).toEqual(second.view.render(100));
+    expect(owner.render(100)).toEqual([
+      ...first.view.render(100),
+      ...second.view.render(100),
+      ...blanks(6),
+    ]);
+    owner.finish();
+  });
+
+  it.each([false, true])(
+    "reuses six rows after a ten-to-four shrink (immediate seal=%s)",
+    (immediate) => {
+      const owner = new TranscriptOwner(() => 100);
+      const first = owner.acquire(() => new Text(`${"A\n".repeat(9)}A`, 0, 0), {
+        leadingSpacer: false,
+      });
+      expect(owner.render(100)).toHaveLength(10);
+      first.view.setText("A1\nA2\nA3\nA4");
+      if (!immediate) {
+        expect(owner.render(100)).toHaveLength(10);
+      }
+      owner.finish(first);
+      const cold = owner.children[0];
+      const actual = first.view.render(100);
+      expect(cold?.render(100)).toEqual(actual);
+      expect(actual).toHaveLength(4);
+      expect(owner.render(100)).toEqual([...actual, ...blanks(6)]);
+      const second = owner.acquire(() => new Text("B1\nB2\nB3", 0, 0));
+      expect(owner.render(100)).toEqual([
+        ...actual,
+        "",
+        ...second.view.render(100),
+        ...blanks(2),
+      ]);
+      second.view.setText("B1\nB2\nB3\nB4\nB5");
+      expect(owner.render(100)).toHaveLength(10);
+      second.view.setText("B1\nB2\nB3\nB4\nB5\nB6");
+      expect(owner.render(100)).toHaveLength(11);
+      second.view.setText("B1");
+      owner.finish(second);
+      const third = owner.acquire(() => new Text("C1\nC2", 0, 0), {
+        label: "Continuation",
+      });
+      expect(owner.render(100)).toHaveLength(11);
+      expect(owner.render(100).slice(0, 7)).toEqual([
+        ...actual,
+        "",
+        ...second.view.render(100),
+        "",
+      ]);
+      owner.finish(third);
+      expect(cold?.render(100)).toEqual(actual);
+      expect(owner.children).toContain(cold);
+    }
+  );
+
+  it("one-shot appends consume the reserve, including their normal separator", () => {
+    const owner = new TranscriptOwner(() => 100);
+    const first = mount(owner);
+    first.view.setPrettyBlock("HEADER", long);
+    expect(owner.render(100)).toHaveLength(10);
+    first.view.setPrettyBlock("HEADER", "SHORT");
+    addChatComponent(owner, new Text("USER1\nUSER2\nUSER3", 0, 0));
+    const actual = owner.children.flatMap((child) => child.render(100));
+    expect(actual).toHaveLength(7);
+    expect(owner.render(100)).toEqual([...actual, ...blanks(3)]);
+    owner.reset("session-navigation");
+    expect(owner.render(100)).toEqual([]);
+    owner.addChild(new Text("NEW", 0, 0));
+    expect(owner.render(100)).toHaveLength(1);
+  });
+
+  it.each(["", "ERROR"])(
+    "partial or error output preserves earlier genuine blank rows: %j",
+    async (result) => {
+      const owner = new TranscriptOwner(() => 100);
+      const genuine = ["OLD", "", "", "MARKDOWN GAP", "", ""];
+      owner.addChild({ render: () => genuine, invalidate: vi.fn() });
+      const cold = owner.children[0];
+      const lease = mount(owner);
+      await lease.view.appendInputChunk(
+        JSON.stringify({ message: long }).slice(0, -1)
+      );
+      const height = owner.render(100).length;
+      lease.view.setPrettyBlock("DONE", result, { isError: result !== "" });
+      owner.finish();
+      addChatComponent(owner, new Text("USER", 0, 0));
+      expect(cold?.render(100)).toEqual(genuine);
+      expect(owner.render(100).slice(0, genuine.length)).toEqual(genuine);
+      expect(owner.render(100)).toHaveLength(height);
+    }
+  );
+
+  it("drops sealed synthetic reserve on resize without reopening COLD content", () => {
+    let width = 100;
+    const owner = new TranscriptOwner(() => width);
+    let rows = ["ACTUAL", ...blanks(9)];
+    const render = vi.fn(() => rows);
+    owner.acquire(() => ({ render, invalidate: vi.fn() }), {
+      leadingSpacer: false,
+    });
+    owner.render(width);
+    rows = ["ACTUAL", "", ""];
+    owner.finish();
+    const count = render.mock.calls.length;
+    expect(owner.render(width)).toHaveLength(10);
+    width = 48;
+    expect(owner.render(width)).toEqual(rows);
+    width = 100;
+    expect(owner.render(width)).toEqual(rows);
+    expect(render).toHaveBeenCalledTimes(count);
+  });
+
+  it.each([
+    "REAL\n\n",
+    "\x1b_Ga=T,f=100;ASSET\x1b\\",
+    "\x1b]1337;File=inline=1:ASSET\x07",
+    "\x1bPqASSET\x1b\\",
+  ])("never reclaims genuine blank or graphic reserved rows: %j", (payload) => {
+    const owner = new TranscriptOwner(() => 100);
+    const actual = [...payload.split("\n"), ...blanks(4)];
+    let rows = [...actual, ...Array.from({ length: 8 }, () => "PREVIEW")];
+    owner.acquire(() => ({ render: () => rows, invalidate: vi.fn() }), {
+      leadingSpacer: false,
+    });
+    const high = owner.render(100).length;
+    rows = actual;
+    owner.finish();
+    const cold = owner.children[0];
+    owner.acquire(() => new Text("NEXT", 0, 0));
+    expect(cold?.render(100)).toEqual(actual);
+    expect(owner.render(100)).toEqual([
+      ...actual,
+      "",
+      ...new Text("NEXT", 0, 0).render(100),
+      ...blanks(6),
+    ]);
+    expect(owner.render(100)).toHaveLength(high);
+    owner.finish();
+    expect(cold?.render(100)).toEqual(actual);
+  });
+
+  it("recomputes on every width change, including returning to a prior width", () => {
+    let width = 48;
+    const owner = new TranscriptOwner(() => width);
+    const lease = mount(owner);
+    lease.view.setPrettyBlock("HEADER", "word ".repeat(35));
+    const narrow = owner.render(width).length;
+    width = 100;
+    const wide = owner.render(width).length;
+    expect(wide).toBeLessThan(narrow);
+    expect(owner.render(width)).toEqual(lease.view.render(width));
+    lease.view.setPrettyBlock("HEADER", "SHORT");
+    expectReservation(owner, lease.view, width, wide);
+    width = 48;
+    owner.invalidate();
+    expect(owner.render(width)).toEqual(lease.view.render(width));
+    expect(owner.render(width)).toHaveLength(3);
+    width = 100;
+    owner.finish();
+    expect(owner.render(width)).toHaveLength(3);
+  });
+
+  it("uses empty rows, never copies ANSI backgrounds, links or cursor markers", () => {
+    const owner = new TranscriptOwner(() => 48);
+    const lease = mount(owner);
+    lease.view.setPrettyBlock("HEADER", `\x1b[31m${long}\x1b[0m`, {
+      allowAnsi: true,
+    });
+    owner.render(48);
+    lease.view.setPrettyBlock(
+      "HEADER",
+      "\x1b]8;;https://example.test\x07ERR\x1b]8;;\x07",
+      { allowAnsi: true, isError: true }
+    );
+    const real = lease.view.render(48);
+    const padded = owner.render(48);
+    expect(padded.slice(0, real.length)).toEqual(real);
+    expect(padded.slice(real.length)).toEqual(blanks(7));
+    expect(padded.every((row) => visibleWidth(row) <= 48)).toBe(true);
+    expect(padded.slice(real.length).map(stripTerminalSequences)).toEqual(
+      blanks(7)
+    );
+    owner.finish();
+  });
+
+  it("delegates invalidation and counts only rendered, not unseen, heights", () => {
+    const owner = new TranscriptOwner(() => 48);
+    let rows = ["LONG", ...blanks(8)];
+    const invalidate = vi.fn();
+    const lease = owner.acquire(() => ({ render: () => rows, invalidate }), {
+      leadingSpacer: false,
+    });
+    rows = ["SHORT"];
+    expect(owner.render(48)).toEqual(rows);
+    owner.invalidate();
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    owner.finish(lease);
+  });
+});

--- a/apps/coding-agent/src/tui/input-routing.test.ts
+++ b/apps/coding-agent/src/tui/input-routing.test.ts
@@ -33,6 +33,25 @@ describe("dispatchUserInput", () => {
     expect(thread.steer).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { activeId: "same", returnedId: "same", consumeRun: false },
+    { activeId: "old", returnedId: "new", consumeRun: true },
+    { activeId: undefined, returnedId: undefined, consumeRun: true },
+  ])(
+    "routes distinct wrappers by execution identity: $activeId / $returnedId",
+    async ({ activeId, returnedId, consumeRun }) => {
+      const activeRun = { ...createRun(), runId: activeId };
+      const returned = { ...createRun(), runId: returnedId };
+      const result = await dispatchUserInput({
+        activeRun,
+        hooks,
+        input: "steer",
+        thread: { send: vi.fn(), steer: async () => returned },
+      });
+      expect(result).toMatchObject({ consumeRun, type: "steered" });
+    }
+  );
+
   it("steers an active run without sending a separate turn", async () => {
     const run = createRun();
     const thread = {

--- a/apps/coding-agent/src/tui/input-routing.ts
+++ b/apps/coding-agent/src/tui/input-routing.ts
@@ -71,7 +71,12 @@ export const dispatchUserInput = async (options: {
 
   const run = await options.thread.steer(prepared.message);
   return {
-    consumeRun: run !== options.activeRun,
+    // Public instrumentation may wrap the same execution in a fresh object.
+    // Its event stream is still single-consumer; queued steering must not
+    // subscribe again or tear down the original turn's UI ownership.
+    consumeRun:
+      run !== options.activeRun &&
+      (run.runId === undefined || run.runId !== options.activeRun.runId),
     run,
     translatedDisplay: prepared.translatedDisplay,
     type: "steered",

--- a/apps/coding-agent/src/tui/model-command.test.ts
+++ b/apps/coding-agent/src/tui/model-command.test.ts
@@ -37,8 +37,12 @@ describe("/model command", () => {
 
     expect(switchModel).toHaveBeenCalledWith("model-b");
     expect(result.success).toBe(true);
-    expect(result.action).toEqual({ type: "refresh-header" });
-    expect(result.message).toContain("Model switched to model-b");
+    expect(result.action).toEqual({
+      type: "refresh-header",
+      reason: "model-change",
+    });
+    expect(result.message?.match(/model-b/g)).toHaveLength(1);
+    expect(result.message?.split("\n")).toHaveLength(1);
   });
 
   it("opens the picker with a partial model id as its search query", async () => {

--- a/apps/coding-agent/src/tui/model-command.ts
+++ b/apps/coding-agent/src/tui/model-command.ts
@@ -108,9 +108,9 @@ function applySwitch(
     };
   }
   return {
-    action: { type: "refresh-header" },
+    action: { type: "refresh-header", reason: "model-change" },
     success: true,
-    message: `Model switched to ${modelId}. New steps use it immediately.`,
+    message: `Model changed to ${modelId}.`,
   };
 }
 

--- a/apps/coding-agent/src/tui/read-streaming-display.test.ts
+++ b/apps/coding-agent/src/tui/read-streaming-display.test.ts
@@ -254,9 +254,9 @@ describe("streamed read display", () => {
         expect(view.render(160).slice(2)).toEqual(
           errorSurface.render(160).slice(1)
         );
-        for (const row of view.render(160).slice(2)) {
-          expect(row).toMatch(BACKGROUND_PATTERN);
-        }
+        const errorBody = view.render(160).slice(2).join("\n");
+        expect(errorBody).not.toBe("");
+        expect(errorBody).toMatch(BACKGROUND_PATTERN);
         errorSurface.setPrettyBlock("", String(failure));
         expect(view.render(160).slice(2)).not.toEqual(
           errorSurface.render(160).slice(1)

--- a/apps/coding-agent/src/tui/read-streaming-display.test.ts
+++ b/apps/coding-agent/src/tui/read-streaming-display.test.ts
@@ -23,6 +23,8 @@ import type { TuiStreamPart } from "./stream-handlers";
 import { BaseToolCallView } from "./tool-call-view";
 
 const HASHLINE_ANCHOR_PATTERN = /\d+#[A-Z]+\|/;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: assert an ANSI background without pinning its palette color
+const BACKGROUND_PATTERN = /\x1b\[(?:4[0-8]|10[0-7])(?:;[\d;]+)?m/;
 const identity = (text: string): string => text;
 const theme: MarkdownTheme = {
   heading: identity,
@@ -250,6 +252,13 @@ describe("streamed read display", () => {
       try {
         errorSurface.setPrettyBlock("", String(failure), { isError: true });
         expect(view.render(160).slice(2)).toEqual(
+          errorSurface.render(160).slice(1)
+        );
+        for (const row of view.render(160).slice(2)) {
+          expect(row).toMatch(BACKGROUND_PATTERN);
+        }
+        errorSurface.setPrettyBlock("", String(failure));
+        expect(view.render(160).slice(2)).not.toEqual(
           errorSurface.render(160).slice(1)
         );
       } finally {

--- a/apps/coding-agent/src/tui/read-streaming-display.test.ts
+++ b/apps/coding-agent/src/tui/read-streaming-display.test.ts
@@ -180,7 +180,8 @@ describe("streamed read display", () => {
       );
       expect(text(view)).toContain("child/");
       expect(text(view)).toContain("empty.txt");
-      expect(view.render(160).join("\n")).not.toContain("\x1b[100m");
+      const directoryRows = view.render(160);
+      expect(directoryRows).toEqual(directoryRows.map(stripTerminalSequences));
       const empty = { path: "listing/empty.txt" };
       view.setFinalInput(empty);
       const output = await tool.execute?.(empty, {
@@ -245,7 +246,15 @@ describe("streamed read display", () => {
       view.setFinalInput(input);
       view.setError(parts[1]?.error);
       expect(text(view)).toContain("ENOENT");
-      expect(view.render(160).join("\n")).toContain("\x1b[48;5;88m");
+      const errorSurface = createView();
+      try {
+        errorSurface.setPrettyBlock("", String(failure), { isError: true });
+        expect(view.render(160).slice(2)).toEqual(
+          errorSurface.render(160).slice(1)
+        );
+      } finally {
+        errorSurface.dispose();
+      }
     } finally {
       view.dispose();
       await rm(workspace, { recursive: true, force: true });

--- a/apps/coding-agent/src/tui/read-streaming-display.test.ts
+++ b/apps/coding-agent/src/tui/read-streaming-display.test.ts
@@ -1,0 +1,254 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import {
+  type MarkdownTheme,
+  stripTerminalSequences,
+} from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { computeFileHash } from "../workspace-tools/hashline";
+import { createReadFileTool } from "../workspace-tools/read-file";
+import { agentEventStreamParts } from "./agent-event-stream";
+import { captureComponent, renderColdContent } from "./cold-content";
+import { createToolRenderers } from "./renderers/tool-renderers";
+import type { TuiStreamPart } from "./stream-handlers";
+import { BaseToolCallView } from "./tool-call-view";
+
+const HASHLINE_ANCHOR_PATTERN = /\d+#[A-Z]+\|/;
+const identity = (text: string): string => text;
+const theme: MarkdownTheme = {
+  heading: identity,
+  link: identity,
+  linkUrl: identity,
+  code: identity,
+  codeBlock: identity,
+  codeBlockBorder: identity,
+  quote: identity,
+  quoteBorder: identity,
+  hr: identity,
+  listBullet: identity,
+  bold: identity,
+  italic: identity,
+  strikethrough: identity,
+  underline: identity,
+};
+const createView = (raw = false) =>
+  new BaseToolCallView(
+    "read-stream",
+    "read_file",
+    theme,
+    undefined,
+    raw,
+    createToolRenderers()
+  );
+const text = (view: BaseToolCallView) =>
+  view.render(160).map(stripTerminalSequences).join("\n");
+
+// Equality asserts a shared shipped header, not a separate wording contract.
+describe("streamed read display", () => {
+  it("uses the completed header for streamed paths and ranges without claiming file content", async () => {
+    const streamed = createView();
+    const completed = createView();
+    try {
+      for (const [chunk, input] of [
+        ['{"path":"READ', { path: "READ" }],
+        ['ME.md","offset":1', { path: "README.md", offset: 1 }],
+        [',"limit":65}', { path: "README.md", offset: 1, limit: 65 }],
+      ] as const) {
+        await streamed.appendInputChunk(chunk);
+        completed.setFinalInput(input);
+        completed.setOutput(
+          "OK - file\npath: README.md\nfile_hash: unused\nlines: 0/0\n"
+        );
+        expect(streamed.render(160)[0]).toEqual(completed.render(160)[0]);
+        expect(text(streamed)).not.toContain("READ_SENTINEL");
+      }
+      streamed.setFinalInput({ path: "README.md", offset: 1, limit: 65 });
+      expect(streamed.render(160)[0]).toEqual(completed.render(160)[0]);
+    } finally {
+      streamed.dispose();
+      completed.dispose();
+    }
+  });
+
+  it.each(["README.md", "目錄/한글.md", "`**literal**`.md"])(
+    "uses the safe completed path header while pending: %j",
+    async (path) => {
+      const pending = createView();
+      const completed = createView();
+      try {
+        await pending.appendInputChunk(JSON.stringify({ path }).slice(0, -1));
+        completed.setFinalInput({ path });
+        expect(pending.render(160)[0]).toEqual(completed.render(160)[0]);
+        expect(stripTerminalSequences(pending.render(160)[0] ?? "")).toContain(
+          path
+        );
+      } finally {
+        pending.dispose();
+        completed.dispose();
+      }
+    }
+  );
+
+  it("preserves raw headers and generic fallback until a path is present", async () => {
+    const raw = createView(true);
+    const fallback = createView();
+    try {
+      await raw.appendInputChunk('{"offset":1');
+      const rawHeader = raw.render(160)[0];
+      await raw.appendInputChunk(',"path":"README.md"}');
+      expect(raw.render(160)[0]).toBe(rawHeader);
+      await fallback.appendInputChunk('{"offset":1');
+      const noPathHeader = fallback.render(160)[0];
+      await fallback.appendInputChunk(',"path":""}');
+      expect(fallback.render(160)[0]).toBe(noPathHeader);
+    } finally {
+      raw.dispose();
+      fallback.dispose();
+    }
+  });
+
+  it("renders a real read result, preserving canonical hashes, range, content and file permissions", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "pss-read-display-"));
+    const view = createView();
+    try {
+      const content = `${Array.from({ length: 70 }, (_, i) => `READ_SENTINEL_${i + 1}`).join("\n")}\n`;
+      const path = join(workspace, "README.md");
+      await writeFile(path, content, { mode: 0o640 });
+      const before = await stat(path);
+      await view.appendInputChunk('{"path":"README.md","offset":1,"limit":65}');
+      const input = { path: "README.md", offset: 1, limit: 65 };
+      view.setFinalInput(input);
+      expect(text(view)).not.toContain("READ_SENTINEL");
+      const tool = createReadFileTool(workspace);
+      const output = await tool.execute?.(input, {
+        toolCallId: "read-stream",
+        messages: [],
+        context: undefined,
+      });
+      expect(typeof output).toBe("string");
+      expect(output).toContain(`file_hash: ${computeFileHash(content)}`);
+      expect(output).toContain("lines: 1-65/70");
+      expect(output).toContain("READ_SENTINEL_1\n");
+      expect(output).toContain("READ_SENTINEL_65");
+      expect(output).not.toContain("READ_SENTINEL_66");
+      expect(text(view)).not.toContain("READ_SENTINEL");
+      view.setOutput(output);
+      expect(text(view)).toContain("READ_SENTINEL_65");
+      expect(text(view)).not.toContain("READ_SENTINEL_1\n");
+      expect(text(view)).not.toContain("file_hash");
+      expect(text(view)).not.toMatch(HASHLINE_ANCHOR_PATTERN);
+      const cold = captureComponent(view, 160);
+      expect(renderColdContent(cold, 160)).toEqual(view.render(160));
+      expect(
+        renderColdContent(cold, 48).map(stripTerminalSequences).join("\n")
+      ).toContain("READ_SENTINEL_65");
+      expect(await readFile(path, "utf8")).toBe(content);
+      const after = await stat(path);
+      expect(after.mode).toBe(before.mode);
+      expect(after.mtimeMs).toBe(before.mtimeMs);
+    } finally {
+      view.dispose();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("shows real directory results and empty files without inventing contents", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "pss-read-display-"));
+    const view = createView();
+    try {
+      await mkdir(join(workspace, "listing"));
+      await mkdir(join(workspace, "listing", "child"));
+      await writeFile(join(workspace, "listing", "empty.txt"), "");
+      const tool = createReadFileTool(workspace);
+      const input = { path: "listing" };
+      view.setFinalInput(input);
+      view.setOutput(
+        await tool.execute?.(input, {
+          toolCallId: "read-stream",
+          messages: [],
+          context: undefined,
+        })
+      );
+      expect(text(view)).toContain("child/");
+      expect(text(view)).toContain("empty.txt");
+      expect(view.render(160).join("\n")).not.toContain("\x1b[100m");
+      const empty = { path: "listing/empty.txt" };
+      view.setFinalInput(empty);
+      const output = await tool.execute?.(empty, {
+        toolCallId: "read-stream",
+        messages: [],
+        context: undefined,
+      });
+      expect(output).toContain("lines: 0/0");
+      view.setOutput(output);
+      expect(view.render(160)).toHaveLength(1);
+    } finally {
+      view.dispose();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("unwraps a same-id text result and routes execution errors to the error surface", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "pss-read-display-"));
+    const view = createView();
+    try {
+      const input = { path: "missing.txt" };
+      const tool = createReadFileTool(workspace);
+      let failure: unknown;
+      try {
+        await tool.execute?.(input, {
+          toolCallId: "read-stream",
+          messages: [],
+          context: undefined,
+        });
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(Error);
+      function* events() {
+        yield {
+          type: "tool-result" as const,
+          toolCallId: "read-stream",
+          toolName: "read_file",
+          output: { type: "text" as const, value: "READ_SENTINEL" },
+        };
+        yield {
+          type: "tool-result" as const,
+          toolCallId: "read-stream",
+          toolName: "read_file",
+          output: { type: "error-text" as const, value: String(failure) },
+        };
+      }
+      const parts: TuiStreamPart[] = [];
+      for await (const part of agentEventStreamParts(Readable.from(events()))) {
+        parts.push(part);
+      }
+      expect(parts[0]).toMatchObject({
+        type: "tool-result",
+        toolCallId: "read-stream",
+        output: "READ_SENTINEL",
+      });
+      expect(parts[1]).toMatchObject({
+        type: "tool-error",
+        toolCallId: "read-stream",
+        error: String(failure),
+      });
+      view.setFinalInput(input);
+      view.setError(parts[1]?.error);
+      expect(text(view)).toContain("ENOENT");
+      expect(view.render(160).join("\n")).toContain("\x1b[48;5;88m");
+    } finally {
+      view.dispose();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/coding-agent/src/tui/renderers/file.ts
+++ b/apps/coding-agent/src/tui/renderers/file.ts
@@ -2,9 +2,10 @@ import type { BaseToolCallView } from "../tool-call-view";
 import { groupStartLine, parseDiffSection, renderDiffGroup } from "./diff";
 import { highlightCode } from "./highlight";
 import {
+  formatReadHeader,
+  formatWriteHeader,
   isRecord,
   normalizedLines,
-  numberField,
   renderToolError,
   stringField,
 } from "./utils";
@@ -55,17 +56,6 @@ const formatEditHunk = (edit: EditOp): string =>
 const summarizeEdits = (edits: EditOp[]): string =>
   edits.map(formatEditHunk).join("\n\n");
 
-const getReadHeaderSuffix = (input: Record<string, unknown>): string => {
-  const parts: string[] = [];
-  if (numberField(input, "offset") !== undefined) {
-    parts.push(`offset: ${numberField(input, "offset")}`);
-  }
-  if (numberField(input, "limit") !== undefined) {
-    parts.push(`limit: ${numberField(input, "limit")}`);
-  }
-  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
-};
-
 export const renderReadFile = (
   view: BaseToolCallView,
   input: unknown,
@@ -84,7 +74,7 @@ export const renderReadFile = (
 
   const outputText = typeof output === "string" ? output : undefined;
   const isDirectory = outputText?.startsWith("OK - directory") === true;
-  const header = `**read${isDirectory ? " dir" : ""}** \`${path}\`${getReadHeaderSuffix(input)}`;
+  const header = formatReadHeader(path, input, isDirectory);
 
   if (outputText === undefined) {
     view.setPrettyBlock(header, "");
@@ -125,7 +115,7 @@ export const renderWriteFile = (
   }
 
   view.setPrettyBlock(
-    `**write** \`${path}\``,
+    formatWriteHeader(path),
     typeof output === "string" && output.startsWith("OK - wrote")
       ? normalizedLines(content).join("\n")
       : ""

--- a/apps/coding-agent/src/tui/renderers/shell-output.test.ts
+++ b/apps/coding-agent/src/tui/renderers/shell-output.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createShellExecuteTool } from "../../workspace-tools/shell-execute";
+import { stripTerminalEscapes } from "../terminal-safety";
+import { BaseToolCallView } from "../tool-call-view";
+import { createToolRenderers } from "./tool-renderers";
+
+const theme: MarkdownTheme = {
+  heading: (text) => text,
+  link: (text) => text,
+  linkUrl: (text) => text,
+  code: (text) => text,
+  codeBlock: (text) => text,
+  codeBlockBorder: (text) => text,
+  quote: (text) => text,
+  quoteBorder: (text) => text,
+  hr: (text) => text,
+  listBullet: (text) => text,
+  bold: (text) => text,
+  italic: (text) => text,
+  strikethrough: (text) => text,
+  underline: (text) => text,
+};
+
+const cases = [
+  { command: "printf 'file.html\\n'", body: "file.html\n", exit: "0" },
+  { command: "true", body: "", exit: "0" },
+  {
+    command: "printf 'warning\\n' >&2",
+    body: "\nstderr:\nwarning\n",
+    exit: "0",
+  },
+  {
+    command: "printf 'out\\n'; printf 'err\\n' >&2; exit 1",
+    body: "out\n\nstderr:\nerr\n",
+    exit: "1",
+  },
+  { command: "exit 1", body: "", exit: "1" },
+  {
+    command: "printf 'before\\nstderr:\\nafter\\n'",
+    body: "before\nstderr:\nafter\n",
+    exit: "0",
+  },
+  { command: "printf 'stderr:'", body: "stderr:", exit: "0" },
+  { command: "printf ' \\t\\n' >&2", body: "", exit: "0" },
+  { command: "printf ' \\t\\n'", body: " \t\n", exit: "0" },
+  {
+    command: "printf 'file.html\\n'; printf ' \\t\\n' >&2",
+    body: "file.html\n",
+    exit: "0",
+  },
+  { command: "kill -TERM $$", body: "", exit: "null" },
+] as const;
+
+const ERROR_BG = "\x1b[48;5;88m";
+
+describe("shell result display from real commands", () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), "pss-shell-display-"));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it.each(cases)(
+    "renders $command without inventing stderr",
+    async (testCase) => {
+      // Given an actual shell executor and the production tool view.
+      const execute = createShellExecuteTool(workspace).execute;
+      if (!execute) {
+        throw new Error("Expected an executable shell tool");
+      }
+      const input = { command: testCase.command };
+      const view = new BaseToolCallView(
+        "shell-test",
+        "shell_execute",
+        theme,
+        undefined,
+        false,
+        createToolRenderers()
+      );
+      const block = vi.spyOn(view, "setPrettyBlock");
+      view.setFinalInput(input);
+
+      try {
+        // When the real command completes and its result reaches the view.
+        const output = await execute(input, {
+          context: {},
+          messages: [],
+          toolCallId: "shell-test",
+        });
+        if (typeof output !== "string") {
+          throw new TypeError("Expected a string shell result");
+        }
+        view.setOutput(output);
+
+        // Then raw metadata stays truthful and the pretty body has no empty section.
+        const lines = output.split("\n");
+        expect(lines[1]).toBe(`exit_code: ${testCase.exit}`);
+        expect(lines[2]).toBe(
+          `signal: ${testCase.exit === "null" ? "SIGTERM" : "none"}`
+        );
+        expect(lines[3]).toBe("stdout:");
+        expect(lines.slice(4).join("\n")).toBe(testCase.body);
+        expect(output.startsWith("ERROR")).toBe(testCase.exit !== "0");
+        const body = testCase.body.trim() ? testCase.body : "(No output)";
+        const suffix = testCase.exit === "0" ? "" : `  (exit ${testCase.exit})`;
+        expect(block).toHaveBeenLastCalledWith(
+          `**bash** \`${testCase.command}\`${suffix}`,
+          body,
+          { isError: testCase.exit !== "0" }
+        );
+        const rendered = view.render(120).join("\n");
+        expect(rendered.includes(ERROR_BG)).toBe(testCase.exit !== "0");
+        const visible = stripTerminalEscapes(rendered)
+          .split("\n")
+          .map((line) => line.trim())
+          .join("\n");
+        expect(visible).toContain(body.trim());
+      } finally {
+        view.dispose();
+      }
+    }
+  );
+});

--- a/apps/coding-agent/src/tui/renderers/tool-renderers.test.ts
+++ b/apps/coding-agent/src/tui/renderers/tool-renderers.test.ts
@@ -397,3 +397,130 @@ describe("createToolRenderers — workspace tools", () => {
     expect(text).toContain(ERROR_BG);
   });
 });
+
+describe("progressive tool arguments", () => {
+  const cases = [
+    ["write_file", '{"path":"demo.ts","content":"EARLY', ' LATER"}'],
+    [
+      "edit_file",
+      '{"path":"demo.ts","edits":[{"new_content":"EARLY',
+      ' LATER","op":"append"}]}',
+    ],
+    ["read_file", '{"path":"EARLY', ' LATER","offset":2}'],
+    ["delete_file", '{"path":"EARLY', ' LATER"}'],
+    ["glob_files", '{"path":"EARLY', ' LATER","pattern":"*.ts"}'],
+    ["grep_files", '{"include":"EARLY', ' LATER","pattern":"TODO"}'],
+    ["shell_execute", '{"cwd":"EARLY', ' LATER","command":"pwd"}'],
+    ["generic_tool", '{"data":"EARLY', ' LATER"}'],
+  ];
+  it.each(cases)(
+    "%s reveals every available field before execution",
+    async (name, early, later) => {
+      const view = new BaseToolCallView(
+        "stream",
+        name,
+        theme,
+        undefined,
+        false,
+        createToolRenderers()
+      );
+      await view.appendInputChunk(early);
+      expect(renderText(view)).toContain("EARLY");
+      await view.appendInputChunk(later);
+      expect(renderText(view)).toContain("LATER");
+      view.setFinalInput(JSON.parse(early + later));
+      expect(renderText(view)).toContain("LATER");
+      expect(renderText(view)).not.toContain("OK -");
+      view.dispose();
+    }
+  );
+
+  it.each([true, false])(
+    "write decodes source with path first=%s and replaces preview once",
+    async (pathFirst) => {
+      const content = 'EARLY "quote"\nLATER 한글 café 😀\nEND';
+      const input = pathFirst
+        ? { path: "sample.ts", content }
+        : { content, path: "sample.ts" };
+      const full = JSON.stringify(input);
+      const view = new BaseToolCallView(
+        "stream",
+        "write_file",
+        theme,
+        undefined,
+        false,
+        createToolRenderers()
+      );
+      if (pathFirst) {
+        const pathEnd = full.indexOf(",");
+        await view.appendInputChunk(full.slice(0, pathEnd));
+        expect(renderText(view)).toContain("sample.ts");
+        await view.appendInputChunk(full.slice(pathEnd, full.indexOf("LATER")));
+      } else {
+        await view.appendInputChunk(full.slice(0, full.indexOf("LATER")));
+      }
+      expect(renderText(view)).toContain('EARLY "quote"');
+      expect(renderText(view)).not.toContain("\\n");
+      await view.appendInputChunk(full.slice(full.indexOf("LATER")));
+      const lines = view.render(120);
+      expect(lines.some((line) => line.includes("LATER 한글 café 😀"))).toBe(
+        true
+      );
+      expect(lines.findIndex((line) => line.includes("LATER"))).toBeGreaterThan(
+        lines.findIndex((line) => line.includes("EARLY"))
+      );
+      view.setFinalInput(input);
+      expect(renderText(view)).toContain("LATER");
+      view.setOutput("OK - wrote file");
+      expect(renderText(view).split("EARLY")).toHaveLength(2);
+      expect(renderText(view)).not.toContain('"content"');
+      view.dispose();
+    }
+  );
+
+  it("sanitizes decoded controls while Unicode escapes are split across chunks", async () => {
+    const view = new BaseToolCallView(
+      "stream",
+      "write_file",
+      theme,
+      undefined,
+      false,
+      createToolRenderers()
+    );
+    await view.appendInputChunk('{"content":"EARLY \\uD83D');
+    await view.appendInputChunk(
+      '\\uDE00\\nLATER \\u001b]52;c;payload\\u0007"}'
+    );
+    const text = renderText(view);
+    expect(text).toContain("EARLY 😀");
+    expect(text).toContain("LATER ^[]52;c;payload^G");
+    expect(text).not.toContain("\u001b]");
+    view.dispose();
+  });
+});
+
+describe("characterization: write result and error", () => {
+  it("final success renders decoded content exactly once", () => {
+    const view = createView(
+      "write_file",
+      { path: "a.ts", content: "FINAL_A\nFINAL_B" },
+      "OK - wrote file"
+    );
+    expect(renderText(view).split("FINAL_A")).toHaveLength(2);
+    expect(renderText(view)).toContain("FINAL_B");
+    expect(renderText(view)).not.toContain("OK - wrote");
+    view.dispose();
+  });
+  it("error replaces successful source presentation", () => {
+    const view = createView(
+      "write_file",
+      { path: "a.ts", content: "UNWRITTEN" },
+      undefined,
+      "ERROR_SENTINEL"
+    );
+    expect(renderText(view)).toContain("ERROR_SENTINEL");
+    expect(renderText(view)).toContain(ERROR_BG);
+    expect(renderText(view)).not.toContain("UNWRITTEN");
+    view.dispose();
+  });
+});

--- a/apps/coding-agent/src/tui/renderers/tool-renderers.ts
+++ b/apps/coding-agent/src/tui/renderers/tool-renderers.ts
@@ -82,7 +82,9 @@ const renderGrepFiles = (
   if (include) {
     context.push(`include: ${include}`);
   }
-  const header = `**grep** \`${pattern}\`${context.length > 0 ? ` (${context.join(", ")})` : ""}`;
+  const header = `**grep** \`${pattern}\`${
+    context.length > 0 ? ` (${context.join(", ")})` : ""
+  }`;
 
   if (typeof output !== "string" || output.length === 0) {
     view.setPrettyBlock(header, "");
@@ -133,9 +135,11 @@ const renderShellExecute = (
   // "OK|ERROR - ...", "exit_code:", "signal:", "stdout:" precede the body.
   const body = lines.slice(4).join("\n");
 
-  view.setPrettyBlock(`**bash** \`${displayCommand}\`${headerSuffix}`, body, {
-    isError: isErrorOutput,
-  });
+  view.setPrettyBlock(
+    `**bash** \`${displayCommand}\`${headerSuffix}`,
+    body.trim() ? body : "(No output)",
+    { isError: isErrorOutput }
+  );
 };
 
 /**

--- a/apps/coding-agent/src/tui/renderers/utils.ts
+++ b/apps/coding-agent/src/tui/renderers/utils.ts
@@ -25,6 +25,19 @@ export const stringField = (obj: unknown, key: string): string | undefined => {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 };
 
+const formatFileHeader = (operation: string, path: string): string => {
+  const safePath = sanitizeTerminalText(path, path.length);
+  const longestRun = Array.from(safePath.matchAll(/`+/g)).reduce(
+    (longest, match) => Math.max(longest, match[0].length),
+    0
+  );
+  const fence = "`".repeat(longestRun + 1);
+  return `**${operation}** ${fence} ${safePath} ${fence}`;
+};
+
+export const formatWriteHeader = (path: string): string =>
+  formatFileHeader("write", path);
+
 export const numberField = (obj: unknown, key: string): number | undefined => {
   if (!isRecord(obj)) {
     return;
@@ -33,6 +46,22 @@ export const numberField = (obj: unknown, key: string): number | undefined => {
   return typeof value === "number" && Number.isFinite(value)
     ? value
     : undefined;
+};
+
+export const formatReadHeader = (
+  path: string,
+  input: unknown,
+  isDirectory = false
+): string => {
+  const parts: string[] = [];
+  for (const key of ["offset", "limit"]) {
+    const value = numberField(input, key);
+    if (value !== undefined) {
+      parts.push(`${key}: ${value}`);
+    }
+  }
+  const suffix = parts.length > 0 ? ` (${parts.join(", ")})` : "";
+  return `${formatFileHeader(isDirectory ? "read dir" : "read", path)}${suffix}`;
 };
 
 export const safeStringify = (value: unknown): string => {

--- a/apps/coding-agent/src/tui/repeated-notice.test.ts
+++ b/apps/coding-agent/src/tui/repeated-notice.test.ts
@@ -51,9 +51,11 @@ vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
 
 import type { CodingAgentExtensionUi } from "../extensions/types";
 import { createAgentTUI } from "./agent";
+import { createModelCommand } from "./model-command";
 import { createRepeatedNotice } from "./repeated-notice";
 import { TuiSessionMachine } from "./session-state";
 import { sanitizeTerminalText } from "./terminal-safety";
+import { TranscriptOwner } from "./transcript-owner";
 
 const EMPTY_NOTICE = "Please enter a message.";
 const NOTICE_PULSE_MS = 140;
@@ -105,9 +107,7 @@ const rows = (): string[] => {
       }
       return;
     }
-    if (component instanceof Text) {
-      collected.push(component.render(80).join("\n").trim());
-    }
+    collected.push(...component.render(80).map((line) => line.trim()));
   };
   walk(surface);
   return collected;
@@ -154,19 +154,23 @@ afterEach(() => {
 });
 
 const controllerFixture = () => {
-  const chatContainer = new Container();
+  const chatContainer = new TranscriptOwner(() => 80);
   const requestRender = vi.fn();
+  const rows: Text[] = [];
   const controller = createRepeatedNotice({
     appendNotice: (message) => {
       if (!message) {
         return;
       }
       const normalText = `normal:${message}`;
-      const row = new Text(normalText);
-      chatContainer.addChild(row);
-      return { normalText, row };
+      const lease = chatContainer.acquire(() => new Text(normalText), {
+        leadingSpacer: false,
+        settle: () => controller.settle(),
+      });
+      rows.push(lease.view);
+      return { normalText, row: lease.view, isActive: () => lease.active };
     },
-    chatContainer,
+    normalStyle: (message) => `normal:${message}`,
     pulseStyle: (message) => `pulse:${message}`,
     requestRender,
   });
@@ -175,10 +179,72 @@ const controllerFixture = () => {
       .flatMap((row) => row.render(80))
       .map((line) => line.trim())
       .filter(Boolean);
-  return { chatContainer, contents, controller, requestRender };
+  return { chatContainer, contents, controller, requestRender, rows };
 };
 
 describe("repeated notice pulse ownership", () => {
+  it("replaces the current keyed notice and restores the latest text with one rearmed timer", () => {
+    const { controller, contents } = controllerFixture();
+    controller.show("MODEL_A", "model-change");
+    for (const model of ["MODEL_B", "MODEL_C", "MODEL_D"]) {
+      controller.show(model, "model-change");
+      vi.advanceTimersByTime(NOTICE_PULSE_MS / 2);
+      expect(contents()).toEqual([`pulse:${model}`]);
+      expect(vi.getTimerCount()).toBe(1);
+    }
+    vi.advanceTimersByTime(NOTICE_PULSE_MS);
+    expect(contents()).toEqual(["normal:MODEL_D"]);
+    expect(vi.getTimerCount()).toBe(0);
+    controller.stop();
+  });
+
+  it.each(["cold", "content", "different-key", "unkeyed"] as const)(
+    "does not replace a keyed notice across %s",
+    (boundary) => {
+      const { controller, chatContainer, contents, rows } = controllerFixture();
+      controller.show("MODEL_A", "model-change");
+      controller.show("MODEL_B", "model-change");
+      if (boundary === "cold") {
+        chatContainer.finish();
+      }
+      if (boundary === "content") {
+        chatContainer.addChild(new Text("CONTENT"));
+      }
+      if (boundary === "different-key") {
+        controller.show("MODEL_B", "other");
+      }
+      if (boundary === "unkeyed") {
+        controller.show("MODEL_B");
+      }
+      const before = contents();
+      const oldSetter = vi.spyOn(rows[0], "setText");
+      controller.show("MODEL_C", "model-change");
+      expect(contents()).toEqual([...before, "normal:MODEL_C"]);
+      expect(contents()[0]).toBe("normal:MODEL_B");
+      expect(oldSetter).not.toHaveBeenCalled();
+      controller.stop();
+    }
+  );
+
+  it("never reuses a sealed notice even while it is still the transcript tail", () => {
+    const { controller, chatContainer, contents, rows } = controllerFixture();
+    controller.show("A");
+    controller.show("A");
+    chatContainer.finish();
+    const cold = chatContainer.render(80);
+    const oldSetter = vi.spyOn(rows[0], "setText");
+    controller.settle();
+    vi.advanceTimersByTime(NOTICE_PULSE_MS);
+    expect(chatContainer.render(80)).toEqual(cold);
+    controller.show("A");
+    controller.show("A");
+    expect(contents()).toEqual(["normal:A", "pulse:A"]);
+    expect(oldSetter).not.toHaveBeenCalled();
+    expect(chatContainer.children[0]?.render(80)).toEqual(cold);
+    controller.settle();
+    controller.stop();
+  });
+
   it("restores the old row before a distinct notice replaces its pulse", () => {
     const { controller, contents, requestRender } = controllerFixture();
     controller.show("A");
@@ -198,7 +264,7 @@ describe("repeated notice pulse ownership", () => {
   });
 
   it.each(["user", "assistant", "tool"])(
-    "restores a stale pulse and appends afresh after %s content",
+    "settles before %s content and appends subsequent notices afresh",
     (kind) => {
       const { controller, chatContainer, contents } = controllerFixture();
       controller.show("A");
@@ -229,12 +295,16 @@ describe("repeated notice pulse ownership", () => {
   it.each(["reset", "timer"])(
     "does not repaint a cleared row on %s",
     (action) => {
-      const { controller, chatContainer, requestRender } = controllerFixture();
+      const { controller, chatContainer, requestRender, rows } =
+        controllerFixture();
       controller.show("A");
       controller.show("A");
-      const row = chatContainer.children[0] as Text;
+      const row = rows[0];
       const setText = vi.spyOn(row, "setText");
-      chatContainer.clear();
+      chatContainer.reset("session-navigation");
+      // The owner settles while still HOT, before revoking/resetting the epoch.
+      expect(setText).toHaveBeenCalledExactlyOnceWith("normal:A");
+      setText.mockClear();
       requestRender.mockClear();
       if (action === "reset") {
         controller.reset();
@@ -244,7 +314,7 @@ describe("repeated notice pulse ownership", () => {
       expect(requestRender).not.toHaveBeenCalled();
       controller.show("A");
       expect(chatContainer.children).toHaveLength(1);
-      expect(chatContainer.children[0]).not.toBe(row);
+      expect(rows.at(-1)).not.toBe(row);
       controller.stop();
     }
   );
@@ -260,10 +330,11 @@ describe("repeated notice pulse ownership", () => {
   });
 
   it("stop cancels without repainting disposed UI, including later calls", () => {
-    const { controller, chatContainer, requestRender } = controllerFixture();
+    const { controller, chatContainer, requestRender, rows } =
+      controllerFixture();
     controller.show("A");
     controller.show("A");
-    const setText = vi.spyOn(chatContainer.children[0] as Text, "setText");
+    const setText = vi.spyOn(rows[0], "setText");
     requestRender.mockClear();
     controller.stop();
     controller.show("A");
@@ -280,6 +351,49 @@ describe("repeated notice pulse ownership", () => {
 });
 
 describe.sequential("common system notices", () => {
+  it("sanitizes keyed model updates before pulse and restores the newest normal text", async () => {
+    let current = "MODEL_A";
+    const hostile = "MODEL_B\x1b[2J\x1b]52;c;payload\x07";
+    const model = createModelCommand({
+      currentModelId: () => current,
+      listModelIds: async () => ["MODEL_A", "MODEL_FIRST", hostile],
+      switchModel: (id) => {
+        current = id;
+      },
+    });
+    let requested = "MODEL_FIRST";
+    const command = {
+      ...model,
+      execute: () => model.execute({ args: [requested] }),
+    };
+    const ready = idleGate();
+    const run = createAgentTUI({ thread: thread(), commands: [command] });
+    const matching = () => rows().filter((row) => row.includes("MODEL_"));
+    try {
+      await ready;
+      let settled = idleGate();
+      input("/model\r");
+      await settled;
+      requested = hostile;
+      settled = idleGate();
+      input("/model\r");
+      await settled;
+      const result = await createModelCommand({
+        currentModelId: () => "",
+        listModelIds: async () => [hostile],
+        switchModel: () => undefined,
+      }).execute({ args: [hostile] });
+      const cleaned = sanitizeTerminalText(result.message ?? "");
+      expect(matching()).toEqual([`\x1b[47m\x1b[30m${cleaned}\x1b[0m`]);
+      vi.advanceTimersByTime(NOTICE_PULSE_MS);
+      expect(matching()).toEqual([`\x1b[38;5;245m${cleaned}\x1b[0m`]);
+      expect(matching().join("")).not.toContain("\x1b[2J");
+      expect(matching().join("")).not.toContain("\x1b]52");
+    } finally {
+      await exit(run);
+    }
+  });
+
   it("routes generic notifications through sanitized normal and pulse rendering", async () => {
     let ui!: CodingAgentExtensionUi;
     const idle = idleGate();

--- a/apps/coding-agent/src/tui/repeated-notice.test.ts
+++ b/apps/coding-agent/src/tui/repeated-notice.test.ts
@@ -1,0 +1,488 @@
+import {
+  type Component,
+  Container,
+  type Terminal,
+  Text,
+  type TuiMainScreen,
+} from "@earendil-works/pi-tui";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const terminalHarness = vi.hoisted(() => ({
+  send: (_data: string): void => undefined,
+  surface: undefined as TuiMainScreen | undefined,
+}));
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  const noop = () => undefined;
+  class TestTerminal implements Terminal {
+    columns = 80;
+    rows = 24;
+    kittyProtocolActive = false;
+    clearFromCursor = noop;
+    clearLine = noop;
+    clearScreen = noop;
+    hideCursor = noop;
+    moveBy = noop;
+    setProgress = noop;
+    setTitle = noop;
+    showCursor = noop;
+    stop = noop;
+    write = noop;
+    drainInput() {
+      return Promise.resolve();
+    }
+    start(onInput: (data: string) => void) {
+      terminalHarness.send = onInput;
+    }
+  }
+  class TestScreen extends actual.TuiMainScreen {
+    override start() {
+      terminalHarness.surface = this;
+      super.start();
+    }
+  }
+  return {
+    ...actual,
+    ProcessTerminal: TestTerminal,
+    TuiMainScreen: TestScreen,
+  };
+});
+
+import type { CodingAgentExtensionUi } from "../extensions/types";
+import { createAgentTUI } from "./agent";
+import { createRepeatedNotice } from "./repeated-notice";
+import { TuiSessionMachine } from "./session-state";
+import { sanitizeTerminalText } from "./terminal-safety";
+
+const EMPTY_NOTICE = "Please enter a message.";
+const NOTICE_PULSE_MS = 140;
+const GRAY_NOTICE = `\x1b[38;5;245m${EMPTY_NOTICE}\x1b[0m`;
+const PULSED_NOTICE = `\x1b[47m\x1b[30m${EMPTY_NOTICE}\x1b[0m`;
+
+const gate = <T = void>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+const idleGate = () => {
+  const idle = gate();
+  const original = TuiSessionMachine.prototype.awaitInput;
+  const spy = vi
+    .spyOn(TuiSessionMachine.prototype, "awaitInput")
+    .mockImplementation(function (this: TuiSessionMachine, resolve) {
+      original.call(this, resolve);
+      spy.mockRestore();
+      idle.resolve();
+    });
+  return idle.promise;
+};
+
+const input = (value: string) => {
+  for (const char of value) {
+    terminalHarness.send(char);
+  }
+};
+
+/**
+ * Every mounted leaf row, in visual order. `Text` renders with one column of
+ * padding, so the styled cell is compared after trimming the pad — the ANSI
+ * styling itself is asserted byte-for-byte.
+ */
+const rows = (): string[] => {
+  const surface = terminalHarness.surface;
+  if (!surface) {
+    throw new Error("No mounted surface");
+  }
+  const collected: string[] = [];
+  const walk = (component: Component): void => {
+    if (component instanceof Container) {
+      for (const child of component.children) {
+        walk(child);
+      }
+      return;
+    }
+    if (component instanceof Text) {
+      collected.push(component.render(80).join("\n").trim());
+    }
+  };
+  walk(surface);
+  return collected;
+};
+
+const noticeRows = (): string[] =>
+  rows().filter((row) => row.includes(EMPTY_NOTICE));
+
+const exit = async (run: Promise<void>) => {
+  process.emit("SIGINT", "SIGINT");
+  process.emit("SIGINT", "SIGINT");
+  await run;
+  expect(vi.getTimerCount()).toBe(0);
+};
+
+const thread = () => ({
+  interrupt: vi.fn(),
+  send: vi.fn(() => {
+    throw new Error("Unexpected send");
+  }),
+  steer: vi.fn(() => {
+    throw new Error("Unexpected steer");
+  }),
+});
+
+/**
+ * Submits an empty line and waits for the TUI to be back at the prompt, so
+ * every assertion runs against a settled transcript instead of a race.
+ */
+const submitEmpty = async (): Promise<void> => {
+  const settled = idleGate();
+  input("\r");
+  await settled;
+};
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+  });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+const controllerFixture = () => {
+  const chatContainer = new Container();
+  const requestRender = vi.fn();
+  const controller = createRepeatedNotice({
+    appendNotice: (message) => {
+      if (!message) {
+        return;
+      }
+      const normalText = `normal:${message}`;
+      const row = new Text(normalText);
+      chatContainer.addChild(row);
+      return { normalText, row };
+    },
+    chatContainer,
+    pulseStyle: (message) => `pulse:${message}`,
+    requestRender,
+  });
+  const contents = () =>
+    chatContainer.children
+      .flatMap((row) => row.render(80))
+      .map((line) => line.trim())
+      .filter(Boolean);
+  return { chatContainer, contents, controller, requestRender };
+};
+
+describe("repeated notice pulse ownership", () => {
+  it("restores the old row before a distinct notice replaces its pulse", () => {
+    const { controller, contents, requestRender } = controllerFixture();
+    controller.show("A");
+    controller.show("A");
+    expect(contents()).toEqual(["pulse:A"]);
+    controller.show("B");
+    expect(contents()).toEqual(["normal:A", "normal:B"]);
+    controller.show("B");
+    vi.advanceTimersByTime(NOTICE_PULSE_MS);
+    expect(contents()).toEqual(["normal:A", "normal:B"]);
+    controller.settle();
+    controller.stop();
+    const renders = requestRender.mock.calls.length;
+    vi.runAllTimers();
+    expect(requestRender).toHaveBeenCalledTimes(renders);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each(["user", "assistant", "tool"])(
+    "restores a stale pulse and appends afresh after %s content",
+    (kind) => {
+      const { controller, chatContainer, contents } = controllerFixture();
+      controller.show("A");
+      controller.show("A");
+      chatContainer.addChild(new Text(`${kind}:content`));
+      controller.show("A");
+      expect(contents()).toEqual(["normal:A", `${kind}:content`, "normal:A"]);
+      controller.show("A");
+      expect(contents()).toEqual(["normal:A", `${kind}:content`, "pulse:A"]);
+      vi.advanceTimersByTime(NOTICE_PULSE_MS);
+      expect(contents()).toEqual(["normal:A", `${kind}:content`, "normal:A"]);
+      controller.stop();
+    }
+  );
+
+  it("restores before reset drops a mounted pulse and starts fresh", () => {
+    const { controller, contents } = controllerFixture();
+    controller.show("A");
+    controller.show("A");
+    controller.reset();
+    expect(contents()).toEqual(["normal:A"]);
+    expect(vi.getTimerCount()).toBe(0);
+    controller.show("A");
+    expect(contents()).toEqual(["normal:A", "normal:A"]);
+    controller.stop();
+  });
+
+  it.each(["reset", "timer"])(
+    "does not repaint a cleared row on %s",
+    (action) => {
+      const { controller, chatContainer, requestRender } = controllerFixture();
+      controller.show("A");
+      controller.show("A");
+      const row = chatContainer.children[0] as Text;
+      const setText = vi.spyOn(row, "setText");
+      chatContainer.clear();
+      requestRender.mockClear();
+      if (action === "reset") {
+        controller.reset();
+      }
+      vi.advanceTimersByTime(NOTICE_PULSE_MS);
+      expect(setText).not.toHaveBeenCalled();
+      expect(requestRender).not.toHaveBeenCalled();
+      controller.show("A");
+      expect(chatContainer.children).toHaveLength(1);
+      expect(chatContainer.children[0]).not.toBe(row);
+      controller.stop();
+    }
+  );
+
+  it("restores even when the replacement renders nothing", () => {
+    const { controller, contents } = controllerFixture();
+    controller.show("A");
+    controller.show("A");
+    controller.show("");
+    expect(contents()).toEqual(["normal:A"]);
+    expect(vi.getTimerCount()).toBe(0);
+    controller.stop();
+  });
+
+  it("stop cancels without repainting disposed UI, including later calls", () => {
+    const { controller, chatContainer, requestRender } = controllerFixture();
+    controller.show("A");
+    controller.show("A");
+    const setText = vi.spyOn(chatContainer.children[0] as Text, "setText");
+    requestRender.mockClear();
+    controller.stop();
+    controller.show("A");
+    controller.show("B");
+    controller.reset();
+    controller.settle();
+    controller.stop();
+    vi.runAllTimers();
+    expect(setText).not.toHaveBeenCalled();
+    expect(requestRender).not.toHaveBeenCalled();
+    expect(chatContainer.children).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe.sequential("common system notices", () => {
+  it("routes generic notifications through sanitized normal and pulse rendering", async () => {
+    let ui!: CodingAgentExtensionUi;
+    const idle = idleGate();
+    const run = createAgentTUI({
+      thread: thread(),
+      onExtensionUiReady: (createUi) => {
+        ui = createUi();
+      },
+    });
+    const message = "Notice \x1b[2J\x1b]52;c;payload\x07\r!";
+    const cleaned = sanitizeTerminalText(message);
+    const matching = () => rows().filter((row) => row.includes("Notice "));
+    try {
+      await idle;
+      ui.notify(message);
+      expect(matching()).toEqual([`\x1b[38;5;245m${cleaned}\x1b[0m`]);
+      ui.notify(message);
+      expect(matching()).toEqual([`\x1b[47m\x1b[30m${cleaned}\x1b[0m`]);
+      ui.notify("Different notice");
+      expect(matching()).toEqual([`\x1b[38;5;245m${cleaned}\x1b[0m`]);
+      ui.notify(message);
+      expect(matching()).toEqual([
+        `\x1b[38;5;245m${cleaned}\x1b[0m`,
+        `\x1b[38;5;245m${cleaned}\x1b[0m`,
+      ]);
+    } finally {
+      await exit(run);
+    }
+    const preserved = rows();
+    ui.notify(message);
+    expect(rows()).toEqual(preserved);
+  });
+
+  it.each([false, true])(
+    "routes repeated command messages and caught system errors (throws=%s)",
+    async (throws) => {
+      const message = "Fixture \x1b[2J failure";
+      const cleaned = sanitizeTerminalText(
+        `${throws ? "Error: " : ""}${message}`
+      );
+      const idle = idleGate();
+      const run = createAgentTUI({
+        thread: thread(),
+        commands: [
+          {
+            name: "note",
+            description: "fixture",
+            execute: () => {
+              if (throws) {
+                throw new Error(message);
+              }
+              return { success: true, message };
+            },
+          },
+        ],
+      });
+      try {
+        await idle;
+        for (const expected of [
+          `\x1b[38;5;245m${cleaned}\x1b[0m`,
+          `\x1b[47m\x1b[30m${cleaned}\x1b[0m`,
+        ]) {
+          const settled = idleGate();
+          input("/note\r");
+          await settled;
+          expect(rows().filter((row) => row.includes("Fixture "))).toEqual([
+            expected,
+          ]);
+        }
+        vi.advanceTimersByTime(NOTICE_PULSE_MS);
+        expect(rows().filter((row) => row.includes("Fixture "))).toEqual([
+          `\x1b[38;5;245m${cleaned}\x1b[0m`,
+        ]);
+      } finally {
+        await exit(run);
+      }
+    }
+  );
+
+  it("appends after real user content interrupts an active empty-input pulse", async () => {
+    const idle = idleGate();
+    const run = createAgentTUI({
+      thread: thread(),
+      preprocessUserInput: async () => ({
+        success: false,
+        error: "Input rejected.",
+      }),
+    });
+    try {
+      await idle;
+      await submitEmpty();
+      await submitEmpty();
+      const settled = idleGate();
+      input("Visible user content\r");
+      await settled;
+      expect(noticeRows()).toEqual([GRAY_NOTICE]);
+      await submitEmpty();
+      expect(noticeRows()).toEqual([GRAY_NOTICE, GRAY_NOTICE]);
+    } finally {
+      await exit(run);
+    }
+  });
+});
+
+describe.sequential("repeated empty-input notice", () => {
+  it("reuses one row and pulses black text on white instead of appending duplicates", async () => {
+    const idle = idleGate();
+    const run = createAgentTUI({ thread: thread() });
+    try {
+      await idle;
+
+      await submitEmpty();
+      expect(noticeRows()).toEqual([GRAY_NOTICE]);
+
+      await submitEmpty();
+      // Still exactly one row: the repeat reuses the visible notice.
+      expect(noticeRows()).toEqual([PULSED_NOTICE]);
+
+      vi.advanceTimersByTime(NOTICE_PULSE_MS);
+      // Restored to the byte-identical normal style.
+      expect(noticeRows()).toEqual([GRAY_NOTICE]);
+    } finally {
+      await exit(run);
+    }
+  });
+
+  it("keeps one row and one pulse timer across rapid repeats", async () => {
+    const idle = idleGate();
+    const run = createAgentTUI({ thread: thread() });
+    try {
+      await idle;
+
+      await submitEmpty();
+      const baseTimers = vi.getTimerCount();
+
+      for (let attempt = 0; attempt < 4; attempt++) {
+        await submitEmpty();
+        vi.advanceTimersByTime(NOTICE_PULSE_MS / 4);
+        expect(noticeRows()).toEqual([PULSED_NOTICE]);
+        // The repeat re-arms the same pulse rather than stacking timers.
+        expect(vi.getTimerCount()).toBe(baseTimers + 1);
+      }
+
+      vi.advanceTimersByTime(NOTICE_PULSE_MS);
+      expect(noticeRows()).toEqual([GRAY_NOTICE]);
+      expect(vi.getTimerCount()).toBe(baseTimers);
+    } finally {
+      await exit(run);
+    }
+  });
+
+  it("appends a fresh notice once other content lands after the tracked row", async () => {
+    const idle = idleGate();
+    const run = createAgentTUI({
+      thread: thread(),
+      commands: [
+        {
+          name: "note",
+          description: "fixture",
+          execute: () => ({ success: true, message: "Fixture ran." }),
+        },
+      ],
+    });
+    try {
+      await idle;
+
+      await submitEmpty();
+      expect(noticeRows()).toEqual([GRAY_NOTICE]);
+
+      const settled = idleGate();
+      input("/note\r");
+      await settled;
+      expect(rows().some((row) => row.includes("Fixture ran."))).toBe(true);
+
+      // The tracked notice is no longer the last row, so this is a genuinely
+      // new notice and must not be suppressed.
+      await submitEmpty();
+      expect(noticeRows()).toEqual([GRAY_NOTICE, GRAY_NOTICE]);
+
+      // The newest notice is the one that pulses.
+      await submitEmpty();
+      expect(noticeRows()).toEqual([GRAY_NOTICE, PULSED_NOTICE]);
+      vi.advanceTimersByTime(NOTICE_PULSE_MS);
+      expect(noticeRows()).toEqual([GRAY_NOTICE, GRAY_NOTICE]);
+    } finally {
+      await exit(run);
+    }
+  });
+
+  it("leaves no pulse timer or stuck inversion when the TUI shuts down mid-pulse", async () => {
+    const idle = idleGate();
+    const run = createAgentTUI({ thread: thread() });
+    await idle;
+
+    await submitEmpty();
+    await submitEmpty();
+    expect(noticeRows()).toEqual([PULSED_NOTICE]);
+
+    // exit() asserts the timer count is zero, i.e. the in-flight pulse timer
+    // was cleared by disposal rather than left to fire after teardown.
+    await exit(run);
+
+    // The preserved final frame must not freeze the notice inverted.
+    expect(noticeRows()).toEqual([GRAY_NOTICE]);
+  });
+});

--- a/apps/coding-agent/src/tui/repeated-notice.ts
+++ b/apps/coding-agent/src/tui/repeated-notice.ts
@@ -1,4 +1,4 @@
-import type { Container, Text } from "@earendil-works/pi-tui";
+import type { Text } from "@earendil-works/pi-tui";
 
 /**
  * Reuse-and-pulse behaviour for immediately repeated TUI system notices.
@@ -11,8 +11,9 @@ import type { Container, Text } from "@earendil-works/pi-tui";
  * MATCHING SCOPE — deliberately narrow:
  *
  * - Only the *current notice instance* is reusable: the exact `Text` row this
- *   module appended, only while it is still the LAST child of the chat
- *   container, and only for a byte-identical message.
+ *   module appended, only while its transcript lease is active, and only for
+ *   a byte-identical message (or the same explicit semantic key). Mounted
+ *   presentation wrappers are not identity.
  * - Anything landing after it (assistant text, tool output, a user message, a
  *   different notice) makes the tracked row stale, so the next notice is
  *   appended fresh. A genuinely new notice is never suppressed.
@@ -20,8 +21,8 @@ import type { Container, Text } from "@earendil-works/pi-tui";
  *   never inspected, compared, or collapsed.
  *
  * The pulse is pure view state on a mounted component: nothing here reaches
- * persisted session state, and restore writes back the byte-identical string
- * captured when the row was created.
+ * persisted session state, and restore writes back the newest normal text.
+ * Keyed updates replace only the current HOT notice, never historical content.
  */
 
 export const NOTICE_PULSE_MS = 140;
@@ -36,14 +37,16 @@ export interface RepeatedNotice {
   settle(): void;
   /**
    * Renders terminal-sanitized `message`. Appends a new row, or pulses the
-   * current notice instance when this is an immediate identical repeat.
+   * current notice instance for an immediate identical repeat or matching key.
    */
-  show(message: string): void;
+  show(message: string, key?: string): void;
   /** Tears down without painting; call settle before the UI's final render. */
   stop(): void;
 }
 
 export interface AppendedNotice {
+  /** True only while this notice owns the live transcript lease. */
+  readonly isActive: () => boolean;
   /** The byte-identical normal-style string the row was created with. */
   readonly normalText: string;
   readonly row: Text;
@@ -55,23 +58,22 @@ export interface RepeatedNoticeOptions {
    * renders to nothing and no row was added.
    */
   appendNotice: (message: string) => AppendedNotice | undefined;
-  /** The chat container the notice rows live in; used for staleness checks. */
-  chatContainer: Pick<Container, "children">;
+  /** Styles the newest sanitized notice for normal display after a pulse. */
+  normalStyle: (message: string) => string;
   /** Styles the sanitized notice with white background and black text. */
   pulseStyle: (message: string) => string;
   requestRender: () => void;
 }
 
-interface TrackedNotice {
-  readonly message: string;
-  /** The byte-identical normal-style string to restore after the pulse. */
-  readonly normalText: string;
-  readonly row: Text;
+interface TrackedNotice extends AppendedNotice {
+  readonly key?: string;
+  message: string;
+  normalText: string;
 }
 
 export const createRepeatedNotice = ({
   appendNotice,
-  chatContainer,
+  normalStyle,
   pulseStyle,
   requestRender,
 }: RepeatedNoticeOptions): RepeatedNotice => {
@@ -87,7 +89,7 @@ export const createRepeatedNotice = ({
   };
 
   const restore = (notice: TrackedNotice): boolean => {
-    if (!chatContainer.children.includes(notice.row)) {
+    if (!notice.isActive()) {
       return false;
     }
     notice.row.setText(notice.normalText);
@@ -109,23 +111,32 @@ export const createRepeatedNotice = ({
    * The reusable notice for `message`, or `undefined` when this is not an
    * immediate identical repeat of the still-visible current notice.
    */
-  const reusableFor = (message: string): TrackedNotice | undefined => {
-    if (tracked === undefined || tracked.message !== message) {
+  const reusableFor = (
+    message: string,
+    key?: string
+  ): TrackedNotice | undefined => {
+    if (
+      tracked === undefined ||
+      tracked.key !== key ||
+      (key === undefined && tracked.message !== message)
+    ) {
       return;
     }
     // Anything appended after the tracked row makes it stale, so a later
     // exchange never suppresses a genuinely new notice.
-    return chatContainer.children.at(-1) === tracked.row ? tracked : undefined;
+    return tracked.isActive() ? tracked : undefined;
   };
 
   return {
-    show(message: string): void {
+    show(message: string, key?: string): void {
       if (stopped) {
         return;
       }
 
-      const current = reusableFor(message);
+      const current = reusableFor(message, key);
       if (current !== undefined) {
+        current.message = message;
+        current.normalText = normalStyle(message);
         current.row.setText(pulseStyle(message));
         // A rapid repeat re-arms the single pulse instead of stacking timers,
         // so the inversion can never outlive the last attempt.
@@ -144,9 +155,7 @@ export const createRepeatedNotice = ({
       settle();
       const appended = appendNotice(message);
       tracked =
-        appended === undefined
-          ? undefined
-          : { message, normalText: appended.normalText, row: appended.row };
+        appended === undefined ? undefined : { key, message, ...appended };
       requestRender();
     },
     reset(): void {

--- a/apps/coding-agent/src/tui/repeated-notice.ts
+++ b/apps/coding-agent/src/tui/repeated-notice.ts
@@ -1,0 +1,163 @@
+import type { Container, Text } from "@earendil-works/pi-tui";
+
+/**
+ * Reuse-and-pulse behaviour for immediately repeated TUI system notices.
+ *
+ * A user who presses Enter on an empty composer twice gets no new information
+ * from a second identical row, only a taller transcript. Instead the already
+ * visible row is briefly re-rendered inverted and then restored, which reads as
+ * "yes, still the same notice" without growing the transcript.
+ *
+ * MATCHING SCOPE — deliberately narrow:
+ *
+ * - Only the *current notice instance* is reusable: the exact `Text` row this
+ *   module appended, only while it is still the LAST child of the chat
+ *   container, and only for a byte-identical message.
+ * - Anything landing after it (assistant text, tool output, a user message, a
+ *   different notice) makes the tracked row stale, so the next notice is
+ *   appended fresh. A genuinely new notice is never suppressed.
+ * - This is NOT transcript deduplication. Assistant/model/tool/user content is
+ *   never inspected, compared, or collapsed.
+ *
+ * The pulse is pure view state on a mounted component: nothing here reaches
+ * persisted session state, and restore writes back the byte-identical string
+ * captured when the row was created.
+ */
+
+export const NOTICE_PULSE_MS = 140;
+
+export interface RepeatedNotice {
+  /** Restores a still-mounted pulse and drops the tracked row and timer. */
+  reset(): void;
+  /**
+   * Ends any in-flight pulse immediately, restoring the normal style. Used at
+   * shutdown so the final preserved frame never keeps a row inverted.
+   */
+  settle(): void;
+  /**
+   * Renders terminal-sanitized `message`. Appends a new row, or pulses the
+   * current notice instance when this is an immediate identical repeat.
+   */
+  show(message: string): void;
+  /** Tears down without painting; call settle before the UI's final render. */
+  stop(): void;
+}
+
+export interface AppendedNotice {
+  /** The byte-identical normal-style string the row was created with. */
+  readonly normalText: string;
+  readonly row: Text;
+}
+
+export interface RepeatedNoticeOptions {
+  /**
+   * Appends a fresh notice row, or returns `undefined` when the message
+   * renders to nothing and no row was added.
+   */
+  appendNotice: (message: string) => AppendedNotice | undefined;
+  /** The chat container the notice rows live in; used for staleness checks. */
+  chatContainer: Pick<Container, "children">;
+  /** Styles the sanitized notice with white background and black text. */
+  pulseStyle: (message: string) => string;
+  requestRender: () => void;
+}
+
+interface TrackedNotice {
+  readonly message: string;
+  /** The byte-identical normal-style string to restore after the pulse. */
+  readonly normalText: string;
+  readonly row: Text;
+}
+
+export const createRepeatedNotice = ({
+  appendNotice,
+  chatContainer,
+  pulseStyle,
+  requestRender,
+}: RepeatedNoticeOptions): RepeatedNotice => {
+  let tracked: TrackedNotice | undefined;
+  let pulseTimer: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  const clearPulse = (): void => {
+    if (pulseTimer !== undefined) {
+      clearTimeout(pulseTimer);
+      pulseTimer = undefined;
+    }
+  };
+
+  const restore = (notice: TrackedNotice): boolean => {
+    if (!chatContainer.children.includes(notice.row)) {
+      return false;
+    }
+    notice.row.setText(notice.normalText);
+    return true;
+  };
+
+  const settle = (): void => {
+    if (pulseTimer === undefined) {
+      return;
+    }
+    // Restore while the old pulse still has an owner, before replacing it.
+    if (tracked !== undefined) {
+      restore(tracked);
+    }
+    clearPulse();
+  };
+
+  /**
+   * The reusable notice for `message`, or `undefined` when this is not an
+   * immediate identical repeat of the still-visible current notice.
+   */
+  const reusableFor = (message: string): TrackedNotice | undefined => {
+    if (tracked === undefined || tracked.message !== message) {
+      return;
+    }
+    // Anything appended after the tracked row makes it stale, so a later
+    // exchange never suppresses a genuinely new notice.
+    return chatContainer.children.at(-1) === tracked.row ? tracked : undefined;
+  };
+
+  return {
+    show(message: string): void {
+      if (stopped) {
+        return;
+      }
+
+      const current = reusableFor(message);
+      if (current !== undefined) {
+        current.row.setText(pulseStyle(message));
+        // A rapid repeat re-arms the single pulse instead of stacking timers,
+        // so the inversion can never outlive the last attempt.
+        clearPulse();
+        pulseTimer = setTimeout(() => {
+          pulseTimer = undefined;
+          if (restore(current)) {
+            requestRender();
+          }
+        }, NOTICE_PULSE_MS);
+        pulseTimer.unref?.();
+        requestRender();
+        return;
+      }
+
+      settle();
+      const appended = appendNotice(message);
+      tracked =
+        appended === undefined
+          ? undefined
+          : { message, normalText: appended.normalText, row: appended.row };
+      requestRender();
+    },
+    reset(): void {
+      settle();
+      tracked = undefined;
+    },
+    settle,
+    stop(): void {
+      stopped = true;
+      clearPulse();
+      tracked = undefined;
+    },
+  };
+};

--- a/apps/coding-agent/src/tui/retry-status.test.ts
+++ b/apps/coding-agent/src/tui/retry-status.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRetryStatus, retryWaitMessage } from "./retry-status";
+
+describe("retryWaitMessage", () => {
+  it("names the next physical attempt and the budget including this retry", () => {
+    expect(
+      retryWaitMessage({ attempt: 1, remainingMs: 4000, remainingRetries: 2 })
+    ).toBe("Retrying in 4s · attempt 2 · 2 retries left");
+  });
+
+  it("uses the singular budget noun for a final retry", () => {
+    expect(
+      retryWaitMessage({ attempt: 2, remainingMs: 1000, remainingRetries: 1 })
+    ).toBe("Retrying in 1s · attempt 3 · 1 retry left");
+  });
+
+  it("rounds a partial second up so the countdown never shows a dead 0s", () => {
+    expect(
+      retryWaitMessage({ attempt: 1, remainingMs: 1, remainingRetries: 2 })
+    ).toBe("Retrying in 1s · attempt 2 · 2 retries left");
+  });
+
+  it("drops the countdown once the deadline has passed", () => {
+    expect(
+      retryWaitMessage({ attempt: 1, remainingMs: 0, remainingRetries: 2 })
+    ).toBe("Retrying now · attempt 2 · 2 retries left");
+  });
+
+  it("reports the first attempt when the failure preceded any physical call", () => {
+    expect(
+      retryWaitMessage({ attempt: 0, remainingMs: 2000, remainingRetries: 3 })
+    ).toBe("Retrying in 2s · attempt 1 · 3 retries left");
+  });
+});
+
+const createHarness = () => {
+  const messages: Array<string | null> = [];
+  let now = 10_000;
+  const status = createRetryStatus({
+    now: () => now,
+    setMessage: (message) => messages.push(message),
+  });
+  return {
+    advance: (ms: number) => {
+      now += ms;
+      vi.advanceTimersByTime(ms);
+    },
+    messages,
+    status,
+  };
+};
+
+describe("createRetryStatus", () => {
+  it("shows the countdown immediately and ticks it down once per second", () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+
+    h.status.scheduled({
+      attempt: 1,
+      delayMs: 3000,
+      remainingRetries: 2,
+      retryAt: 13_000,
+    });
+    expect(h.messages).toEqual(["Retrying in 3s · attempt 2 · 2 retries left"]);
+
+    h.advance(1000);
+    expect(h.messages.at(-1)).toBe(
+      "Retrying in 2s · attempt 2 · 2 retries left"
+    );
+
+    h.advance(1000);
+    expect(h.messages.at(-1)).toBe(
+      "Retrying in 1s · attempt 2 · 2 retries left"
+    );
+
+    h.status.stop();
+    vi.useRealTimers();
+  });
+
+  it("clears the status and stops ticking when the wait completes", () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+
+    h.status.scheduled({
+      attempt: 1,
+      delayMs: 3000,
+      remainingRetries: 2,
+      retryAt: 13_000,
+    });
+    h.status.clear();
+    expect(h.messages.at(-1)).toBeNull();
+
+    const settled = h.messages.length;
+    h.advance(5000);
+    expect(h.messages).toHaveLength(settled);
+
+    h.status.stop();
+    vi.useRealTimers();
+  });
+
+  it("replaces an in-flight countdown when a later retry is scheduled", () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+
+    h.status.scheduled({
+      attempt: 1,
+      delayMs: 4000,
+      remainingRetries: 2,
+      retryAt: 14_000,
+    });
+    h.status.scheduled({
+      attempt: 2,
+      delayMs: 8000,
+      remainingRetries: 1,
+      retryAt: 18_000,
+    });
+    expect(h.messages.at(-1)).toBe("Retrying in 8s · attempt 3 · 1 retry left");
+
+    h.advance(1000);
+    expect(h.messages.at(-1)).toBe("Retrying in 7s · attempt 3 · 1 retry left");
+
+    h.status.stop();
+    vi.useRealTimers();
+  });
+
+  it("stops the timer on teardown without emitting a stale clear", () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+
+    h.status.scheduled({
+      attempt: 1,
+      delayMs: 3000,
+      remainingRetries: 2,
+      retryAt: 13_000,
+    });
+    h.status.stop();
+
+    const settled = h.messages.length;
+    h.advance(5000);
+    expect(h.messages).toHaveLength(settled);
+    vi.useRealTimers();
+  });
+
+  it("reports whether a wait is currently active", () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+
+    expect(h.status.isWaiting()).toBe(false);
+    h.status.scheduled({
+      attempt: 1,
+      delayMs: 3000,
+      remainingRetries: 2,
+      retryAt: 13_000,
+    });
+    expect(h.status.isWaiting()).toBe(true);
+    h.status.clear();
+    expect(h.status.isWaiting()).toBe(false);
+
+    h.status.stop();
+    vi.useRealTimers();
+  });
+
+  it("holds the deadline message instead of counting into the past", () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+
+    h.status.scheduled({
+      attempt: 1,
+      delayMs: 2000,
+      remainingRetries: 2,
+      retryAt: 12_000,
+    });
+    h.advance(4000);
+    expect(h.messages.at(-1)).toBe("Retrying now · attempt 2 · 2 retries left");
+
+    h.status.stop();
+    vi.useRealTimers();
+  });
+});

--- a/apps/coding-agent/src/tui/retry-status.ts
+++ b/apps/coding-agent/src/tui/retry-status.ts
@@ -1,0 +1,110 @@
+/**
+ * Live countdown state for a runtime `model-retry` wait.
+ *
+ * The runtime owns the retry decision; this module only turns a scheduled
+ * wait into the one-row foreground status the footer already renders. It is
+ * deliberately clock-injected so tests drive the countdown with fake timers
+ * instead of sleeping.
+ */
+
+const RETRY_TICK_INTERVAL_MS = 1000;
+const MILLISECONDS_PER_SECOND = 1000;
+
+export interface RetryWaitSchedule {
+  /** Last physical call number; 0 when nothing was called yet. */
+  readonly attempt: number;
+  readonly delayMs: number;
+  /** Unspent retry budget INCLUDING the scheduled retry. */
+  readonly remainingRetries: number;
+  /** Unix epoch milliseconds the next attempt is due at. */
+  readonly retryAt: number;
+}
+
+/**
+ * Formats the footer label. The attempt shown is the call the wait leads to,
+ * so it is one past the last physical call the runtime reported.
+ */
+export const retryWaitMessage = ({
+  attempt,
+  remainingMs,
+  remainingRetries,
+}: {
+  attempt: number;
+  remainingMs: number;
+  remainingRetries: number;
+}): string => {
+  const countdown =
+    remainingMs > 0
+      ? `Retrying in ${Math.ceil(remainingMs / MILLISECONDS_PER_SECOND)}s`
+      : "Retrying now";
+  const budget = `${remainingRetries} ${
+    remainingRetries === 1 ? "retry" : "retries"
+  } left`;
+  return `${countdown} · attempt ${attempt + 1} · ${budget}`;
+};
+
+export interface RetryStatus {
+  /** Drops the wait status without emitting a message when nothing waits. */
+  clear(): void;
+  isWaiting(): boolean;
+  scheduled(schedule: RetryWaitSchedule): void;
+  /** Tears the timer down for good; never emits. */
+  stop(): void;
+}
+
+export const createRetryStatus = ({
+  now,
+  setMessage,
+}: {
+  now: () => number;
+  /** Receives the countdown label, or `null` once the wait is over. */
+  setMessage: (message: string | null) => void;
+}): RetryStatus => {
+  let schedule: RetryWaitSchedule | undefined;
+  let ticker: ReturnType<typeof setInterval> | undefined;
+
+  const stopTicker = (): void => {
+    if (ticker !== undefined) {
+      clearInterval(ticker);
+      ticker = undefined;
+    }
+  };
+
+  const emit = (): void => {
+    if (!schedule) {
+      return;
+    }
+    setMessage(
+      retryWaitMessage({
+        attempt: schedule.attempt,
+        remainingMs: Math.max(0, schedule.retryAt - now()),
+        remainingRetries: schedule.remainingRetries,
+      })
+    );
+  };
+
+  return {
+    clear(): void {
+      if (!schedule) {
+        return;
+      }
+      schedule = undefined;
+      stopTicker();
+      setMessage(null);
+    },
+    isWaiting: () => schedule !== undefined,
+    scheduled(next: RetryWaitSchedule): void {
+      schedule = next;
+      emit();
+      if (ticker === undefined) {
+        ticker = setInterval(emit, RETRY_TICK_INTERVAL_MS);
+        // A pending countdown must never hold the process open by itself.
+        ticker.unref?.();
+      }
+    },
+    stop(): void {
+      schedule = undefined;
+      stopTicker();
+    },
+  };
+};

--- a/apps/coding-agent/src/tui/retry-wait-footer.test.ts
+++ b/apps/coding-agent/src/tui/retry-wait-footer.test.ts
@@ -1,0 +1,334 @@
+import { Container } from "@earendil-works/pi-tui";
+import type { AgentEvent } from "@minpeter/pss-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { FooterStatusBar } from "./agent";
+import { agentEventStreamParts } from "./agent-event-stream";
+import { createRetryStatus } from "./retry-status";
+import { createSpinnerOrchestrator } from "./spinner-orchestrator";
+import {
+  type PiTuiStreamState,
+  STREAM_HANDLERS,
+  type TuiStreamPart,
+} from "./stream-handlers";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: test helper strips ANSI emitted by the footer
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+
+const RETRY_AT = 1_700_000_004_000;
+const NOW = 1_700_000_000_000;
+const SPINNER_FRAME_PATTERN = /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/;
+
+/**
+ * Composes the real chain a turn drives — runtime event -> stream part ->
+ * dispatch handler -> retry countdown -> spinner orchestrator -> footer row —
+ * so the assertion is on the rendered status line, not on an internal hook.
+ */
+const createFooterHarness = () => {
+  const requestRender = vi.fn();
+  const footer = new FooterStatusBar({ requestRender });
+  const chatContainer = new Container();
+  let foregroundMessage: string | null = null;
+  let now = NOW;
+
+  const setForeground = (message: string | null): void => {
+    foregroundMessage = message;
+    footer.setForegroundMessage(message);
+  };
+
+  const orchestrator = createSpinnerOrchestrator(
+    {
+      clearStatus: () => setForeground(null),
+      hasSpinner: () => foregroundMessage !== null,
+      setMessage: (message) => setForeground(message),
+      showLoader: (message) => setForeground(message),
+    },
+    "Working..."
+  );
+  const retryStatus = createRetryStatus({
+    now: () => now,
+    setMessage: (message) => {
+      if (message === null) {
+        orchestrator.onRetryWaitEnd();
+      } else {
+        orchestrator.onRetryWaitMessage(message);
+      }
+    },
+  });
+
+  const state = {
+    activeToolInputs: new Map(),
+    chatContainer,
+    ensureAssistantView: () => ({
+      appendReasoning: () => undefined,
+      appendText: () => undefined,
+    }),
+    ensureToolView: () => {
+      throw new Error("tool view should not be used");
+    },
+    flags: {
+      showFiles: false,
+      showFinishReason: false,
+      showRawToolIo: false,
+      showReasoning: true,
+      showSources: false,
+      showSteps: false,
+      showToolResults: true,
+    },
+    getToolView: () => undefined,
+    onReasoningEnd: orchestrator.onReasoningEnd,
+    onReasoningStart: orchestrator.onReasoningStart,
+    onRetryClear: retryStatus.clear,
+    onRetryWait: retryStatus.scheduled,
+    onToolPendingEnd: orchestrator.onToolPendingEnd,
+    onToolPendingStart: orchestrator.onToolPendingStart,
+    pendingToolCallIds: new Set<string>(),
+    resetAssistantView: () => undefined,
+    streamedToolCallIds: new Set<string>(),
+  } as unknown as PiTuiStreamState;
+
+  const dispatch = async (events: AgentEvent[]): Promise<TuiStreamPart[]> => {
+    const source = (async function* () {
+      yield* events;
+    })();
+    const parts: TuiStreamPart[] = [];
+    for await (const part of agentEventStreamParts(source)) {
+      parts.push(part);
+      await STREAM_HANDLERS[part.type]?.(part, state);
+    }
+    return parts;
+  };
+
+  return {
+    advance: (ms: number) => {
+      now += ms;
+      vi.advanceTimersByTime(ms);
+    },
+    chatContainer,
+    dispatch,
+    footerText: () =>
+      footer
+        .render(80)
+        .map((line) => line.replace(ANSI_PATTERN, "").trimEnd())
+        .join("\n"),
+    retryStatus,
+    showWorking: () => setForeground("Working..."),
+    stop: () => {
+      retryStatus.stop();
+      footer.stop();
+    },
+  };
+};
+
+const scheduled: AgentEvent = {
+  attempt: 1,
+  attemptId: "step-1",
+  delayMs: 4000,
+  phase: "scheduled",
+  remainingRetries: 2,
+  retryAt: RETRY_AT,
+  type: "model-retry",
+} as AgentEvent;
+
+describe("retry wait in the TUI footer", () => {
+  it("shows the countdown with attempt and budget while a retry is pending", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    h.showWorking();
+
+    await h.dispatch([scheduled]);
+    expect(h.footerText()).toContain(
+      "Retrying in 4s · attempt 2 · 2 retries left"
+    );
+
+    h.advance(2000);
+    expect(h.footerText()).toContain(
+      "Retrying in 2s · attempt 2 · 2 retries left"
+    );
+
+    h.stop();
+    vi.useRealTimers();
+  });
+
+  it("keeps a running spinner frame in front of the retry label", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    h.showWorking();
+
+    await h.dispatch([scheduled]);
+    expect(h.footerText().trimStart().charAt(0)).toMatch(SPINNER_FRAME_PATTERN);
+
+    h.stop();
+    vi.useRealTimers();
+  });
+
+  it("restores the working label once the wait completes", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    h.showWorking();
+
+    await h.dispatch([scheduled]);
+    await h.dispatch([
+      {
+        attempt: 1,
+        attemptId: "step-1",
+        phase: "started",
+        remainingRetries: 1,
+        type: "model-retry",
+      } as AgentEvent,
+    ]);
+
+    expect(h.footerText()).toContain("Working...");
+    expect(h.footerText()).not.toContain("Retrying");
+
+    h.advance(5000);
+    expect(h.footerText()).not.toContain("Retrying");
+
+    h.stop();
+    vi.useRealTimers();
+  });
+
+  it.each(["cancelled", "exhausted", "non-retryable", "stream-ended"] as const)(
+    "drops the banner when the retry stops as %s",
+    async (reason) => {
+      vi.useFakeTimers();
+      const h = createFooterHarness();
+      h.showWorking();
+
+      await h.dispatch([scheduled]);
+      await h.dispatch([
+        {
+          attempt: 2,
+          attemptId: "step-1",
+          phase: "stopped",
+          reason,
+          remainingRetries: 0,
+          type: "model-retry",
+        } as AgentEvent,
+      ]);
+
+      expect(h.footerText()).not.toContain("Retrying");
+      expect(h.retryStatus.isWaiting()).toBe(false);
+
+      h.stop();
+      vi.useRealTimers();
+    }
+  );
+
+  it("never writes the retry wait into the transcript", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    h.showWorking();
+
+    await h.dispatch([
+      scheduled,
+      {
+        attempt: 1,
+        attemptId: "step-1",
+        phase: "started",
+        remainingRetries: 1,
+        type: "model-retry",
+      } as AgentEvent,
+    ]);
+
+    expect(h.chatContainer.render(80).join("\n").trim()).toBe("");
+
+    h.stop();
+    vi.useRealTimers();
+  });
+
+  it("does not let the wait label survive into the next step's streaming", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    h.showWorking();
+
+    await h.dispatch([scheduled]);
+    await h.dispatch([
+      {
+        attempt: 1,
+        attemptId: "step-1",
+        phase: "started",
+        remainingRetries: 1,
+        type: "model-retry",
+      } as AgentEvent,
+      { text: "hi", type: "assistant-reasoning-delta" } as AgentEvent,
+    ]);
+
+    expect(h.footerText()).toContain("Thinking...");
+    expect(h.footerText()).not.toContain("Retrying");
+
+    h.stop();
+    vi.useRealTimers();
+  });
+
+  it("holds the retry label over a concurrent reasoning delta", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    h.showWorking();
+
+    await h.dispatch([scheduled]);
+    await h.dispatch([
+      { text: "hi", type: "assistant-reasoning-delta" } as AgentEvent,
+    ]);
+
+    expect(h.footerText()).toContain("Retrying in");
+    expect(h.footerText()).not.toContain("Thinking...");
+
+    h.stop();
+    vi.useRealTimers();
+  });
+
+  // A session switch tears the stream down mid-wait. The teardown must clear
+  // the countdown so the next thread never inherits the previous one's banner.
+  it("leaves no countdown running after a mid-wait teardown", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    h.showWorking();
+
+    await h.dispatch([scheduled]);
+    expect(h.retryStatus.isWaiting()).toBe(true);
+
+    h.retryStatus.clear();
+    h.retryStatus.stop();
+
+    expect(h.retryStatus.isWaiting()).toBe(false);
+    expect(h.footerText()).not.toContain("Retrying");
+
+    // Only the retry text must stay gone; the base spinner keeps animating.
+    h.advance(10_000);
+    expect(h.footerText()).not.toContain("Retrying");
+    expect(h.footerText()).toContain("Working...");
+
+    h.stop();
+    vi.useRealTimers();
+  });
+
+  it("keeps the one-row footer height while the countdown runs", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    h.showWorking();
+
+    await h.dispatch([scheduled]);
+    expect(h.footerText().split("\n")).toHaveLength(1);
+
+    h.stop();
+    vi.useRealTimers();
+  });
+
+  it("truncates the countdown inside a narrow terminal instead of overflowing", async () => {
+    vi.useFakeTimers();
+    const h = createFooterHarness();
+    const footer = new FooterStatusBar({ requestRender: vi.fn() });
+    h.showWorking();
+    await h.dispatch([scheduled]);
+    footer.setForegroundMessage("Retrying in 4s · attempt 2 · 2 retries left");
+
+    for (const width of [12, 24, 40]) {
+      const [line = ""] = footer.render(width);
+      expect(line.replace(ANSI_PATTERN, "").length).toBeLessThanOrEqual(width);
+    }
+
+    footer.stop();
+    h.stop();
+    vi.useRealTimers();
+  });
+});

--- a/apps/coding-agent/src/tui/retry-wait-footer.test.ts
+++ b/apps/coding-agent/src/tui/retry-wait-footer.test.ts
@@ -105,9 +105,9 @@ const createFooterHarness = () => {
     },
     chatContainer,
     dispatch,
-    footerText: () =>
+    footerText: (width = 80) =>
       footer
-        .render(80)
+        .render(width)
         .map((line) => line.replace(ANSI_PATTERN, "").trimEnd())
         .join("\n"),
     retryStatus,
@@ -317,17 +317,17 @@ describe("retry wait in the TUI footer", () => {
   it("truncates the countdown inside a narrow terminal instead of overflowing", async () => {
     vi.useFakeTimers();
     const h = createFooterHarness();
-    const footer = new FooterStatusBar({ requestRender: vi.fn() });
     h.showWorking();
     await h.dispatch([scheduled]);
-    footer.setForegroundMessage("Retrying in 4s · attempt 2 · 2 retries left");
-
+    const full = h.footerText();
     for (const width of [12, 24, 40]) {
-      const [line = ""] = footer.render(width);
-      expect(line.replace(ANSI_PATTERN, "").length).toBeLessThanOrEqual(width);
+      const line = h.footerText(width);
+      expect(line).toMatch(SPINNER_FRAME_PATTERN);
+      expect(line.length).toBeLessThanOrEqual(width);
+      // Truncation must retain the actual pipeline output, not a separate label.
+      expect(line.slice(0, -1)).toBe(full.slice(0, line.length - 1));
     }
 
-    footer.stop();
     h.stop();
     vi.useRealTimers();
   });

--- a/apps/coding-agent/src/tui/session-commands.ts
+++ b/apps/coding-agent/src/tui/session-commands.ts
@@ -217,7 +217,6 @@ function createNameCommand(context: SessionCommandContext): TuiCommand {
         context.onRenamed(entry);
         return {
           action: { type: "refresh-header" },
-          message: `Session named ${JSON.stringify(name)}.`,
           success: true,
         };
       }),

--- a/apps/coding-agent/src/tui/session-commands.ts
+++ b/apps/coding-agent/src/tui/session-commands.ts
@@ -18,6 +18,7 @@ import type {
   TuiCommandResult,
 } from "./command";
 import { sessionPrimaryLabel } from "./session-option-format";
+import { sessionResumeSelector } from "./terminal-exit";
 
 /** Extension-UI select is capped at 100 options. */
 const MAX_PICKER_OPTIONS = 100;
@@ -75,8 +76,8 @@ function createNewCommand(context: SessionCommandContext): TuiCommand {
         const entry = await context.manager.createSession(name);
         await context.switchThread(entry, "new");
         return {
-          action: { clear: true, type: "session" },
-          message: `Started new session ${describeSession(entry)}.`,
+          action: { clear: true, reason: "new", type: "session" },
+          message: `Started new session ${sessionResumeSelector(entry.key)}.`,
           success: true,
         };
       }),

--- a/apps/coding-agent/src/tui/session-state.test.ts
+++ b/apps/coding-agent/src/tui/session-state.test.ts
@@ -104,6 +104,20 @@ describe("TuiSessionMachine turn", () => {
     expect(session.activeTurn).toBeUndefined();
   });
 
+  it("restores a still-running predecessor when a distinct steering run finishes first", () => {
+    const session = new TuiSessionMachine();
+    const original = fakeRun();
+    const steering = fakeRun();
+    session.beginTurn(original);
+    session.beginTurn(steering);
+    session.endTurn(steering);
+    expect(session.activeTurn?.run).toBe(original);
+    expect(session.markInterrupted()).toBe(original);
+    expect(session.wasInterrupted(original)).toBe(true);
+    session.endTurn(original);
+    expect(session.activeTurn).toBeUndefined();
+  });
+
   it("resets the interrupted flag when a replacement run begins", () => {
     const session = new TuiSessionMachine();
     const first = fakeRun();

--- a/apps/coding-agent/src/tui/session-state.ts
+++ b/apps/coding-agent/src/tui/session-state.ts
@@ -61,6 +61,7 @@ function createTurnMachine(): Fsm<TurnState> {
 export class TuiSessionMachine {
   readonly #prompt = createPromptMachine();
   readonly #turn = createTurnMachine();
+  readonly #pendingTurns = new Map<AgentTurn, boolean>();
 
   get promptState(): PromptState {
     return this.#prompt.state;
@@ -135,6 +136,7 @@ export class TuiSessionMachine {
    * with a newly started one, so `active -> active` is a legal transition.
    */
   beginTurn(run: AgentTurn): void {
+    this.#pendingTurns.set(run, false);
     this.#turn.to({ tag: "active", interrupted: false, run });
   }
 
@@ -147,14 +149,18 @@ export class TuiSessionMachine {
     if (turn.tag !== "active") {
       return;
     }
+    // thread.interrupt() cancels the physical thread, including a predecessor
+    // whose steering acknowledgement has already finished consuming events.
+    for (const run of this.#pendingTurns.keys()) {
+      this.#pendingTurns.set(run, true);
+    }
     this.#turn.to({ ...turn, interrupted: true });
     return turn.run;
   }
 
-  /** Whether `run` is still the active turn and was interrupted. */
+  /** Whether this still-pending run was interrupted. */
   wasInterrupted(run: AgentTurn): boolean {
-    const turn = this.#turn.state;
-    return turn.tag === "active" && turn.run === run && turn.interrupted;
+    return this.#pendingTurns.get(run) === true;
   }
 
   /**
@@ -163,9 +169,15 @@ export class TuiSessionMachine {
    * predecessor.
    */
   endTurn(run: AgentTurn): void {
+    this.#pendingTurns.delete(run);
     const turn = this.#turn.state;
     if (turn.tag === "active" && turn.run === run) {
-      this.#turn.to({ tag: "none" });
+      const pending = [...this.#pendingTurns].at(-1);
+      this.#turn.to(
+        pending === undefined
+          ? { tag: "none" }
+          : { tag: "active", run: pending[0], interrupted: pending[1] }
+      );
     }
   }
 }

--- a/apps/coding-agent/src/tui/session-title-notice.test.ts
+++ b/apps/coding-agent/src/tui/session-title-notice.test.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type Component,
+  stripTerminalSequences,
+  type Terminal,
+  type TuiMainScreen,
+} from "@earendil-works/pi-tui";
+import { MockLanguageModelV4 } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const terminal = vi.hoisted(() => ({
+  input: (_data: string): void => undefined,
+  screen: undefined as TuiMainScreen | undefined,
+}));
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  const noop = () => undefined;
+  class LocalTerminal implements Terminal {
+    columns = 120;
+    rows = 40;
+    kittyProtocolActive = false;
+    clearFromCursor = noop;
+    clearLine = noop;
+    clearScreen = noop;
+    hideCursor = noop;
+    moveBy = noop;
+    setProgress = noop;
+    setTitle = noop;
+    showCursor = noop;
+    stop = noop;
+    write = noop;
+    drainInput() {
+      return Promise.resolve();
+    }
+    start(input: (data: string) => void) {
+      terminal.input = input;
+    }
+  }
+  class LocalScreen extends actual.TuiMainScreen {
+    override start() {
+      terminal.screen = this;
+      super.start();
+    }
+  }
+  return {
+    ...actual,
+    ProcessTerminal: LocalTerminal,
+    TuiMainScreen: LocalScreen,
+  };
+});
+
+import { type AgentTUIConfig, createAgentTUI } from "./agent";
+import { startTui } from "./app";
+import { TuiSessionMachine } from "./session-state";
+
+function gate() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+async function bounded<T>(promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Missing title fixture event")),
+          5000
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+function idle() {
+  const ready = gate();
+  const original = TuiSessionMachine.prototype.awaitInput;
+  const spy = vi
+    .spyOn(TuiSessionMachine.prototype, "awaitInput")
+    .mockImplementation(function (this: TuiSessionMachine, resolve) {
+      original.call(this, resolve);
+      spy.mockRestore();
+      ready.resolve();
+    });
+  return bounded(ready.promise);
+}
+function surface() {
+  if (!terminal.screen) {
+    throw new Error("TUI not mounted");
+  }
+  return terminal.screen;
+}
+const lines = (component: Component = surface().children[1]) =>
+  stripTerminalSequences(component.render(120).join("\n"))
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+const send = (text: string) => {
+  for (const char of text) {
+    terminal.input(char);
+  }
+};
+async function command(text: string) {
+  const ready = idle();
+  send(`${text}\r`);
+  await ready;
+}
+function rendered(predicate: () => boolean) {
+  const ready = gate();
+  const screen = surface();
+  const original = screen.requestRender.bind(screen);
+  const spy = vi.spyOn(screen, "requestRender").mockImplementation((force) => {
+    original(force);
+    if (predicate()) {
+      spy.mockRestore();
+      ready.resolve();
+    }
+  });
+  return bounded(ready.promise).finally(() => spy.mockRestore());
+}
+const usage = {
+  inputTokens: {
+    total: 1,
+    noCache: 1,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 1, text: 1, reasoning: undefined },
+};
+const finishReason = { raw: "stop", unified: "stop" } as const;
+let directory: string;
+let config: AgentTUIConfig;
+let run: Promise<number> | undefined;
+let generate: ReturnType<typeof vi.fn>;
+async function fixture(failTitle = false) {
+  const doGenerate = vi.fn(() => {
+    if (failTitle) {
+      return Promise.reject(new Error("TITLE_PROVIDER_ERROR"));
+    }
+    return Promise.resolve({
+      content: [{ type: "text" as const, text: "자동 제목 TITLE_A" }],
+      finishReason,
+      usage,
+      warnings: [],
+    });
+  });
+  generate = doGenerate;
+  const model = new MockLanguageModelV4({
+    doGenerate,
+    doStream: async () => ({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "text-start", id: "answer" });
+          controller.enqueue({
+            type: "text-delta",
+            id: "answer",
+            delta: "ANSWER_SENTINEL",
+          });
+          controller.enqueue({ type: "text-end", id: "answer" });
+          controller.enqueue({ type: "finish", finishReason, usage });
+          controller.close();
+        },
+      }),
+    }),
+  });
+  const ready = idle();
+  run = startTui(
+    { cwd: directory, model, tools: {} },
+    {
+      createTui(value) {
+        config = value;
+        return createAgentTUI(value);
+      },
+    }
+  );
+  await ready;
+}
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "pss-title-notice-"));
+  vi.stubEnv("HOME", directory);
+  vi.stubEnv("PSS_THREAD_DIR", join(directory, "threads"));
+  vi.stubEnv("PSS_THREAD_KEY", "");
+  vi.stubEnv("PSS_DISABLE_UPDATE_CHECK", "1");
+  vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  vi.spyOn(process.stderr, "write").mockReturnValue(true);
+});
+afterEach(async () => {
+  try {
+    if (run) {
+      process.emit("SIGINT", "SIGINT");
+      process.emit("SIGINT", "SIGINT");
+      expect(await bounded(run)).toBe(0);
+    }
+  } finally {
+    run = undefined;
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe.sequential("session title notices through startTui", () => {
+  it("emits one automatic title row after completion without duplicating model/cwd or changing COLD", async () => {
+    await fixture();
+    const header = lines(surface().children[0]);
+    const done = rendered(() =>
+      lines().some((line) => line.includes("TITLE_A"))
+    );
+    await command("USER_SENTINEL");
+    await done;
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(lines()).toHaveLength(3);
+    expect(lines().filter((line) => line.includes("TITLE_A"))).toHaveLength(1);
+    expect(lines().at(-1)).toBe(
+      'Session title updated to "자동 제목 TITLE_A".'
+    );
+    expect(lines().join("\n")).not.toContain(directory);
+    expect(lines().join("\n")).not.toContain(header[1]);
+    expect(lines(surface().children[0])).toEqual(header);
+    const before = lines();
+    await command("/name 자동 제목 TITLE_A");
+    expect(lines()).toEqual(before);
+  });
+
+  it("renders a direct rename once and retains navigation", async () => {
+    await fixture();
+    const header = lines(surface().children[0]);
+    await command("/name 직접 TITLE_B");
+    expect(lines()).toEqual(['Session title updated to "직접 TITLE_B".']);
+    expect(lines(surface().children[0])).toEqual(header);
+    const before = lines();
+    await command("/name 직접 TITLE_B");
+    expect(lines()).toEqual(before);
+    await command("/name");
+    expect(lines()).toHaveLength(2);
+    await command("/new SESSION_NEXT");
+    expect(lines().join("\n")).toContain(directory);
+    expect(lines().join("\n")).toContain("SESSION_NEXT");
+    expect(lines(surface().children[0])).toEqual(header);
+  });
+
+  it("reports the persisted fallback, not a failed generated title", async () => {
+    await fixture(true);
+    const done = rendered(() => lines().length > 2);
+    await command("FALLBACK_TITLE");
+    await done;
+    expect(generate).toHaveBeenCalled();
+    expect(lines()).toHaveLength(3);
+    expect(lines().at(-1)).toBe('Session title updated to "FALLBACK_TITLE".');
+    expect(lines().join("\n")).not.toContain("TITLE_PROVIDER_ERROR");
+  });
+
+  it("renders structured title metadata safely without relying on subtitle changes", async () => {
+    await fixture();
+    const name = '제목 "quoted"\nnext\t\x1b[2J\x1b]52;c;payload\x07\u2028end';
+    const current = config.currentSession?.();
+    if (!current) {
+      throw new Error("Missing session metadata");
+    }
+    config.onTurnComplete = () => {
+      config.currentSession = () => ({ ...current, name });
+      config.footer = { text: "FOOTER_UPDATED" };
+    };
+    const done = rendered(() =>
+      lines().some((line) => line.includes("quoted"))
+    );
+    await command("USER_SENTINEL");
+    await done;
+    expect(lines()).toHaveLength(3);
+    expect(lines().at(-1)).toBe(
+      'Session title updated to "제목 "quoted"^Jnext^I^[[2J^[]52;c;payload^Gend".'
+    );
+    expect(lines(surface().children.at(-1))).toContain("FOOTER_UPDATED");
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a title when completion yields no metadata change", async () => {
+    await fixture();
+    config.onTurnComplete = () => undefined;
+    const done = rendered(() => lines().length === 2);
+    await command("USER_SENTINEL");
+    await done;
+    expect(lines()).toEqual(["USER_SENTINEL", "ANSWER_SENTINEL"]);
+  });
+
+  it("does not append status when a completion callback resolves after teardown", async () => {
+    await fixture();
+    const entered = gate();
+    const release = gate();
+    config.onTurnComplete = async () => {
+      entered.resolve();
+      await release.promise;
+      config.currentSession = () => ({
+        key: "LATE_SESSION",
+        name: "LATE_TITLE",
+      });
+      if (config.header) {
+        config.header.subtitle = "LATE_TITLE";
+      }
+    };
+    await command("USER_SENTINEL");
+    await bounded(entered.promise);
+    const before = lines();
+    process.emit("SIGINT", "SIGINT");
+    process.emit("SIGINT", "SIGINT");
+    release.resolve();
+    expect(await bounded(Promise.resolve(run))).toBe(0);
+    run = undefined;
+    expect(lines()).toEqual(before);
+  });
+});

--- a/apps/coding-agent/src/tui/session-title-notice.test.ts
+++ b/apps/coding-agent/src/tui/session-title-notice.test.ts
@@ -279,7 +279,9 @@ describe.sequential("new session notices through startTui", () => {
       const header = lines(surface().children[0]);
       const previousKey = config.currentSession?.().key;
       await command("/name PREVIOUS_SESSION");
-      const reset = vi.spyOn(TranscriptOwner.prototype, "reset");
+      const transcript = surface().children[1] as TranscriptOwner;
+      const previousEpoch = transcript.epoch;
+      const reset = vi.spyOn(transcript, "reset");
       const newCommand = config.commands?.find((item) => item.name === "new");
       if (!newCommand) {
         throw new Error("Missing new command");
@@ -295,6 +297,8 @@ describe.sequential("new session notices through startTui", () => {
       }
       expect(current.key).not.toBe(previousKey);
       expect(reset).toHaveBeenCalledExactlyOnceWith("session-navigation");
+      expect(surface().children[1]).toBe(transcript);
+      expect(transcript.epoch).toBe(previousEpoch + 1);
       const result = await execute.mock.results[0]?.value;
       if (!result?.message) {
         throw new Error("Missing new-session result");
@@ -326,6 +330,7 @@ describe.sequential("new session notices through startTui", () => {
       await command("/refresh-test");
       expect(lines()).toEqual(before);
       expect(reset).toHaveBeenCalledTimes(1);
+      expect(transcript.epoch).toBe(previousEpoch + 1);
     }
   );
 });

--- a/apps/coding-agent/src/tui/session-title-notice.test.ts
+++ b/apps/coding-agent/src/tui/session-title-notice.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rename, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -52,9 +52,13 @@ vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
   };
 });
 
+import { sessionGuard } from "../extensions/capabilities";
+import type { CodingAgentExtensionInput } from "../extensions/types";
+import { readSessionIndex, sessionIndexPath } from "../sessions/session-index";
 import { type AgentTUIConfig, createAgentTUI } from "./agent";
 import { startTui } from "./app";
 import { TuiSessionMachine } from "./session-state";
+import { TranscriptOwner } from "./transcript-owner";
 
 function gate() {
   let resolve!: () => void;
@@ -139,7 +143,10 @@ let directory: string;
 let config: AgentTUIConfig;
 let run: Promise<number> | undefined;
 let generate: ReturnType<typeof vi.fn>;
-async function fixture(failTitle = false) {
+async function fixture(
+  failTitle = false,
+  extensions: readonly CodingAgentExtensionInput[] = []
+) {
   const doGenerate = vi.fn(() => {
     if (failTitle) {
       return Promise.reject(new Error("TITLE_PROVIDER_ERROR"));
@@ -172,7 +179,7 @@ async function fixture(failTitle = false) {
   });
   const ready = idle();
   run = startTui(
-    { cwd: directory, model, tools: {} },
+    { cwd: directory, extensions, model, tools: {} },
     {
       createTui(value) {
         config = value;
@@ -204,6 +211,123 @@ afterEach(async () => {
     vi.unstubAllEnvs();
     await rm(directory, { recursive: true, force: true });
   }
+});
+
+describe.sequential("new session notices through startTui", () => {
+  it("does not reset, switch, or announce success when a guard refuses creation", async () => {
+    await fixture(false, [
+      {
+        id: "new-guard",
+        default: (pss) => {
+          pss.provide(
+            sessionGuard({
+              beforeSwitch: () => ({
+                cancel: true,
+                reason: "REFUSAL_SENTINEL",
+              }),
+            })
+          );
+        },
+      },
+    ]);
+    const current = config.currentSession?.();
+    const before = await readSessionIndex(
+      sessionIndexPath(join(directory, "threads"))
+    );
+    const reset = vi.spyOn(TranscriptOwner.prototype, "reset");
+    await command("/new");
+    expect(lines()).toHaveLength(1);
+    expect(lines()[0]).toContain("REFUSAL_SENTINEL");
+    expect(config.currentSession?.()).toEqual(current);
+    expect(reset).not.toHaveBeenCalled();
+    expect(
+      await readSessionIndex(sessionIndexPath(join(directory, "threads")))
+    ).toEqual(before);
+  });
+  it("retains the current session and transcript when durable creation fails", async () => {
+    await fixture();
+    await command("/name RETAINED_SESSION");
+    const before = lines();
+    const current = config.currentSession?.();
+    const reset = vi.spyOn(TranscriptOwner.prototype, "reset");
+    const newCommand = config.commands?.find((item) => item.name === "new");
+    if (!newCommand) {
+      throw new Error("Missing new command");
+    }
+    const execute = vi.spyOn(newCommand, "execute");
+    const path = sessionIndexPath(join(directory, "threads"));
+    await rename(path, `${path}.saved`);
+    await mkdir(path);
+    try {
+      await command("/clear");
+      const result = await execute.mock.results[0]?.value;
+      expect(result?.success).toBe(false);
+      expect(result?.action).toBeUndefined();
+      expect(lines().join(" ")).toBe([...before, result?.message].join(" "));
+      expect(config.currentSession?.()).toEqual(current);
+      expect(reset).not.toHaveBeenCalled();
+    } finally {
+      await rm(path, { recursive: true });
+      await rename(`${path}.saved`, path);
+    }
+  });
+
+  it.each(["/new", "/clear", "/new NAMED_SESSION"])(
+    "%s resets once, switches durably, and synchronizes status without extra rows",
+    async (input) => {
+      await fixture();
+      const header = lines(surface().children[0]);
+      const previousKey = config.currentSession?.().key;
+      await command("/name PREVIOUS_SESSION");
+      const reset = vi.spyOn(TranscriptOwner.prototype, "reset");
+      const newCommand = config.commands?.find((item) => item.name === "new");
+      if (!newCommand) {
+        throw new Error("Missing new command");
+      }
+      const execute = vi.spyOn(newCommand, "execute");
+      if (config.footer) {
+        config.footer.text = "FOOTER_SENTINEL";
+      }
+      await command(input);
+      const current = config.currentSession?.();
+      if (!current) {
+        throw new Error("Missing current session");
+      }
+      expect(current.key).not.toBe(previousKey);
+      expect(reset).toHaveBeenCalledExactlyOnceWith("session-navigation");
+      const result = await execute.mock.results[0]?.value;
+      if (!result?.message) {
+        throw new Error("Missing new-session result");
+      }
+      expect(result.action).toEqual({
+        clear: true,
+        reason: "new",
+        type: "session",
+      });
+      // Compare shipped copy to command output; assert the selector as data.
+      expect(lines()).toEqual([result.message]);
+      expect(result.message.split(" ").at(-1)).toBe(
+        `${current.key.split("#").at(-1)}.`
+      );
+      expect(lines(surface().children[0])).toEqual(header);
+      expect(lines(surface().children.at(-1))).not.toContain("FOOTER_SENTINEL");
+      const index = await readSessionIndex(
+        sessionIndexPath(join(directory, "threads"))
+      );
+      expect(index.active[directory]).toBe(current.key);
+      expect(
+        index.sessions.find((entry) => entry.key === current.key)?.name
+      ).toBe(input.includes("NAMED_SESSION") ? "NAMED_SESSION" : undefined);
+      const before = lines();
+      config.preprocessCommand = (_input, hooks) => {
+        hooks.updateHeader();
+        return Promise.resolve(null);
+      };
+      await command("/refresh-test");
+      expect(lines()).toEqual(before);
+      expect(reset).toHaveBeenCalledTimes(1);
+    }
+  );
 });
 
 describe.sequential("session title notices through startTui", () => {
@@ -241,8 +365,8 @@ describe.sequential("session title notices through startTui", () => {
     await command("/name");
     expect(lines()).toHaveLength(2);
     await command("/new SESSION_NEXT");
-    expect(lines().join("\n")).toContain(directory);
-    expect(lines().join("\n")).toContain("SESSION_NEXT");
+    expect(config.currentSession?.().name).toBe("SESSION_NEXT");
+    expect(lines()).toHaveLength(1);
     expect(lines(surface().children[0])).toEqual(header);
   });
 

--- a/apps/coding-agent/src/tui/snapshot-views.ts
+++ b/apps/coding-agent/src/tui/snapshot-views.ts
@@ -1,0 +1,127 @@
+import {
+  type DefaultTextStyle,
+  Markdown,
+  type MarkdownTheme,
+  Text,
+} from "@earendil-works/pi-tui";
+import {
+  type ColdContent,
+  type ColdTheme,
+  captureStyle,
+  preservePresentation,
+} from "./cold-content";
+
+/** Host-owned views retain source explicitly; no reads of pi-tui private state. */
+export class SnapshotText extends Text {
+  #source: string;
+  readonly #paddingX: number;
+  readonly #paddingY: number;
+  #background: ((text: string) => string) | undefined;
+
+  constructor(
+    text = "",
+    paddingX = 1,
+    paddingY = 1,
+    background?: (text: string) => string
+  ) {
+    super(text, paddingX, paddingY, background);
+    this.#source = text;
+    this.#paddingX = paddingX;
+    this.#paddingY = paddingY;
+    this.#background = background;
+  }
+  override setText(text: string): void {
+    this.#source = text;
+    super.setText(text);
+  }
+  override setCustomBgFn(background?: (text: string) => string): void {
+    this.#background = background;
+    super.setCustomBgFn(background);
+  }
+  captureCold(width: number): ColdContent {
+    return preservePresentation(
+      {
+        kind: "text",
+        text: this.#source,
+        paddingX: this.#paddingX,
+        paddingY: this.#paddingY,
+        background: this.#background && captureStyle(this.#background),
+      },
+      super.render(width),
+      width
+    );
+  }
+}
+
+export class SnapshotMarkdown extends Markdown {
+  #source: string;
+  readonly #paddingX: number;
+  readonly #paddingY: number;
+  readonly #theme: MarkdownTheme;
+  readonly #style: DefaultTextStyle | undefined;
+
+  constructor(
+    text: string,
+    paddingX: number,
+    paddingY: number,
+    theme: MarkdownTheme,
+    style?: DefaultTextStyle
+  ) {
+    super(text, paddingX, paddingY, theme, style);
+    this.#source = text;
+    this.#paddingX = paddingX;
+    this.#paddingY = paddingY;
+    this.#theme = theme;
+    this.#style = style;
+  }
+  override setText(text: string): void {
+    this.#source = text;
+    super.setText(text);
+  }
+  captureCold(width: number): ColdContent {
+    const { highlightCode, codeBlockIndent, ...styles } = this.#theme;
+    const highlighted: Record<string, readonly string[]> = {};
+    if (highlightCode) {
+      // Highlight once synchronously while HOT. COLD only looks up copied runs.
+      const capturingTheme = {
+        ...this.#theme,
+        highlightCode: (code: string, language?: string) => {
+          const lines = highlightCode(code, language);
+          highlighted[JSON.stringify([code, language])] = [...lines];
+          return lines;
+        },
+      };
+      new Markdown(
+        this.#source,
+        this.#paddingX,
+        this.#paddingY,
+        capturingTheme,
+        this.#style
+      ).render(width);
+    }
+    const theme = {
+      ...Object.fromEntries(
+        Object.entries(styles).map(([key, value]) => [key, captureStyle(value)])
+      ),
+      codeBlockIndent,
+      ...(highlightCode ? { highlighted } : {}),
+    } as ColdTheme;
+    const { color, bgColor, ...flags } = this.#style ?? {};
+    return preservePresentation(
+      {
+        kind: "markdown",
+        text: this.#source,
+        paddingX: this.#paddingX,
+        paddingY: this.#paddingY,
+        theme,
+        defaultStyle: this.#style && {
+          ...flags,
+          color: color && captureStyle(color),
+          bgColor: bgColor && captureStyle(bgColor),
+        },
+      },
+      super.render(width),
+      width
+    );
+  }
+}

--- a/apps/coding-agent/src/tui/snapshot-views.ts
+++ b/apps/coding-agent/src/tui/snapshot-views.ts
@@ -81,6 +81,7 @@ export class SnapshotMarkdown extends Markdown {
   captureCold(width: number): ColdContent {
     const { highlightCode, codeBlockIndent, ...styles } = this.#theme;
     const highlighted: Record<string, readonly string[]> = {};
+    let rows: string[];
     if (highlightCode) {
       // Highlight once synchronously while HOT. COLD only looks up copied runs.
       const capturingTheme = {
@@ -91,13 +92,15 @@ export class SnapshotMarkdown extends Markdown {
           return lines;
         },
       };
-      new Markdown(
+      rows = new Markdown(
         this.#source,
         this.#paddingX,
         this.#paddingY,
         capturingTheme,
         this.#style
       ).render(width);
+    } else {
+      rows = super.render(width);
     }
     const theme = {
       ...Object.fromEntries(
@@ -120,7 +123,7 @@ export class SnapshotMarkdown extends Markdown {
           bgColor: bgColor && captureStyle(bgColor),
         },
       },
-      super.render(width),
+      rows,
       width
     );
   }

--- a/apps/coding-agent/src/tui/spinner-orchestrator.test.ts
+++ b/apps/coding-agent/src/tui/spinner-orchestrator.test.ts
@@ -68,8 +68,8 @@ describe("createSpinnerOrchestrator", () => {
       });
 
       orch.onReasoningEnd();
-      expect(h.events).toContainEqual({ type: "clearStatus" });
-      expect(h.state().hasSpinner).toBe(false);
+      expect(h.events).not.toContainEqual({ type: "clearStatus" });
+      expect(h.state().hasSpinner).toBe(true);
     });
   });
 
@@ -96,7 +96,7 @@ describe("createSpinnerOrchestrator", () => {
       });
 
       orch.onToolPendingEnd();
-      expect(h.state().hasSpinner).toBe(false);
+      expect(h.state().hasSpinner).toBe(true);
     });
 
     it("keeps Executing... until all parallel tool calls finish", () => {
@@ -212,8 +212,8 @@ describe("createSpinnerOrchestrator", () => {
       expect(h.state().currentMessage).toBe("Executing...");
 
       orch.onToolPendingEnd();
-      expect(h.events).toContainEqual({ type: "clearStatus" });
-      expect(h.state().hasSpinner).toBe(false);
+      expect(h.events).not.toContainEqual({ type: "clearStatus" });
+      expect(h.state().hasSpinner).toBe(true);
     });
 
     // Regression: tool-revived spinner ownership must transfer to reasoning
@@ -237,8 +237,104 @@ describe("createSpinnerOrchestrator", () => {
       expect(h.state().hasSpinner).toBe(true);
 
       orch.onReasoningEnd();
-      expect(h.events).toContainEqual({ type: "clearStatus" });
+      expect(h.events).not.toContainEqual({ type: "clearStatus" });
+      expect(h.state().hasSpinner).toBe(true);
+    });
+  });
+
+  describe("retry wait", () => {
+    it("outranks the streaming label while the wait is active", () => {
+      const h = createAdapter(true);
+      const orch = createSpinnerOrchestrator(h.adapter, "Working...");
+
+      orch.onReasoningStart();
+      expect(h.state().currentMessage).toBe("Thinking...");
+
+      orch.onRetryWaitMessage("Retrying in 4s · attempt 2 · 2 retries left");
+      expect(h.state()).toEqual({
+        hasSpinner: true,
+        currentMessage: "Retrying in 4s · attempt 2 · 2 retries left",
+      });
+
+      orch.onRetryWaitMessage("Retrying in 3s · attempt 2 · 2 retries left");
+      expect(h.state().currentMessage).toBe(
+        "Retrying in 3s · attempt 2 · 2 retries left"
+      );
+    });
+
+    it("restores the streaming label the turn was showing when the wait ends", () => {
+      const h = createAdapter(true);
+      const orch = createSpinnerOrchestrator(h.adapter, "Working...");
+
+      orch.onReasoningStart();
+      orch.onRetryWaitMessage("Retrying in 4s · attempt 2 · 2 retries left");
+      orch.onRetryWaitEnd();
+
+      expect(h.state()).toEqual({
+        hasSpinner: true,
+        currentMessage: "Thinking...",
+      });
+    });
+
+    it("restores the executing label when tools were pending under the wait", () => {
+      const h = createAdapter(true);
+      const orch = createSpinnerOrchestrator(h.adapter, "Working...");
+
+      orch.onToolPendingStart();
+      orch.onRetryWaitMessage("Retrying in 4s · attempt 2 · 2 retries left");
+      orch.onRetryWaitEnd();
+
+      expect(h.state().currentMessage).toBe("Executing...");
+    });
+
+    it("revives a cleared spinner for the wait and clears it again afterwards", () => {
+      const h = createAdapter(false);
+      const orch = createSpinnerOrchestrator(h.adapter, undefined);
+
+      orch.onRetryWaitMessage("Retrying in 4s · attempt 2 · 2 retries left");
+      expect(h.events).toContainEqual({
+        type: "showLoader",
+        message: "Retrying in 4s · attempt 2 · 2 retries left",
+      });
+
+      orch.onRetryWaitEnd();
+      expect(h.events.at(-1)).toEqual({ type: "clearStatus" });
       expect(h.state().hasSpinner).toBe(false);
+    });
+
+    it("falls back to the base label when nothing else was streaming", () => {
+      const h = createAdapter(true);
+      const orch = createSpinnerOrchestrator(h.adapter, "Working...");
+
+      orch.onRetryWaitMessage("Retrying in 4s · attempt 2 · 2 retries left");
+      orch.onRetryWaitEnd();
+
+      expect(h.state().currentMessage).toBe("Working...");
+    });
+
+    it("ignores a wait end that no wait started, leaving status untouched", () => {
+      const h = createAdapter(true);
+      const orch = createSpinnerOrchestrator(h.adapter, "Working...");
+      const setMessage = vi.spyOn(h.adapter, "setMessage");
+      const clearStatus = vi.spyOn(h.adapter, "clearStatus");
+
+      orch.onRetryWaitEnd();
+
+      expect(setMessage).not.toHaveBeenCalled();
+      expect(clearStatus).not.toHaveBeenCalled();
+    });
+
+    it("keeps the wait label while tools start and finish underneath it", () => {
+      const h = createAdapter(true);
+      const orch = createSpinnerOrchestrator(h.adapter, "Working...");
+
+      orch.onRetryWaitMessage("Retrying in 4s · attempt 2 · 2 retries left");
+      orch.onToolPendingStart();
+      orch.onToolPendingEnd();
+
+      expect(h.state().currentMessage).toBe(
+        "Retrying in 4s · attempt 2 · 2 retries left"
+      );
     });
   });
 

--- a/apps/coding-agent/src/tui/spinner-orchestrator.test.ts
+++ b/apps/coding-agent/src/tui/spinner-orchestrator.test.ts
@@ -243,6 +243,16 @@ describe("createSpinnerOrchestrator", () => {
   });
 
   describe("retry wait", () => {
+    it.each([undefined, null, ""])(
+      "clears an existing retry label without a base (%s)",
+      (base) => {
+        const h = createAdapter(true);
+        const orch = createSpinnerOrchestrator(h.adapter, base);
+        orch.onRetryWaitMessage("retry-status");
+        orch.onRetryWaitEnd();
+        expect(h.state()).toEqual({ hasSpinner: false, currentMessage: null });
+      }
+    );
     it("outranks the streaming label while the wait is active", () => {
       const h = createAdapter(true);
       const orch = createSpinnerOrchestrator(h.adapter, "Working...");

--- a/apps/coding-agent/src/tui/spinner-orchestrator.ts
+++ b/apps/coding-agent/src/tui/spinner-orchestrator.ts
@@ -8,6 +8,10 @@ export interface SpinnerOrchestratorAdapter {
 export interface SpinnerOrchestrator {
   onReasoningEnd: () => void;
   onReasoningStart: () => void;
+  /** Ends the retry wait and restores whatever label the turn implies. */
+  onRetryWaitEnd: () => void;
+  /** Shows or refreshes the retry countdown, outranking every other label. */
+  onRetryWaitMessage: (message: string) => void;
   onToolPendingEnd: () => void;
   onToolPendingStart: () => void;
 }
@@ -18,6 +22,8 @@ export const createSpinnerOrchestrator = (
 ): SpinnerOrchestrator => {
   let reasoningActive = false;
   let reasoningRevivedSpinner = false;
+  let retryWaiting = false;
+  let retryRevivedSpinner = false;
   let toolPendingCount = 0;
   let toolRevivedSpinner = false;
 
@@ -28,8 +34,44 @@ export const createSpinnerOrchestrator = (
   };
 
   return {
+    onRetryWaitMessage: (message: string) => {
+      // The provider call is not in flight during the wait, so the countdown
+      // replaces any streaming label until the wait resolves.
+      retryWaiting = true;
+      if (adapter.hasSpinner()) {
+        adapter.setMessage(message);
+        return;
+      }
+      adapter.showLoader(message);
+      retryRevivedSpinner = true;
+    },
+    onRetryWaitEnd: () => {
+      if (!retryWaiting) {
+        return;
+      }
+      retryWaiting = false;
+      if (reasoningActive) {
+        adapter.setMessage("Thinking...");
+        retryRevivedSpinner = false;
+        return;
+      }
+      if (toolPendingCount > 0) {
+        adapter.setMessage("Executing...");
+        retryRevivedSpinner = false;
+        return;
+      }
+      if (retryRevivedSpinner && !baseLoaderMessage) {
+        adapter.clearStatus();
+        retryRevivedSpinner = false;
+        return;
+      }
+      restoreBase();
+    },
     onReasoningStart: () => {
       reasoningActive = true;
+      if (retryWaiting) {
+        return;
+      }
       if (adapter.hasSpinner()) {
         adapter.setMessage("Thinking...");
       } else {
@@ -39,6 +81,9 @@ export const createSpinnerOrchestrator = (
     },
     onReasoningEnd: () => {
       reasoningActive = false;
+      if (retryWaiting) {
+        return;
+      }
       if (toolPendingCount > 0) {
         if (adapter.hasSpinner()) {
           adapter.setMessage("Executing...");
@@ -51,7 +96,7 @@ export const createSpinnerOrchestrator = (
         }
         return;
       }
-      if (reasoningRevivedSpinner) {
+      if (reasoningRevivedSpinner && !baseLoaderMessage) {
         adapter.clearStatus();
         reasoningRevivedSpinner = false;
         return;
@@ -60,7 +105,7 @@ export const createSpinnerOrchestrator = (
     },
     onToolPendingStart: () => {
       toolPendingCount += 1;
-      if (reasoningActive) {
+      if (reasoningActive || retryWaiting) {
         return;
       }
       if (adapter.hasSpinner()) {
@@ -72,7 +117,7 @@ export const createSpinnerOrchestrator = (
     },
     onToolPendingEnd: () => {
       toolPendingCount = Math.max(0, toolPendingCount - 1);
-      if (toolPendingCount > 0) {
+      if (toolPendingCount > 0 || retryWaiting) {
         return;
       }
       if (reasoningActive) {
@@ -82,7 +127,7 @@ export const createSpinnerOrchestrator = (
         }
         return;
       }
-      if (toolRevivedSpinner) {
+      if (toolRevivedSpinner && !baseLoaderMessage) {
         adapter.clearStatus();
         toolRevivedSpinner = false;
         return;

--- a/apps/coding-agent/src/tui/spinner-orchestrator.ts
+++ b/apps/coding-agent/src/tui/spinner-orchestrator.ts
@@ -23,7 +23,6 @@ export const createSpinnerOrchestrator = (
   let reasoningActive = false;
   let reasoningRevivedSpinner = false;
   let retryWaiting = false;
-  let retryRevivedSpinner = false;
   let toolPendingCount = 0;
   let toolRevivedSpinner = false;
 
@@ -43,7 +42,6 @@ export const createSpinnerOrchestrator = (
         return;
       }
       adapter.showLoader(message);
-      retryRevivedSpinner = true;
     },
     onRetryWaitEnd: () => {
       if (!retryWaiting) {
@@ -52,17 +50,14 @@ export const createSpinnerOrchestrator = (
       retryWaiting = false;
       if (reasoningActive) {
         adapter.setMessage("Thinking...");
-        retryRevivedSpinner = false;
         return;
       }
       if (toolPendingCount > 0) {
         adapter.setMessage("Executing...");
-        retryRevivedSpinner = false;
         return;
       }
-      if (retryRevivedSpinner && !baseLoaderMessage) {
+      if (!baseLoaderMessage) {
         adapter.clearStatus();
-        retryRevivedSpinner = false;
         return;
       }
       restoreBase();

--- a/apps/coding-agent/src/tui/startup-status.test.ts
+++ b/apps/coding-agent/src/tui/startup-status.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runCodingAgentCli } from "../cli";
+import { showStartupStatus } from "./startup-status";
+
+const SPINNER_PATTERN = /[\u2800-\u28ff]/u;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: strip terminal control sequences for width checks
+const ANSI_PATTERN = /\x1b\[[0-9;]*[mK]/g;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("pre-mount startup status", () => {
+  it("covers CLI extension discovery before startTui exists", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const tty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    let entered!: () => void;
+    let release!: () => void;
+    const loading = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const run = runCodingAgentCli({
+      argv: [],
+      loadExtensions: async () => {
+        entered();
+        await pending;
+        return { extensions: [], notices: [] };
+      },
+      start: async () => 0,
+    });
+    try {
+      await loading;
+      const before = String(write.mock.calls.at(-1)?.[0]);
+      vi.advanceTimersByTime(80);
+      const after = String(write.mock.calls.at(-1)?.[0]);
+      expect(before.match(SPINNER_PATTERN)?.[0]).toBeDefined();
+      expect(after.match(SPINNER_PATTERN)?.[0]).toBeDefined();
+      expect(after.match(SPINNER_PATTERN)?.[0]).not.toBe(
+        before.match(SPINNER_PATTERN)?.[0]
+      );
+    } finally {
+      release();
+      await run;
+      expect(vi.getTimerCount()).toBe(0);
+      if (tty) {
+        Object.defineProperty(process.stdout, "isTTY", tty);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
+  });
+  it.each([1, 2, 80])(
+    "animates at %i columns and clears exactly once before mount",
+    (columns) => {
+      vi.useFakeTimers();
+      const tty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+      const width = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+      Object.defineProperty(process.stdout, "isTTY", {
+        configurable: true,
+        value: true,
+      });
+      Object.defineProperty(process.stdout, "columns", {
+        configurable: true,
+        value: columns,
+      });
+      const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+      try {
+        const stop = showStartupStatus();
+        const before = String(write.mock.calls.at(-1)?.[0]);
+        vi.advanceTimersByTime(80);
+        const after = String(write.mock.calls.at(-1)?.[0]);
+        expect(before.match(SPINNER_PATTERN)?.[0]).toBeDefined();
+        expect(after.match(SPINNER_PATTERN)?.[0]).toBeDefined();
+        expect(after.match(SPINNER_PATTERN)?.[0]).not.toBe(
+          before.match(SPINNER_PATTERN)?.[0]
+        );
+        expect(
+          after.replace(ANSI_PATTERN, "").replace("\r", "").length
+        ).toBeLessThanOrEqual(columns);
+        stop();
+        const writes = write.mock.calls.length;
+        stop();
+        vi.advanceTimersByTime(80);
+        expect(write.mock.calls).toHaveLength(writes);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        if (tty) {
+          Object.defineProperty(process.stdout, "isTTY", tty);
+        } else {
+          Reflect.deleteProperty(process.stdout, "isTTY");
+        }
+        if (width) {
+          Object.defineProperty(process.stdout, "columns", width);
+        } else {
+          Reflect.deleteProperty(process.stdout, "columns");
+        }
+      }
+    }
+  );
+});

--- a/apps/coding-agent/src/tui/startup-status.test.ts
+++ b/apps/coding-agent/src/tui/startup-status.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCodingAgentCli } from "../cli";
+import { PENDING_SPINNER_INTERVAL_MS } from "./pending-spinner";
 import { showStartupStatus } from "./startup-status";
 
 const SPINNER_PATTERN = /[\u2800-\u28ff]/u;
@@ -41,7 +42,7 @@ describe("pre-mount startup status", () => {
     try {
       await loading;
       const before = String(write.mock.calls.at(-1)?.[0]);
-      vi.advanceTimersByTime(80);
+      vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
       const after = String(write.mock.calls.at(-1)?.[0]);
       expect(before.match(SPINNER_PATTERN)?.[0]).toBeDefined();
       expect(after.match(SPINNER_PATTERN)?.[0]).toBeDefined();
@@ -51,13 +52,13 @@ describe("pre-mount startup status", () => {
     } finally {
       release();
       await run;
-      expect(vi.getTimerCount()).toBe(0);
       if (tty) {
         Object.defineProperty(process.stdout, "isTTY", tty);
       } else {
         Reflect.deleteProperty(process.stdout, "isTTY");
       }
     }
+    expect(vi.getTimerCount()).toBe(0);
   });
   it.each([1, 2, 80])(
     "animates at %i columns and clears exactly once before mount",
@@ -77,7 +78,7 @@ describe("pre-mount startup status", () => {
       try {
         const stop = showStartupStatus();
         const before = String(write.mock.calls.at(-1)?.[0]);
-        vi.advanceTimersByTime(80);
+        vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
         const after = String(write.mock.calls.at(-1)?.[0]);
         expect(before.match(SPINNER_PATTERN)?.[0]).toBeDefined();
         expect(after.match(SPINNER_PATTERN)?.[0]).toBeDefined();
@@ -90,7 +91,7 @@ describe("pre-mount startup status", () => {
         stop();
         const writes = write.mock.calls.length;
         stop();
-        vi.advanceTimersByTime(80);
+        vi.advanceTimersByTime(PENDING_SPINNER_INTERVAL_MS);
         expect(write.mock.calls).toHaveLength(writes);
         expect(vi.getTimerCount()).toBe(0);
       } finally {

--- a/apps/coding-agent/src/tui/startup-status.ts
+++ b/apps/coding-agent/src/tui/startup-status.ts
@@ -1,0 +1,35 @@
+import { createSpinnerTicker, stylePendingIndicator } from "./pending-spinner";
+
+export async function withStartupStatus<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  const stop = showStartupStatus();
+  try {
+    return await operation();
+  } finally {
+    stop();
+  }
+}
+
+/** Minimal pre-mount status; relinquishes the line before pi-tui owns stdout. */
+export function showStartupStatus(): () => void {
+  if (!process.stdout.isTTY) {
+    return () => undefined;
+  }
+  const ticker = createSpinnerTicker((frame) => {
+    const width = Math.max(1, process.stdout.columns ?? 80);
+    const label = "Starting...".slice(0, Math.max(0, width - 2));
+    process.stdout.write(
+      `\r\x1b[2K${label ? stylePendingIndicator(frame, label) : frame}`
+    );
+  });
+  let stopped = false;
+  return () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    ticker.stop();
+    process.stdout.write("\r\x1b[2K");
+  };
+}

--- a/apps/coding-agent/src/tui/startup-status.ts
+++ b/apps/coding-agent/src/tui/startup-status.ts
@@ -1,9 +1,16 @@
 import { createSpinnerTicker, stylePendingIndicator } from "./pending-spinner";
 
+export interface StartupStatusOutput {
+  readonly columns?: number;
+  readonly isTTY?: boolean;
+  write(text: string): unknown;
+}
+
 export async function withStartupStatus<T>(
-  operation: () => Promise<T>
+  operation: () => Promise<T>,
+  stdout: StartupStatusOutput = process.stdout
 ): Promise<T> {
-  const stop = showStartupStatus();
+  const stop = showStartupStatus(stdout);
   try {
     return await operation();
   } finally {
@@ -12,14 +19,16 @@ export async function withStartupStatus<T>(
 }
 
 /** Minimal pre-mount status; relinquishes the line before pi-tui owns stdout. */
-export function showStartupStatus(): () => void {
-  if (!process.stdout.isTTY) {
+export function showStartupStatus(
+  stdout: StartupStatusOutput = process.stdout
+): () => void {
+  if (!stdout.isTTY) {
     return () => undefined;
   }
   const ticker = createSpinnerTicker((frame) => {
-    const width = Math.max(1, process.stdout.columns ?? 80);
+    const width = Math.max(1, stdout.columns ?? 80);
     const label = "Starting...".slice(0, Math.max(0, width - 2));
-    process.stdout.write(
+    stdout.write(
       `\r\x1b[2K${label ? stylePendingIndicator(frame, label) : frame}`
     );
   });
@@ -30,6 +39,6 @@ export function showStartupStatus(): () => void {
     }
     stopped = true;
     ticker.stop();
-    process.stdout.write("\r\x1b[2K");
+    stdout.write("\r\x1b[2K");
   };
 }

--- a/apps/coding-agent/src/tui/stream-handlers.test.ts
+++ b/apps/coding-agent/src/tui/stream-handlers.test.ts
@@ -95,6 +95,78 @@ describe("stream-handlers", () => {
     expect(output).toContain("waiting for user or policy decision");
   });
 
+  it("routes a scheduled retry to the wait hook without adding a transcript row", () => {
+    const onRetryWait = vi.fn();
+    const onRetryClear = vi.fn();
+    const { chatContainer, state } = createState({
+      onRetryClear,
+      onRetryWait,
+    });
+
+    STREAM_HANDLERS["retry-wait"]?.(
+      {
+        attempt: 1,
+        attemptId: "step-1",
+        delayMs: 4000,
+        phase: "scheduled",
+        remainingRetries: 2,
+        retryAt: 1_700_000_004_000,
+        type: "retry-wait",
+      } as never,
+      state
+    );
+
+    expect(onRetryWait).toHaveBeenCalledWith({
+      attempt: 1,
+      delayMs: 4000,
+      remainingRetries: 2,
+      retryAt: 1_700_000_004_000,
+    });
+    expect(onRetryClear).not.toHaveBeenCalled();
+    expect(chatContainer.render(120).join("\n").trim()).toBe("");
+  });
+
+  it.each(["started", "stopped"])(
+    "clears the retry wait on a %s retry phase",
+    (phase) => {
+      const onRetryWait = vi.fn();
+      const onRetryClear = vi.fn();
+      const { chatContainer, state } = createState({
+        onRetryClear,
+        onRetryWait,
+      });
+
+      STREAM_HANDLERS["retry-wait"]?.(
+        {
+          attempt: 1,
+          attemptId: "step-1",
+          phase,
+          remainingRetries: phase === "started" ? 1 : 0,
+          type: "retry-wait",
+        } as never,
+        state
+      );
+
+      expect(onRetryClear).toHaveBeenCalledTimes(1);
+      expect(onRetryWait).not.toHaveBeenCalled();
+      expect(chatContainer.render(120).join("\n").trim()).toBe("");
+    }
+  );
+
+  it("keeps retry waits out of the first-visible-part gate", () => {
+    expect(
+      isVisibleStreamPart({ type: "retry-wait" } as never, {
+        showFiles: false,
+        showFinishReason: false,
+        showRawToolIo: false,
+        showReasoning: true,
+        showSources: false,
+        showSteps: false,
+        showToolResults: true,
+      })
+    ).toBe(false);
+  });
+
   it("treats tool approval requests as visible stream parts", () => {
     expect(
       isVisibleStreamPart({ type: "tool-approval-request" } as never, {

--- a/apps/coding-agent/src/tui/stream-handlers.test.ts
+++ b/apps/coding-agent/src/tui/stream-handlers.test.ts
@@ -75,6 +75,45 @@ function createState(overrides: Partial<PiTuiStreamState> = {}): {
 }
 
 describe("stream-handlers", () => {
+  it("finishes hidden tool results without mounting a continuation or keeping its ticker", async () => {
+    vi.useFakeTimers();
+    const { state } = createState();
+    state.flags.showToolResults = false;
+    const view = state.ensureToolView("hidden", "fixture");
+    state.finishToolView = vi.fn(() => {
+      view.settle();
+      view.dispose();
+    });
+    const ensure = vi.spyOn(state, "ensureToolView");
+    try {
+      await STREAM_HANDLERS["tool-input-start"](
+        {
+          type: "tool-input-start",
+          toolCallId: "hidden",
+          toolName: "fixture",
+        },
+        state
+      );
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+      ensure.mockClear();
+      handleToolResult(
+        {
+          type: "tool-result",
+          toolCallId: "hidden",
+          toolName: "fixture",
+          output: "HIDDEN_RESULT",
+        },
+        state
+      );
+      expect(state.finishToolView).toHaveBeenCalledExactlyOnceWith("hidden");
+      expect(ensure).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      view.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("renders tool approval requests instead of ignoring them", () => {
     const { chatContainer, state } = createState();
 

--- a/apps/coding-agent/src/tui/stream-handlers.ts
+++ b/apps/coding-agent/src/tui/stream-handlers.ts
@@ -1,10 +1,6 @@
-import {
-  type Container,
-  type Markdown,
-  Spacer,
-  Text,
-} from "@earendil-works/pi-tui";
+import { type Component, type Container, Spacer } from "@earendil-works/pi-tui";
 import type { RetryWaitSchedule } from "./retry-status";
+import { SnapshotText as Text } from "./snapshot-views";
 import type { AssistantStreamView } from "./stream-views";
 import { sanitizeTerminalText } from "./terminal-safety";
 import type { ToolCallView } from "./tool-call-view";
@@ -64,7 +60,7 @@ export const UNKNOWN_TOOL_NAME = "tool";
 
 export const addChatComponent = (
   chatContainer: Container,
-  component: Container | Text | Markdown,
+  component: Component,
   options: { addLeadingSpacer?: boolean } = {}
 ): void => {
   if (options.addLeadingSpacer ?? true) {

--- a/apps/coding-agent/src/tui/stream-handlers.ts
+++ b/apps/coding-agent/src/tui/stream-handlers.ts
@@ -4,6 +4,7 @@ import {
   Spacer,
   Text,
 } from "@earendil-works/pi-tui";
+import type { RetryWaitSchedule } from "./retry-status";
 import type { AssistantStreamView } from "./stream-views";
 import { sanitizeTerminalText } from "./terminal-safety";
 import type { ToolCallView } from "./tool-call-view";
@@ -99,6 +100,8 @@ export interface PiTuiStreamState {
   getToolView: (toolCallId: string) => ToolCallView | undefined;
   onReasoningEnd?: () => void;
   onReasoningStart?: () => void;
+  onRetryClear?: () => void;
+  onRetryWait?: (schedule: RetryWaitSchedule) => void;
   onToolPendingEnd?: () => void;
   onToolPendingStart?: () => void;
   pendingToolCallIds: Set<string>;
@@ -333,6 +336,24 @@ export const handleToolApprovalRequest: StreamPartHandler = (part, state) => {
   );
 };
 
+/**
+ * Runtime retry phases. Only `scheduled` means a wait is pending; `started`
+ * and `stopped` both end it, so both clear the status.
+ */
+export const handleRetryWait: StreamPartHandler = (part, state) => {
+  if (part.phase !== "scheduled") {
+    state.onRetryClear?.();
+    return;
+  }
+
+  state.onRetryWait?.({
+    attempt: Number(part.attempt ?? 0),
+    delayMs: Number(part.delayMs ?? 0),
+    remainingRetries: Number(part.remainingRetries ?? 0),
+    retryAt: Number(part.retryAt ?? 0),
+  });
+};
+
 export const handleStartStep: StreamPartHandler = (_part, state) => {
   if (!state.flags.showSteps) {
     return;
@@ -398,6 +419,7 @@ export const STREAM_HANDLERS: Record<string, StreamPartHandler> = {
   "tool-error": handleToolError,
   "tool-output-denied": handleToolOutputDenied,
   "tool-approval-request": handleToolApprovalRequest,
+  "retry-wait": handleRetryWait,
   "start-step": handleStartStep,
   "finish-step": handleFinishStep,
   source: handleSource,
@@ -419,6 +441,9 @@ export const isVisibleStreamPart = (
     case "reasoning-end":
     case "start":
     case "tool-input-end":
+    // A retry wait renders as foreground status only, so it must not open the
+    // transcript or count as the turn's first visible part.
+    case "retry-wait":
       return false;
     case "text-start":
       return true;

--- a/apps/coding-agent/src/tui/stream-handlers.ts
+++ b/apps/coding-agent/src/tui/stream-handlers.ts
@@ -40,6 +40,8 @@ const getToolInputChunk = (part: {
 };
 
 export interface ToolInputRenderState {
+  // Canonical arguments outlive any individual display lease/continuation.
+  finalInput?: unknown;
   hasContent: boolean;
   inputBuffer: string;
   renderedInputLength: number;
@@ -94,8 +96,11 @@ export interface PiTuiRenderFlags {
 export interface PiTuiStreamState {
   activeToolInputs: Map<string, ToolInputRenderState>;
   chatContainer: Container;
+  endAssistantView?: (kind: "reasoning" | "text") => void;
   ensureAssistantView: () => AssistantStreamView;
   ensureToolView: (toolCallId: string, toolName: string) => ToolCallView;
+  finishOutput?: () => void;
+  finishToolView?: (toolCallId: string) => void;
   flags: PiTuiRenderFlags;
   getToolView: (toolCallId: string) => ToolCallView | undefined;
   onReasoningEnd?: () => void;
@@ -121,12 +126,8 @@ export const syncToolInputToView = async (
 
   const existingView = state.getToolView(toolCallId);
   const pendingInput = toolState.inputBuffer.slice(
-    toolState.renderedInputLength
+    existingView ? toolState.renderedInputLength : 0
   );
-  if (!existingView && pendingInput.length === 0) {
-    return;
-  }
-
   state.resetAssistantView(true);
   const toolView =
     existingView ?? state.ensureToolView(toolCallId, toolState.toolName);
@@ -148,7 +149,16 @@ export type StreamPartHandler = (
 ) => void | Promise<void>;
 
 export const handleTextStart: StreamPartHandler = (_part, state) => {
+  state.resetAssistantView();
   state.ensureAssistantView();
+};
+
+export const handleTextEnd: StreamPartHandler = (_part, state) => {
+  if (state.endAssistantView) {
+    state.endAssistantView("text");
+  } else {
+    state.resetAssistantView();
+  }
 };
 
 export const handleTextDelta: StreamPartHandler = (part, state) => {
@@ -156,6 +166,7 @@ export const handleTextDelta: StreamPartHandler = (part, state) => {
 };
 
 export const handleReasoningStart: StreamPartHandler = (_part, state) => {
+  state.resetAssistantView();
   if (state.flags.showReasoning) {
     state.ensureAssistantView();
   }
@@ -171,6 +182,11 @@ export const handleReasoningDelta: StreamPartHandler = (part, state) => {
 };
 
 export const handleReasoningEnd: StreamPartHandler = (_part, state) => {
+  if (state.endAssistantView) {
+    state.endAssistantView("reasoning");
+  } else {
+    state.resetAssistantView();
+  }
   state.onReasoningEnd?.();
 };
 
@@ -248,7 +264,9 @@ export const handleToolCall: StreamPartHandler = (part, state) => {
     state.streamedToolCallIds.has(toolCallId) &&
     inputState?.hasContent === true;
 
-  state.activeToolInputs.delete(toolCallId);
+  const canonical = inputState ?? createToolInputState(toolName);
+  canonical.finalInput = part.input;
+  state.activeToolInputs.set(toolCallId, canonical);
   state.streamedToolCallIds.delete(toolCallId);
 
   state.resetAssistantView(true);
@@ -277,6 +295,7 @@ export const handleToolResult: StreamPartHandler = (part, state) => {
   state.resetAssistantView(true);
   const view = state.ensureToolView(toolCallId, toolName);
   view.setOutput(part.output);
+  state.finishToolView?.(toolCallId);
 };
 
 export const handleToolError: StreamPartHandler = (part, state) => {
@@ -286,6 +305,7 @@ export const handleToolError: StreamPartHandler = (part, state) => {
   state.resetAssistantView(true);
   const view = state.ensureToolView(toolCallId, toolName);
   view.setError(part.error);
+  state.finishToolView?.(toolCallId);
 };
 
 export const handleToolOutputDenied: StreamPartHandler = (part, state) => {
@@ -297,6 +317,7 @@ export const handleToolOutputDenied: StreamPartHandler = (part, state) => {
   view.setOutputDenied(
     typeof part.reason === "string" ? part.reason : undefined
   );
+  state.finishToolView?.(toolCallId);
 };
 
 export const handleToolApprovalRequest: StreamPartHandler = (part, state) => {
@@ -364,6 +385,8 @@ export const handleStartStep: StreamPartHandler = (_part, state) => {
 };
 
 export const handleFinishStep: StreamPartHandler = (part, state) => {
+  state.finishOutput?.();
+  state.resetAssistantView();
   if (!state.flags.showSteps) {
     return;
   }
@@ -394,6 +417,8 @@ export const handleFile: StreamPartHandler = (part, state) => {
 };
 
 export const handleFinish: StreamPartHandler = (part, state) => {
+  state.finishOutput?.();
+  state.resetAssistantView();
   if (!state.flags.showFinishReason) {
     return;
   }
@@ -408,6 +433,11 @@ export const handleFinish: StreamPartHandler = (part, state) => {
 export const STREAM_HANDLERS: Record<string, StreamPartHandler> = {
   "text-start": handleTextStart,
   "text-delta": handleTextDelta,
+  "text-end": handleTextEnd,
+  abort: (_part, state) => {
+    state.finishOutput?.();
+    state.resetAssistantView();
+  },
   "reasoning-start": handleReasoningStart,
   "reasoning-delta": handleReasoningDelta,
   "reasoning-end": handleReasoningEnd,
@@ -427,7 +457,7 @@ export const STREAM_HANDLERS: Record<string, StreamPartHandler> = {
   finish: handleFinish,
 };
 
-export const IGNORE_PART_TYPES = new Set(["abort", "text-end", "start"]);
+export const IGNORE_PART_TYPES = new Set(["start"]);
 
 export const isVisibleStreamPart = (
   part: TuiStreamPart,

--- a/apps/coding-agent/src/tui/stream-handlers.ts
+++ b/apps/coding-agent/src/tui/stream-handlers.ts
@@ -106,7 +106,7 @@ export interface PiTuiStreamState {
   onToolPendingEnd?: () => void;
   onToolPendingStart?: () => void;
   pendingToolCallIds: Set<string>;
-  resetAssistantView: (suppressLeadingSpacer?: boolean) => void;
+  resetAssistantView: () => void;
   streamedToolCallIds: Set<string>;
 }
 
@@ -124,7 +124,7 @@ export const syncToolInputToView = async (
   const pendingInput = toolState.inputBuffer.slice(
     existingView ? toolState.renderedInputLength : 0
   );
-  state.resetAssistantView(true);
+  state.resetAssistantView();
   const toolView =
     existingView ?? state.ensureToolView(toolCallId, toolState.toolName);
 
@@ -265,7 +265,7 @@ export const handleToolCall: StreamPartHandler = (part, state) => {
   state.activeToolInputs.set(toolCallId, canonical);
   state.streamedToolCallIds.delete(toolCallId);
 
-  state.resetAssistantView(true);
+  state.resetAssistantView();
   const view = state.ensureToolView(toolCallId, toolName);
   view.setFinalInput(part.input);
 
@@ -288,7 +288,7 @@ export const handleToolResult: StreamPartHandler = (part, state) => {
     return;
   }
 
-  state.resetAssistantView(true);
+  state.resetAssistantView();
   const view = state.ensureToolView(toolCallId, toolName);
   view.setOutput(part.output);
   state.finishToolView?.(toolCallId);
@@ -298,7 +298,7 @@ export const handleToolError: StreamPartHandler = (part, state) => {
   const toolCallId = String(part.toolCallId ?? "");
   const toolName = String(part.toolName ?? "");
   firePendingEndIfTracked(state, toolCallId);
-  state.resetAssistantView(true);
+  state.resetAssistantView();
   const view = state.ensureToolView(toolCallId, toolName);
   view.setError(part.error);
   state.finishToolView?.(toolCallId);
@@ -308,7 +308,7 @@ export const handleToolOutputDenied: StreamPartHandler = (part, state) => {
   const toolCallId = String(part.toolCallId ?? "");
   const toolName = String(part.toolName ?? "");
   firePendingEndIfTracked(state, toolCallId);
-  state.resetAssistantView(true);
+  state.resetAssistantView();
   const view = state.ensureToolView(toolCallId, toolName);
   view.setOutputDenied(
     typeof part.reason === "string" ? part.reason : undefined
@@ -325,7 +325,7 @@ export const handleToolApprovalRequest: StreamPartHandler = (part, state) => {
   };
 
   firePendingEndIfTracked(state, approvalPart.toolCallId);
-  state.resetAssistantView(true);
+  state.resetAssistantView();
   const view = state.ensureToolView(
     approvalPart.toolCallId,
     approvalPart.toolName

--- a/apps/coding-agent/src/tui/stream-handlers.ts
+++ b/apps/coding-agent/src/tui/stream-handlers.ts
@@ -285,6 +285,7 @@ export const handleToolResult: StreamPartHandler = (part, state) => {
   firePendingEndIfTracked(state, toolCallId);
 
   if (!state.flags.showToolResults) {
+    state.finishToolView?.(toolCallId);
     return;
   }
 

--- a/apps/coding-agent/src/tui/stream-views.test.ts
+++ b/apps/coding-agent/src/tui/stream-views.test.ts
@@ -113,6 +113,23 @@ describe("AssistantStreamView terminal safety", () => {
     expect(output).not.toContain("\u0007");
   });
 
+  it("expands text without lifting the reasoning bound in a mixed view", () => {
+    const view = new AssistantStreamView(markdownTheme);
+    const source = (prefix: string) =>
+      Array.from(
+        { length: 20 },
+        (_, i) => `${prefix}_${String(i).padStart(2, "0")}`
+      ).join("\n");
+    view.appendReasoning(source("THINK"));
+    view.appendText(source("TEXT"));
+    expect(view.render(48)).toHaveLength(8);
+    view.completeText();
+    const output = view.render(48).join("\n");
+    expect(output.match(/THINK_\d+/g)).toHaveLength(8);
+    expect(output.match(/TEXT_\d+/g)).toHaveLength(20);
+    view.dispose();
+  });
+
   it("preserves leading indentation for Markdown code blocks", () => {
     const view = new AssistantStreamView({
       ...markdownTheme,

--- a/apps/coding-agent/src/tui/stream-views.ts
+++ b/apps/coding-agent/src/tui/stream-views.ts
@@ -9,6 +9,7 @@ import type {
   AssistantRenderer,
   AssistantTextView,
 } from "./assistant-renderer";
+import { renderBodyTail } from "./body-viewport";
 import { sanitizeTerminalText } from "./terminal-safety";
 
 const ANSI_RESET = "\x1b[0m";
@@ -50,6 +51,7 @@ export class AssistantStreamView extends Container {
   private readonly assistantRenderer: AssistantRenderer | undefined;
   private readonly controller = new AbortController();
   private disposed = false;
+  private textComplete = false;
   private readonly foregroundColor: string | undefined;
   private readonly markdownTheme: MarkdownTheme;
   private readonly notify: (message: string) => void;
@@ -89,6 +91,28 @@ export class AssistantStreamView extends Container {
       }
     };
     this.refresh();
+  }
+
+  override render(width: number): string[] {
+    if (!this.textComplete) {
+      return renderBodyTail(super.render(width), width);
+    }
+    return this.children.flatMap((child) => {
+      const lines = child.render(width);
+      const reasoning = this.segments.some(
+        (segment) => segment.view === child && segment.type === "reasoning"
+      );
+      return reasoning ? renderBodyTail(lines, width) : lines;
+    });
+  }
+
+  get contentKind(): "reasoning" | "text" | undefined {
+    return this.segments.at(-1)?.type;
+  }
+
+  /** Expand text before sealing, without restarting an async renderer. */
+  completeText(): void {
+    this.textComplete = true;
   }
 
   appendReasoning(delta: string): void {

--- a/apps/coding-agent/src/tui/stream-views.ts
+++ b/apps/coding-agent/src/tui/stream-views.ts
@@ -1,15 +1,16 @@
-import {
-  Container,
-  Markdown,
-  type MarkdownTheme,
-  Spacer,
-} from "@earendil-works/pi-tui";
+import { Container, type MarkdownTheme, Spacer } from "@earendil-works/pi-tui";
 
 import type {
   AssistantRenderer,
   AssistantTextView,
 } from "./assistant-renderer";
 import { renderBodyTail } from "./body-viewport";
+import {
+  type ColdContent,
+  captureComponent,
+  selectColdTail,
+} from "./cold-content";
+import { SnapshotMarkdown as Markdown } from "./snapshot-views";
 import { sanitizeTerminalText } from "./terminal-safety";
 
 const ANSI_RESET = "\x1b[0m";
@@ -104,6 +105,20 @@ export class AssistantStreamView extends Container {
       );
       return reasoning ? renderBodyTail(lines, width) : lines;
     });
+  }
+
+  captureCold(width: number): ColdContent {
+    const children = this.children.map((child) => {
+      const content = captureComponent(child, width);
+      const reasoning = this.segments.some(
+        (segment) => segment.view === child && segment.type === "reasoning"
+      );
+      return this.textComplete && reasoning
+        ? selectColdTail(content, width)
+        : content;
+    });
+    const content: ColdContent = { kind: "group", children };
+    return this.textComplete ? content : selectColdTail(content, width);
   }
 
   get contentKind(): "reasoning" | "text" | undefined {

--- a/apps/coding-agent/src/tui/terminal-exit.test.ts
+++ b/apps/coding-agent/src/tui/terminal-exit.test.ts
@@ -1,16 +1,47 @@
+import type { TuiMainScreenRenderState } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import {
   formatSessionResumeHint,
   terminalExitCursorSequence,
 } from "./terminal-exit";
 
+const state = (
+  rows: number,
+  cursor: number,
+  viewportTop = 0
+): TuiMainScreenRenderState => ({
+  previousLines: Array.from({ length: rows }, () => ""),
+  previousWidth: 48,
+  previousHeight: 10,
+  hardwareCursorRow: cursor,
+  cursorRow: rows - 1,
+  maxLinesRendered: rows,
+  previousViewportTop: viewportTop,
+});
+
 describe("terminal exit", () => {
-  it("erases the composer rows below the transcript", () => {
-    expect(terminalExitCursorSequence(4)).toBe("\x1b[4A\r\x1b[J");
+  it("reclaims the top composer border from the actual editor cursor", () => {
+    expect(terminalExitCursorSequence(state(12, 9), 4)).toBe("\x1b[1A\r\x1b[J");
   });
 
-  it("only erases in place when no composer rows were rendered", () => {
-    expect(terminalExitCursorSequence(0)).toBe("\r\x1b[J");
+  it("uses the same relative geometry after a long transcript scrolls", () => {
+    expect(terminalExitCursorSequence(state(102, 99, 92), 4)).toBe(
+      "\x1b[1A\r\x1b[J"
+    );
+  });
+
+  it("moves down if a non-editor focus left the cursor above the composer", () => {
+    expect(terminalExitCursorSequence(state(12, 6), 4)).toBe("\x1b[2B\r\x1b[J");
+  });
+
+  it("does not move above the viewport for an oversized composer", () => {
+    expect(terminalExitCursorSequence(state(20, 17, 10), 15)).toBe(
+      "\x1b[7A\r\x1b[J"
+    );
+  });
+
+  it("only erases in place when the cursor is already on the border", () => {
+    expect(terminalExitCursorSequence(state(12, 8), 4)).toBe("\r\x1b[J");
   });
 
   it("prints a directly usable resume command", () => {

--- a/apps/coding-agent/src/tui/terminal-exit.ts
+++ b/apps/coding-agent/src/tui/terminal-exit.ts
@@ -1,3 +1,5 @@
+import type { TuiMainScreenRenderState } from "@earendil-works/pi-tui";
+
 export const formatSessionResumeHint = (sessionKey: string): string =>
   `To resume this session: pss --session ${sessionResumeSelector(sessionKey)}`;
 
@@ -6,7 +8,19 @@ const sessionResumeSelector = (sessionKey: string): string => {
   return separator >= 0 ? sessionKey.slice(separator + 1) : sessionKey;
 };
 
-export const terminalExitCursorSequence = (composerRows: number): string => {
-  const cursor = composerRows === 0 ? "\r" : `\x1b[${composerRows}A\r`;
-  return `${cursor}\x1b[J`;
+export const terminalExitCursorSequence = (
+  state: TuiMainScreenRenderState,
+  composerRows: number
+): string => {
+  // Reclaim the top border's row, not the row after it. Shutdown logs may
+  // replace the composer here; the outer exit block restores its separator.
+  // Clamp only to the visible viewport if an oversized composer scrolled.
+  const borderRow = Math.max(
+    state.previousViewportTop,
+    state.previousLines.length - composerRows
+  );
+  const delta = borderRow - state.hardwareCursorRow;
+  const cursor =
+    delta === 0 ? "" : `\x1b[${Math.abs(delta)}${delta < 0 ? "A" : "B"}`;
+  return `${cursor}\r\x1b[J`;
 };

--- a/apps/coding-agent/src/tui/terminal-exit.ts
+++ b/apps/coding-agent/src/tui/terminal-exit.ts
@@ -3,7 +3,7 @@ import type { TuiMainScreenRenderState } from "@earendil-works/pi-tui";
 export const formatSessionResumeHint = (sessionKey: string): string =>
   `To resume this session: pss --session ${sessionResumeSelector(sessionKey)}`;
 
-const sessionResumeSelector = (sessionKey: string): string => {
+export const sessionResumeSelector = (sessionKey: string): string => {
   const separator = sessionKey.lastIndexOf("#");
   return separator >= 0 ? sessionKey.slice(separator + 1) : sessionKey;
 };

--- a/apps/coding-agent/src/tui/tool-call-view.test.ts
+++ b/apps/coding-agent/src/tui/tool-call-view.test.ts
@@ -272,3 +272,108 @@ describe("BaseToolCallView render shape fixtures", () => {
     view.dispose();
   });
 });
+
+describe("progressive shared input ownership", () => {
+  it.each([false, true])(
+    "reveals generic input before execution (raw=%s)",
+    async (raw) => {
+      const view = new BaseToolCallView(
+        "stream",
+        "generic",
+        markdownTheme,
+        undefined,
+        raw
+      );
+      await view.appendInputChunk('{"message":"EARLY');
+      expect(view.render(120).join("\n")).toContain("EARLY");
+      await view.appendInputChunk(' LATER"}');
+      expect(view.render(120).join("\n")).toContain("LATER");
+      view.dispose();
+    }
+  );
+
+  it("owns streaming input even when a custom renderer claims an empty body", async () => {
+    const view = new BaseToolCallView(
+      "stream",
+      "custom",
+      markdownTheme,
+      undefined,
+      false,
+      {
+        custom: (target, _input, output) =>
+          target.setPrettyBlock(
+            "custom",
+            typeof output === "string" ? output : ""
+          ),
+      }
+    );
+    await view.appendInputChunk('{"message":"EARLY');
+    expect(view.render(120).join("\n")).toContain("EARLY");
+    await view.appendInputChunk(' LATER"}');
+    view.setFinalInput({ message: "EARLY LATER" });
+    expect(view.render(120).join("\n")).toContain("LATER");
+    view.setOutput("CUSTOM_RESULT");
+    expect(view.render(120).join("\n")).toContain("CUSTOM_RESULT");
+    expect(view.render(120).join("\n")).not.toContain("EARLY");
+    view.dispose();
+  });
+
+  it("shows broken JSON safely instead of silently dropping input", async () => {
+    const view = new BaseToolCallView("stream", "generic", markdownTheme);
+    await view.appendInputChunk("broken EARLY \u001b]52;c;payload\u0007");
+    const text = view.render(120).join("\n");
+    expect(text).toContain("EARLY");
+    expect(text).not.toContain("\u001b]");
+    expect(text).not.toContain("\u0007");
+    view.dispose();
+  });
+});
+
+describe("characterization: shared terminal states", () => {
+  it("raw mode bypasses custom renderers and preserves input and result", async () => {
+    const renderer = vi.fn();
+    const view = new BaseToolCallView(
+      "raw",
+      "custom",
+      markdownTheme,
+      undefined,
+      true,
+      { custom: renderer }
+    );
+    await view.appendInputChunk('{"content":"RAW_EARLY\\nRAW_LATER"}');
+    expect(view.render(120).join("\n")).toContain("RAW_EARLY\\nRAW_LATER");
+    view.setFinalInput({ content: "RAW_EARLY\nRAW_LATER" });
+    view.setOutput("RAW_RESULT");
+    expect(view.render(120).join("\n")).toContain("RAW_RESULT");
+    expect(renderer).not.toHaveBeenCalled();
+    view.dispose();
+  });
+
+  it("denied output does not render a success result", () => {
+    const view = new BaseToolCallView("denied", "generic", markdownTheme);
+    view.setFinalInput({ path: "x" });
+    view.setOutputDenied("DENIED_SENTINEL");
+    expect(view.render(120).join("\n")).toContain("DENIED_SENTINEL");
+    view.dispose();
+  });
+
+  it("dispose stops pending animation without inventing an output on abort", () => {
+    vi.useFakeTimers();
+    const requestRender = vi.fn();
+    const view = new BaseToolCallView(
+      "abort",
+      "generic",
+      markdownTheme,
+      requestRender
+    );
+    const before = requestRender.mock.calls.length;
+    vi.advanceTimersByTime(80);
+    expect(requestRender.mock.calls.length).toBeGreaterThan(before);
+    view.dispose();
+    const stopped = requestRender.mock.calls.length;
+    vi.advanceTimersByTime(160);
+    expect(requestRender).toHaveBeenCalledTimes(stopped);
+    expect(view.render(120).join("\n")).not.toContain("Output");
+    vi.useRealTimers();
+  });
+});

--- a/apps/coding-agent/src/tui/tool-call-view.ts
+++ b/apps/coding-agent/src/tui/tool-call-view.ts
@@ -2,11 +2,12 @@ import {
   Container,
   Markdown,
   type MarkdownTheme,
+  Spacer,
   Text,
-  truncateToWidth,
   visibleWidth,
 } from "@earendil-works/pi-tui";
 import { parsePartialJson } from "ai";
+import { BodyViewport, renderBodyTail } from "./body-viewport";
 import {
   createSpinnerTicker,
   type SpinnerTicker,
@@ -148,20 +149,25 @@ class BackgroundBody {
     }
 
     const normalizedText = this.text.replace(TAB_PATTERN, "   ");
-    const contentWidth = Math.max(1, width - this.paddingX * 2);
-    const leftMargin = " ".repeat(this.paddingX);
-    const rightMargin = " ".repeat(this.paddingX);
+    const padding = Math.min(
+      this.paddingX,
+      Math.max(0, Math.floor((width - 1) / 2))
+    );
+    const contentWidth = Math.max(1, width - padding * 2);
+    const leftMargin = " ".repeat(padding);
+    const rightMargin = " ".repeat(padding);
 
-    const renderedLines = normalizedText.split("\n").map((line) => {
-      const truncatedLine = truncateToWidth(line, contentWidth, "");
-      const lineWithMargins = `${leftMargin}${truncatedLine}${rightMargin}`;
-      const visLen = visibleWidth(lineWithMargins);
-      const paddedLine = `${lineWithMargins}${" ".repeat(Math.max(0, width - visLen))}`;
+    const renderedLines = renderBodyTail([normalizedText], contentWidth).map(
+      (line) => {
+        const lineWithMargins = `${leftMargin}${line}${rightMargin}`;
+        const visLen = visibleWidth(lineWithMargins);
+        const paddedLine = `${lineWithMargins}${" ".repeat(Math.max(0, width - visLen))}`;
 
-      return this.backgroundEnabled
-        ? this.backgroundFn(paddedLine)
-        : paddedLine;
-    });
+        return this.backgroundEnabled
+          ? this.backgroundFn(paddedLine)
+          : paddedLine;
+      }
+    );
 
     const result = ["", ...renderedLines];
     this.cachedText = this.text;
@@ -181,11 +187,12 @@ export interface ToolRendererMap {
 
 export class BaseToolCallView extends Container {
   private readonly callId: string;
-  private readonly content: TrimmedMarkdown;
+  private readonly content = new Container();
   private readonly markdownTheme: MarkdownTheme;
   private readonly renderers?: ToolRendererMap;
   private readonly showRawToolIo: boolean;
   private displayMode: "content" | "pretty" | "pending" = "content";
+  private disposed = false;
   private error: unknown;
   private finalInput: unknown;
   private inputBuffer = "";
@@ -218,18 +225,28 @@ export class BaseToolCallView extends Container {
     this.showRawToolIo = showRawToolIo ?? false;
     this.renderers = renderers;
     this.requestRender = requestRender ?? (() => undefined);
-    this.content = new TrimmedMarkdown("", 1, 0, markdownTheme);
     this.addChild(this.content);
     this.refresh();
   }
 
+  settle(): void {
+    if (this.pendingIndicator) {
+      this.pendingIndicator.setText("Preparing tool call…");
+    }
+    this.stopPendingIndicator();
+  }
+
   dispose(): void {
+    this.disposed = true;
     this.stopPendingIndicator();
   }
 
   async appendInputChunk(chunk: string): Promise<void> {
     this.inputBuffer += chunk;
     const { value, state } = await parsePartialJson(this.inputBuffer);
+    if (this.disposed) {
+      return;
+    }
     // Suppress transient empty objects during partial parsing to prevent
     // renderers from briefly showing "(unknown)" headers before real data arrives.
     if (state !== "successful-parse" && isPlainEmptyObject(value)) {
@@ -292,6 +309,9 @@ export class BaseToolCallView extends Container {
       useBackground?: boolean;
     }
   ): void {
+    if (this.disposed) {
+      return;
+    }
     this.prettyBlockActive = true;
     this.ensurePrettyBlockComponents();
 
@@ -323,7 +343,7 @@ export class BaseToolCallView extends Container {
     const body = new BackgroundBody("", 1, applyGrayBackground);
     const block = new Container();
     block.addChild(header);
-    block.addChild(body as unknown as InstanceType<typeof Container>);
+    block.addChild(body);
 
     this.readHeader = header;
     this.readBody = body;
@@ -428,6 +448,9 @@ export class BaseToolCallView extends Container {
   }
 
   private refresh(): void {
+    if (this.disposed) {
+      return;
+    }
     if (this.isEmptyState()) {
       this.setDisplayMode("pending");
       return;
@@ -452,7 +475,12 @@ export class BaseToolCallView extends Container {
       }
       if (this.renderedOverride) {
         this.setDisplayMode("content");
-        this.content.setText(this.renderedOverride);
+        this.content.clear();
+        this.content.addChild(
+          new BodyViewport(
+            new TrimmedMarkdown(this.renderedOverride, 1, 0, this.markdownTheme)
+          )
+        );
         return;
       }
     }
@@ -460,31 +488,54 @@ export class BaseToolCallView extends Container {
     this.setDisplayMode("content");
 
     const resolvedToolName = this.toolName || UNKNOWN_TOOL_NAME;
-    const blocks: string[] = [
-      `**Tool** \`${resolvedToolName}\` (\`${this.callId}\`)`,
+    this.content.clear();
+    this.content.addChild(
+      new TrimmedMarkdown(
+        `**Tool** \`${resolvedToolName}\` (\`${this.callId}\`)`,
+        1,
+        0,
+        this.markdownTheme
+      )
+    );
+    const sections = [
+      { label: "Input", language: "json", value: bestInput },
+      { label: "Output", language: "text", value: this.output },
+      { label: "Error", language: "text", value: this.error },
     ];
-
-    if (bestInput !== undefined) {
-      blocks.push(`**Input**\n\n${renderCodeBlock("json", bestInput)}`);
-    }
-
-    if (this.output !== undefined) {
-      blocks.push(`**Output**\n\n${renderCodeBlock("text", this.output)}`);
-    }
-
-    if (this.error !== undefined) {
-      blocks.push(`**Error**\n\n${renderCodeBlock("text", this.error)}`);
-    }
-
-    if (this.outputDenied) {
-      blocks.push(
-        this.outputDeniedReason
-          ? `**Output** denied: ${this.outputDeniedReason}`
-          : "**Output** denied by model/policy"
+    for (const { label, language, value } of sections) {
+      if (value === undefined) {
+        continue;
+      }
+      this.content.addChild(new Spacer(1));
+      this.content.addChild(
+        new TrimmedMarkdown(`**${label}**`, 1, 0, this.markdownTheme)
+      );
+      this.content.addChild(new Spacer(1));
+      this.content.addChild(
+        new BodyViewport(
+          new TrimmedMarkdown(
+            renderCodeBlock(language, value),
+            1,
+            0,
+            this.markdownTheme
+          )
+        )
       );
     }
 
-    this.content.setText(blocks.join("\n\n"));
+    if (this.outputDenied) {
+      this.content.addChild(new Spacer(1));
+      this.content.addChild(
+        new TrimmedMarkdown(
+          this.outputDeniedReason
+            ? `**Output** denied: ${this.outputDeniedReason}`
+            : "**Output** denied by model/policy",
+          1,
+          0,
+          this.markdownTheme
+        )
+      );
+    }
   }
 }
 

--- a/apps/coding-agent/src/tui/tool-call-view.ts
+++ b/apps/coding-agent/src/tui/tool-call-view.ts
@@ -1,18 +1,21 @@
 import {
   Container,
-  Markdown,
   type MarkdownTheme,
   Spacer,
-  Text,
   visibleWidth,
 } from "@earendil-works/pi-tui";
 import { parsePartialJson } from "ai";
 import { BodyViewport, renderBodyTail } from "./body-viewport";
+import { type ColdContent, captureStyle, selectTextTail } from "./cold-content";
 import {
   createSpinnerTicker,
   type SpinnerTicker,
   stylePendingIndicator,
 } from "./pending-spinner";
+import {
+  SnapshotMarkdown as Markdown,
+  SnapshotText as Text,
+} from "./snapshot-views";
 import { sanitizeTerminalText } from "./terminal-safety";
 
 const UNKNOWN_TOOL_NAME = "tool";
@@ -79,6 +82,13 @@ const applyErrorBackground = (text: string): string =>
   `${ANSI_BG_DARK_RED}${text}${ANSI_RESET}`;
 
 class TrimmedMarkdown extends Markdown {
+  override captureCold(width: number): ColdContent {
+    const content = super.captureCold(width);
+    return content.kind === "markdown"
+      ? { ...content, trimEnd: true }
+      : content;
+  }
+
   override render(width: number): string[] {
     const lines = super.render(width);
     let end = lines.length;
@@ -130,6 +140,26 @@ class BackgroundBody {
     this.cachedText = undefined;
     this.cachedWidth = undefined;
     this.cachedLines = undefined;
+  }
+
+  captureCold(width: number): ColdContent {
+    if (!this.text.trim()) {
+      return { kind: "group", children: [] };
+    }
+    const content = selectTextTail(
+      {
+        kind: "text",
+        text: this.text,
+        paddingX: this.paddingX,
+        paddingY: 0,
+        background: this.backgroundEnabled
+          ? captureStyle(this.backgroundFn)
+          : undefined,
+      },
+      width,
+      8
+    );
+    return { kind: "group", children: [{ kind: "spacer", rows: 1 }, content] };
   }
 
   render(width: number): string[] {

--- a/apps/coding-agent/src/tui/tool-call-view.ts
+++ b/apps/coding-agent/src/tui/tool-call-view.ts
@@ -46,6 +46,21 @@ const renderCodeBlock = (language: string, value: unknown): string => {
   return `${fence}${language}\n${text}\n${fence}`;
 };
 
+// Strings stay decoded (especially multiline source) rather than being
+// re-escaped by JSON.stringify. The pretty-block boundary sanitizes every field.
+const formatInputPreview = (value: unknown): string => {
+  if (typeof value !== "object" || value === null) {
+    return safeStringify(value);
+  }
+  const fields = Object.entries(value);
+  if (fields.length === 0) {
+    return safeStringify(value);
+  }
+  return fields
+    .map(([key, field]) => `${key}: ${formatInputPreview(field)}`)
+    .join("\n");
+};
+
 const isPlainEmptyObject = (value: unknown): boolean => {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -399,13 +414,12 @@ export class BaseToolCallView extends Container {
     return this.renderedOverride !== null || this.prettyBlockActive;
   }
 
-  private shouldSuppressRawFallback(): boolean {
+  private shouldRenderInputPreview(): boolean {
     if (this.showRawToolIo) {
       return false;
     }
 
     return (
-      this.finalInput === undefined &&
       this.output === undefined &&
       this.error === undefined &&
       !this.outputDenied &&
@@ -421,6 +435,17 @@ export class BaseToolCallView extends Container {
 
     const bestInput = this.resolveBestInput();
 
+    // Own streamed arguments until a result/error arrives: result renderers may
+    // intentionally claim an empty body, or require fields not yet received.
+    // Keep this same preview across the complete-input/execution boundary.
+    if (this.shouldRenderInputPreview()) {
+      this.setPrettyBlock(
+        `**${this.toolName || UNKNOWN_TOOL_NAME}** input`,
+        formatInputPreview(bestInput)
+      );
+      return;
+    }
+
     if (!this.showRawToolIo && this.tryRenderWithCustomRenderer(bestInput)) {
       if (this.prettyBlockActive) {
         return;
@@ -433,10 +458,6 @@ export class BaseToolCallView extends Container {
     }
 
     this.setDisplayMode("content");
-
-    if (this.shouldSuppressRawFallback()) {
-      return;
-    }
 
     const resolvedToolName = this.toolName || UNKNOWN_TOOL_NAME;
     const blocks: string[] = [

--- a/apps/coding-agent/src/tui/tool-call-view.ts
+++ b/apps/coding-agent/src/tui/tool-call-view.ts
@@ -70,6 +70,14 @@ const formatInputPreview = (value: unknown): string => {
     .join("\n");
 };
 
+const isInvalidArgumentsError = (
+  value: unknown
+): value is Record<string, unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  "code" in value &&
+  value.code === "INVALID_TOOL_ARGUMENTS";
+
 const isPlainEmptyObject = (value: unknown): boolean => {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -493,6 +501,36 @@ export class BaseToolCallView extends Container {
     return `**${this.toolName || UNKNOWN_TOOL_NAME}** input`;
   }
 
+  private renderInvalidArguments(error: Record<string, unknown>): void {
+    // SDK's final {} is a placeholder, not the rejected arguments. Never feed
+    // a partially parsed value to a success/custom result renderer.
+    const safeInput = sanitizeTerminalText(this.inputBuffer);
+    const preview =
+      safeInput.length <= 300
+        ? safeInput.replaceAll("\n", "\\n")
+        : [
+            `End: ${safeInput.slice(-120).replaceAll("\n", "\\n")}`,
+            "… [preview truncated] …",
+            `Start: ${safeInput.slice(0, 120).replaceAll("\n", "\\n")}`,
+          ].join("\n");
+    const message =
+      typeof error.message === "string"
+        ? sanitizeTerminalText(error.message)
+        : "Tool arguments are invalid or incomplete.";
+    this.setPrettyBlock(
+      `**${this.toolName || UNKNOWN_TOOL_NAME}** - invalid arguments (not executed)`,
+      [
+        error.kind === "schema-validation"
+          ? "Input preview (schema validation failed):"
+          : "Input preview (invalid/incomplete JSON):",
+        preview || "No streamed argument preview available.",
+        "",
+        `INVALID_TOOL_ARGUMENTS: ${message}`,
+      ].join("\n"),
+      { isError: true }
+    );
+  }
+
   private refresh(): void {
     if (this.disposed) {
       return;
@@ -503,6 +541,10 @@ export class BaseToolCallView extends Container {
     }
 
     const bestInput = this.resolveBestInput();
+    if (isInvalidArgumentsError(this.error)) {
+      this.renderInvalidArguments(this.error);
+      return;
+    }
 
     // Own streamed arguments until a result/error arrives: result renderers may
     // intentionally claim an empty body, or require fields not yet received.

--- a/apps/coding-agent/src/tui/tool-call-view.ts
+++ b/apps/coding-agent/src/tui/tool-call-view.ts
@@ -13,6 +13,11 @@ import {
   stylePendingIndicator,
 } from "./pending-spinner";
 import {
+  formatReadHeader,
+  formatWriteHeader,
+  stringField,
+} from "./renderers/utils";
+import {
   SnapshotMarkdown as Markdown,
   SnapshotText as Text,
 } from "./snapshot-views";
@@ -477,6 +482,17 @@ export class BaseToolCallView extends Container {
     );
   }
 
+  private inputPreviewHeader(input: unknown): string {
+    const path = stringField(input, "path");
+    if (path && this.toolName === "write_file") {
+      return formatWriteHeader(path);
+    }
+    if (path && this.toolName === "read_file") {
+      return formatReadHeader(path, input);
+    }
+    return `**${this.toolName || UNKNOWN_TOOL_NAME}** input`;
+  }
+
   private refresh(): void {
     if (this.disposed) {
       return;
@@ -493,7 +509,7 @@ export class BaseToolCallView extends Container {
     // Keep this same preview across the complete-input/execution boundary.
     if (this.shouldRenderInputPreview()) {
       this.setPrettyBlock(
-        `**${this.toolName || UNKNOWN_TOOL_NAME}** input`,
+        this.inputPreviewHeader(bestInput),
         formatInputPreview(bestInput)
       );
       return;

--- a/apps/coding-agent/src/tui/tool-call-view.ts
+++ b/apps/coding-agent/src/tui/tool-call-view.ts
@@ -6,7 +6,12 @@ import {
 } from "@earendil-works/pi-tui";
 import { parsePartialJson } from "ai";
 import { BodyViewport, renderBodyTail } from "./body-viewport";
-import { type ColdContent, captureStyle, selectTextTail } from "./cold-content";
+import {
+  type ColdContent,
+  captureStyle,
+  hasGraphics,
+  selectTextTail,
+} from "./cold-content";
 import {
   createSpinnerTicker,
   type SpinnerTicker,
@@ -159,6 +164,13 @@ class BackgroundBody {
     if (!this.text.trim()) {
       return { kind: "group", children: [] };
     }
+    if (hasGraphics([this.text])) {
+      return {
+        kind: "fixed",
+        rows: [...this.render(width)],
+        reason: "graphics",
+      };
+    }
     const content = selectTextTail(
       {
         kind: "text",
@@ -200,17 +212,18 @@ class BackgroundBody {
     const leftMargin = " ".repeat(padding);
     const rightMargin = " ".repeat(padding);
 
-    const renderedLines = renderBodyTail([normalizedText], contentWidth).map(
-      (line) => {
-        const lineWithMargins = `${leftMargin}${line}${rightMargin}`;
-        const visLen = visibleWidth(lineWithMargins);
-        const paddedLine = `${lineWithMargins}${" ".repeat(Math.max(0, width - visLen))}`;
+    const renderedLines = renderBodyTail(
+      normalizedText.split("\n"),
+      contentWidth
+    ).map((line) => {
+      const lineWithMargins = `${leftMargin}${line}${rightMargin}`;
+      const visLen = visibleWidth(lineWithMargins);
+      const paddedLine = `${lineWithMargins}${" ".repeat(Math.max(0, width - visLen))}`;
 
-        return this.backgroundEnabled
-          ? this.backgroundFn(paddedLine)
-          : paddedLine;
-      }
-    );
+      return this.backgroundEnabled
+        ? this.backgroundFn(paddedLine)
+        : paddedLine;
+    });
 
     const result = ["", ...renderedLines];
     this.cachedText = this.text;

--- a/apps/coding-agent/src/tui/tool-input-token-usage.test.ts
+++ b/apps/coding-agent/src/tui/tool-input-token-usage.test.ts
@@ -358,6 +358,9 @@ describe.sequential("streamed tool argument usage in the mounted footer", () => 
         await app;
         await agent.dispose();
       }
-    }
+    },
+    // Real mounted rendering of large arguments/results exceeds 5s on Node 24
+    // under CI contention. Keep event gates and their 3s bounds unchanged.
+    15_000
   );
 });

--- a/apps/coding-agent/src/tui/tool-input-token-usage.test.ts
+++ b/apps/coding-agent/src/tui/tool-input-token-usage.test.ts
@@ -1,0 +1,363 @@
+import {
+  type Component,
+  Container,
+  stripTerminalSequences,
+  type Terminal,
+  type TuiMainScreen,
+} from "@earendil-works/pi-tui";
+import {
+  type AgentEvent,
+  type AgentTurn,
+  type ContextUsageSnapshot,
+  createAgent,
+} from "@minpeter/pss-runtime";
+import { jsonSchema, tool } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  send: (_data: string): void => undefined,
+  surface: undefined as TuiMainScreen | undefined,
+}));
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  const noop = () => undefined;
+  class TestTerminal implements Terminal {
+    columns = 120;
+    rows = 40;
+    kittyProtocolActive = false;
+    clearFromCursor = noop;
+    clearLine = noop;
+    clearScreen = noop;
+    hideCursor = noop;
+    moveBy = noop;
+    setProgress = noop;
+    setTitle = noop;
+    showCursor = noop;
+    stop = noop;
+    write = noop;
+    drainInput() {
+      return Promise.resolve();
+    }
+    start(onInput: (data: string) => void) {
+      harness.send = onInput;
+    }
+  }
+  class TestScreen extends actual.TuiMainScreen {
+    override start() {
+      harness.surface = this;
+      super.start();
+    }
+  }
+  return {
+    ...actual,
+    ProcessTerminal: TestTerminal,
+    TuiMainScreen: TestScreen,
+  };
+});
+
+import { createAgentTUI, FooterStatusBar } from "./agent";
+import { TuiSessionMachine } from "./session-state";
+import { contextUsageFooter } from "./usage-footer";
+
+const gate = <T = void>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+const bounded = async <T>(promise: Promise<T>): Promise<T> => {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("Missing stream event")),
+          3000
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+const findFooter = (component: Component): FooterStatusBar | undefined => {
+  if (component instanceof FooterStatusBar) {
+    return component;
+  }
+  if (component instanceof Container) {
+    for (const child of component.children) {
+      const result = findFooter(child);
+      if (result) {
+        return result;
+      }
+    }
+  }
+  return;
+};
+const idleGate = () => {
+  const idle = gate();
+  const original = TuiSessionMachine.prototype.awaitInput;
+  const spy = vi
+    .spyOn(TuiSessionMachine.prototype, "awaitInput")
+    .mockImplementation(function (this: TuiSessionMachine, resolve) {
+      original.call(this, resolve);
+      spy.mockRestore();
+      idle.resolve();
+    });
+  return idle.promise;
+};
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe.sequential("streamed tool argument usage in the mounted footer", () => {
+  it.each(["reported", "missing", "aborted"] as const)(
+    "counts generated arguments before execution with %s final usage",
+    async (completion) => {
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+      const controllerReady = gate<ReadableStreamDefaultController>();
+      const secondProvider = gate();
+      const releaseSecond = gate();
+      const toolStarted = vi.fn();
+      const releaseTools = gate();
+      let calls = 0;
+      const model = new MockLanguageModelV4({
+        doStream: async () => {
+          if (calls++ > 0) {
+            secondProvider.resolve();
+            await releaseSecond.promise;
+          }
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                if (calls === 1) {
+                  controllerReady.resolve(controller);
+                } else {
+                  controller.enqueue({
+                    type: "finish",
+                    finishReason: { raw: "stop", unified: "stop" },
+                    usage: {
+                      inputTokens: {
+                        total: 20,
+                        noCache: 20,
+                        cacheRead: undefined,
+                        cacheWrite: undefined,
+                      },
+                      outputTokens: { total: 1, text: 1, reasoning: undefined },
+                    },
+                  });
+                  controller.close();
+                }
+              },
+            }),
+          };
+        },
+      });
+      const agent = await createAgent({
+        model,
+        ...(completion === "missing"
+          ? { contextTokens: { calibration: false } }
+          : {}),
+        tools: {
+          write_file: tool({
+            inputSchema: jsonSchema<{ content: string; path: string }>({
+              type: "object",
+              properties: {
+                path: { type: "string" },
+                content: { type: "string" },
+              },
+              required: ["path", "content"],
+            }),
+            execute: async (args) => {
+              toolStarted(args);
+              await releaseTools.promise;
+              return "TOOL_STDOUT_".repeat(5000);
+            },
+          }),
+        },
+      });
+      const thread = agent.thread("tool-tokens");
+      const events: AgentEvent[] = [];
+      const snapshots: ContextUsageSnapshot[] = [];
+      let pendingEvent:
+        | {
+            predicate: (event: AgentEvent) => boolean;
+            done: ReturnType<typeof gate<void>>;
+          }
+        | undefined;
+      const nextEvent = (predicate: (event: AgentEvent) => boolean) => {
+        const done = gate();
+        pendingEvent = { predicate, done };
+        return done.promise;
+      };
+      const observe = (turn: AgentTurn): AgentTurn => ({
+        ...turn,
+        events: () =>
+          (async function* () {
+            for await (const event of turn.events()) {
+              events.push(event);
+              yield event;
+              if (pendingEvent?.predicate(event)) {
+                pendingEvent.done.resolve();
+                pendingEvent = undefined;
+              }
+            }
+          })(),
+      });
+      const footer: { text?: string } = {};
+      const idle = idleGate();
+      const app = createAgentTUI({
+        footer,
+        thread: {
+          interrupt: () => thread.interrupt(),
+          send: async (text) => observe(await thread.send(text)),
+          steer: (text) => thread.steer(text),
+        },
+        onContextUsage: (snapshot) => {
+          snapshots.push(snapshot);
+          footer.text = contextUsageFooter(snapshot);
+        },
+      });
+      await idle;
+      const settled = idleGate();
+      let generated = "";
+      try {
+        const initial = nextEvent((event) => event.type === "context-usage");
+        for (const character of "go\r") {
+          harness.send(character);
+        }
+        const controller = await bounded(controllerReady.promise);
+        await bounded(initial);
+        const assertLive = () => {
+          const snapshot = snapshots.at(-1);
+          expect(snapshot?.currentRequest.output.tokens).toBe(
+            Math.ceil(generated.length / 4)
+          );
+          expect(snapshot?.currentRequest.output.basis).toBe("heuristic");
+          const mounted = harness.surface && findFooter(harness.surface);
+          expect(mounted).toBeDefined();
+          expect(
+            stripTerminalSequences(mounted?.render(120).join("") ?? "")
+              .trimEnd()
+              .endsWith(footer.text ?? "")
+          ).toBe(true);
+          expect(toolStarted).not.toHaveBeenCalled();
+        };
+        assertLive();
+        const delta = async (part: {
+          type: string;
+          id: string;
+          delta: string;
+        }) => {
+          const consumed = nextEvent((event) => event.type === "context-usage");
+          generated += part.delta;
+          controller.enqueue(part);
+          await bounded(consumed);
+          assertLive();
+        };
+        if (completion === "missing") {
+          for (const kind of ["text", "reasoning"]) {
+            controller.enqueue({ type: `${kind}-start`, id: kind });
+            await delta({
+              type: `${kind}-delta`,
+              id: kind,
+              delta: "prefix 世界",
+            });
+            controller.enqueue({ type: `${kind}-end`, id: kind });
+          }
+        }
+        const argumentsById = new Map<string, string>();
+        for (const id of completion === "missing" ? ["one", "two"] : ["one"]) {
+          const args = JSON.stringify({
+            path: `${id}.txt`,
+            content: `\\"世界😀${"content".repeat(5000)}`,
+          });
+          argumentsById.set(id, args);
+          controller.enqueue({
+            type: "tool-input-start",
+            id,
+            toolName: "write_file",
+          });
+          for (const chunk of [
+            args.slice(0, 30),
+            args.slice(30, 256),
+            args.slice(256, 8192),
+            args.slice(8192),
+          ]) {
+            await delta({ type: "tool-input-delta", id, delta: chunk });
+          }
+          controller.enqueue({ type: "tool-input-end", id });
+        }
+        if (completion === "aborted") {
+          thread.interrupt();
+          controller.close();
+          await settled;
+          expect(toolStarted).not.toHaveBeenCalled();
+          expect(events.some((event) => event.type === "turn-abort")).toBe(
+            true
+          );
+          expect(snapshots.at(-1)?.currentRequest.output.tokens).toBe(0);
+          expect(events.some((event) => event.type === "model-usage")).toBe(
+            false
+          );
+          return;
+        }
+        for (const [id, args] of argumentsById) {
+          controller.enqueue({
+            type: "tool-call",
+            toolCallId: id,
+            toolName: "write_file",
+            input: args,
+          });
+        }
+        const result = nextEvent((event) => event.type === "tool-result");
+        controller.enqueue({
+          type: "finish",
+          finishReason: { raw: "tool_calls", unified: "tool-calls" },
+          usage:
+            completion === "reported"
+              ? {
+                  inputTokens: { total: 41, cacheRead: 11, noCache: 30 },
+                  outputTokens: { total: 777 },
+                }
+              : { inputTokens: {}, outputTokens: {} },
+        });
+        controller.close();
+        releaseTools.resolve();
+        await result;
+        const final = snapshots.at(-1)?.currentRequest.output;
+        expect(final?.tokens).toBe(
+          completion === "reported" ? 777 : Math.ceil(generated.length / 4)
+        );
+        expect(final?.basis).toBe(
+          completion === "reported" ? "reported" : "heuristic"
+        );
+        const usage = events.find((event) => event.type === "model-usage");
+        if (completion === "reported") {
+          expect(usage).toMatchObject({
+            inputTokens: 41,
+            outputTokens: 777,
+            cacheReadTokens: 11,
+          });
+        }
+        await bounded(secondProvider.promise);
+        releaseSecond.resolve();
+        await settled;
+      } finally {
+        releaseTools.resolve();
+        releaseSecond.resolve();
+        thread.interrupt();
+        await settled;
+        process.emit("SIGINT", "SIGINT");
+        process.emit("SIGINT", "SIGINT");
+        await app;
+        await agent.dispose();
+      }
+    }
+  );
+});

--- a/apps/coding-agent/src/tui/transcript-owner.test.ts
+++ b/apps/coding-agent/src/tui/transcript-owner.test.ts
@@ -1,0 +1,114 @@
+import {
+  type Container,
+  stripTerminalSequences,
+  Text,
+} from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { ColdSnapshot, TranscriptOwner } from "./transcript-owner";
+
+const text = (owner: Container, width = 80) =>
+  stripTerminalSequences(owner.render(width).join("\n"));
+
+describe("single transcript owner", () => {
+  it("settles, snapshots, revokes, detaches and disposes before unrelated append", () => {
+    const owner = new TranscriptOwner(() => 80);
+    const order: string[] = [];
+    const lease = owner.acquire(
+      (permission) => {
+        const view = new Text("PULSE", 0, 0);
+        permission.signal.addEventListener("abort", () => {
+          order.push("revoke");
+          expect(permission.active).toBe(false);
+          view.setText("BUGGY_ABORT");
+        });
+        return view;
+      },
+      {
+        settle: (view) => {
+          order.push("settle");
+          expect(lease.active).toBe(true);
+          view.setText("NORMAL");
+        },
+        dispose: (view) => {
+          order.push("dispose");
+          view.setText("BUGGY_DISPOSE");
+        },
+      }
+    );
+    owner.addChild(new Text("USER", 0, 0));
+    expect(order).toEqual(["settle", "revoke", "dispose"]);
+    expect(text(owner)).toContain("NORMAL");
+    expect(text(owner)).toContain("USER");
+    expect(text(owner)).not.toContain("BUGGY");
+    expect(
+      owner.children.every((component) => component instanceof ColdSnapshot)
+    ).toBe(true);
+  });
+
+  it("cannot let one stream's finally freeze another owner's HOT notice", () => {
+    const owner = new TranscriptOwner(() => 80);
+    const stream = owner.acquire(() => new Text("STREAM", 0, 0));
+    const notice = owner.acquire(() => new Text("NOTICE", 0, 0));
+    owner.finish(stream);
+    expect(stream.active).toBe(false);
+    expect(notice.active).toBe(true);
+    const hot = owner.children.filter((c) => !(c instanceof ColdSnapshot));
+    expect(hot).toHaveLength(1);
+    expect(hot[0]?.render(80)).toEqual(notice.view.render(80));
+    owner.finish(notice);
+    expect(notice.active).toBe(false);
+  });
+
+  it("reset revokes callbacks and epoch signals before mounting replacement with reused IDs", () => {
+    const owner = new TranscriptOwner(() => 80);
+    const epochSignal = owner.signal;
+    const publish = vi.fn();
+    const old = owner.acquire(() => new Text("OLD", 0, 0));
+    const callback = () => {
+      old.view.setText("STALE");
+      if (old.active) {
+        publish();
+      }
+    };
+    owner.reset("session-navigation");
+    const current = owner.acquire(() => new Text("NEW", 0, 0));
+    callback();
+    expect(epochSignal.aborted).toBe(true);
+    expect(old.active).toBe(false);
+    expect(current.active).toBe(true);
+    expect(current.epoch).toBe(old.epoch + 1);
+    expect(publish).not.toHaveBeenCalled();
+    expect(text(owner)).not.toContain("STALE");
+  });
+
+  it("never invokes an old renderer on invalidation/resize, preserving ANSI, wide text and chosen rows", () => {
+    let width = 16;
+    const owner = new TranscriptOwner(() => width);
+    const render = vi.fn(() => ["\x1b[31m漢字🙂ABCDEFG\x1b[0m", "chosen tail"]);
+    owner.acquire(() => ({ render, invalidate: vi.fn() }));
+    owner.finish();
+    const original = owner.render(width);
+    const count = render.mock.calls.length;
+    width = 5;
+    owner.invalidate();
+    const narrow = owner.render(width);
+    expect(stripTerminalSequences(narrow.join(""))).toContain("漢字🙂ABCDEFG");
+    width = 16;
+    expect(owner.render(width)).toEqual(original);
+    expect(render).toHaveBeenCalledTimes(count);
+  });
+
+  it.each([
+    "\x1b_Ga=T,f=100;ASSET\x1b\\",
+    "\x1b]1337;File=inline=1:ASSET\x07",
+    "\x1bPqASSET\x1b\\",
+  ])("preserves graphics and reserved rows atomically: %j", (payload) => {
+    const lines = [payload, ...Array.from({ length: 12 }, () => "")];
+    const snapshot = new ColdSnapshot(lines, 100);
+    const original = [...lines];
+    lines[0] = "REPLACED_ASSET";
+    expect(snapshot.render(10)).toEqual(original);
+    expect(snapshot.render(100)).toEqual(original);
+    expect(snapshot.render(200)).toHaveLength(13);
+  });
+});

--- a/apps/coding-agent/src/tui/transcript-owner.ts
+++ b/apps/coding-agent/src/tui/transcript-owner.ts
@@ -1,40 +1,49 @@
+import { type Component, Container, Spacer } from "@earendil-works/pi-tui";
 import {
-  type Component,
-  Container,
-  Spacer,
-  Text,
-  wrapTextWithAnsi,
-} from "@earendil-works/pi-tui";
+  type ColdContent,
+  captureComponent,
+  hasGraphics,
+  renderColdContent,
+} from "./cold-content";
+import { SnapshotText as Text } from "./snapshot-views";
 
-/** Captured presentation, never a renderer or canonical Markdown source. */
+/** Immutable content with width-dependent, synchronous, renderer-free layout. */
 export class ColdSnapshot implements Component {
-  readonly #lines: readonly string[];
-  readonly #width: number;
-  readonly #graphics: boolean;
+  readonly #content: ColdContent;
 
-  constructor(lines: readonly string[], width: number) {
-    this.#lines = [...lines];
-    this.#width = width;
-    // Retain entire graphics transmissions AND their reserved rows atomically.
-    this.#graphics = lines.some(
-      (line) =>
-        line.includes("\x1b_G") ||
-        line.includes("\x1b]1337;File=") ||
-        line.includes("\x1bP")
-    );
+  constructor(content: ColdContent | readonly string[], _width?: number) {
+    // Reject callbacks and detach every nested array/object supplied by a view.
+    this.#content = structuredClone(
+      Array.isArray(content)
+        ? {
+            kind: "fixed",
+            rows: content,
+            reason: hasGraphics(content) ? "graphics" : "opaque-renderer",
+          }
+        : content
+    ) as ColdContent;
+  }
+
+  static capture(component: Component, width: number): ColdSnapshot {
+    const rows = [...component.render(width)];
+    return new ColdSnapshot({
+      kind: "selected",
+      width,
+      rows,
+      content: captureComponent(component, width),
+    });
+  }
+
+  captureCold(): ColdContent {
+    return structuredClone(this.#content);
   }
 
   invalidate(): void {
-    /* Immutable, including selected tail and graphics asset. */
+    /* No live renderer or source survives handoff. */
   }
 
   render(width: number): string[] {
-    if (width === this.#width || this.#graphics) {
-      return [...this.#lines];
-    }
-    return this.#lines.flatMap((line) =>
-      wrapTextWithAnsi(line, Math.max(1, width))
-    );
+    return renderColdContent(this.#content, Math.max(1, width));
   }
 }
 
@@ -92,9 +101,7 @@ export class TranscriptOwner extends Container {
   /** One-shot appends are immediately COLD. No caller can bypass handoff. */
   override addChild(component: Component): void {
     this.finish();
-    super.addChild(
-      new ColdSnapshot(component.render(this.#width()), this.#width())
-    );
+    super.addChild(ColdSnapshot.capture(component, this.#width()));
   }
 
   acquire<T extends Component>(
@@ -138,9 +145,7 @@ export class TranscriptOwner extends Container {
       mounted = block;
     }
     if (options.leadingSpacer ?? true) {
-      super.addChild(
-        new ColdSnapshot(new Spacer(1).render(this.#width()), this.#width())
-      );
+      super.addChild(ColdSnapshot.capture(new Spacer(1), this.#width()));
     }
     super.addChild(mounted);
     this.#hot = {
@@ -168,7 +173,7 @@ export class TranscriptOwner extends Container {
         this.#reservationWidth = width;
       }
       // Snapshot actual rows, never the owner's synthetic trailing reserve.
-      const snapshot = new ColdSnapshot(hot.mounted.render(width), width);
+      const snapshot = ColdSnapshot.capture(hot.mounted, width);
       this.#hot = undefined;
       this.children[this.children.indexOf(hot.mounted)] = snapshot;
       // Revoke before callbacks from abort/dispose can request renders or notify.

--- a/apps/coding-agent/src/tui/transcript-owner.ts
+++ b/apps/coding-agent/src/tui/transcript-owner.ts
@@ -1,0 +1,191 @@
+import {
+  type Component,
+  Container,
+  Spacer,
+  Text,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+
+/** Captured presentation, never a renderer or canonical Markdown source. */
+export class ColdSnapshot implements Component {
+  readonly #lines: readonly string[];
+  readonly #width: number;
+  readonly #graphics: boolean;
+
+  constructor(lines: readonly string[], width: number) {
+    this.#lines = [...lines];
+    this.#width = width;
+    // Retain entire graphics transmissions AND their reserved rows atomically.
+    this.#graphics = lines.some(
+      (line) =>
+        line.includes("\x1b_G") ||
+        line.includes("\x1b]1337;File=") ||
+        line.includes("\x1bP")
+    );
+  }
+
+  invalidate(): void {
+    /* Immutable, including selected tail and graphics asset. */
+  }
+
+  render(width: number): string[] {
+    if (width === this.#width || this.#graphics) {
+      return [...this.#lines];
+    }
+    return this.#lines.flatMap((line) =>
+      wrapTextWithAnsi(line, Math.max(1, width))
+    );
+  }
+}
+
+export interface TranscriptLease<T extends Component = Component> {
+  readonly active: boolean;
+  readonly epoch: number;
+  readonly signal: AbortSignal;
+  readonly view: T;
+}
+
+interface HotBlock {
+  controller: AbortController;
+  dispose?: () => void;
+  lease: TranscriptLease;
+  mounted: Component;
+  settle?: () => void;
+}
+
+/** The single output owner, shared by dispatch, commands, replay and input. */
+export class TranscriptOwner extends Container {
+  #epoch = 0;
+  #epochController = new AbortController();
+  #sealing = false;
+  #hot: HotBlock | undefined;
+  #reservationWidth: number | undefined;
+  #height = 0;
+  readonly #width: () => number;
+
+  constructor(width: () => number) {
+    super();
+    this.#width = width;
+  }
+  get epoch(): number {
+    return this.#epoch;
+  }
+  get signal(): AbortSignal {
+    return this.#epochController.signal;
+  }
+
+  override render(width: number): string[] {
+    const lines = super.render(width);
+    this.#height =
+      width === this.#reservationWidth
+        ? Math.max(this.#height, lines.length)
+        : lines.length;
+    this.#reservationWidth = width;
+    // Only the owner synthesizes padding, after ALL actual content. Appends
+    // (including separators) consume this tail without changing COLD rows.
+    return [
+      ...lines,
+      ...Array.from({ length: this.#height - lines.length }, () => ""),
+    ];
+  }
+
+  /** One-shot appends are immediately COLD. No caller can bypass handoff. */
+  override addChild(component: Component): void {
+    this.finish();
+    super.addChild(
+      new ColdSnapshot(component.render(this.#width()), this.#width())
+    );
+  }
+
+  acquire<T extends Component>(
+    create: (
+      permission: Pick<TranscriptLease, "active" | "signal" | "epoch">
+    ) => T,
+    options: {
+      dispose?: (view: T) => void;
+      label?: string;
+      leadingSpacer?: boolean;
+      settle?: (view: T) => void;
+    } = {}
+  ): TranscriptLease<T> {
+    this.finish();
+    const controller = new AbortController();
+    const epoch = this.#epoch;
+    const owner = this;
+    const permission = {
+      epoch,
+      signal: controller.signal,
+      get active() {
+        return (
+          !(owner.#sealing || controller.signal.aborted) &&
+          owner.epoch === epoch
+        );
+      },
+    };
+    const view = create(permission);
+    const lease = {
+      ...permission,
+      get active() {
+        return permission.active;
+      },
+      view,
+    };
+    let mounted: Component = view;
+    if (options.label) {
+      const block = new Container();
+      block.addChild(new Text(options.label, 1, 0));
+      block.addChild(view);
+      mounted = block;
+    }
+    if (options.leadingSpacer ?? true) {
+      super.addChild(
+        new ColdSnapshot(new Spacer(1).render(this.#width()), this.#width())
+      );
+    }
+    super.addChild(mounted);
+    this.#hot = {
+      controller,
+      lease,
+      mounted,
+      settle: () => options.settle?.(view),
+      dispose: () => options.dispose?.(view),
+    };
+    return lease;
+  }
+
+  /** A stream may finish only its own lease, never another command's tail. */
+  finish(lease?: TranscriptLease): void {
+    const hot = this.#hot;
+    if (!hot || (lease && hot.lease !== lease)) {
+      return;
+    }
+    hot.settle?.();
+    this.#sealing = true;
+    try {
+      const width = this.#width();
+      if (width !== this.#reservationWidth) {
+        this.#height = 0;
+        this.#reservationWidth = width;
+      }
+      // Snapshot actual rows, never the owner's synthetic trailing reserve.
+      const snapshot = new ColdSnapshot(hot.mounted.render(width), width);
+      this.#hot = undefined;
+      this.children[this.children.indexOf(hot.mounted)] = snapshot;
+      // Revoke before callbacks from abort/dispose can request renders or notify.
+      hot.controller.abort();
+      hot.dispose?.();
+    } finally {
+      this.#sealing = false;
+    }
+  }
+
+  reset(_reason: "initial-replay" | "session-navigation"): void {
+    this.finish();
+    this.#epoch += 1;
+    this.#epochController.abort();
+    this.#epochController = new AbortController();
+    super.clear();
+    this.#height = 0;
+    this.#reservationWidth = undefined;
+  }
+}

--- a/apps/coding-agent/src/tui/transcript-owner.ts
+++ b/apps/coding-agent/src/tui/transcript-owner.ts
@@ -25,12 +25,13 @@ export class ColdSnapshot implements Component {
   }
 
   static capture(component: Component, width: number): ColdSnapshot {
-    const rows = [...component.render(width)];
+    const content = captureComponent(component, width);
+    const rows = renderColdContent(content, width);
     return new ColdSnapshot({
       kind: "selected",
       width,
       rows,
-      content: captureComponent(component, width),
+      content,
     });
   }
 

--- a/apps/coding-agent/src/tui/write-streaming-header.test.ts
+++ b/apps/coding-agent/src/tui/write-streaming-header.test.ts
@@ -1,0 +1,171 @@
+import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { createToolRenderers } from "./renderers/tool-renderers";
+import { sanitizeTerminalText } from "./terminal-safety";
+import { BaseToolCallView } from "./tool-call-view";
+
+const identity = (text: string): string => text;
+const theme: MarkdownTheme = {
+  heading: identity,
+  link: identity,
+  linkUrl: identity,
+  code: identity,
+  codeBlock: identity,
+  codeBlockBorder: identity,
+  quote: identity,
+  quoteBorder: identity,
+  hr: identity,
+  listBullet: identity,
+  bold: identity,
+  italic: identity,
+  strikethrough: identity,
+  underline: identity,
+};
+const createView = (raw = false, toolName = "write_file") =>
+  new BaseToolCallView(
+    "stream",
+    toolName,
+    theme,
+    undefined,
+    raw,
+    createToolRenderers()
+  );
+const header = (view: BaseToolCallView) => view.render(240)[0];
+const finalHeader = (path: string) => {
+  const view = createView();
+  view.setFinalInput({ path, content: "" });
+  view.setOutput("OK - wrote 0 bytes");
+  const result = header(view);
+  view.dispose();
+  return result;
+};
+
+describe("streaming write header", () => {
+  it("uses path-only and split paths before final input on the same card", async () => {
+    const view = createView();
+    try {
+      await view.appendInputChunk('{"path":"');
+      const generic = createView(false, "generic");
+      generic.setPrettyBlock("**write_file** input", "");
+      expect(header(view)).toBe(header(generic));
+      generic.dispose();
+      const card = view.children[0];
+      for (const [chunk, path] of [
+        ["ind", "ind"],
+        ["ex.html", "index.html"],
+        ['","content":"EARLY', "index.html"],
+        ['\\nLATER"}', "index.html"],
+      ]) {
+        await view.appendInputChunk(chunk);
+        expect(header(view)).toBe(finalHeader(path));
+        expect(view.children).toEqual([card]);
+      }
+      expect(view.render(240).join("\n")).toContain("EARLY");
+      expect(view.render(240).join("\n")).toContain("LATER");
+      view.setFinalInput({ path: "index.html", content: "EARLY\nLATER" });
+      expect(header(view)).toBe(finalHeader("index.html"));
+      expect(view.children).toEqual([card]);
+      view.setOutput("OK - wrote file");
+      expect(header(view)).toBe(finalHeader("index.html"));
+      expect(view.render(240).join("\n")).toContain("LATER");
+      expect(view.children).toEqual([card]);
+    } finally {
+      view.dispose();
+    }
+  });
+
+  it("keeps early content visible when content arrives before the path", async () => {
+    const view = createView();
+    try {
+      await view.appendInputChunk('{"content":"EARLY');
+      const before = header(view);
+      const card = view.children[0];
+      expect(view.render(240).join("\n")).toContain("EARLY");
+      await view.appendInputChunk('","path":"');
+      expect(header(view)).toBe(before);
+      await view.appendInputChunk("late.html");
+      expect(header(view)).toBe(finalHeader("late.html"));
+      expect(view.render(240).join("\n")).toContain("EARLY");
+      expect(view.children).toEqual([card]);
+    } finally {
+      view.dispose();
+    }
+  });
+
+  it.each([
+    "index.html",
+    "目錄/한글.html",
+    "`**not-bold**`[link](https://example.com).html",
+    "```ticks``.html",
+    " control\t\n\r\u001b]52;c;payload\u0007\u009b31m.html ",
+  ])(
+    "renders literal safe paths identically to the final header: %j",
+    async (path) => {
+      const view = createView();
+      try {
+        await view.appendInputChunk(JSON.stringify({ path }).slice(0, -1));
+        expect(header(view)).toBe(finalHeader(path));
+        expect(header(view)?.trimEnd()).toBe(
+          ` write ${sanitizeTerminalText(path, path.length)}`.trimEnd()
+        );
+        expect(view.render(240)[1]).toBe("");
+      } finally {
+        view.dispose();
+      }
+    }
+  );
+
+  it.each(["", null, 123])(
+    "keeps a generic header for invalid paths: %j",
+    async (path) => {
+      const view = createView();
+      const expected = createView();
+      try {
+        expected.setPrettyBlock("**write_file** input", "");
+        await view.appendInputChunk(JSON.stringify({ path, content: "EARLY" }));
+        expect(header(view)).toBe(header(expected));
+      } finally {
+        view.dispose();
+        expected.dispose();
+      }
+    }
+  );
+
+  it("preserves error headers and settled/aborted previews", async () => {
+    const view = createView();
+    const expected = createView();
+    try {
+      await view.appendInputChunk('{"path":"index.html","content":"EARLY');
+      view.settle();
+      expect(header(view)).toBe(finalHeader("index.html"));
+      view.setError("WRITE_FAILED");
+      expected.setFinalInput({ path: "index.html", content: "EARLY" });
+      expected.setError("WRITE_FAILED");
+      expect(view.render(240)).toEqual(expected.render(240));
+      const frozen = view.render(240);
+      view.dispose();
+      await view.appendInputChunk("IGNORED");
+      expect(view.render(240)).toEqual(frozen);
+    } finally {
+      view.dispose();
+      expected.dispose();
+    }
+  });
+
+  it("does not specialize raw mode or other tools", async () => {
+    for (const [raw, tool] of [
+      [true, "write_file"],
+      [false, "unrelated_tool"],
+    ] as const) {
+      const view = createView(raw, tool);
+      try {
+        await view.appendInputChunk('{"content":"EARLY');
+        const before = header(view);
+        await view.appendInputChunk('","path":"index.html');
+        expect(header(view)).toBe(before);
+      } finally {
+        view.dispose();
+      }
+    }
+  });
+});

--- a/apps/coding-agent/src/workspace-tools/edit-file.test.ts
+++ b/apps/coding-agent/src/workspace-tools/edit-file.test.ts
@@ -1,0 +1,255 @@
+import {
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { asSchema, generateText, type ToolExecutionOptions } from "ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createOpenAICompatibleModelFromEnv } from "../model";
+import { createEditFileTool } from "./edit-file";
+import { createReadFileTool } from "./read-file";
+
+const ANCHOR_EXAMPLE_PATTERN = /\b\d+#[A-Za-z0-9]+\b/gu;
+const ANCHOR_SHAPE_PATTERN = /^\d+#[ZPMQVRWSNKTXJBYH]{2}$/u;
+const READ_ANCHOR_PATTERN = /^(\d+#[ZPMQVRWSNKTXJBYH]{2})\|/gmu;
+const FILE_HASH_PATTERN = /^file_hash: ([0-9a-f]{8})$/mu;
+const fixture = "alpha\nbeta\ngamma\ndelta\nepsilon\n";
+const options: ToolExecutionOptions<Record<string, unknown>> = {
+  context: {},
+  messages: [],
+  toolCallId: "edit-anchor-test",
+};
+
+function descriptions(value: unknown): string[] {
+  if (value === null || typeof value !== "object") {
+    return [];
+  }
+  return Object.entries(value).flatMap(([key, child]) =>
+    key === "description" && typeof child === "string"
+      ? [child]
+      : descriptions(child)
+  );
+}
+
+async function snapshot(workspace: string) {
+  const path = join(workspace, "fixture.txt");
+  const metadata = await stat(path, { bigint: true });
+  return {
+    bytes: await readFile(path),
+    ctimeNs: metadata.ctimeNs,
+    entries: await readdir(workspace),
+    inode: metadata.ino,
+    mtimeNs: metadata.mtimeNs,
+  };
+}
+
+describe("edit_file anchor contract", () => {
+  let workspace: string;
+  let anchors: string[];
+  let hash: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), "pss-edit-anchor-test-"));
+    await writeFile(join(workspace, "fixture.txt"), fixture);
+    const read = createReadFileTool(workspace).execute;
+    if (read === undefined) {
+      throw new Error("Expected executable read_file.");
+    }
+    const output = String(await read({ path: "fixture.txt" }, options));
+    anchors = [...output.matchAll(READ_ANCHOR_PATTERN)].map(
+      (match) => match[1]
+    );
+    const fileHash = FILE_HASH_PATTERN.exec(output)?.[1];
+    if (fileHash === undefined || anchors.length !== 5) {
+      throw new Error("Expected read_file anchors and file hash.");
+    }
+    hash = fileHash;
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { force: true, recursive: true });
+  });
+
+  it("serializes non-strict generation with optional hash and anchor fields through the SDK", async () => {
+    const requests: unknown[] = [];
+    const before = await snapshot(workspace);
+    const model = createOpenAICompatibleModelFromEnv({
+      runtimeEnv: {
+        AI_API_KEY: "fixture-key",
+        AI_BASE_URL: "https://fixture.invalid/v1",
+        AI_MODEL: "fixture-model",
+      },
+      fetch: (_url, init) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return Promise.resolve(
+          Response.json({
+            id: "fixture-response",
+            object: "chat.completion",
+            created: 0,
+            model: "fixture-model",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "OK" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 1,
+              total_tokens: 2,
+            },
+          })
+        );
+      },
+    });
+    const result = await generateText({
+      model,
+      prompt: "Reply OK without calling a tool.",
+      tools: { edit_file: createEditFileTool(workspace) },
+    });
+    expect(result.text).toBe("OK");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "edit_file",
+            strict: false,
+            parameters: {
+              required: ["path", "edits"],
+              additionalProperties: false,
+              properties: {
+                expected_file_hash: { type: "string" },
+                edits: {
+                  items: {
+                    required: ["op", "new_content"],
+                    additionalProperties: false,
+                    properties: {
+                      target: { type: "string" },
+                      first: { type: "string" },
+                      last: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+    expect(await snapshot(workspace)).toEqual(before);
+  });
+
+  it("ships anchor example tokens with the parser's valid shape", async () => {
+    const definition = createEditFileTool(workspace);
+    const schema = await asSchema(definition.inputSchema).jsonSchema;
+    if (typeof definition.description !== "string") {
+      throw new TypeError("Expected a static edit_file description.");
+    }
+    const tokens = [definition.description, ...descriptions(schema)]
+      .flatMap((text) => [...text.matchAll(ANCHOR_EXAMPLE_PATTERN)])
+      .map((match) => match[0]);
+    expect(tokens.length).toBeGreaterThan(0);
+    for (const token of tokens) {
+      // Shape is not content validity: actual edits below copy fresh read anchors.
+      expect(token).toMatch(ANCHOR_SHAPE_PATTERN);
+    }
+  });
+
+  it.each(["target", "range"])(
+    "edits with omitted unused fields: %s",
+    async (variant) => {
+      const execute = createEditFileTool(workspace).execute;
+      if (execute === undefined) {
+        throw new Error("Expected executable edit_file.");
+      }
+      await execute(
+        {
+          path: "fixture.txt",
+          expected_file_hash: hash,
+          edits: [
+            {
+              op: "replace",
+              ...(variant === "target"
+                ? { target: anchors[1] }
+                : { first: anchors[1], last: anchors[2] }),
+              new_content: "replacement",
+            },
+          ],
+        },
+        options
+      );
+      expect(await readFile(join(workspace, "fixture.txt"), "utf8")).toBe(
+        variant === "target"
+          ? "alpha\nreplacement\ngamma\ndelta\nepsilon\n"
+          : "alpha\nreplacement\ndelta\nepsilon\n"
+      );
+    }
+  );
+
+  it.each([
+    "both",
+    "empty-range",
+    "empty-target",
+    "placeholder-range",
+    "partial-empty-range",
+    "batch-conflict",
+    "stale-hash",
+    "stale-anchor",
+    "overlap",
+    "insertion-intersection",
+  ])("rejects %s without any mutation", async (scenario) => {
+    const execute = createEditFileTool(workspace).execute;
+    if (execute === undefined) {
+      throw new Error("Expected executable edit_file.");
+    }
+    const target = {
+      op: "replace" as const,
+      target: anchors[1],
+      new_content: "replacement",
+    };
+    const range = {
+      op: "replace" as const,
+      first: anchors[1],
+      last: anchors[2],
+      new_content: "replacement",
+    };
+    const conflict = { ...target, first: "", last: "" };
+    const cases = {
+      both: [{ ...range, target: anchors[0] }],
+      "empty-range": [conflict],
+      "empty-target": [{ ...range, target: "" }],
+      "placeholder-range": [{ ...target, first: "N/A", last: "N/A" }],
+      "partial-empty-range": [{ ...target, first: "" }],
+      "batch-conflict": [target, conflict],
+      "stale-hash": [target],
+      "stale-anchor": [
+        { ...target, target: anchors[1] === "2#ZZ" ? "2#PP" : "2#ZZ" },
+      ],
+      overlap: [target, range],
+      "insertion-intersection": [
+        range,
+        { op: "append" as const, target: anchors[1], new_content: "insert" },
+      ],
+    };
+    const before = await snapshot(workspace);
+    await expect(
+      execute(
+        {
+          path: "fixture.txt",
+          expected_file_hash: scenario === "stale-hash" ? "00000000" : hash,
+          edits: cases[scenario as keyof typeof cases],
+        },
+        options
+      )
+    ).rejects.toBeInstanceOf(Error);
+    expect(await snapshot(workspace)).toEqual(before);
+  });
+});

--- a/apps/coding-agent/src/workspace-tools/edit-file.ts
+++ b/apps/coding-agent/src/workspace-tools/edit-file.ts
@@ -17,25 +17,25 @@ const editSchema = z
     op: z
       .enum(["replace", "append", "prepend"])
       .describe(
-        "replace/append/prepend. Anchors are LINE#ID from read_file (e.g. 5#a3f2); never include |content."
+        "replace/append/prepend. Anchors are LINE#ID (shape example: 5#WM); copy actual anchors from the latest read_file, never include |content or invent hashes. Omit unused anchor fields entirely; empty strings, null, and placeholders are not omission."
       ),
     target: z
       .string()
       .optional()
       .describe(
-        'Line reference "LINE#ID" for one-line replace, or the insert point for append/prepend. Copy from read_file (e.g. "5#a3f2"); never include |content.'
+        'Line reference "LINE#ID" for one-line replace, or the insert point for append/prepend. Shape example: "5#WM"; copy the actual anchor from the latest read_file, never include |content. When using target, omit first and last entirely. For a replace range, omit target entirely; do not send an empty string, null, or a placeholder.'
       ),
     first: z
       .string()
       .optional()
       .describe(
-        'Start line ref "LINE#ID" for an inclusive replace range. Pair with last; do not combine with target.'
+        'Start line ref "LINE#ID" copied from the latest read_file for an inclusive replace range. Pair with last and omit target entirely. For one-line replace or append/prepend, omit first entirely; do not send an empty string, null, or a placeholder.'
       ),
     last: z
       .string()
       .optional()
       .describe(
-        'End line ref "LINE#ID" for an inclusive replace range. Pair with first; do not combine with target.'
+        'End line ref "LINE#ID" copied from the latest read_file for an inclusive replace range. Pair with first and omit target entirely. For one-line replace or append/prepend, omit last entirely; do not send an empty string, null, or a placeholder.'
       ),
     new_content: z
       .union([
@@ -125,7 +125,7 @@ function resolveEdit(
   if (edit.first !== undefined || edit.last !== undefined) {
     if (edit.target !== undefined) {
       throw new Error(
-        "replace accepts either target for one line or first+last for a range, not both."
+        'replace accepts either target for one line or first+last for a range, not both. For one line, keep target and omit first and last entirely. For a range, keep first and last and omit target entirely. Empty strings (""), null, and placeholders are not omission; remove the unused keys from the edit object.'
       );
     }
     if (edit.first === undefined) {
@@ -266,8 +266,9 @@ export function createEditFileTool(
   workspace: string
 ): Tool<z.infer<typeof inputSchema>, string> {
   return tool({
+    strict: false,
     description:
-      'Apply deterministic plugsuits-style hashline edits. CRITICAL: anchors are LINE#ID only (e.g. "5#a3f2") copied from read_file; never include |content or invent hashes. replace uses target for one line, or first+last for an inclusive range (never both); append/prepend insert relative to an optional target. Re-read after edits before another call on the same path.',
+      'Apply deterministic plugsuits-style hashline edits. CRITICAL: anchors are LINE#ID only (shape example: "5#WM"); copy actual anchors from the latest read_file, never include |content or invent hashes. For one-line replace, supply target and omit first and last entirely. For an inclusive replace range, supply first+last and omit target entirely (never both). append/prepend insert relative to an optional target; omit first and last entirely. Omit unused anchor fields entirely: empty strings (""), null, and placeholders are not omission. Re-read after edits before another call on the same path.',
     inputSchema,
     execute: async ({ path, expected_file_hash: expectedHash, edits }) => {
       for (const edit of edits) {

--- a/apps/coding-agent/src/workspace-tools/shell-execute.ts
+++ b/apps/coding-agent/src/workspace-tools/shell-execute.ts
@@ -136,8 +136,7 @@ export function createShellExecuteTool(
           `signal: ${result.signal ?? "none"}`,
           "stdout:",
           result.stdout,
-          "stderr:",
-          result.stderr,
+          ...(result.stderr.trim() ? ["stderr:", result.stderr] : []),
         ].join("\n")
       );
     },

--- a/apps/coding-agent/src/workspace-tools/write-file.test.ts
+++ b/apps/coding-agent/src/workspace-tools/write-file.test.ts
@@ -1,0 +1,391 @@
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateText, type ToolExecutionOptions } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenAICompatibleModelFromEnv } from "../model";
+import { computeFileHash } from "./hashline";
+import { createReadFileTool } from "./read-file";
+import { createWriteFileTool } from "./write-file";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...original,
+    chmod: vi.fn(original.chmod),
+    mkdir: vi.fn(original.mkdir),
+    readFile: vi.fn(original.readFile),
+    rename: vi.fn(original.rename),
+    rm: vi.fn(original.rm),
+    writeFile: vi.fn(original.writeFile),
+  };
+});
+
+const original =
+  await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+const executionOptions: ToolExecutionOptions<Record<string, unknown>> = {
+  context: {},
+  messages: [],
+  toolCallId: "write-file-hash-test",
+};
+const FILE_HASH_PATTERN = /^file_hash: ([0-9a-f]{8})$/m;
+
+function executeWrite(workspace: string) {
+  const { execute } = createWriteFileTool(workspace);
+  if (execute === undefined) {
+    throw new Error("Expected executable write_file tool.");
+  }
+  return execute;
+}
+
+async function readHash(workspace: string, path: string): Promise<string> {
+  const { execute } = createReadFileTool(workspace);
+  if (execute === undefined) {
+    throw new Error("Expected executable read_file tool.");
+  }
+  const output = String(await execute({ path }, executionOptions));
+  const hash = FILE_HASH_PATTERN.exec(output)?.[1];
+  if (hash === undefined) {
+    throw new Error("Expected read_file hash metadata.");
+  }
+  return hash;
+}
+
+function expectNoMutations(): void {
+  for (const operation of [chmod, mkdir, rename, rm, writeFile]) {
+    expect(operation).not.toHaveBeenCalled();
+  }
+}
+
+describe("write_file hash preconditions", () => {
+  let workspace: string;
+
+  it("sends explicit non-strict generation while keeping the hash optional", async () => {
+    const requests: unknown[] = [];
+    const model = createOpenAICompatibleModelFromEnv({
+      runtimeEnv: {
+        AI_API_KEY: "fixture-key",
+        AI_BASE_URL: "https://fixture.invalid/v1",
+        AI_MODEL: "fixture-model",
+      },
+      fetch: (_url, init) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return Promise.resolve(
+          Response.json({
+            id: "fixture-response",
+            object: "chat.completion",
+            created: 0,
+            model: "fixture-model",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "OK" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 1,
+              total_tokens: 2,
+            },
+          })
+        );
+      },
+    });
+    const result = await generateText({
+      model,
+      prompt: "Reply OK without calling a tool.",
+      tools: { write_file: createWriteFileTool(workspace) },
+    });
+    expect(result.text).toBe("OK");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "write_file",
+            strict: false,
+            parameters: {
+              required: ["path", "content"],
+              additionalProperties: false,
+            },
+          },
+        },
+      ],
+    });
+    expectNoMutations();
+  });
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    workspace = await original.mkdtemp(join(tmpdir(), "pss-write-hash-test-"));
+  });
+
+  afterEach(async () => {
+    await original.rm(workspace, { force: true, recursive: true });
+    await expect(original.lstat(workspace)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it.each([
+    ".invalid",
+    ". . . . ",
+    "        ",
+    "E3B0C442",
+    "e3b0c442\n",
+    "",
+    null,
+  ])("rejects invalid hash %j in the SDK before execution", async (hash) => {
+    const definition = createWriteFileTool(workspace);
+    const execute = vi.fn(executeWrite(workspace));
+    const result = await generateText({
+      model: new MockLanguageModelV4({
+        doGenerate: {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "invalid-hash",
+              toolName: "write_file",
+              input: JSON.stringify({
+                content: "replacement",
+                expected_file_hash: hash,
+                path: "missing/deep/index.html",
+              }),
+            },
+          ],
+          finishReason: { raw: "tool-calls", unified: "tool-calls" },
+          usage: {
+            inputTokens: {
+              cacheRead: undefined,
+              cacheWrite: undefined,
+              noCache: 1,
+              total: 1,
+            },
+            outputTokens: {
+              reasoning: undefined,
+              text: 1,
+              total: 1,
+            },
+          },
+          warnings: [],
+        },
+      }),
+      prompt: "Run the fixture tool call.",
+      tools: { write_file: { ...definition, execute } },
+    });
+
+    expect(result.toolCalls[0]).toMatchObject({
+      invalid: true,
+      error: { name: "AI_InvalidToolInputError" },
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+    expectNoMutations();
+    expect(await original.readdir(workspace)).toEqual([]);
+  });
+
+  it.each(["index.html", "missing/deep/index.html"])(
+    "rejects guarded creation of %s before any mutation",
+    async (path) => {
+      await expect(
+        executeWrite(workspace)(
+          {
+            content: "replacement",
+            expected_file_hash: "00000000",
+            path,
+          },
+          executionOptions
+        )
+      ).rejects.toMatchObject({
+        name: "FileHashPreconditionError",
+        code: "FILE_HASH_TARGET_MISSING",
+        cause: { code: "ENOENT" },
+      });
+      expectNoMutations();
+      expect(await original.readdir(workspace)).toEqual([]);
+    }
+  );
+
+  it("does not treat the empty-file hash as a missing-file sentinel", async () => {
+    expect(computeFileHash("")).toBe("e3b0c442");
+    await expect(
+      executeWrite(workspace)(
+        {
+          content: "replacement",
+          expected_file_hash: "e3b0c442",
+          path: "index.html",
+        },
+        executionOptions
+      )
+    ).rejects.toMatchObject({
+      name: "FileHashPreconditionError",
+      code: "FILE_HASH_TARGET_MISSING",
+      cause: { code: "ENOENT" },
+    });
+    expectNoMutations();
+    expect(await original.readdir(workspace)).toEqual([]);
+  });
+
+  it.each(["index.html", "missing/deep/index.html"])(
+    "creates %s without a hash",
+    async (path) => {
+      await executeWrite(workspace)(
+        { content: "new content", path },
+        executionOptions
+      );
+      expect(await original.readFile(join(workspace, path), "utf8")).toBe(
+        "new content"
+      );
+      expect(readFile).not.toHaveBeenCalled();
+      expect(rename).toHaveBeenCalledOnce();
+    }
+  );
+
+  it.each(["", "original\n"])(
+    "overwrites %j using its exact read_file hash and preserves permissions",
+    async (content) => {
+      const path = join(workspace, "index.html");
+      await original.writeFile(path, content, { mode: 0o640 });
+      const hash = await readHash(workspace, "index.html");
+      vi.clearAllMocks();
+
+      await executeWrite(workspace)(
+        {
+          content: "replacement",
+          expected_file_hash: hash,
+          path: "index.html",
+        },
+        executionOptions
+      );
+      expect(readFile).toHaveBeenCalledTimes(2);
+      expect(await original.readFile(path, "utf8")).toBe("replacement");
+      expect((await original.stat(path)).mode % 0o1000).toBe(0o640);
+      expect(await original.readdir(workspace)).toEqual(["index.html"]);
+    }
+  );
+
+  it("rejects a stale read_file hash without changing target bytes", async () => {
+    const path = join(workspace, "index.html");
+    await original.writeFile(path, "original");
+    const hash = await readHash(workspace, "index.html");
+    await original.writeFile(path, "concurrent change");
+    vi.clearAllMocks();
+
+    await expect(
+      executeWrite(workspace)(
+        {
+          content: "replacement",
+          expected_file_hash: hash,
+          path: "index.html",
+        },
+        executionOptions
+      )
+    ).rejects.toMatchObject({
+      name: "FileHashPreconditionError",
+      code: "FILE_HASH_MISMATCH",
+    });
+    expect(readFile).toHaveBeenCalledOnce();
+    expectNoMutations();
+    expect(await original.readFile(path, "utf8")).toBe("concurrent change");
+  });
+
+  it.each(["delete", "change"])(
+    "fails closed and removes its temp file when the target undergoes %s after the first check",
+    async (action) => {
+      const path = join(workspace, "index.html");
+      await original.writeFile(path, "original");
+      const hash = await readHash(workspace, "index.html");
+      vi.clearAllMocks();
+      // Gate on the completed real temp write: the first hash check has passed,
+      // and the second check must still observe this concurrent mutation.
+      vi.mocked(writeFile).mockImplementationOnce(async (...args) => {
+        await original.writeFile(...args);
+        expect(args[0]).not.toBe(path);
+        expect(readFile).toHaveBeenCalledTimes(1);
+        if (action === "delete") {
+          await original.rm(path);
+        } else {
+          await original.writeFile(path, "concurrent change");
+        }
+      });
+
+      const attempt = executeWrite(workspace)(
+        {
+          content: "replacement",
+          expected_file_hash: hash,
+          path: "index.html",
+        },
+        executionOptions
+      );
+      if (action === "delete") {
+        await expect(attempt).rejects.toMatchObject({
+          name: "FileHashPreconditionError",
+          code: "FILE_HASH_TARGET_MISSING",
+          cause: { code: "ENOENT" },
+        });
+        await expect(original.lstat(path)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        expect(await original.readdir(workspace)).toEqual([]);
+      } else {
+        await expect(attempt).rejects.toMatchObject({
+          name: "FileHashPreconditionError",
+          code: "FILE_HASH_MISMATCH",
+        });
+        expect(await original.readFile(path, "utf8")).toBe("concurrent change");
+        expect(await original.readdir(workspace)).toEqual(["index.html"]);
+      }
+      expect(readFile).toHaveBeenCalledTimes(2);
+      expect(writeFile).toHaveBeenCalledOnce();
+      expect(rename).not.toHaveBeenCalled();
+      expect(rm).toHaveBeenCalledOnce();
+    }
+  );
+
+  it.each([1, 2])(
+    "preserves an EACCES error at hash check %s",
+    async (check) => {
+      const path = join(workspace, "index.html");
+      await original.writeFile(path, "original");
+      const hash = await readHash(workspace, "index.html");
+      vi.clearAllMocks();
+      const denied = Object.assign(new Error("fixture read denied"), {
+        code: "EACCES",
+      });
+      if (check === 2) {
+        vi.mocked(readFile).mockImplementationOnce(original.readFile);
+      }
+      vi.mocked(readFile).mockRejectedValueOnce(denied);
+
+      await expect(
+        executeWrite(workspace)(
+          {
+            content: "replacement",
+            expected_file_hash: hash,
+            path: "index.html",
+          },
+          executionOptions
+        )
+      ).rejects.toBe(denied);
+      expect(await original.readFile(path, "utf8")).toBe("original");
+      expect(await original.readdir(workspace)).toEqual(["index.html"]);
+      expect(rename).not.toHaveBeenCalled();
+      if (check === 1) {
+        expectNoMutations();
+      } else {
+        expect(writeFile).toHaveBeenCalledOnce();
+        expect(rm).toHaveBeenCalledOnce();
+      }
+    }
+  );
+});

--- a/apps/coding-agent/src/workspace-tools/write-file.test.ts
+++ b/apps/coding-agent/src/workspace-tools/write-file.test.ts
@@ -137,6 +137,47 @@ describe("write_file hash preconditions", () => {
     });
   });
 
+  it("rejects truncated JSON before invoking write_file", async () => {
+    const definition = createWriteFileTool(workspace);
+    const execute = vi.fn(executeWrite(workspace));
+    const result = await generateText({
+      model: new MockLanguageModelV4({
+        doGenerate: {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "truncated-write",
+              toolName: "write_file",
+              input: '{"path":"index.html","content":"partial\\\\"',
+            },
+          ],
+          finishReason: { raw: "length", unified: "length" },
+          usage: {
+            inputTokens: {
+              cacheRead: undefined,
+              cacheWrite: undefined,
+              noCache: 1,
+              total: 1,
+            },
+            outputTokens: { reasoning: undefined, text: 29_346, total: 29_346 },
+          },
+          warnings: [],
+        },
+      }),
+      prompt: "Run the fixture tool call.",
+      tools: { write_file: { ...definition, execute } },
+    });
+
+    expect(result.toolCalls[0]).toMatchObject({
+      input: {},
+      invalid: true,
+      error: { name: "AI_InvalidToolInputError" },
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expectNoMutations();
+    expect(await original.readdir(workspace)).toEqual([]);
+  });
+
   it.each([
     ".invalid",
     ". . . . ",

--- a/apps/coding-agent/src/workspace-tools/write-file.ts
+++ b/apps/coding-agent/src/workspace-tools/write-file.ts
@@ -33,13 +33,30 @@ const inputSchema = z
       ),
     expected_file_hash: z
       .string()
-      .length(8)
+      .regex(
+        /^[0-9a-f]{8}$/,
+        "expected_file_hash must be exactly 8 lowercase hex characters; uppercase is not accepted. Copy the exact file_hash from the latest successful read_file for this existing path, or omit expected_file_hash entirely to intentionally create a new file. Never invent a hash."
+      )
       .optional()
       .describe(
-        "8-hex file_hash from the latest read_file; provide when overwriting to reject stale content."
+        "Optional overwrite guard: copy the exact 8-character lowercase hex file_hash from the latest successful read_file for this same existing path. OMIT this field entirely for a new file. Never invent hashes or use placeholders, sentinels, or null."
       ),
   })
   .strict();
+
+class FileHashPreconditionError extends Error {
+  readonly code: "FILE_HASH_MISMATCH" | "FILE_HASH_TARGET_MISSING";
+
+  constructor(
+    code: FileHashPreconditionError["code"],
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = "FileHashPreconditionError";
+    this.code = code;
+  }
+}
 
 async function assertExpectedHash(
   path: string,
@@ -48,11 +65,24 @@ async function assertExpectedHash(
   if (expectedHash === undefined) {
     return;
   }
-  const current = await readFile(path, "utf8");
+  let current: string;
+  try {
+    current = await readFile(path, "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      throw new FileHashPreconditionError(
+        "FILE_HASH_TARGET_MISSING",
+        "Cannot validate expected_file_hash: a guarded overwrite requires an existing file, but the target does not exist and has no file hash. Omit expected_file_hash entirely only if you intentionally want to create a new file. Do not invent a hash or create an empty file to satisfy the guard.",
+        { cause: error }
+      );
+    }
+    throw error;
+  }
   const currentHash = computeFileHash(current);
   if (currentHash !== expectedHash) {
-    throw new Error(
-      `Stale file hash ${expectedHash}; current hash is ${currentHash}.`
+    throw new FileHashPreconditionError(
+      "FILE_HASH_MISMATCH",
+      `Stale file hash ${expectedHash}; current hash is ${currentHash}. Read this existing file again with read_file and use its fresh file_hash before overwriting.`
     );
   }
 }
@@ -109,8 +139,9 @@ export function createWriteFileTool(
 ): Tool<z.infer<typeof inputSchema>, string> {
   return tool({
     description:
-      "Create or replace a UTF-8 file atomically. Prefer edit_file for surgical changes. Pass expected_file_hash when overwriting a file you read.",
+      "Create or replace a UTF-8 file atomically, creating missing parent directories. Prefer edit_file for surgical changes. For a new file, OMIT expected_file_hash entirely. For a guarded overwrite, copy the exact file_hash from the latest successful read_file for the same existing path. Never invent hashes or use placeholders, sentinels, or null.",
     inputSchema,
+    strict: false,
     execute: async ({ path, content, expected_file_hash: expectedHash }) => {
       const resolved = await resolveWorkspacePath(workspace, path);
       await assertExpectedHash(resolved.path, expectedHash);

--- a/apps/coding-agent/vitest.config.ts
+++ b/apps/coding-agent/vitest.config.ts
@@ -1,7 +1,18 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
+    // Resolve runtime integration tests to source in Vite, not via a static
+    // cross-package import that also enters tsdown's declaration graph.
+    alias: [
+      {
+        find: /^@minpeter\/pss-runtime$/,
+        replacement: fileURLToPath(
+          new URL("../../packages/runtime/src/index.ts", import.meta.url)
+        ),
+      },
+    ],
     conditions: ["@minpeter/pss-source", "import", "module", "default"],
   },
   test: {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "check:tegami-notes": "node scripts/check-tegami-notes.mjs",
     "coverage": "pnpm --filter @minpeter/pss-coding-agent build && vitest run --config vitest.coverage.config.ts --coverage",
     "dev": "pnpm --filter @minpeter/pss-example-basic start",
-    "dev:tui": "tsx --conditions=@minpeter/pss-source apps/coding-agent/src/tui/app.ts",
+    "dev:tui": "tsx --conditions=@minpeter/pss-source scripts/dev-tui.mjs",
     "eval:edge-remote": "pnpm --filter @minpeter/pss-worker-agent eval:remote",
     "eval:provider": "pnpm --filter @minpeter/pss-example-evals eval",
     "format": "ultracite fix .",

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -12,8 +12,9 @@ Minimal, platform-agnostic agent runtime with keyed threads, synchronized
 - **Provider boundary:** `model` accepts concrete AI SDK language-model objects
   for the versions represented by the exported `LanguageModel` type (currently
   v2, v3, and v4). PSS normalizes its own event protocol, but provider model
-  availability, token accounting, streaming quality, and retry behavior remain
-  provider/SDK concerns. `observedRetryable` is evidence, not a retry promise.
+  availability, token accounting, and streaming quality remain provider/SDK
+  concerns. PSS owns retries at observed provider-call boundaries and reports
+  its decisions through `model-retry`; `observedRetryable` alone is not a promise.
 - **Durability boundary:** durability comes from the selected `AgentHost`.
   Omitting `host` uses an in-memory host and does not survive process loss. File
   and Cloudflare hosts persist committed snapshots, execution records, and
@@ -100,8 +101,8 @@ instrumentation can still observe them. The committed `assistant-output`,
 record.
 
 Live consumers also receive `model-attempt` start/end pairs for each physical
-provider call, including AI SDK retries beneath streaming and non-streaming
-steps. An end event includes its outcome, duration when measurable, and
+provider call, including runtime-owned retries beneath streaming and
+non-streaming steps. An end event includes its outcome, duration when measurable, and
 normalized provider error when a failure can be classified. Object models are
 observed directly; string model ids are observed when `AI_SDK_DEFAULT_PROVIDER`
 is configured. String ids resolved through the SDK's implicit gateway emit no
@@ -109,6 +110,56 @@ attempt events because the SDK exposes neither that resolved model nor failures
 inside its retry loop. These events are likewise ephemeral and excluded from
 durable replay and result payloads; `model-usage` remains the durable
 successful-step record.
+
+`ModelRetry` / `model-retry` reports authoritative decisions at the same observed
+boundary, with the same `attemptId` as `model-attempt` and `model-usage`:
+
+- `scheduled`: a wait is armed for `delayMs`, with `retryAt` in Unix epoch
+  milliseconds. `remainingRetries` is unspent budget **including this scheduled
+  retry** (2 on the first failure, 1 on the second).
+- `started`: the actual wait completed, immediately before the next attempt.
+  `remainingRetries` excludes the retry now being consumed (1, then 0).
+- `stopped`: no further retry is scheduled or will occur; `remainingRetries`
+  is 0 even if unused budget existed. `reason` is `cancelled`, `exhausted`,
+  `non-retryable`, or `stream-ended` (a returned stream failed or ended without
+  a finish marker; replaying it could duplicate output).
+
+`attempt` is the last physical call number, so a retry after call 1 reports
+`attempt: 1` in both `scheduled` and `started`; the following `model-attempt`
+starts call 2. Cancellation before any call reports 0. A successful call emits
+no retry event. Only `phase === "scheduled"` means a retry is pending; a
+`started` event clears the countdown and a `stopped` event clears it permanently.
+A schedule is an intention, not a guarantee: aborting during backoff, including
+from a scheduling callback, prevents the next physical call and emits
+`stopped` / `cancelled`. A consumer cancelling on `started` can still prevent
+that call. Timer deadlines are not a guarantee of punctual event-loop execution.
+
+```ts
+const retryDeadlines = new Map<string, number>();
+for await (const event of turn.events()) {
+  if (event.type !== "model-retry") continue;
+  if (event.phase === "scheduled") {
+    retryDeadlines.set(event.attemptId, event.retryAt);
+    // Render Math.max(0, event.retryAt - Date.now()) locally; no tick events.
+  } else {
+    retryDeadlines.delete(event.attemptId);
+  }
+}
+```
+
+The policy preserves the SDK baseline: at most two retries (three provider
+calls), 2000/4000 ms exponential backoff, and explicit `isRetryable` on
+`APICallError` or `GatewayError`. Valid `retry-after-ms` takes precedence over
+`retry-after` seconds or HTTP dates; invalid/out-of-range values fall back to
+backoff. Abort errors are never retried. SDK retries are disabled only on these
+observed paths. Retrying a provider call does not rerun tools or replay a
+returned stream. Implicit-gateway strings retain SDK-owned retries and emit
+neither attempt nor retry events. Internal automatic compaction requests remain
+outside the public turn stream.
+
+Retry events contain only runtime counters, timestamps, phases, and fixed
+reasons, not provider prose, headers, prompts, or credentials. They are
+live-only, bypass hooks, and never enter durable replay or result payloads.
 
 Both "deltas then committed" and "just committed" are valid sequences, so a
 renderer must dedupe against the committed event. Render the committed text
@@ -136,7 +187,7 @@ On a mid-stream abort, a prefix of deltas can remain in the in-memory stream
 before `turn-abort`. Consumers must tolerate deltas without committed output.
 
 `isStreamAgentEvent` classifies the five delta kinds plus `context-usage` and
-`model-attempt`. `streamAgentEventTypes` and the `StreamAgentEvent` type are
+`model-attempt` / `model-retry`. `streamAgentEventTypes` and the `StreamAgentEvent` type are
 exported alongside it from the package root. Stream events are their own class:
 not visible, lifecycle, tool, or telemetry events. Filter them when
 accumulating a transcript:
@@ -184,8 +235,8 @@ events. Metadata excludes request/response bodies, raw headers, URLs, stacks,
 credentials, and arbitrary causes.
 
 `observedRetryable` reports what the SDK or transport observed. It does not
-promise that PSS will retry. A future retry policy must communicate its actual
-decision separately.
+promise that PSS will retry. Use live `model-retry` decisions for actual
+scheduling, cancellation, and exhaustion, not this error metadata.
 
 `model` is the single public constructor key for model execution. Pass an AI SDK
 `LanguageModel` object and configure runtime-owned prompting through
@@ -705,7 +756,8 @@ attempt whose generated state later fails to commit and is retried. Each retry
 invokes a new runtime model step and therefore receives a new `attemptId`.
 
 `model-usage` is operational telemetry, not an exactly-once billing ledger.
-AI SDK retries are exposed as live-only `model-attempt` events, but there
+Observed retries are exposed as live-only `model-attempt` and `model-retry`
+events, but there
 can still be no durable usage record when an adapter cannot parse the response,
 tool-call ID post-processing fails after a billed response, the process stops
 between the provider response and local event emission, or durable persistence

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -149,9 +149,12 @@ for await (const event of turn.events()) {
 
 The policy preserves the SDK baseline: at most two retries (three provider
 calls), 2000/4000 ms exponential backoff, and explicit `isRetryable` on
-`APICallError` or `GatewayError`. Valid `retry-after-ms` takes precedence over
-`retry-after` seconds or HTTP dates; invalid/out-of-range values fall back to
-backoff. Abort errors are never retried. SDK retries are disabled only on these
+`APICallError` or `GatewayError`. A parseable `retry-after-ms` takes precedence over `retry-after` seconds or
+HTTP dates. If it is unparseable, the runtime tries `retry-after`; if it is
+parseable but nonfinite, negative, or outside the allowed range, the runtime
+uses exponential backoff directly. A valid `retry-after` is used only when
+`retry-after-ms` is absent or unparseable; otherwise the delay falls back to
+exponential backoff. Abort errors are never retried. SDK retries are disabled only on these
 observed paths. Retrying a provider call does not rerun tools or replay a
 returned stream. Implicit-gateway strings retain SDK-owned retries and emit
 neither attempt nor retry events. Internal automatic compaction requests remain

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -153,8 +153,8 @@ calls), 2000/4000 ms exponential backoff, and explicit `isRetryable` on
 HTTP dates. If it is unparseable, the runtime tries `retry-after`; if it is
 parseable but nonfinite, negative, or outside the allowed range, the runtime
 uses exponential backoff directly. A valid `retry-after` is used only when
-`retry-after-ms` is absent or unparseable; otherwise the delay falls back to
-exponential backoff. Abort errors are never retried. SDK retries are disabled only on these
+`retry-after-ms` is absent or unparseable. Abort errors are never retried.
+SDK retries are disabled only on these
 observed paths. Retrying a provider call does not rerun tools or replay a
 returned stream. Implicit-gateway strings retain SDK-owned retries and emit
 neither attempt nor retry events. Internal automatic compaction requests remain

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -118,6 +118,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.exact-optional.json --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/gateway": "4.0.40",
     "@jsquash/avif": "^2.1.1",
     "@jsquash/webp": "^1.5.0",
     "@opentelemetry/api": "^1.9.1",

--- a/packages/runtime/public-api.snapshot.json
+++ b/packages/runtime/public-api.snapshot.json
@@ -63,6 +63,7 @@
       "type ModelPromptMeasurement",
       "type ModelPromptMeasurementProfile",
       "type ModelPromptTool",
+      "type ModelRetry",
       "type ModelToolCacheFingerprintMetadata",
       "type ModelUsage",
       "type NormalizedTurnError",

--- a/packages/runtime/src/contracts/root-api-events.test.ts
+++ b/packages/runtime/src/contracts/root-api-events.test.ts
@@ -7,6 +7,7 @@ import type {
   AgentTransformDecision,
   ControlAgentEvent,
   LifecycleAgentEvent,
+  ModelRetry,
   StreamAgentEvent,
   TelemetryAgentEvent,
   TurnErrorMetadataV1,
@@ -101,6 +102,23 @@ describe("runtime root event API exports", () => {
       "assistant-output-delta",
       "tool-call-input-delta",
     ]);
+  });
+
+  it("exports and classifies retry lifecycle events as ephemeral control events", () => {
+    const retry = {
+      attempt: 1,
+      attemptId: "retry-step",
+      delayMs: 2000,
+      phase: "scheduled",
+      remainingRetries: 2,
+      retryAt: 2000,
+      type: "model-retry",
+    } satisfies ModelRetry;
+    expect(isStreamAgentEvent(retry)).toBe(true);
+    expect(isControlAgentEvent(retry)).toBe(true);
+    expect(isVisibleAgentEvent(retry)).toBe(false);
+    expect(isLifecycleAgentEvent(retry)).toBe(false);
+    expect(isTelemetryAgentEvent(retry)).toBe(false);
   });
 
   it("types host tool interception decisions", () => {

--- a/packages/runtime/src/contracts/root-api.test.ts
+++ b/packages/runtime/src/contracts/root-api.test.ts
@@ -112,6 +112,7 @@ describe("runtime public exports", () => {
       | "assistant-reasoning-delta"
       | "context-usage"
       | "model-attempt"
+      | "model-retry"
       | "tool-call-input-delta"
       | "tool-call-input-end"
       | "tool-call-input-start"

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -134,6 +134,7 @@ export type {
   InputSource,
   LifecycleAgentEvent,
   ModelAttempt,
+  ModelRetry,
   ModelUsage,
   RuntimeInput,
   StreamAgentEvent,

--- a/packages/runtime/src/llm/context-tokens.test.ts
+++ b/packages/runtime/src/llm/context-tokens.test.ts
@@ -103,6 +103,34 @@ describe("ContextTokenMeter", () => {
     });
   });
 
+  it("counts streamed tool arguments as generated output until usage is reported", () => {
+    const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
+    meter.begin({
+      attemptId: "tool-stream",
+      fixedFingerprint: "fixed",
+      measurement: measurement(10),
+    });
+
+    const before = meter.snapshot().currentRequest.output.tokens;
+    meter.outputDelta("tool-stream", '{"path":"src/世界.ts",');
+    const during = meter.snapshot().currentRequest.output;
+    expect(during.tokens).toBeGreaterThan(before);
+    expect(during.basis).toBe("heuristic");
+
+    meter.report("tool-stream", {
+      attemptId: "tool-stream",
+      inputTokens: 12,
+      outputTokens: 4,
+      totalTokens: 16,
+      type: "model-usage",
+    });
+    expect(meter.snapshot().currentRequest.output).toEqual({
+      basis: "reported",
+      marginTokens: 0,
+      tokens: 4,
+    });
+  });
+
   it("derives a missing reported side from total usage", () => {
     const meter = new ContextTokenMeter(new ContextTokenCalibrationRegistry());
     meter.begin({

--- a/packages/runtime/src/llm/invalid-tool-input.ts
+++ b/packages/runtime/src/llm/invalid-tool-input.ts
@@ -1,0 +1,58 @@
+import { InvalidToolInputError, JSONParseError } from "ai";
+import type { ModelStepStreamFinalResult } from "./model-step-stream";
+
+/** Only SDK-rejected calls qualify; executor error text is not evidence of rejection. */
+export function normalizeInvalidToolResults({
+  responseMessages,
+  finalStep,
+  finishReason,
+}: Pick<
+  ModelStepStreamFinalResult,
+  "responseMessages" | "finalStep" | "finishReason"
+>): ModelStepStreamFinalResult["responseMessages"] {
+  const rejected = new Map(
+    (finalStep?.toolCalls ?? []).flatMap((call) => {
+      if (
+        !call.invalid ||
+        call.providerExecuted ||
+        !InvalidToolInputError.isInstance(call.error)
+      ) {
+        return [];
+      }
+      return [[call.toolCallId, call.error] as const];
+    })
+  );
+  return responseMessages.map((message) => {
+    if (message.role !== "tool") {
+      return message;
+    }
+    return {
+      ...message,
+      content: message.content.map((part) => {
+        if (part.type !== "tool-result") {
+          return part;
+        }
+        const error = rejected.get(part.toolCallId);
+        if (error === undefined) {
+          return part;
+        }
+        const malformedJson = JSONParseError.isInstance(error.cause);
+        return {
+          ...part,
+          output: {
+            type: "error-json" as const,
+            value: {
+              code: "INVALID_TOOL_ARGUMENTS",
+              kind: malformedJson ? "json-parse" : "schema-validation",
+              message: malformedJson
+                ? "Tool arguments are invalid or incomplete JSON. This tool was not executed. If output was truncated, retry using smaller writes or edits; generating a long file in one call may exceed generation limits. Do not use incomplete content or invent overwrite hashes."
+                : "Tool arguments do not match the input schema. This tool was not executed. Correct the required fields and their types before submitting a new call. Do not invent overwrite hashes.",
+              inputCharacters: error.toolInput.length,
+              ...(finishReason === "length" ? { finishReason } : {}),
+            },
+          },
+        };
+      }),
+    };
+  });
+}

--- a/packages/runtime/src/llm/model-attempt.test.ts
+++ b/packages/runtime/src/llm/model-attempt.test.ts
@@ -586,12 +586,14 @@ describe("model-attempt stream events", () => {
       },
     ]);
 
-    await generateModelStepResult({
-      history: prompt,
-      model,
-      onStreamEvent: (event) => events.push(event),
-      signal: new AbortController().signal,
-    });
+    await expect(
+      generateModelStepResult({
+        history: prompt,
+        model,
+        onStreamEvent: (event) => events.push(event),
+        signal: new AbortController().signal,
+      })
+    ).rejects.toBe(fixtureError);
 
     expect(attemptEvents(events)).toEqual([
       expect.objectContaining({ attempt: 1, phase: "start" }),
@@ -621,12 +623,14 @@ describe("model-attempt stream events", () => {
       },
     ]);
 
-    await generateModelStepResult({
-      history: prompt,
-      model,
-      onStreamEvent: (event) => events.push(event),
-      signal: new AbortController().signal,
-    });
+    await expect(
+      generateModelStepResult({
+        history: prompt,
+        model,
+        onStreamEvent: (event) => events.push(event),
+        signal: new AbortController().signal,
+      })
+    ).rejects.toThrow("Model stream ended without a finish event.");
 
     expect(attemptEvents(events)).toEqual([
       expect.objectContaining({ attempt: 1, phase: "start" }),

--- a/packages/runtime/src/llm/model-attempt.ts
+++ b/packages/runtime/src/llm/model-attempt.ts
@@ -21,8 +21,8 @@ export interface ModelAttemptTracker {
 /**
  * Tracks provider call attempts for one runtime model step.
  *
- * AI SDK language-model middleware wraps each physical provider call inside
- * the SDK's retry closure. Each wrapper invocation opens an attempt and closes
+ * The runtime wraps each physical provider call inside its retry closure.
+ * Each wrapper invocation opens an attempt and closes
  * it immediately after that call settles, before any retry backoff begins.
  */
 export function createModelAttemptTracker({

--- a/packages/runtime/src/llm/model-retry-stream.test.ts
+++ b/packages/runtime/src/llm/model-retry-stream.test.ts
@@ -1,0 +1,159 @@
+import { APICallError, jsonSchema, tool } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  createMockLanguageModelV4,
+  createStreamingMockLanguageModelV4,
+  mockLanguageModelV4Text,
+  mockLanguageModelV4ToolCall,
+} from "../testing/mock-language-model-v4-test-utils";
+import type { ModelRetry, StreamAgentEvent } from "../thread/protocol/events";
+import { generateModelStepResult } from "./model-step";
+import {
+  createModelStepStream,
+  type ModelStepStreamPart,
+} from "./model-step-stream";
+
+const history = [{ content: "go", role: "user" }] as const;
+const failure = () =>
+  new APICallError({
+    message: "private error",
+    requestBodyValues: {},
+    responseHeaders: { "retry-after-ms": "0" },
+    statusCode: 429,
+    url: "https://fixture.test",
+  });
+
+describe("retry boundaries after a provider response", () => {
+  it.each(["error-part", "stream-error", "missing-finish"] as const)(
+    "never retries or duplicates output after %s",
+    async (mode) => {
+      let calls = 0;
+      const error = failure();
+      const events: StreamAgentEvent[] = [];
+      const model = createStreamingMockLanguageModelV4(() => {
+        calls += 1;
+        return Promise.resolve({
+          stream: new ReadableStream({
+            start(controller) {
+              controller.enqueue({ type: "stream-start", warnings: [] });
+              controller.enqueue({ id: "text", type: "text-start" });
+              controller.enqueue({
+                delta: "prefix",
+                id: "text",
+                type: "text-delta",
+              });
+              controller.enqueue({ id: "text", type: "text-end" });
+              if (mode === "error-part") {
+                controller.enqueue({ error, type: "error" });
+                const { finishReason, usage } = mockLanguageModelV4Text("");
+                controller.enqueue({ finishReason, type: "finish", usage });
+              }
+              if (mode !== "stream-error") {
+                controller.close();
+              }
+            },
+            pull(controller) {
+              controller.error(error);
+            },
+          }),
+        });
+      });
+      await generateModelStepResult({
+        history,
+        model,
+        signal: new AbortController().signal,
+        onStreamEvent: (event) => events.push(event),
+      }).catch((caught: unknown) => {
+        expect(caught).toBe(error);
+      });
+      expect(calls).toBe(1);
+      expect(
+        events.filter((event) => event.type === "model-retry")
+      ).toMatchObject([
+        {
+          attempt: 1,
+          phase: "stopped",
+          reason: "stream-ended",
+          remainingRetries: 0,
+        },
+      ]);
+      expect(
+        events.filter((event) => event.type === "assistant-output-delta")
+      ).toEqual([{ text: "prefix", type: "assistant-output-delta" }]);
+    }
+  );
+
+  it("retries only the non-streaming call and executes its tool once", async () => {
+    let calls = 0;
+    let executions = 0;
+    const events: ModelRetry[] = [];
+    const model = createMockLanguageModelV4(() => {
+      calls += 1;
+      if (calls === 1) {
+        throw failure();
+      }
+      return Promise.resolve(
+        mockLanguageModelV4ToolCall({
+          input: {},
+          toolCallId: "call",
+          toolName: "count",
+        })
+      );
+    });
+    const handle = createModelStepStream({
+      attemptId: "direct-provider-seam",
+      messages: [...history],
+      model,
+      onRetry: (event) => events.push(event),
+      tools: {
+        count: tool({
+          inputSchema: jsonSchema({
+            type: "object",
+            properties: {},
+            additionalProperties: false,
+          }),
+          execute: () => {
+            executions += 1;
+            return "done";
+          },
+        }),
+      },
+    });
+    const parts: ModelStepStreamPart[] = [];
+    for await (const part of handle.parts) {
+      parts.push(part);
+    }
+    const result = await handle.finalize();
+    expect(await handle.finalize()).toBe(result);
+    expect(calls).toBe(2);
+    expect(executions).toBe(1);
+    expect(
+      parts.filter((part) => part.type === "tool-input-start")
+    ).toHaveLength(1);
+    expect(events).toMatchObject([
+      { attemptId: "direct-provider-seam", phase: "scheduled" },
+      { attemptId: "direct-provider-seam", phase: "started" },
+    ]);
+  });
+
+  it("keeps implicit gateway strings unobserved without making a network call", async () => {
+    const original = globalThis.AI_SDK_DEFAULT_PROVIDER;
+    globalThis.AI_SDK_DEFAULT_PROVIDER = undefined;
+    const controller = new AbortController();
+    controller.abort();
+    const events: StreamAgentEvent[] = [];
+    try {
+      await expect(
+        generateModelStepResult({
+          history,
+          model: "openai/fixture",
+          signal: controller.signal,
+          onStreamEvent: (event) => events.push(event),
+        })
+      ).rejects.toThrow();
+      expect(events).toEqual([]);
+    } finally {
+      globalThis.AI_SDK_DEFAULT_PROVIDER = original;
+    }
+  });
+});

--- a/packages/runtime/src/llm/model-retry-stream.test.ts
+++ b/packages/runtime/src/llm/model-retry-stream.test.ts
@@ -58,14 +58,20 @@ describe("retry boundaries after a provider response", () => {
           }),
         });
       });
-      await generateModelStepResult({
+      const result = generateModelStepResult({
         history,
         model,
         signal: new AbortController().signal,
         onStreamEvent: (event) => events.push(event),
-      }).catch((caught: unknown) => {
-        expect(caught).toBe(error);
       });
+      if (mode === "stream-error") {
+        await expect(result).rejects.toBe(error);
+      } else {
+        await expect(result).resolves.toMatchObject({
+          messages: expect.any(Array),
+          usage: expect.objectContaining({ type: "model-usage" }),
+        });
+      }
       expect(calls).toBe(1);
       expect(
         events.filter((event) => event.type === "model-retry")

--- a/packages/runtime/src/llm/model-retry-stream.test.ts
+++ b/packages/runtime/src/llm/model-retry-stream.test.ts
@@ -58,20 +58,16 @@ describe("retry boundaries after a provider response", () => {
           }),
         });
       });
-      const result = generateModelStepResult({
-        history,
-        model,
-        signal: new AbortController().signal,
-        onStreamEvent: (event) => events.push(event),
-      });
-      if (mode === "stream-error") {
-        await expect(result).rejects.toBe(error);
-      } else {
-        await expect(result).resolves.toMatchObject({
-          messages: expect.any(Array),
-          usage: expect.objectContaining({ type: "model-usage" }),
-        });
-      }
+      await expect(
+        generateModelStepResult({
+          history,
+          model,
+          signal: new AbortController().signal,
+          onStreamEvent: (event) => events.push(event),
+        })
+      ).rejects.toSatisfy((caught: unknown) =>
+        mode === "missing-finish" ? caught instanceof Error : caught === error
+      );
       expect(calls).toBe(1);
       expect(
         events.filter((event) => event.type === "model-retry")

--- a/packages/runtime/src/llm/model-retry.test.ts
+++ b/packages/runtime/src/llm/model-retry.test.ts
@@ -1,0 +1,460 @@
+import { GatewayInternalServerError } from "@ai-sdk/gateway";
+import { APICallError, customProvider, RetryError } from "ai";
+import { convertArrayToReadableStream } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockLanguageModelV4,
+  createStreamingMockLanguageModelV4,
+  mockLanguageModelV4Text,
+} from "../testing/mock-language-model-v4-test-utils";
+import type { StreamAgentEvent } from "../thread/protocol/events";
+import { generateModelStepResult } from "./model-step";
+
+const epoch = 1_800_000_000_000;
+const history = [{ content: "go", role: "user" }] as const;
+const signal = new AbortController().signal;
+const failure = (statusCode = 429, responseHeaders?: Record<string, string>) =>
+  new APICallError({
+    message: "private provider text",
+    requestBodyValues: { prompt: "private prompt" },
+    responseHeaders,
+    statusCode,
+    url: "https://private-provider.test/key",
+  });
+
+function fixture(
+  path: "stream" | "generate" | "string",
+  failCount = 1,
+  error: Error = failure()
+) {
+  const calls: number[] = [];
+  const execute = () => {
+    calls.push(Date.now());
+    if (calls.length <= failCount) {
+      throw error;
+    }
+    return mockLanguageModelV4Text("done");
+  };
+  const model =
+    path === "stream"
+      ? createStreamingMockLanguageModelV4(() => {
+          const result = execute();
+          return Promise.resolve({
+            stream: convertArrayToReadableStream([
+              { type: "stream-start", warnings: [] },
+              { id: "text", type: "text-start" },
+              { delta: "done", id: "text", type: "text-delta" },
+              { id: "text", type: "text-end" },
+              {
+                finishReason: result.finishReason,
+                type: "finish",
+                usage: result.usage,
+              },
+            ]),
+          });
+        })
+      : createMockLanguageModelV4(() => Promise.resolve(execute()));
+  if (path === "string") {
+    globalThis.AI_SDK_DEFAULT_PROVIDER = customProvider({
+      languageModels: { fixture: model },
+    });
+  }
+  return { calls, model: path === "string" ? ("fixture" as const) : model };
+}
+
+const retries = (events: readonly StreamAgentEvent[]) =>
+  events.filter((event) => event.type === "model-retry");
+
+// Backoff itself is the behavior under test. Virtual time drives the actual
+// provider-call seam, never a second policy or a mocked SDK retry loop.
+describe("authoritative model retry lifecycle", () => {
+  let originalProvider: typeof globalThis.AI_SDK_DEFAULT_PROVIDER;
+  beforeEach(() => {
+    originalProvider = globalThis.AI_SDK_DEFAULT_PROVIDER;
+    vi.useFakeTimers();
+    vi.setSystemTime(epoch);
+  });
+  afterEach(() => {
+    globalThis.AI_SDK_DEFAULT_PROVIDER = originalProvider;
+    vi.useRealTimers();
+  });
+
+  it.each(["stream", "generate", "string"] as const)(
+    "owns the wait and event ordering for %s models",
+    async (path) => {
+      const { model, calls } = fixture(path);
+      const events: StreamAgentEvent[] = [];
+      const pending = generateModelStepResult({
+        signal,
+        history,
+        model,
+        onStreamEvent: (event) => events.push(event),
+      });
+      await vi.runAllTimersAsync();
+      const result = await pending;
+      expect(calls).toEqual([epoch, epoch + 2000]);
+      expect(
+        events
+          .filter((event) => event.type !== "assistant-output-delta")
+          .map((event) => [
+            event.type,
+            "phase" in event ? event.phase : undefined,
+          ])
+      ).toEqual([
+        ["model-attempt", "start"],
+        ["model-attempt", "end"],
+        ["model-retry", "scheduled"],
+        ["model-retry", "started"],
+        ["model-attempt", "start"],
+        ["model-attempt", "end"],
+      ]);
+      expect(retries(events)).toEqual([
+        {
+          attempt: 1,
+          attemptId: result.usage.attemptId,
+          delayMs: 2000,
+          phase: "scheduled",
+          remainingRetries: 2,
+          retryAt: epoch + 2000,
+          type: "model-retry",
+        },
+        {
+          attempt: 1,
+          attemptId: result.usage.attemptId,
+          phase: "started",
+          remainingRetries: 1,
+          type: "model-retry",
+        },
+      ]);
+      expect(
+        events.filter((event) => event.type === "assistant-output-delta")
+      ).toEqual([{ text: "done", type: "assistant-output-delta" }]);
+      expect(
+        events
+          .filter(
+            (event) => event.type === "model-attempt" && event.phase === "end"
+          )
+          .map((event) =>
+            "durationMs" in event ? event.durationMs : undefined
+          )
+      ).toEqual([0, 0]);
+      expect(JSON.stringify(retries(events))).not.toContain("private");
+    }
+  );
+
+  it("arms the reported deadline before notifying scheduling subscribers", async () => {
+    const { model, calls } = fixture("generate");
+    const events: StreamAgentEvent[] = [];
+    const pending = generateModelStepResult({
+      history,
+      model,
+      signal,
+      onStreamEvent: (event) => {
+        events.push(event);
+        if (event.type === "model-retry" && event.phase === "scheduled") {
+          vi.advanceTimersByTime(500);
+        }
+      },
+    });
+    await vi.runAllTimersAsync();
+    await pending;
+    expect(calls).toEqual([epoch, epoch + 2000]);
+    expect(retries(events)[0]).toMatchObject({ retryAt: epoch + 2000 });
+  });
+
+  it("does not schedule on success", async () => {
+    const { model, calls } = fixture("generate", 0);
+    const events: StreamAgentEvent[] = [];
+    await generateModelStepResult({
+      signal,
+      history,
+      model,
+      onStreamEvent: (event) => events.push(event),
+    });
+    expect(calls).toEqual([epoch]);
+    expect(retries(events)).toEqual([]);
+  });
+
+  it("exhausts exactly two retries with independent exponential delays", async () => {
+    const { model, calls } = fixture("stream", 3);
+    const events: StreamAgentEvent[] = [];
+    const pending = generateModelStepResult({
+      signal,
+      history,
+      model,
+      onStreamEvent: (event) => events.push(event),
+    }).catch((error: unknown) => error);
+    await vi.runAllTimersAsync();
+    expect(await pending).toBeInstanceOf(RetryError);
+    expect(calls).toEqual([epoch, epoch + 2000, epoch + 6000]);
+    expect(retries(events)).toMatchObject([
+      {
+        attempt: 1,
+        delayMs: 2000,
+        phase: "scheduled",
+        remainingRetries: 2,
+        retryAt: epoch + 2000,
+      },
+      { attempt: 1, phase: "started", remainingRetries: 1 },
+      {
+        attempt: 2,
+        delayMs: 4000,
+        phase: "scheduled",
+        remainingRetries: 1,
+        retryAt: epoch + 6000,
+      },
+      { attempt: 2, phase: "started", remainingRetries: 0 },
+      {
+        attempt: 3,
+        phase: "stopped",
+        reason: "exhausted",
+        remainingRetries: 0,
+      },
+    ]);
+  });
+
+  it.each([401, 403, 400])(
+    "stops a nonretryable %i failure",
+    async (status) => {
+      const error = failure(status);
+      const { model, calls } = fixture("generate", 3, error);
+      const events: StreamAgentEvent[] = [];
+      await expect(
+        generateModelStepResult({
+          signal,
+          history,
+          model,
+          onStreamEvent: (event) => events.push(event),
+        })
+      ).rejects.toBe(error);
+      expect(calls).toEqual([epoch]);
+      expect(retries(events)).toMatchObject([
+        {
+          attempt: 1,
+          phase: "stopped",
+          reason: "non-retryable",
+          remainingRetries: 0,
+        },
+      ]);
+    }
+  );
+
+  it.each([
+    "before",
+    "scheduled-callback",
+    "during-wait",
+    "started-callback",
+  ] as const)("cancels %s without another physical call", async (when) => {
+    const { model, calls } = fixture("stream");
+    const events: StreamAgentEvent[] = [];
+    const controller = new AbortController();
+    if (when === "before") {
+      controller.abort();
+    }
+    const pending = generateModelStepResult({
+      history,
+      model,
+      signal: controller.signal,
+      onStreamEvent: (event) => {
+        events.push(event);
+        if (
+          event.type === "model-retry" &&
+          ((when === "scheduled-callback" && event.phase === "scheduled") ||
+            (when === "started-callback" && event.phase === "started"))
+        ) {
+          controller.abort();
+        }
+      },
+    }).catch((error: unknown) => error);
+    if (when === "during-wait") {
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(retries(events)).toMatchObject([{ phase: "scheduled" }]);
+      controller.abort();
+    }
+    await vi.runAllTimersAsync();
+    expect(await pending).toMatchObject({ name: "AbortError" });
+    expect(calls).toHaveLength(when === "before" ? 0 : 1);
+    expect(retries(events).at(-1)).toMatchObject({
+      attempt: when === "before" ? 0 : 1,
+      phase: "stopped",
+      reason: "cancelled",
+      remainingRetries: 0,
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([
+    [{ "retry-after-ms": "125", "retry-after": "9" }, 125],
+    [{ "retry-after": "0.5" }, 500],
+    [{ "retry-after": new Date(epoch + 3000).toUTCString() }, 3000],
+    [{ "retry-after-ms": "bad", "retry-after": "1" }, 1000],
+    [{ "retry-after-ms": "-1", "retry-after": "1" }, 2000],
+    [{ "retry-after-ms": "60000" }, 2000],
+    [{ "retry-after-ms": "0" }, 0],
+  ] as const)(
+    "uses SDK-compatible header override %j",
+    async (headers, delayMs) => {
+      const { model, calls } = fixture("generate", 1, failure(429, headers));
+      const events: StreamAgentEvent[] = [];
+      const pending = generateModelStepResult({
+        signal,
+        history,
+        model,
+        onStreamEvent: (event) => events.push(event),
+      });
+      await vi.runAllTimersAsync();
+      await pending;
+      expect(calls).toEqual([epoch, epoch + delayMs]);
+      expect(retries(events)[0]).toMatchObject({
+        delayMs,
+        retryAt: epoch + delayMs,
+      });
+    }
+  );
+
+  it.each(["AbortError", "TimeoutError", "ResponseAborted"])(
+    "never retries provider %s errors without an aborted signal",
+    async (name) => {
+      const error = Object.assign(new Error("provider abort"), { name });
+      const { model, calls } = fixture("generate", 3, error);
+      const events: StreamAgentEvent[] = [];
+      await expect(
+        generateModelStepResult({
+          history,
+          model,
+          signal,
+          onStreamEvent: (event) => events.push(event),
+        })
+      ).rejects.toBe(error);
+      expect(calls).toHaveLength(1);
+      expect(retries(events)).toMatchObject([
+        { phase: "stopped", reason: "cancelled", remainingRetries: 0 },
+      ]);
+    }
+  );
+
+  it("retries gateway errors using their API-call cause's delay", async () => {
+    const error = new GatewayInternalServerError({
+      message: "private gateway",
+      cause: failure(503, { "retry-after-ms": "75" }),
+    });
+    const { model, calls } = fixture("generate", 1, error);
+    const events: StreamAgentEvent[] = [];
+    const pending = generateModelStepResult({
+      history,
+      model,
+      signal,
+      onStreamEvent: (event) => events.push(event),
+    });
+    await vi.runAllTimersAsync();
+    await pending;
+    expect(calls).toEqual([epoch, epoch + 75]);
+    expect(retries(events)[0]).toMatchObject({
+      delayMs: 75,
+      retryAt: epoch + 75,
+    });
+  });
+
+  it("honors explicit isRetryable instead of inferring from HTTP status", async () => {
+    const error = new APICallError({
+      isRetryable: false,
+      message: "fixture",
+      requestBodyValues: {},
+      statusCode: 429,
+      url: "https://fixture.test",
+    });
+    const { model, calls } = fixture("stream", 3, error);
+    const events: StreamAgentEvent[] = [];
+    const pending = generateModelStepResult({
+      history,
+      model,
+      signal,
+      onStreamEvent: (event) => events.push(event),
+    }).catch((caught: unknown) => caught);
+    await vi.runAllTimersAsync();
+    expect(await pending).toBe(error);
+    expect(calls).toHaveLength(1);
+    expect(retries(events)).toMatchObject([
+      { phase: "stopped", reason: "non-retryable" },
+    ]);
+  });
+
+  it("retains failure classification when a retry becomes nonretryable", async () => {
+    const error = failure(401);
+    let calls = 0;
+    const model = createMockLanguageModelV4(() => {
+      calls += 1;
+      throw calls === 1 ? failure() : error;
+    });
+    const events: StreamAgentEvent[] = [];
+    const pending = generateModelStepResult({
+      history,
+      model,
+      signal,
+      onStreamEvent: (event) => events.push(event),
+    }).catch((caught: unknown) => caught);
+    await vi.runAllTimersAsync();
+    expect(await pending).toMatchObject({
+      lastError: error,
+      reason: "errorNotRetryable",
+    });
+    expect(calls).toBe(2);
+    expect(retries(events).at(-1)).toMatchObject({
+      attempt: 2,
+      phase: "stopped",
+      reason: "non-retryable",
+      remainingRetries: 0,
+    });
+    expect(
+      events.filter((event) => event.type === "model-attempt").at(-1)
+    ).toMatchObject({ error: { category: "authentication", status: 401 } });
+  });
+
+  it("isolates concurrent waits on a shared model", async () => {
+    const calls = new Map<string, number>();
+    const model = createMockLanguageModelV4(({ prompt }) => {
+      const key = JSON.stringify(prompt);
+      const count = (calls.get(key) ?? 0) + 1;
+      calls.set(key, count);
+      if (count === 1) {
+        throw failure();
+      }
+      return Promise.resolve(mockLanguageModelV4Text("done"));
+    });
+    const first: StreamAgentEvent[] = [];
+    const second: StreamAgentEvent[] = [];
+    const controller = new AbortController();
+    const a = generateModelStepResult({
+      history,
+      model,
+      signal: controller.signal,
+      onStreamEvent: (event) => {
+        first.push(event);
+        if (event.type === "model-retry" && event.phase === "scheduled") {
+          controller.abort();
+        }
+      },
+    }).catch((error: unknown) => error);
+    const b = generateModelStepResult({
+      signal,
+      history: [{ content: "other", role: "user" }],
+      model,
+      onStreamEvent: (event) => second.push(event),
+    });
+    await vi.runAllTimersAsync();
+    expect(await a).toMatchObject({ name: "AbortError" });
+    await b;
+    expect([...calls.values()]).toEqual([1, 2]);
+    expect(retries(first).at(-1)).toMatchObject({
+      phase: "stopped",
+      reason: "cancelled",
+    });
+    expect(retries(second).map((event) => event.phase)).toEqual([
+      "scheduled",
+      "started",
+    ]);
+    expect(retries(first)[0]?.attemptId).not.toBe(
+      retries(second)[0]?.attemptId
+    );
+  });
+});

--- a/packages/runtime/src/llm/model-retry.test.ts
+++ b/packages/runtime/src/llm/model-retry.test.ts
@@ -410,6 +410,55 @@ describe("authoritative model retry lifecycle", () => {
     ).toMatchObject({ error: { category: "authentication", status: 401 } });
   });
 
+  it("classifies a final nonretryable failure after two retries", async () => {
+    let calls = 0;
+    const finalError = failure(401);
+    const model = createMockLanguageModelV4(() => {
+      calls += 1;
+      throw calls === 3 ? finalError : failure();
+    });
+    const events: StreamAgentEvent[] = [];
+    const pending = expect(
+      generateModelStepResult({
+        history,
+        model,
+        signal,
+        onStreamEvent: (event) => events.push(event),
+      })
+    ).rejects.toMatchObject({
+      lastError: finalError,
+      reason: "errorNotRetryable",
+    });
+    await vi.runAllTimersAsync();
+    await pending;
+    expect(calls).toBe(3);
+    expect(retries(events).at(-1)).toMatchObject({
+      attempt: 3,
+      phase: "stopped",
+      reason: "non-retryable",
+    });
+  });
+
+  it("cleans up a pre-aborted attempt before provider execution", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const events: StreamAgentEvent[] = [];
+    const model = createMockLanguageModelV4(() => {
+      throw new Error("provider should not be called");
+    });
+    await expect(
+      generateModelStepResult({
+        history,
+        model,
+        signal: controller.signal,
+        onStreamEvent: (event) => events.push(event),
+      })
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(retries(events)).toMatchObject([
+      { attempt: 0, phase: "stopped", reason: "cancelled" },
+    ]);
+  });
+
   it("isolates concurrent waits on a shared model", async () => {
     const calls = new Map<string, number>();
     const model = createMockLanguageModelV4(({ prompt }) => {

--- a/packages/runtime/src/llm/model-retry.ts
+++ b/packages/runtime/src/llm/model-retry.ts
@@ -1,0 +1,204 @@
+import { GatewayError } from "@ai-sdk/gateway";
+import { APICallError, RetryError } from "ai";
+import type { ModelRetry } from "../thread/protocol/events";
+
+/** Owns the wait and decision at the provider-call boundary, never an SDK step. */
+export function createModelRetry({
+  attemptId,
+  abortSignal,
+  onRetry,
+}: {
+  readonly attemptId: string;
+  readonly abortSignal?: AbortSignal;
+  readonly onRetry?: (event: ModelRetry) => void;
+}) {
+  let attempt = 0;
+  let stopped = false;
+  const stop = (
+    reason: Extract<ModelRetry, { phase: "stopped" }>["reason"]
+  ) => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    onRetry?.({
+      attempt,
+      attemptId,
+      phase: "stopped",
+      reason,
+      remainingRetries: 0,
+      type: "model-retry",
+    });
+  };
+  const checkAbort = () => {
+    if (abortSignal?.aborted) {
+      stop("cancelled");
+      abortSignal.throwIfAborted();
+    }
+  };
+
+  const checkFailure = (error: unknown, errors: unknown[]) => {
+    checkAbort();
+    if (isAbortError(error)) {
+      stop("cancelled");
+      throw error;
+    }
+    errors.push(error);
+    if (errors.length === 3) {
+      stop("exhausted");
+      throw new RetryError({
+        errors,
+        message: "Provider retries exhausted.",
+        reason: "maxRetriesExceeded",
+      });
+    }
+    if (!isRetryable(error)) {
+      stop("non-retryable");
+      if (errors.length === 1) {
+        throw error;
+      }
+      throw new RetryError({
+        errors,
+        message: "Provider retry failed with a non-retryable error.",
+        reason: "errorNotRetryable",
+      });
+    }
+    return error;
+  };
+
+  return {
+    checkAbort,
+    stopStream(error: unknown) {
+      stop(
+        abortSignal?.aborted || isAbortError(error)
+          ? "cancelled"
+          : "stream-ended"
+      );
+    },
+    async execute<T>(call: () => PromiseLike<T>): Promise<T> {
+      const errors: unknown[] = [];
+      while (true) {
+        checkAbort();
+        attempt += 1;
+        let error: unknown;
+        try {
+          return await call();
+        } catch (failure) {
+          error = failure;
+        }
+        const retryableError = checkFailure(error, errors);
+        const remainingRetries = 3 - errors.length;
+        const delayMs = retryDelay(
+          retryableError,
+          2000 * 2 ** (errors.length - 1)
+        );
+        const retryAt = Date.now() + delayMs;
+        try {
+          await waitForRetry(delayMs, abortSignal, () =>
+            onRetry?.({
+              attempt,
+              attemptId,
+              delayMs,
+              phase: "scheduled",
+              remainingRetries,
+              retryAt,
+              type: "model-retry",
+            })
+          );
+        } catch (failure) {
+          stop(abortSignal?.aborted ? "cancelled" : "non-retryable");
+          throw failure;
+        }
+        checkAbort();
+        onRetry?.({
+          attempt,
+          attemptId,
+          phase: "started",
+          remainingRetries: remainingRetries - 1,
+          type: "model-retry",
+        });
+      }
+    },
+  };
+}
+
+function isRetryable(error: unknown): error is APICallError | GatewayError {
+  return (
+    error instanceof Error &&
+    (APICallError.isInstance(error) || GatewayError.isInstance(error)) &&
+    error.isRetryable === true
+  );
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof Error || error instanceof DOMException) &&
+    (error.name === "AbortError" ||
+      error.name === "TimeoutError" ||
+      error.name === "ResponseAborted")
+  );
+}
+
+/** Matches AI SDK 7's retry header precedence and bounded delay selection. */
+function retryDelay(
+  error: APICallError | GatewayError,
+  exponentialDelay: number
+): number {
+  const apiError = APICallError.isInstance(error) ? error : error.cause;
+  const headers = APICallError.isInstance(apiError)
+    ? apiError.responseHeaders
+    : undefined;
+  let delay: number | undefined;
+  const milliseconds = headers?.["retry-after-ms"];
+  if (milliseconds) {
+    const parsed = Number.parseFloat(milliseconds);
+    if (!Number.isNaN(parsed)) {
+      delay = parsed;
+    }
+  }
+  const after = headers?.["retry-after"];
+  if (after && delay === undefined) {
+    const seconds = Number.parseFloat(after);
+    delay = Number.isNaN(seconds)
+      ? Date.parse(after) - Date.now()
+      : seconds * 1000;
+  }
+  return delay !== undefined &&
+    delay >= 0 &&
+    (delay < 60_000 || delay < exponentialDelay)
+    ? delay
+    : exponentialDelay;
+}
+
+function waitForRetry(
+  delayMs: number,
+  signal: AbortSignal | undefined,
+  onScheduled: () => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", abort);
+    };
+    const abort = () => {
+      cleanup();
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+    signal?.addEventListener("abort", abort, { once: true });
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+    // Arm both the deadline and cancellation before publishing the schedule.
+    try {
+      onScheduled();
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+}

--- a/packages/runtime/src/llm/model-retry.ts
+++ b/packages/runtime/src/llm/model-retry.ts
@@ -44,7 +44,7 @@ export function createModelRetry({
       throw error;
     }
     errors.push(error);
-    if (errors.length === 3) {
+    if (errors.length === 3 && isRetryable(error)) {
       stop("exhausted");
       throw new RetryError({
         errors,

--- a/packages/runtime/src/llm/model-step-stream-events.test.ts
+++ b/packages/runtime/src/llm/model-step-stream-events.test.ts
@@ -281,7 +281,7 @@ describe("generateModelStepResult stream events", () => {
         history: prompt,
         model,
         onStreamEvent: (event) => {
-          if (event.type === "model-attempt") {
+          if (event.type === "model-attempt" || event.type === "model-retry") {
             return;
           }
           events.push(event);

--- a/packages/runtime/src/llm/model-step-stream.test.ts
+++ b/packages/runtime/src/llm/model-step-stream.test.ts
@@ -243,6 +243,109 @@ describe("createModelStepStream", () => {
     });
   });
 
+  it.each([undefined, "provider-other"])(
+    "accepts an explicit other finish with raw reason %s",
+    async (raw) => {
+      const model = createStreamingMockLanguageModelV4([
+        {
+          stream: convertArrayToReadableStream([
+            { type: "stream-start", warnings: [] },
+            {
+              finishReason: { raw, unified: "other" },
+              type: "finish",
+              usage: streamUsageFixture,
+            },
+          ] satisfies MockStreamPart[]),
+        },
+      ]);
+      const source = createModelStepStream({ messages: [...prompt], model });
+
+      await expect(collectParts(source.parts)).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "finish",
+            finishReason: "other",
+            rawFinishReason: raw,
+          }),
+        ])
+      );
+      await expect(source.finalize()).resolves.toMatchObject({
+        finishReason: "other",
+      });
+    }
+  );
+
+  it.each([false, true])(
+    "rejects missing provider finish even with SDK synthesized finish: %s",
+    async (partialOutput) => {
+      const chunks: MockStreamPart[] = [{ type: "stream-start", warnings: [] }];
+      if (partialOutput) {
+        chunks.push(
+          { id: "text", type: "text-start" },
+          { delta: "partial", id: "text", type: "text-delta" },
+          { id: "text", type: "text-end" }
+        );
+      }
+      const model = createStreamingMockLanguageModelV4([
+        { stream: convertArrayToReadableStream(chunks) },
+      ]);
+      const source = createModelStepStream({ messages: [...prompt], model });
+
+      const parts = await collectParts(source.parts);
+      expect(parts.some((part) => part.type === "finish")).toBe(partialOutput);
+      if (partialOutput) {
+        expect(parts.at(-1)).toMatchObject({
+          finishReason: "other",
+          type: "finish",
+        });
+      }
+      const finalization = source.finalize();
+      expect(source.finalize()).toBe(finalization);
+      await expect(finalization).rejects.toThrow(
+        "Model stream ended without a finish event."
+      );
+      expect(model.doStreamCalls).toHaveLength(1);
+    }
+  );
+
+  it.each([
+    { error: null, invalidText: false },
+    { error: undefined, invalidText: false },
+    { error: null, invalidText: true },
+    { error: undefined, invalidText: true },
+  ])(
+    "preserves original $error with SDK failure: $invalidText",
+    async ({ error, invalidText }) => {
+      const model = createStreamingMockLanguageModelV4([
+        {
+          stream: convertArrayToReadableStream([
+            { type: "stream-start", warnings: [] },
+            { error, type: "error" },
+            ...(invalidText
+              ? [
+                  {
+                    delta: "no start",
+                    id: "missing",
+                    type: "text-delta",
+                  } as const,
+                ]
+              : []),
+            {
+              finishReason: { raw: "stop", unified: "stop" },
+              type: "finish",
+              usage: streamUsageFixture,
+            },
+          ] satisfies MockStreamPart[]),
+        },
+      ]);
+      const source = createModelStepStream({ messages: [...prompt], model });
+
+      await collectParts(source.parts);
+      await expect(source.finalize()).rejects.toBe(error);
+      expect(model.doStreamCalls).toHaveLength(1);
+    }
+  );
+
   it("synthesizes committed-order parts for a doGenerate-only model and preserves final parity fields", async () => {
     const generateFixture = {
       content: generateContentFixture,

--- a/packages/runtime/src/llm/model-step-stream.ts
+++ b/packages/runtime/src/llm/model-step-stream.ts
@@ -6,6 +6,8 @@ import {
   type ToolChoice,
   type ToolSet,
 } from "ai";
+import type { ModelRetry } from "../thread/protocol/events";
+import { createModelRetry } from "./model-retry";
 import { configuredModelId, configuredProvider } from "./model-usage";
 
 type GenerateTextResult = Awaited<ReturnType<typeof generateText>>;
@@ -18,11 +20,12 @@ export interface ModelAttemptOriginSignal {
 export interface ModelStepStreamOptions {
   readonly abortSignal?: AbortSignal;
   readonly activeTools?: readonly string[];
+  readonly attemptId?: string;
   readonly instructions?: string;
   readonly maxOutputTokens?: number;
   readonly messages: ModelMessage[];
   readonly model: LanguageModel;
-  /** Notified when one physical provider call settles inside SDK retries. */
+  /** Notified when one physical provider call settles, before retry backoff. */
   readonly onAttemptEnd?: (
     result:
       | {
@@ -31,8 +34,9 @@ export interface ModelStepStreamOptions {
         }
       | { readonly error: unknown; readonly outcome: "failed" }
   ) => void;
-  /** Notified when one physical provider call starts inside SDK retries. */
+  /** Notified when one physical provider call starts. */
   readonly onAttemptStart?: (origin: ModelAttemptOriginSignal) => void;
+  readonly onRetry?: (event: ModelRetry) => void;
   readonly seed?: number;
   readonly temperature?: number;
   readonly toolChoice?: ToolChoice<ToolSet>;
@@ -155,7 +159,14 @@ function streamingModelStep(
   let streamFailure: { readonly error: unknown } | undefined;
   let finishedOrigin: ModelAttemptOriginSignal | undefined;
   let attemptOpen = false;
-  const { model, onAttemptEnd, onAttemptStart, ...streamOptions } = options;
+  const {
+    model,
+    attemptId,
+    onRetry,
+    onAttemptEnd,
+    onAttemptStart,
+    ...streamOptions
+  } = options;
   const notifyAttemptStart = (origin: ModelAttemptOriginSignal) => {
     attemptOpen = true;
     onAttemptStart?.(origin);
@@ -166,8 +177,11 @@ function streamingModelStep(
     attemptOpen = false;
     onAttemptEnd?.(attempt);
   };
-  const observedModel = modelWithAttemptObserver({
+  const observed = modelWithAttemptObserver({
     model,
+    attemptId,
+    onRetry,
+    abortSignal: options.abortSignal,
     onAttemptEnd: notifyAttemptEnd,
     onAttemptStart: notifyAttemptStart,
     onProviderStreamError: (error) => {
@@ -176,7 +190,7 @@ function streamingModelStep(
   });
   const result = streamText({
     ...streamOptions,
-    model: observedModel,
+    ...observed.options,
     onError: ({ error }) => {
       streamFailure ??= { error };
     },
@@ -211,6 +225,7 @@ function streamingModelStep(
               error: streamFailure.error,
               outcome: "failed",
             });
+            observed.retry?.stopStream(streamFailure.error);
             return;
           }
           if (finishedOrigin) {
@@ -220,10 +235,9 @@ function streamingModelStep(
             });
             return;
           }
-          notifyAttemptEnd({
-            error: new Error("Model stream ended without a finish event."),
-            outcome: "failed",
-          });
+          const error = new Error("Model stream ended without a finish event.");
+          notifyAttemptEnd({ error, outcome: "failed" });
+          observed.retry?.stopStream(error);
         }
       );
       return finalization;
@@ -234,15 +248,25 @@ function streamingModelStep(
 function generatedModelStep(
   options: ModelStepStreamOptions
 ): ModelStepStreamHandle {
-  const { model, onAttemptEnd, onAttemptStart, ...generateOptions } = options;
-  const observedModel = modelWithAttemptObserver({
+  const {
     model,
+    attemptId,
+    onRetry,
+    onAttemptEnd,
+    onAttemptStart,
+    ...generateOptions
+  } = options;
+  const observed = modelWithAttemptObserver({
+    model,
+    attemptId,
+    onRetry,
+    abortSignal: options.abortSignal,
     onAttemptEnd,
     onAttemptStart,
   });
   const result = generateText({
     ...generateOptions,
-    model: observedModel,
+    ...observed.options,
   });
   let finalization: Promise<ModelStepStreamFinalResult> | undefined;
   return {
@@ -355,25 +379,41 @@ function finalResultFromGenerateText(
 
 function modelWithAttemptObserver({
   model,
+  attemptId = crypto.randomUUID(),
+  abortSignal,
+  onRetry,
   onAttemptEnd,
   onAttemptStart,
   onProviderStreamError,
-}: Pick<ModelStepStreamOptions, "model" | "onAttemptEnd" | "onAttemptStart"> & {
+}: Pick<
+  ModelStepStreamOptions,
+  | "model"
+  | "attemptId"
+  | "abortSignal"
+  | "onRetry"
+  | "onAttemptEnd"
+  | "onAttemptStart"
+> & {
   readonly onProviderStreamError?: (error: unknown) => void;
-}): LanguageModel {
+}): {
+  options: { model: LanguageModel; maxRetries?: number };
+  retry?: ReturnType<typeof createModelRetry>;
+} {
   const resolvedModel =
     typeof model === "string"
       ? globalThis.AI_SDK_DEFAULT_PROVIDER?.languageModel(model)
       : model;
   if (resolvedModel === undefined || typeof resolvedModel === "string") {
-    return model;
+    return { options: { model } };
   }
+  const retry = createModelRetry({ attemptId, abortSignal, onRetry });
+  retry.checkAbort();
   const origin = {
     modelId: configuredModelId(resolvedModel),
     provider: configuredProvider(resolvedModel),
   };
   const target = Object.create(resolvedModel) as Exclude<LanguageModel, string>;
-  return new Proxy(target, {
+  const observedModel = new Proxy(target, {
     get: (_target, property) => {
       const original = Reflect.get(resolvedModel, property, resolvedModel);
       if (
@@ -381,24 +421,32 @@ function modelWithAttemptObserver({
         typeof original === "function"
       ) {
         return (...args: unknown[]) =>
-          observeProviderCall({
-            execute: async () => {
-              const result = await Reflect.apply(original, resolvedModel, args);
-              return property === "doStream" && onProviderStreamError
-                ? observeProviderStreamErrors(result, onProviderStreamError)
-                : result;
-            },
-            origin,
-            onAttemptEnd,
-            onAttemptStart,
-            settleOnReturn: property === "doGenerate",
-          });
+          retry.execute(() =>
+            observeProviderCall({
+              execute: async () => {
+                abortSignal?.throwIfAborted();
+                const result = await Reflect.apply(
+                  original,
+                  resolvedModel,
+                  args
+                );
+                return property === "doStream" && onProviderStreamError
+                  ? observeProviderStreamErrors(result, onProviderStreamError)
+                  : result;
+              },
+              origin,
+              onAttemptEnd,
+              onAttemptStart,
+              settleOnReturn: property === "doGenerate",
+            })
+          );
       }
       return typeof original === "function"
         ? original.bind(resolvedModel)
         : original;
     },
   });
+  return { options: { model: observedModel, maxRetries: 0 }, retry };
 }
 
 function observeProviderStreamErrors(

--- a/packages/runtime/src/llm/model-step-stream.ts
+++ b/packages/runtime/src/llm/model-step-stream.ts
@@ -157,6 +157,7 @@ function streamingModelStep(
   options: ModelStepStreamOptions
 ): ModelStepStreamHandle {
   let streamFailure: { readonly error: unknown } | undefined;
+  let streamFinished = false;
   let finishedOrigin: ModelAttemptOriginSignal | undefined;
   let attemptOpen = false;
   const {
@@ -210,12 +211,16 @@ function streamingModelStep(
       result.stream as AsyncIterable<ModelStepStreamPart>,
       (error) => {
         streamFailure ??= { error };
+      },
+      () => {
+        streamFinished = true;
       }
     ),
     finalize() {
       finalization ??= finalizeStreamingModelStep(
         result,
         () => streamFailure,
+        () => streamFinished,
         () => {
           if (!attemptOpen) {
             return;
@@ -236,6 +241,7 @@ function streamingModelStep(
             return;
           }
           const error = new Error("Model stream ended without a finish event.");
+          streamFailure = { error };
           notifyAttemptEnd({ error, outcome: "failed" });
           observed.retry?.stopStream(error);
         }
@@ -280,11 +286,15 @@ function generatedModelStep(
 
 async function* observeStreamFailures(
   parts: AsyncIterable<ModelStepStreamPart>,
-  onError: (error: unknown) => void
+  onError: (error: unknown) => void,
+  onFinish: () => void
 ): AsyncIterable<ModelStepStreamPart> {
   for await (const part of parts) {
     if (part.type === "error") {
       onError(part.error);
+    }
+    if (part.type === "finish") {
+      onFinish();
     }
     yield part;
   }
@@ -359,10 +369,19 @@ async function finalizeStreamTextResult(
 async function finalizeStreamingModelStep(
   result: ReturnType<typeof streamText>,
   getStreamFailure: () => { readonly error: unknown } | undefined,
+  streamHasFinished: () => boolean,
   settleUnfinishedAttempt: () => void
 ): Promise<ModelStepStreamFinalResult> {
   try {
-    return await finalizeStreamTextResult(result);
+    const finalized = await finalizeStreamTextResult(result);
+    const streamFailure = getStreamFailure();
+    if (streamFailure !== undefined) {
+      throw streamFailure.error;
+    }
+    if (!streamHasFinished() || finalized.finishReason === "other") {
+      throw new Error("Model stream ended without a finish event.");
+    }
+    return finalized;
   } catch (error) {
     throw getStreamFailure()?.error ?? error;
   } finally {

--- a/packages/runtime/src/llm/model-step-stream.ts
+++ b/packages/runtime/src/llm/model-step-stream.ts
@@ -407,7 +407,6 @@ function modelWithAttemptObserver({
     return { options: { model } };
   }
   const retry = createModelRetry({ attemptId, abortSignal, onRetry });
-  retry.checkAbort();
   const origin = {
     modelId: configuredModelId(resolvedModel),
     provider: configuredProvider(resolvedModel),

--- a/packages/runtime/src/llm/model-step-stream.ts
+++ b/packages/runtime/src/llm/model-step-stream.ts
@@ -157,7 +157,6 @@ function streamingModelStep(
   options: ModelStepStreamOptions
 ): ModelStepStreamHandle {
   let streamFailure: { readonly error: unknown } | undefined;
-  let streamFinished = false;
   let finishedOrigin: ModelAttemptOriginSignal | undefined;
   let attemptOpen = false;
   const {
@@ -211,16 +210,12 @@ function streamingModelStep(
       result.stream as AsyncIterable<ModelStepStreamPart>,
       (error) => {
         streamFailure ??= { error };
-      },
-      () => {
-        streamFinished = true;
       }
     ),
     finalize() {
       finalization ??= finalizeStreamingModelStep(
         result,
         () => streamFailure,
-        () => streamFinished,
         () => {
           if (!attemptOpen) {
             return;
@@ -286,15 +281,11 @@ function generatedModelStep(
 
 async function* observeStreamFailures(
   parts: AsyncIterable<ModelStepStreamPart>,
-  onError: (error: unknown) => void,
-  onFinish: () => void
+  onError: (error: unknown) => void
 ): AsyncIterable<ModelStepStreamPart> {
   for await (const part of parts) {
     if (part.type === "error") {
       onError(part.error);
-    }
-    if (part.type === "finish") {
-      onFinish();
     }
     yield part;
   }
@@ -369,7 +360,6 @@ async function finalizeStreamTextResult(
 async function finalizeStreamingModelStep(
   result: ReturnType<typeof streamText>,
   getStreamFailure: () => { readonly error: unknown } | undefined,
-  streamHasFinished: () => boolean,
   settleUnfinishedAttempt: () => void
 ): Promise<ModelStepStreamFinalResult> {
   try {
@@ -378,12 +368,10 @@ async function finalizeStreamingModelStep(
     if (streamFailure !== undefined) {
       throw streamFailure.error;
     }
-    if (!streamHasFinished() || finalized.finishReason === "other") {
-      throw new Error("Model stream ended without a finish event.");
-    }
     return finalized;
   } catch (error) {
-    throw getStreamFailure()?.error ?? error;
+    const streamFailure = getStreamFailure();
+    throw streamFailure === undefined ? error : streamFailure.error;
   } finally {
     settleUnfinishedAttempt();
   }
@@ -471,6 +459,7 @@ function observeProviderStreamErrors(
   value: unknown,
   onError: (error: unknown) => void
 ): unknown {
+  let finished = false;
   const result = value as {
     readonly stream: ReadableStream<{
       readonly error?: unknown;
@@ -485,7 +474,17 @@ function observeProviderStreamErrors(
           if (part.type === "error") {
             onError(part.error);
           }
+          if (part.type === "finish") {
+            finished = true;
+          }
           controller.enqueue(part);
+        },
+        flush() {
+          // The SDK can synthesize a finish after partial output. Only a
+          // provider finish proves that the physical stream completed.
+          if (!finished) {
+            onError(new Error("Model stream ended without a finish event."));
+          }
         },
       })
     ),

--- a/packages/runtime/src/llm/model-step.ts
+++ b/packages/runtime/src/llm/model-step.ts
@@ -137,6 +137,8 @@ export async function generateModelStepResult({
   assertNoUnsupportedToolApproval(prepared.tools);
   const attemptTracker = createModelAttemptTracker({ attemptId });
   const handle = createModelStepStream({
+    attemptId,
+    onRetry: onStreamEvent,
     activeTools: prepared.activeTools,
     abortSignal: signal,
     instructions: prompt.instructions,

--- a/packages/runtime/src/llm/model-step.ts
+++ b/packages/runtime/src/llm/model-step.ts
@@ -9,6 +9,7 @@ import {
   enforceContextGate,
   materializeModelPromptTools,
 } from "./context-gate";
+import { normalizeInvalidToolResults } from "./invalid-tool-input";
 import { createModelAttemptTracker } from "./model-attempt";
 import { ModelToolSelectionError } from "./model-step-error";
 import { resolveModelStepOptions } from "./model-step-preparation";
@@ -225,9 +226,11 @@ export async function generateModelStepResult({
     );
     return {
       ...(usageSnapshot ? { contextUsage: usageSnapshot } : {}),
-      messages: responseMessages.map((message) =>
-        rewriteMessageToolCallIds(message, toolCallIds)
-      ),
+      messages: normalizeInvalidToolResults({
+        responseMessages,
+        finishReason,
+        finalStep,
+      }).map((message) => rewriteMessageToolCallIds(message, toolCallIds)),
       usage: normalizedUsage,
     };
   } catch (error) {

--- a/packages/runtime/src/otel/attributes.ts
+++ b/packages/runtime/src/otel/attributes.ts
@@ -23,6 +23,23 @@ export function defaultAgentEventAttributes(event: AgentEvent): Attributes {
       };
     case "model-attempt":
       return { ...base, ...modelAttemptAttributes(event) };
+    case "model-retry":
+      return {
+        ...base,
+        "pss.model_retry.attempt": event.attempt,
+        "pss.model_retry.attempt_id": event.attemptId,
+        "pss.model_retry.phase": event.phase,
+        "pss.model_retry.remaining_retries": event.remainingRetries,
+        ...(event.phase === "scheduled"
+          ? {
+              "pss.model_retry.delay_ms": event.delayMs,
+              "pss.model_retry.retry_at": event.retryAt,
+            }
+          : {}),
+        ...(event.phase === "stopped"
+          ? { "pss.model_retry.reason": event.reason }
+          : {}),
+      };
     case "model-usage":
       return { ...base, ...modelUsageAttributes(event) };
     case "runtime-input":

--- a/packages/runtime/src/otel/index.test.ts
+++ b/packages/runtime/src/otel/index.test.ts
@@ -29,6 +29,67 @@ describe("traceAgentTurn", () => {
     expect(tracer.spans.every((span) => span.ended)).toBe(true);
   });
 
+  it("records retry scheduling and terminal state without provider payloads", async () => {
+    const events = [
+      {
+        attempt: 1,
+        attemptId: "retry-step",
+        delayMs: 2000,
+        phase: "scheduled",
+        remainingRetries: 2,
+        retryAt: 1_800_000_002_000,
+        type: "model-retry",
+      },
+      {
+        attempt: 1,
+        attemptId: "retry-step",
+        phase: "started",
+        remainingRetries: 1,
+        type: "model-retry",
+      },
+      {
+        attempt: 2,
+        attemptId: "retry-step",
+        phase: "stopped",
+        reason: "non-retryable",
+        remainingRetries: 0,
+        type: "model-retry",
+      },
+      { type: "turn-end" },
+    ] satisfies AgentEvent[];
+    const tracer = new RecordingTracer();
+    expect(
+      await collectEvents(
+        traceAgentTurn(singleUseTurn(events), { tracer }).events()
+      )
+    ).toEqual(events);
+    const recorded = spanNamed(tracer, "pss.runtime.turn").events;
+    expect(recorded[0]?.attributes).toEqual({
+      "pss.event.type": "model-retry",
+      "pss.model_retry.attempt": 1,
+      "pss.model_retry.attempt_id": "retry-step",
+      "pss.model_retry.delay_ms": 2000,
+      "pss.model_retry.phase": "scheduled",
+      "pss.model_retry.remaining_retries": 2,
+      "pss.model_retry.retry_at": 1_800_000_002_000,
+    });
+    expect(recorded[1]?.attributes).toEqual({
+      "pss.event.type": "model-retry",
+      "pss.model_retry.attempt": 1,
+      "pss.model_retry.attempt_id": "retry-step",
+      "pss.model_retry.phase": "started",
+      "pss.model_retry.remaining_retries": 1,
+    });
+    expect(recorded[2]?.attributes).toEqual({
+      "pss.event.type": "model-retry",
+      "pss.model_retry.attempt": 2,
+      "pss.model_retry.attempt_id": "retry-step",
+      "pss.model_retry.phase": "stopped",
+      "pss.model_retry.reason": "non-retryable",
+      "pss.model_retry.remaining_retries": 0,
+    });
+  });
+
   it("passes every event through while closing turn, step, and tool spans", async () => {
     const usage = {
       attemptId: "attempt-1",

--- a/packages/runtime/src/otel/trace-state.ts
+++ b/packages/runtime/src/otel/trace-state.ts
@@ -80,6 +80,7 @@ export function recordRuntimeTraceEvent(
     case "assistant-reasoning-delta":
     case "context-usage":
     case "model-attempt":
+    case "model-retry":
     case "model-usage":
     case "runtime-input":
     case "tool-call-input-delta":

--- a/packages/runtime/src/thread/handle/lifecycle.test.ts
+++ b/packages/runtime/src/thread/handle/lifecycle.test.ts
@@ -126,6 +126,13 @@ describe("Agent thread lifecycle", () => {
       { type: "turn-start" },
       { type: "step-start" },
       {
+        attempt: 1,
+        phase: "stopped",
+        reason: "non-retryable",
+        remainingRetries: 0,
+        type: "model-retry",
+      },
+      {
         error: { category: "unknown", version: 1 },
         type: "turn-error",
       },

--- a/packages/runtime/src/thread/handle/stream-events.test.ts
+++ b/packages/runtime/src/thread/handle/stream-events.test.ts
@@ -1,4 +1,4 @@
-import { jsonSchema, tool } from "ai";
+import { APICallError, jsonSchema, tool } from "ai";
 import { convertArrayToReadableStream } from "ai/test";
 import { describe, expect, it, vi } from "vitest";
 import { Agent } from "../../agent/core/agent";
@@ -133,6 +133,112 @@ describe("thread stream events", () => {
     ).toEqual(expectedLiveTypes);
   });
 
+  it("publishes real retry decisions without duplicating output or tool execution or persisting them", async () => {
+    let calls = 0;
+    let executions = 0;
+    const agent = new Agent({
+      host: createInMemoryHost(),
+      model: createStreamingMockLanguageModelV4(() => {
+        calls += 1;
+        if (calls === 1) {
+          throw new APICallError({
+            message: "fixture",
+            requestBodyValues: {},
+            responseHeaders: { "retry-after-ms": "0" },
+            statusCode: 429,
+            url: "https://fixture.test",
+          });
+        }
+        return Promise.resolve({
+          stream: convertArrayToReadableStream<MockStreamPart>(
+            calls === 2 ? firstStreamChunks : finalStreamChunks
+          ),
+        });
+      }),
+      tools: {
+        lookup: tool({
+          ...lookupTool,
+          execute: () => {
+            executions += 1;
+            return { weather: "sunny" };
+          },
+        }),
+      },
+    });
+    const thread = agent.thread("retry-live-and-replay");
+    const live = await collect(await thread.send("go"));
+    const replayed = await collectAsync(thread.events());
+    const retryEvents = live.filter((event) => event.type === "model-retry");
+    expect(retryEvents).toMatchObject([
+      { attempt: 1, delayMs: 0, phase: "scheduled", remainingRetries: 2 },
+      { attempt: 1, phase: "started", remainingRetries: 1 },
+    ]);
+    expect(
+      live
+        .filter((event) => event.type === "model-attempt")
+        .map((event) => [event.attempt, event.phase])
+    ).toEqual([
+      [1, "start"],
+      [1, "end"],
+      [2, "start"],
+      [2, "end"],
+      [1, "start"],
+      [1, "end"],
+    ]);
+    expect(calls).toBe(3);
+    expect(executions).toBe(1);
+    expect(
+      live
+        .filter((event) => event.type === "assistant-output-delta")
+        .map((event) => event.text)
+    ).toEqual(["hello ", "world"]);
+    expect(live.filter((event) => event.type === "tool-result")).toHaveLength(
+      1
+    );
+    expect(replayed.some(({ event }) => isStreamAgentEvent(event))).toBe(false);
+    expect(replayed.map(({ event }) => event.type)).toEqual(
+      committedTypes(live)
+    );
+    await agent.dispose();
+  });
+
+  it("publishes final cancellation when the live consumer interrupts a scheduled retry", async () => {
+    let calls = 0;
+    const agent = new Agent({
+      host: createInMemoryHost(),
+      model: createStreamingMockLanguageModelV4(() => {
+        calls += 1;
+        throw new APICallError({
+          message: "fixture",
+          requestBodyValues: {},
+          statusCode: 429,
+          url: "https://fixture.test",
+        });
+      }),
+    });
+    const thread = agent.thread("retry-interrupt");
+    const turn = await thread.send("go");
+    const live: AgentEvent[] = [];
+    for await (const event of turn.events()) {
+      live.push(event);
+      if (event.type === "model-retry" && event.phase === "scheduled") {
+        thread.interrupt();
+      }
+    }
+    expect(calls).toBe(1);
+    expect(live.filter((event) => event.type === "model-retry")).toMatchObject([
+      { phase: "scheduled", remainingRetries: 2 },
+      { phase: "stopped", reason: "cancelled", remainingRetries: 0 },
+    ]);
+    expect(live.at(-1)).toEqual({ type: "turn-abort" });
+    expect(
+      (await collectAsync(thread.events())).some(({ event }) =>
+        isStreamAgentEvent(event)
+      )
+    ).toBe(false);
+    await agent.dispose();
+  });
+
   it("preserves committed event parity with doGenerate-only models", async () => {
     const streamThread = createStreamThread("stream-parity");
     const generateThread = createGenerateThread("generate-parity");
@@ -164,6 +270,30 @@ describe("thread stream events", () => {
   });
 
   it.each([
+    {
+      attempt: 1,
+      attemptId: "fixture",
+      delayMs: 2000,
+      phase: "scheduled" as const,
+      remainingRetries: 2,
+      retryAt: 2000,
+      type: "model-retry" as const,
+    },
+    {
+      attempt: 1,
+      attemptId: "fixture",
+      phase: "started" as const,
+      remainingRetries: 1,
+      type: "model-retry" as const,
+    },
+    {
+      attempt: 1,
+      attemptId: "fixture",
+      phase: "stopped" as const,
+      reason: "cancelled" as const,
+      remainingRetries: 0 as const,
+      type: "model-retry" as const,
+    },
     {
       text: "must stay ephemeral",
       type: "assistant-output-delta" as const,

--- a/packages/runtime/src/thread/protocol/event-classifiers.ts
+++ b/packages/runtime/src/thread/protocol/event-classifiers.ts
@@ -28,6 +28,7 @@ export const telemetryAgentEventTypes = {
 export const streamAgentEventTypes = Object.freeze({
   "context-usage": true,
   "model-attempt": true,
+  "model-retry": true,
   "assistant-output-delta": true,
   "assistant-reasoning-delta": true,
   "tool-call-input-delta": true,

--- a/packages/runtime/src/thread/protocol/events.ts
+++ b/packages/runtime/src/thread/protocol/events.ts
@@ -117,7 +117,7 @@ export interface ContextUsageEvent extends ContextUsageSnapshot {
 /**
  * One physical provider call attempt inside a single runtime model step.
  *
- * The AI SDK retries failed streaming and non-streaming calls beneath
+ * The runtime retries failed streaming and non-streaming calls beneath
  * `streamText` and `generateText`, so a step's `attemptId` can cover several
  * provider requests. These events expose that otherwise invisible fan-out:
  * `attempt` counts from 1 per physical call, while `attemptId` stays fixed for
@@ -150,6 +150,45 @@ export type ModelAttempt = {
       readonly error?: TurnErrorMetadataV1;
       readonly outcome: "failed";
       readonly phase: "end";
+    }
+);
+
+/**
+ * Live-only authoritative retry state for an observed provider-call boundary.
+ * No event is emitted for a successful call. Only `scheduled` means a retry
+ * is pending; it is an intention that `stopped` can cancel, not a guarantee.
+ */
+export type ModelRetry = {
+  /** Last physical call number (0 when cancelled before any call). */
+  readonly attempt: number;
+  /** Model-step identifier shared with `model-attempt` and `model-usage`. */
+  readonly attemptId: string;
+  readonly type: "model-retry";
+} & (
+  | {
+      readonly phase: "scheduled";
+      /** Actual selected backoff, in milliseconds. */
+      readonly delayMs: number;
+      /** Unix epoch milliseconds; consumers may render a local countdown. */
+      readonly retryAt: number;
+      /** Unspent retry budget INCLUDING the scheduled retry. */
+      readonly remainingRetries: number;
+    }
+  | {
+      /** The wait completed; emitted immediately before the next attempt. */
+      readonly phase: "started";
+      /** Unspent budget AFTER consuming this retry. No wait is pending. */
+      readonly remainingRetries: number;
+    }
+  | {
+      readonly phase: "stopped";
+      readonly reason:
+        | "cancelled"
+        | "exhausted"
+        | "non-retryable"
+        | "stream-ended";
+      /** No further retries will be made, even if budget was unused. */
+      readonly remainingRetries: 0;
     }
 );
 
@@ -246,7 +285,9 @@ export type AgentEvent =
    * Ephemeral per-provider-call attempt signal, including SDK retries; never
    * persisted. The committed model-usage event remains the durable record.
    */
-  | ModelAttempt;
+  | ModelAttempt
+  /** Ephemeral runtime retry scheduling and terminal decisions; never persisted. */
+  | ModelRetry;
 
 export type AgentEventListener = (event: AgentEvent) => void;
 

--- a/packages/runtime/src/thread/protocol/events.ts
+++ b/packages/runtime/src/thread/protocol/events.ts
@@ -117,9 +117,10 @@ export interface ContextUsageEvent extends ContextUsageSnapshot {
 /**
  * One physical provider call attempt inside a single runtime model step.
  *
- * The runtime retries failed streaming and non-streaming calls beneath
- * `streamText` and `generateText`, so a step's `attemptId` can cover several
- * provider requests. These events expose that otherwise invisible fan-out:
+ * On observed model paths, the runtime retries failed streaming and
+ * non-streaming calls beneath `streamText` and `generateText`, so a step's
+ * `attemptId` can cover several provider requests. These events expose that
+ * otherwise invisible fan-out:
  * `attempt` counts from 1 per physical call, while `attemptId` stays fixed for
  * the whole step. End-event duration covers only that provider call and
  * excludes retry backoff. Object models are observed directly. String model

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: 4.0.31
         version: 4.0.31(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: 3.0.20
-        version: 3.0.20(zod@4.4.3)
+        specifier: 3.0.23
+        version: 3.0.23(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: ^0.84.1
         version: 0.84.3
@@ -693,6 +693,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@3.0.23':
+    resolution: {integrity: sha512-rrEABAjpaFPqRV+2JLkgb70r81+yLHdi7ir99lPir8G9tSXWkHjcuTWaKDhkimG/9W1hqsHtkomgPOqK4mC2hQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@4.0.31':
     resolution: {integrity: sha512-7oL7cqfbqvb1FiXrcbPblxI1d1mA159I0a+zbSSkUJEIq4fsg/McU7tQE0l2iJfg1oO1Y9QznJm6HYTJRrAvOA==}
     engines: {node: '>=22'}
@@ -719,6 +725,12 @@ packages:
 
   '@ai-sdk/provider-utils@5.0.20':
     resolution: {integrity: sha512-9W8c2mXiGgbo9sBBT4ybEWF8znxla2CO8VTim8t5oCCLP4aDH4o6RvkHfwL/iLC6mEbO4a6LpS2FBbQHccU+ig==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.21':
+    resolution: {integrity: sha512-Q4z27c5vqKuXZN65QuF7FVm+uvm3qxEioiQ+8c3s5xXlhbE1Y/SLGBB4BuF+UWia4KaDu2HmNpdR1RGW02/eGg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -5311,6 +5323,12 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/openai-compatible@3.0.23(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.5
+      '@ai-sdk/provider-utils': 5.0.21(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/openai@4.0.31(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.5
@@ -5342,6 +5360,15 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.20(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.5
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.21(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.5
       '@standard-schema/spec': 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,9 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@ai-sdk/gateway':
+        specifier: 4.0.40
+        version: 4.0.40(zod@4.4.3)
       '@jsquash/avif':
         specifier: ^2.1.1
         version: 2.1.1

--- a/scripts/dev-tui.mjs
+++ b/scripts/dev-tui.mjs
@@ -1,0 +1,9 @@
+import { startTui } from "../apps/coding-agent/src/tui/app.ts";
+import { parseDirectStartArguments } from "../apps/coding-agent/src/tui/direct-start.ts";
+
+// pnpm runs scripts in the repository but preserves the caller in INIT_CWD.
+// Keep the process there for repository .env loading; only the workspace moves.
+process.exitCode = await startTui({
+  ...parseDirectStartArguments(process.argv.slice(2)),
+  cwd: process.env.INIT_CWD || process.cwd(),
+});

--- a/scripts/dev-tui.test.mjs
+++ b/scripts/dev-tui.test.mjs
@@ -1,0 +1,168 @@
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const packageJson = JSON.parse(
+  readFileSync(join(root, "package.json"), "utf8")
+);
+const marker = "__DEV_TUI_PROBE__";
+let directory;
+let repository;
+let caller;
+let env;
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env,
+    timeout: 30_000,
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  const output = result.stdout
+    .split("\n")
+    .find((line) => line.startsWith(marker));
+  expect(output, result.stdout).toBeDefined();
+  return JSON.parse(output.slice(marker.length));
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "pss-dev-tui-"));
+  repository = join(directory, "repo");
+  caller = join(directory, "caller workspace");
+  const home = join(directory, "home");
+  for (const path of [repository, caller, home]) {
+    mkdirSync(path, { recursive: true });
+  }
+  cpSync(
+    join(root, "apps/coding-agent/src"),
+    join(repository, "apps/coding-agent/src"),
+    { recursive: true }
+  );
+  cpSync(join(root, "scripts"), join(repository, "scripts"), {
+    recursive: true,
+  });
+  symlinkSync(
+    join(root, "apps/coding-agent/node_modules"),
+    join(repository, "apps/coding-agent/node_modules"),
+    "dir"
+  );
+  symlinkSync(
+    join(root, "node_modules"),
+    join(repository, "node_modules"),
+    "dir"
+  );
+  writeFileSync(
+    join(repository, "package.json"),
+    JSON.stringify({
+      type: "module",
+      packageManager: packageJson.packageManager,
+      scripts: { "dev:tui": packageJson.scripts["dev:tui"] },
+    })
+  );
+  writeFileSync(
+    join(repository, ".env"),
+    "AI_API_KEY=fixture-repo-key\nAI_BASE_URL=https://repo.invalid/v1\nAI_MODEL=fixture-repo-model\n"
+  );
+  writeFileSync(
+    join(caller, ".env"),
+    "AI_API_KEY=fixture-caller-key\nAI_BASE_URL=https://caller.invalid/v1\nAI_MODEL=fixture-caller-model\n"
+  );
+  writeFileSync(
+    join(repository, "workspace-marker.txt"),
+    "REPO_WORKSPACE_SENTINEL"
+  );
+  writeFileSync(
+    join(caller, "workspace-marker.txt"),
+    "CALLER_WORKSPACE_SENTINEL"
+  );
+  writeFileSync(join(caller, "AGENTS.md"), "CALLER_CONTEXT_SENTINEL");
+  const probe = join(root, "scripts/fixtures/dev-tui-probe.mjs");
+  env = {
+    ...process.env,
+    AI_API_KEY: "fixture-shell-key",
+    AI_BASE_URL: "https://shell.invalid/v1",
+    AI_MODEL: "fixture-shell-model",
+    HOME: home,
+    INIT_CWD: undefined,
+    NODE_OPTIONS: `--import=${pathToFileURL(probe).href}`,
+    PSS_AUTO_UPDATE: "0",
+    PSS_DISABLE_UPDATE_CHECK: "1",
+    PSS_THREAD_DIR: join(directory, "threads"),
+    PSS_THREAD_KEY: undefined,
+  };
+});
+
+afterEach(() => {
+  rmSync(directory, { force: true, recursive: true });
+});
+
+// The resume case launches two subprocesses, each bounded at 30 seconds.
+// Allow their combined budget plus assertion overhead, including on busy CI.
+describe("dev:tui launcher", { timeout: 65_000 }, () => {
+  it("uses pnpm's invocation cwd for sessions and autocomplete, retaining repository model settings", () => {
+    const result = run("pnpm", ["-C", repository, "dev:tui"], caller);
+    expect(result.initCwd).toBe(caller);
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].cwd).toBe(caller);
+    expect(result.autocompleteCwd).toBe(caller);
+    expect(result.contextPaths).toEqual([join(caller, "AGENTS.md")]);
+    expect(result.callerFileRead).toBe(true);
+    expect(result.model).toBe("fixture-repo-model");
+    expect(result.baseURL).toBe("https://repo.invalid/v1");
+    expect(result.apiKey).toBe("fixture-repo-key");
+  });
+
+  it("keeps repository invocation and --session forwarding working", () => {
+    const initial = run("pnpm", ["-C", repository, "dev:tui"], repository);
+    const key = initial.sessions[0].key;
+    const result = run(
+      "pnpm",
+      ["-C", repository, "dev:tui", "--", "--session", key],
+      repository
+    );
+    expect(result.sessions).toEqual([{ cwd: repository, key }]);
+    expect(result.autocompleteCwd).toBe(repository);
+  });
+
+  it("falls back to process cwd without pnpm's INIT_CWD", () => {
+    const result = run(
+      join(root, "node_modules/.bin/tsx"),
+      [
+        "--conditions=@minpeter/pss-source",
+        join(repository, "scripts/dev-tui.mjs"),
+      ],
+      repository
+    );
+    expect(result.initCwd).toBeUndefined();
+    expect(result.sessions[0].cwd).toBe(repository);
+  });
+
+  it("does not reinterpret INIT_CWD for the existing direct TUI entry", () => {
+    env.INIT_CWD = caller;
+    const result = run(
+      join(root, "node_modules/.bin/tsx"),
+      [
+        "--conditions=@minpeter/pss-source",
+        join(repository, "apps/coding-agent/src/tui/app.ts"),
+      ],
+      repository
+    );
+    expect(result.sessions[0].cwd).toBe(repository);
+    expect(result.autocompleteCwd).toBe(repository);
+    expect(result.callerFileRead).toBe(false);
+  });
+});

--- a/scripts/examples.test.mjs
+++ b/scripts/examples.test.mjs
@@ -67,7 +67,7 @@ describe("examples workspace packages", () => {
     expect(workspace).toContain('- "apps/*"');
     expect(rootPackageJson.workspaces).toContain("apps/*");
     expect(rootPackageJson.scripts["dev:tui"]).toBe(
-      "tsx --conditions=@minpeter/pss-source apps/coding-agent/src/tui/app.ts"
+      "tsx --conditions=@minpeter/pss-source scripts/dev-tui.mjs"
     );
     expect(rootTsconfig.include).toContain("apps/*/src/**/*.ts");
 

--- a/scripts/fixtures/dev-tui-probe.mjs
+++ b/scripts/fixtures/dev-tui-probe.mjs
@@ -1,0 +1,70 @@
+import { registerHooks } from "node:module";
+
+// A subprocess-only terminal seam. Observe, but do not replace, real workspace
+// tools and context loading; no provider request is allowed during startup.
+globalThis.fetch = () => {
+  throw new Error("Unexpected network request");
+};
+globalThis.__devTuiProbe = {};
+
+registerHooks({
+  load(url, context, nextLoad) {
+    if (url.endsWith("/workspace-tools/index.ts")) {
+      return {
+        format: "module",
+        shortCircuit: true,
+        source: `
+          import { createWorkspaceTools as original } from ${JSON.stringify(`${url}?probe-original`)};
+          export function createWorkspaceTools(options) {
+            const tools = original(options);
+            globalThis.__devTuiProbe.tools = tools;
+            return tools;
+          }
+        `,
+      };
+    }
+    if (url.endsWith("/context/index.ts")) {
+      return {
+        format: "module",
+        shortCircuit: true,
+        source: `
+          export * from ${JSON.stringify(`${url}?probe-original`)};
+          import { loadContextResources as original } from ${JSON.stringify(`${url}?probe-original`)};
+          export async function loadContextResources(options) {
+            const resources = await original(options);
+            globalThis.__devTuiProbe.contextPaths = resources.agentsFiles.map(({ path }) => path);
+            return resources;
+          }
+        `,
+      };
+    }
+    if (url.endsWith("/tui/agent.ts")) {
+      return {
+        format: "module",
+        shortCircuit: true,
+        source: `
+          import { readSessionIndex, sessionIndexPath } from '../sessions/session-index.ts';
+          export async function createAgentTUI(config) {
+            const { sessions } = await readSessionIndex(sessionIndexPath(process.env.PSS_THREAD_DIR));
+            const probe = globalThis.__devTuiProbe;
+            const read = await probe.tools.read_file.execute({ path: 'workspace-marker.txt' }, {
+              context: {}, messages: [], toolCallId: 'launcher-probe',
+            });
+            console.log('__DEV_TUI_PROBE__' + JSON.stringify({
+              processCwd: process.cwd(),
+              initCwd: process.env.INIT_CWD,
+              autocompleteCwd: config.cwd ?? process.cwd(),
+              sessions: sessions.map(({ cwd, key }) => ({ cwd, key })),
+              contextPaths: probe.contextPaths,
+              callerFileRead: read.includes('CALLER_WORKSPACE_SENTINEL'),
+              model: process.env.AI_MODEL,
+              baseURL: process.env.AI_BASE_URL,
+              apiKey: process.env.AI_API_KEY,
+            }));
+          }
+        `,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});


### PR DESCRIPTION
## Summary

- Add ephemeral runtime model-retry events for scheduled, started, and stopped retries, including deadline, delay, remaining budget, and cancellation reasons.
- Display retry countdowns and keep the coding-agent busy spinner animated throughout streaming, physical tool execution, between-step waits, retries, compaction, commands, and shutdown cleanup.
- Reuse the existing composer separator for exactly one final session-resume hint after owned cleanup logs/errors; preserve narrow-terminal rendering and current session selection.
- Preserve the invoking workspace for pnpm -C dev:tui while loading repository model settings, and update the compatible provider SDK to handle sparse streaming tool-call indexes.

## Verification

Final pre-push validation passed on this unchanged source tree:

- Runtime: 284 test files, 1760 passed, 5 existing skips.
- Coding-agent: 132 test files, 967 passed.
- dev:tui and file-size checks: 5 passed.
- Runtime's three typecheck configurations and coding-agent typecheck passed.
- Build dependency graph, root lint, runtime API snapshot, Tegami validation, and git diff --check passed.
- LSP diagnostics on 53 changed TypeScript files: no errors.

Manual local QA used deterministic providers and real PTY/xterm captures: 197 spinner checkpoints (182 active animations, 15 clean idle/user waits), plus 24 composer-separator reuse exit cases. Live game-generation QA verified the caller workspace, tool execution, and continued sessions after feedback. Generated game files and local QA captures are not included in this PR.

## Notes

- No claim over arbitrary extension/provider permutations or forced OS termination. Pre-mount signal exits and cancellation-ignoring work beyond reported deadlines retain documented limitations.
- Existing oversized experimental JSON lint warning and bundled-extension self-import build warnings remain unsuppressed.
- Includes patch-level Tegami entries for the affected published packages. This PR does not release them.

## Commits

- 0e26095: runtime retry lifecycle.
- df13b7c: coding-agent progress, workspace, provider compatibility, and final resume output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes authoritative provider retry scheduling from the runtime as live `model-retry` events and stabilizes the coding-agent TUI session so retry state, progress feedback, and terminal resizing behave predictably. Previously retries ran invisibly inside the AI SDK, the busy spinner stalled between phases, tool arguments appeared only after the call completed, identical notices stacked new rows, and sealed transcript output could not reflow.

**New Features**
- Emits scheduled/started/stopped retry events with delay, deadline, remaining budget, and cancellation reasons; extensions subscribe live-only, never persisted.
- Renders a live retry countdown in the TUI footer and clears it on retry start, stop, or session switch.
- Keeps the busy spinner animated through streaming, tool execution, inter-step waits, retries, compaction, commands, and shutdown cleanup.
- Shows streamed arguments for every tool, including decoded multiline source before execution, and reveals `write <path>` and `read <path>` headers as soon as the path streams in.
- Pulses repeated identical system notices in place instead of appending rows.
- Freezes completed output and caps live text at eight rows; completed answers expand to full text before freezing.
- Re-layouts sealed transcript content (text, tables, code, startup info) on terminal resize; opaque graphics stay atomic.
- Reuses trailing padding so shrinking output never lifts the composer, coalesces consecutive model-change notices, and shows only the short session selector in `/new` and `/clear` notices.

**Bug Fixes**
- Classifies final non-retryable provider failures before retry exhaustion and finalizes pre-aborted attempts through the normal path.
- Propagates recorded provider stream errors and missing finish events through the turn error path instead of persisting them as successful turns, detecting missing provider finish events before SDK synthesis and preserving falsy original stream errors.
- Preserves the invoking workspace and startup output stream, and keeps detached callbacks from observing expired busy owners.
- Stages session replay before replacing the transcript, finishes hidden tool results, and cancels extension prompts when interactive access is revoked.
- Preserves multiline tool graphics and sealed transcript presentation during capture, avoiding reflow of box art as Markdown tables.
- Reuses the composer separator for a single final session-resume hint after cleanup logs and errors.
- Omits empty stderr from `shell_execute` output blocks.
- Disables strict tool generation for optional `write_file`/`edit_file` fields and distinguishes malformed, stale, and missing-target hashes.
- Reports rejected tool calls as a bounded `INVALID_TOOL_ARGUMENTS` result instead of the SDK's source dump, keeping the streamed argument preview.
- Leaves one blank row between tool cards and the following assistant or reasoning block.
- Bumps `@ai-sdk/openai-compatible` for sparse streaming tool-call indexes and adds `@ai-sdk/gateway` for runtime retry classification.

<sup>Written for commit b8185dc22a29589657a8ab3dad31ecd21b842c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

