### PR TITLE
fix(coding-agent): uncap assistant text during streaming

### DIFF
--- a/.tegami/2026-09-07-uncapped-streaming-text.md
+++ b/.tegami/2026-09-07-uncapped-streaming-text.md
@@ -1,0 +1,9 @@
+---
+packages:
+  npm:@minpeter/pss-coding-agent:
+    type: patch
+---
+
+## Keep streamed assistant text visible
+
+Render ordinary assistant text without the eight-row streaming tail so the content shown while generating matches the completed transcript. Keep the compact viewport for reasoning and tool bodies.

--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -429,16 +429,16 @@ error rendering; it does not mean the tool has run or a file has been written.
 `showRawToolIo` keeps the JSON input/output view. Shell output still appears
 only when its result arrives, not as live stdout.
 
-Text bodies auto-follow their latest eight terminal rows, including wrapped
-lines, while streaming. On text completion, the current assistant block expands
-its full rendered text before freezing, including all table/code/prose rows.
-Long final answers remain available in terminal scrollback, not necessarily all
-on screen at once. Completed reasoning and interrupted partial text retain their
-displayed tail; later answer text cannot evict completed reasoning. Each
+Ordinary assistant text renders in full from its first streamed delta and freezes
+without a completion-time expansion. Long answers remain available in terminal
+scrollback, not necessarily all on screen at once. Interrupted partial text also
+retains all displayed content. Reasoning bodies auto-follow their latest eight
+terminal rows, including wrapped lines, and retain that displayed tail when
+sealed; later answer text cannot evict completed reasoning. Each
 pretty tool body and each raw Input/Output/Error body has its own window. Tool headers and raw section labels sit outside the
 budget. Earlier content remains stored but is not all visible at once; no new
 scrolling keys or mouse bindings are provided. The composer is unchanged.
-Text-only custom renderers use the same streaming bound and final-text expansion
+Text-only custom assistant renderers also render without the eight-row cap
 (a Markdown override is one body). Image-bearing renderer output, including Kitty/iTerm2 graphics and
 reserved image rows, remains intact and is exempt from the text-row cap.
 
@@ -483,7 +483,7 @@ one block add no separator. New output consumes the shared trailing reserve
 before transcript height grows. Synthetic padding never becomes a
 permanent gap between COLD blocks or enters canonical messages/files. Width
 changes recompute the reservation without stale-width padding; transcript reset
-clears it. Streaming bodies remain capped, while full final-text expansion
+clears it. Reasoning and tool bodies remain capped, while growing assistant text
 consumes or grows the reservation without rewriting older COLD blocks. Clearing
 multiline composer input is separate and unchanged.
 

--- a/apps/coding-agent/src/tui/agent-ownership.test.ts
+++ b/apps/coding-agent/src/tui/agent-ownership.test.ts
@@ -946,7 +946,7 @@ describe.sequential("actual TUI transcript ownership", () => {
   });
 
   it.each([48, 100])(
-    "expands only completed text at width %i",
+    "shows full text live and seals identical rows at width %i",
     async (width) => {
       const app = await fixture();
       terminal.columns = width;
@@ -976,11 +976,11 @@ describe.sequential("actual TUI transcript ownership", () => {
         const cold = prefix();
         await app.emit({ type: "assistant-output-delta", text: answer });
         const active = chat().children.at(-1);
-        expect(rows(active, width)).toHaveLength(8);
-        expect(
-          stripTerminalSequences(rows(active, width).join("\n"))
-        ).not.toContain("HEADER_ID");
+        const live = rows(active, width);
+        expect(live.length).toBeGreaterThan(8);
+        expect(stripTerminalSequences(live.join("\n"))).toContain("HEADER_ID");
         await app.emit({ type: "assistant-output", text: answer });
+        expect(rows(chat().children.at(-1), width)).toEqual(live);
         unchanged(cold);
         const final = stripTerminalSequences(rows(chat(), width).join("\n"));
         for (const marker of [
@@ -1042,8 +1042,10 @@ describe.sequential("actual TUI transcript ownership", () => {
             : { type: "turn-error", message: "FAIL_ID" }
         );
         await app.finish();
-        expect(plain()).not.toContain("TEXT_00");
-        expect(plain()).toContain("TEXT_23");
+        for (const marker of lines) {
+          expect(plain().split(marker)).toHaveLength(2);
+        }
+        expect(rows().slice(0, streamed.length)).toEqual(streamed);
       } else if (mode === "steering") {
         await app.steer();
         const cold = prefix();
@@ -1051,7 +1053,7 @@ describe.sequential("actual TUI transcript ownership", () => {
         await app.emit({ type: "assistant-output-delta", text: continuation });
         await app.emit({ type: "assistant-output", text: text + continuation });
         unchanged(cold);
-        expect(plain()).not.toContain("TEXT_00");
+        expect(plain().split("TEXT_00")).toHaveLength(2);
         for (const marker of lines) {
           expect(plain().split(marker.replace("TEXT", "NEXT"))).toHaveLength(2);
         }
@@ -1060,7 +1062,7 @@ describe.sequential("actual TUI transcript ownership", () => {
         for (const marker of lines) {
           expect(plain().split(marker)).toHaveLength(2);
         }
-        if (mode === "short") {
+        if (mode !== "fallback") {
           expect(rows()).toEqual(streamed);
         }
         if (mode === "late-reasoning") {
@@ -1123,9 +1125,11 @@ describe.sequential("actual TUI transcript ownership", () => {
       await app.emit({ type: "assistant-output-delta", text: "SOURCE_ID" });
       release.resolve();
       await bounded(ready.promise);
-      expect(rows(chat().children.at(-1))).toHaveLength(8);
+      const live = rows(chat().children.at(-1));
+      expect(live).toHaveLength(20);
       await app.emit({ type: "assistant-output", text: "SOURCE_ID" });
       expect(plain().match(/CUSTOM_\d+/g)).toHaveLength(20);
+      expect(rows(chat().children.at(-1))).toEqual(live);
       expect(setText).toHaveBeenCalledTimes(1);
       expect(dispose).toHaveBeenCalledTimes(1);
       expect(context.signal.aborted).toBe(true);

--- a/apps/coding-agent/src/tui/agent.ts
+++ b/apps/coding-agent/src/tui/agent.ts
@@ -616,9 +616,6 @@ const createStreamViewFactories = (options: {
       // Committed reasoning can arrive after text deltas. Never seal that
       // newer text lease, or reopen a lease handed off to steering/tools.
       if (assistantLease?.active && assistantLease.view.contentKind === kind) {
-        if (kind === "text") {
-          assistantLease.view.completeText();
-        }
         resetAssistantView();
       }
     },

--- a/apps/coding-agent/src/tui/app-shutdown.test.ts
+++ b/apps/coding-agent/src/tui/app-shutdown.test.ts
@@ -282,7 +282,7 @@ describe.sequential("startTui final output", () => {
     expect(output.join("").split(hint)).toHaveLength(2);
   });
 
-  it("retains the streamed viewport tail and one composer border after narrow scrolling", async () => {
+  it("retains all streamed text and one composer border after narrow scrolling", async () => {
     const marker = "STREAM_SENTINEL";
     let hint = "";
     terminal.painted = (data) => {
@@ -332,9 +332,9 @@ describe.sequential("startTui final output", () => {
     );
     expect(await run).toBe(0);
     const rows = await expectFinalScreen(output.join(""), hint);
-    expect(rows.filter((row) => row?.includes(marker))).toHaveLength(4);
-    expect(rows.some((row) => row?.includes(`${marker}_35`))).toBe(true);
-    expect(rows.some((row) => row?.includes(`${marker}_1`))).toBe(false);
+    expect(
+      rows.flatMap((row) => row?.match(/STREAM_SENTINEL_\d+/g) ?? [])
+    ).toEqual(Array.from({ length: 35 }, (_, i) => `${marker}_${i + 1}`));
     expect(output.join("").split(hint)).toHaveLength(2);
   });
 

--- a/apps/coding-agent/src/tui/body-viewport.test.ts
+++ b/apps/coding-agent/src/tui/body-viewport.test.ts
@@ -5,6 +5,7 @@ import {
   visibleWidth,
 } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
+import { captureComponent, renderColdContent } from "./cold-content";
 import { AssistantStreamView } from "./stream-views";
 import { BaseToolCallView } from "./tool-call-view";
 
@@ -54,19 +55,30 @@ describe("auto-following body rows", () => {
     const view = new AssistantStreamView(theme);
     view.appendReasoning(source(count));
     const rows = plain(view.render(100));
-    expect(rows.length).toBeLessThanOrEqual(8);
+    expect(rows).toHaveLength(8);
+    expect(plain(renderColdContent(view.captureCold(100), 100))).toEqual(rows);
     expect(rows.join("\n")).toContain(`ROW_${String(count).padStart(2, "0")}`);
     expect(rows.join("\n")).not.toContain("ROW_01");
     view.dispose();
   });
 
-  it("follows text after reasoning without accumulating segment budgets", () => {
+  it("tails only reasoning before uncapped text", () => {
     const view = new AssistantStreamView(theme);
     view.appendReasoning(source(30));
     view.appendText(source(30).replaceAll("ROW", "TEXT"));
-    expect(view.render(48)).toHaveLength(8);
-    expect(plain(view.render(48)).join("\n")).toContain("TEXT_30");
-    expect(plain(view.render(48)).join("\n")).not.toContain("ROW_");
+    const live = view.render(48);
+    expect(live).toHaveLength(39);
+    expect(
+      plain(live)
+        .join("\n")
+        .match(/TEXT_\d+/g)
+    ).toHaveLength(30);
+    expect(
+      plain(live)
+        .join("\n")
+        .match(/ROW_\d+/g)
+    ).toHaveLength(8);
+    expect(renderColdContent(view.captureCold(48), 48)).toEqual(live);
     expect(view).toMatchObject({
       segments: [
         { content: source(30) },
@@ -115,6 +127,9 @@ describe("auto-following body rows", () => {
       view.setOutput(source(30));
       expect(view.render(48).length).toBeLessThanOrEqual(24);
       expect(plain(view.render(48)).join("\n")).toContain("ROW_30");
+      expect(renderColdContent(captureComponent(view, 48), 48)).toEqual(
+        view.render(48)
+      );
       view.setError(source(30).replaceAll("ROW", "ERR"));
       expect(view.render(48).length).toBeLessThanOrEqual(36);
       expect(plain(view.render(48)).join("\n")).toContain("ERR_30");

--- a/apps/coding-agent/src/tui/cold-resize.test.ts
+++ b/apps/coding-agent/src/tui/cold-resize.test.ts
@@ -48,7 +48,6 @@ describe("COLD resize layout", () => {
       dispose: (view) => view.dispose(),
     });
     lease.view.appendText(source);
-    lease.view.completeText();
     owner.finish(lease);
     const original = owner.render(width);
     for (width of [100, 48, 120, 24]) {
@@ -171,7 +170,6 @@ describe("COLD resize layout", () => {
       assistantRenderer: renderer,
     });
     view.appendText(paragraph);
-    view.completeText();
     const snapshot = ColdSnapshot.capture(view, 24);
     view.dispose();
     expect(snapshot.render(120)).toEqual(

--- a/apps/coding-agent/src/tui/cubic-render.test.ts
+++ b/apps/coding-agent/src/tui/cubic-render.test.ts
@@ -96,7 +96,6 @@ describe("Cubic render regressions", () => {
         assistantRenderer: () => custom,
       });
       view.appendText("BODY");
-      view.completeText();
       const hot = view.render(24);
       expect(hot[0]).toBe(header);
       render.mockClear();

--- a/apps/coding-agent/src/tui/stream-views.test.ts
+++ b/apps/coding-agent/src/tui/stream-views.test.ts
@@ -1,6 +1,12 @@
-import type { MarkdownTheme } from "@earendil-works/pi-tui";
+import {
+  Markdown,
+  type MarkdownTheme,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
+import { renderColdContent } from "./cold-content";
 import { AssistantStreamView } from "./stream-views";
+import { TranscriptOwner } from "./transcript-owner";
 
 const markdownTheme: MarkdownTheme = {
   heading: (text) => text,
@@ -113,7 +119,57 @@ describe("AssistantStreamView terminal safety", () => {
     expect(output).not.toContain("\u0007");
   });
 
-  it("expands text without lifting the reasoning bound in a mixed view", () => {
+  it.each([48, 100])(
+    "streams full text from its first delta at width %i",
+    (width) => {
+      const view = new AssistantStreamView(markdownTheme);
+      let text = "";
+      for (const count of [20, 30, 300]) {
+        const delta = Array.from(
+          { length: count },
+          (_, i) => `ROW_${count}_${i} ${"word ".repeat(20)}`
+        ).join("\n");
+        text += `${text ? "\n" : ""}${delta}`;
+        view.appendText(`${count === 20 ? "" : "\n"}${delta}`);
+        const live = view.render(width);
+        expect(live).toEqual(
+          new Markdown(text, 1, 0, markdownTheme).render(width)
+        );
+        expect(live.every((row) => visibleWidth(row) <= width)).toBe(true);
+        expect(renderColdContent(view.captureCold(width), width)).toEqual(live);
+      }
+      view.dispose();
+    }
+  );
+
+  it("preserves hundreds of text rows and height through sealing and resize", () => {
+    let width = 100;
+    const owner = new TranscriptOwner(() => width);
+    const lease = owner.acquire(() => new AssistantStreamView(markdownTheme), {
+      leadingSpacer: false,
+      dispose: (view) => view.dispose(),
+    });
+    const text = Array.from(
+      { length: 400 },
+      (_, i) => `ROW_${i} ${"word ".repeat(20)}`
+    ).join("\n");
+    lease.view.appendText(text);
+    for (width of [100, 48, 100]) {
+      expect(owner.render(width)).toEqual(
+        new Markdown(text, 1, 0, markdownTheme).render(width)
+      );
+    }
+    const live = owner.render(width);
+    owner.finish(lease);
+    expect(owner.render(width)).toEqual(live);
+    for (width of [48, 100]) {
+      expect(owner.render(width)).toEqual(
+        new Markdown(text, 1, 0, markdownTheme).render(width)
+      );
+    }
+  });
+
+  it("keeps text uncapped and reasoning bounded in a mixed view", () => {
     const view = new AssistantStreamView(markdownTheme);
     const source = (prefix: string) =>
       Array.from(
@@ -122,9 +178,11 @@ describe("AssistantStreamView terminal safety", () => {
       ).join("\n");
     view.appendReasoning(source("THINK"));
     view.appendText(source("TEXT"));
-    expect(view.render(48)).toHaveLength(8);
-    view.completeText();
-    const output = view.render(48).join("\n");
+    const live = view.render(48);
+    expect(live).toHaveLength(29);
+    expect(renderColdContent(view.captureCold(48), 48)).toEqual(live);
+    expect(view.render(48)).toEqual(live);
+    const output = live.join("\n");
     expect(output.match(/THINK_\d+/g)).toHaveLength(8);
     expect(output.match(/TEXT_\d+/g)).toHaveLength(20);
     view.dispose();

--- a/apps/coding-agent/src/tui/stream-views.ts
+++ b/apps/coding-agent/src/tui/stream-views.ts
@@ -52,7 +52,6 @@ export class AssistantStreamView extends Container {
   private readonly assistantRenderer: AssistantRenderer | undefined;
   private readonly controller = new AbortController();
   private disposed = false;
-  private textComplete = false;
   private readonly foregroundColor: string | undefined;
   private readonly markdownTheme: MarkdownTheme;
   private readonly notify: (message: string) => void;
@@ -95,9 +94,6 @@ export class AssistantStreamView extends Container {
   }
 
   override render(width: number): string[] {
-    if (!this.textComplete) {
-      return renderBodyTail(super.render(width), width);
-    }
     return this.children.flatMap((child) => {
       const lines = child.render(width);
       const reasoning = this.segments.some(
@@ -113,21 +109,13 @@ export class AssistantStreamView extends Container {
       const reasoning = this.segments.some(
         (segment) => segment.view === child && segment.type === "reasoning"
       );
-      return this.textComplete && reasoning
-        ? selectColdTail(content, width)
-        : content;
+      return reasoning ? selectColdTail(content, width) : content;
     });
-    const content: ColdContent = { kind: "group", children };
-    return this.textComplete ? content : selectColdTail(content, width);
+    return { kind: "group", children };
   }
 
   get contentKind(): "reasoning" | "text" | undefined {
     return this.segments.at(-1)?.type;
-  }
-
-  /** Expand text before sealing, without restarting an async renderer. */
-  completeText(): void {
-    this.textComplete = true;
   }
 
   appendReasoning(delta: string): void {


### PR DESCRIPTION
## Summary
- Render ordinary assistant text in full from its first delta, eliminating completion-time expansion.
- Keep reasoning and tool bodies capped at eight wrapped rows; retain COLD content, resize reflow, staged history replay, and composer ownership.
- Update regression tests and documentation, and add a coding-agent patch release note.

## Verification
- Full TUI suite: 58 files, 617 tests passed.
- Coding-agent typecheck, lint, build, built CLI help, Tegami validation, and git diff --check passed.
- Gate review: APPROVE for the final working tree, with no blockers.
- Prior local PTY captures at 48/100 columns show identical live/completed text. Those captures predate this port onto current main; current-tree coverage is provided by the full TUI suite.

## Scope
Based on released main d094807c. Preserves the Cubic fixes merged in #415. No runtime retry changes or release automation changes. This change was not included in coding-agent 0.0.14-next.19.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders ordinary assistant text in full from its first streamed delta so the content shown while generating matches the completed transcript. Previously the live view showed only an eight-row tail that expanded at completion.

- Reasoning and tool bodies stay capped at eight wrapped rows, including wrapped lines.
- Sealing no longer expands text; live rows and final rows are identical, and interrupted partial text keeps all its content.
- COLD content, resize reflow, staged history replay, and composer ownership are unchanged.
- Adds a patch release note and updates README and regression tests.

<sup>Written for commit fcc5c9de09428bfede5d1d00de6604ef47aa5299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/pss-runtime/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

